### PR TITLE
Version boosted to 2.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ transformed = transform(image=image)
 transformed_image = transformed["image"]
 ```
 
-AlbumentationsX checks for updates on import and collects anonymous usage statistics to improve the library. Both features can be disabled with `ALBUMENTATIONSX_OFFLINE=1`, or individually with `NO_ALBUMENTATIONS_UPDATE=1` (version check) and `ALBUMENTATIONSX_NO_TELEMETRY=1` (telemetry).
+AlbumentationsX checks for updates on import and collects anonymous usage statistics to improve the library. Both features can be disabled with `ALBUMENTATIONS_OFFLINE=1`, or individually with `NO_ALBUMENTATIONS_UPDATE=1` (version check) and `ALBUMENTATIONS_NO_TELEMETRY=1` (telemetry).
 
 ## List of augmentations
 

--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import metadata
 
 try:
-    _metadata = metadata("albumentations")
+    _metadata = metadata("albumentationsx")
     __version__ = _metadata["Version"]
     __author__ = _metadata["Author"]
     __maintainer__ = _metadata["Maintainer"]

--- a/albumentations/core/analytics/settings.py
+++ b/albumentations/core/analytics/settings.py
@@ -49,10 +49,10 @@ class SettingsManager:
                 pass
 
         # Override with environment variables
-        if os.environ.get("ALBUMENTATIONSX_NO_TELEMETRY", "").lower() in ("1", "true"):
+        if os.environ.get("ALBUMENTATIONS_NO_TELEMETRY", "").lower() in ("1", "true"):
             settings["telemetry"] = False
 
-        if os.environ.get("ALBUMENTATIONSX_OFFLINE", "").lower() in ("1", "true"):
+        if os.environ.get("ALBUMENTATIONS_OFFLINE", "").lower() in ("1", "true"):
             settings["telemetry"] = False
             settings["check_updates"] = False
 

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -661,7 +661,7 @@ class Compose(BaseCompose, HubMixin):
             This collects anonymous usage data including pipeline configuration, environment info,
             and common parameter patterns. No image data or personal information is collected.
             Telemetry can be disabled globally via settings.telemetry_enabled = False or by
-            setting the environment variable ALBUMENTATIONSX_NO_TELEMETRY=1. Default is True.
+            setting the environment variable ALBUMENTATIONS_NO_TELEMETRY=1. Default is True.
 
     Examples:
         >>> # Basic usage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [ "setuptools>=45", "wheel" ]
 [project]
 name = "albumentationsx"
 
-version = "2.0.8"
+version = "2.0.9"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volumes, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows."
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ INSTALL_REQUIRES = [
     "PyYAML",
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.9.2",
-    "albucore==0.0.32",
+    "albucore==0.0.33",
     "eval-type-backport; python_version<'3.10'",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ INSTALL_REQUIRES = [
     "PyYAML",
     "typing-extensions>=4.9.0; python_version<'3.10'",
     "pydantic>=2.9.2",
-    "albucore==0.0.29",
+    "albucore==0.0.32",
     "eval-type-backport; python_version<'3.10'",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,3 +84,7 @@ SQUARE_MULTI_UINT8_IMAGE = np.random.randint(low=0, high=256, size=(100, 100, 5)
 SQUARE_MULTI_FLOAT_IMAGE = np.random.uniform(low=0.0, high=1.0, size=(100, 100, 5)).astype(np.float32)
 
 MULTI_IMAGES = [SQUARE_MULTI_UINT8_IMAGE, SQUARE_MULTI_FLOAT_IMAGE]
+
+@pytest.fixture
+def image_float32():
+    return cv2.randu(np.zeros((100, 100, 3), dtype=np.float32), 0, 1)

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -213,13 +213,12 @@ def test_augmentations_wont_change_input(augmentation_cls, params):
         },
     ),
 )
-def test_augmentations_wont_change_float_input(augmentation_cls, params):
-    image = SQUARE_FLOAT_IMAGE
-    float_image_copy = image.copy()
+def test_augmentations_wont_change_float_input(augmentation_cls, params, image_float32):
+    float_image_copy = image_float32.copy()
 
     aug = augmentation_cls(p=1, **params)
 
-    data = {"image": image}
+    data = {"image": image_float32}
 
     if augmentation_cls == A.OverlayElements:
         data["overlay_metadata"] = []
@@ -229,7 +228,7 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params):
             "bbox": (0.1, 0.1, 0.9, 0.2),
         }
     elif augmentation_cls == A.MaskDropout or augmentation_cls == A.ConstrainedCoarseDropout:
-        mask = np.zeros((image.shape[0], image.shape[1], 1), dtype=np.uint8)
+        mask = np.zeros((image_float32.shape[0], image_float32.shape[1], 1), dtype=np.uint8)
         mask[:20, :20] = 1
         data["mask"] = mask
     elif augmentation_cls == A.RandomCropNearBBox:
@@ -237,15 +236,15 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params):
     elif augmentation_cls == A.Mosaic:
         data["mosaic_metadata"] = [
             {
-                "image": image,
+                "image": image_float32,
             }
         ]
     elif augmentation_cls in transforms2metadata_key:
-        data[transforms2metadata_key[augmentation_cls]] = [image]
+        data[transforms2metadata_key[augmentation_cls]] = [image_float32    ]
 
     aug(**data)
 
-    np.testing.assert_array_equal(image, float_image_copy)
+    np.testing.assert_array_equal(image_float32, float_image_copy)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -55,7 +55,7 @@ class TestTelemetrySettings:
 
     def test_telemetry_disable_via_env_var(self, monkeypatch):
         """Test disabling telemetry via environment variable."""
-        monkeypatch.setenv("ALBUMENTATIONSX_NO_TELEMETRY", "1")
+        monkeypatch.setenv("ALBUMENTATIONS_NO_TELEMETRY", "1")
         # Create new settings instance to pick up env var
         from albumentations.core.analytics.settings import SettingsManager
         test_settings = SettingsManager()
@@ -63,7 +63,7 @@ class TestTelemetrySettings:
 
     def test_offline_mode_disables_telemetry(self, monkeypatch):
         """Test that offline mode disables telemetry."""
-        monkeypatch.setenv("ALBUMENTATIONSX_OFFLINE", "1")
+        monkeypatch.setenv("ALBUMENTATIONS_OFFLINE", "1")
         from albumentations.core.analytics.settings import SettingsManager
         test_settings = SettingsManager()
         assert test_settings.telemetry_enabled is False
@@ -679,18 +679,18 @@ class TestComplexPipelines:
 
 
 @pytest.mark.parametrize("env_var,env_value,expected", [
-    ("ALBUMENTATIONSX_NO_TELEMETRY", "1", False),
-    ("ALBUMENTATIONSX_NO_TELEMETRY", "true", False),
-    ("ALBUMENTATIONSX_NO_TELEMETRY", "TRUE", False),
-    ("ALBUMENTATIONSX_NO_TELEMETRY", "0", True),
-    ("ALBUMENTATIONSX_NO_TELEMETRY", "false", True),
-    ("ALBUMENTATIONSX_OFFLINE", "1", False),
+            ("ALBUMENTATIONS_NO_TELEMETRY", "1", False),
+        ("ALBUMENTATIONS_NO_TELEMETRY", "true", False),
+        ("ALBUMENTATIONS_NO_TELEMETRY", "TRUE", False),
+        ("ALBUMENTATIONS_NO_TELEMETRY", "0", True),
+        ("ALBUMENTATIONS_NO_TELEMETRY", "false", True),
+            ("ALBUMENTATIONS_OFFLINE", "1", False),
     ("NO_ALBUMENTATIONS_UPDATE", "1", True),  # Only affects updates, not telemetry
 ])
 def test_environment_variables(monkeypatch, env_var, env_value, expected):
     """Test various environment variable configurations."""
     # Clear all relevant env vars first
-    for var in ["ALBUMENTATIONSX_NO_TELEMETRY", "ALBUMENTATIONSX_OFFLINE", "NO_ALBUMENTATIONS_UPDATE"]:
+    for var in ["ALBUMENTATIONS_NO_TELEMETRY", "ALBUMENTATIONS_OFFLINE", "NO_ALBUMENTATIONS_UPDATE"]:
         monkeypatch.delenv(var, raising=False)
 
     # Set the test env var


### PR DESCRIPTION
## Summary by Sourcery

Bump version to 2.0.9, update albucore dependency, and align telemetry/offline environment variable naming across the library

Enhancements:
- Standardize environment variable names by renaming ALBUMENTATIONSX_NO_TELEMETRY and ALBUMENTATIONSX_OFFLINE to ALBUMENTATIONS_NO_TELEMETRY and ALBUMENTATIONS_OFFLINE across code, tests, and docs

Build:
- Bump project version to 2.0.9
- Update albucore dependency to 0.0.32

Documentation:
- Refresh README and docstrings to reflect the new environment variable names

Tests:
- Update telemetry and offline mode tests to use the renamed environment variables