### PR TITLE
Cleanup in domain adaptation

### DIFF
--- a/albumentations/augmentations/mixing/domain_adaptation.py
+++ b/albumentations/augmentations/mixing/domain_adaptation.py
@@ -167,8 +167,8 @@ class BaseDomainAdaptation(ImageOnlyTransform):
                 f"'{self.metadata_key}' in the input data.",
             )
 
-        if not isinstance(metadata_images, Sequence) or not metadata_images:
-            raise ValueError(
+        if not isinstance(metadata_images, Sequence):
+            raise TypeError(
                 f"Metadata key '{self.metadata_key}' should contain a non-empty sequence of numpy arrays.",
             )
 


### PR DESCRIPTION
## Summary by Sourcery

Refine metadata_images validation by raising a TypeError for incorrect types and eliminating the explicit non-empty sequence check

Enhancements:
- Use TypeError instead of ValueError for non-sequence metadata inputs
- Remove redundant empty-sequence check from metadata validation