### PR TITLE
Cleanup

### DIFF
--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -1859,8 +1859,11 @@ class Posterize(ImageOnlyTransform):
     ) -> np.ndarray:
         return fpixel.posterize(img, num_bits)
 
-    def apply_to_images(self, images: list[np.ndarray], **params: Any) -> list[np.ndarray]:
+    def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
         return self.apply(images, **params)
+
+    def apply_to_volumes(self, volumes: np.ndarray, **params: Any) -> np.ndarray:
+        return self.apply(volumes, **params)
 
     def get_params(self) -> dict[str, Any]:
         if isinstance(self.num_bits, list):
@@ -5137,8 +5140,11 @@ class AdditiveNoise(ImageOnlyTransform):
     ) -> np.ndarray:
         return fpixel.add_noise(img, noise_map)
 
-    def apply_to_images(self, images: list[np.ndarray], **params: Any) -> list[np.ndarray]:
+    def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
         return self.apply(images, **params)
+
+    def apply_to_volumes(self, volumes: np.ndarray, **params: Any) -> np.ndarray:
+        return self.apply(volumes, **params)
 
     def get_params_dependent_on_data(
         self,

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -572,7 +572,7 @@ class DualTransform(BasicTransform):
         apply(img: np.ndarray, **params: Any) -> np.ndarray:
             Apply the transform to the image.
 
-            img: Input image of shape (H, W, C) or (H, W) for grayscale.
+            img: Input image of shape (H, W, C).
             **params: Additional parameters specific to the transform.
 
             Returns Transformed image of the same shape as input.
@@ -580,7 +580,7 @@ class DualTransform(BasicTransform):
         apply_to_images(images: np.ndarray, **params: Any) -> np.ndarray:
             Apply the transform to multiple images.
 
-            images: Input images of shape (N, H, W, C) or (N, H, W) for grayscale.
+            images: Input images of shape (N, H, W, C).
             **params: Additional parameters specific to the transform.
 
             Returns Transformed images in the same format as input.
@@ -593,7 +593,7 @@ class DualTransform(BasicTransform):
 
             Returns Transformed mask in the same format as input.
 
-        apply_to_masks(masks: np.ndarray, **params: Any) -> np.ndarray | list[np.ndarray]:
+        apply_to_masks(masks: np.ndarray, **params: Any) -> np.ndarray:
             Apply the transform to multiple masks.
 
             masks: Array of shape (N, H, W) or (N, H, W, C) where N is number of masks
@@ -619,7 +619,7 @@ class DualTransform(BasicTransform):
         apply_to_volume(volume: np.ndarray, **params: Any) -> np.ndarray:
             Apply the transform to a volume.
 
-            volume: Input volume of shape (D, H, W) or (D, H, W, C).
+            volume: Input volume of shape (D, H, W, C).
             **params: Additional parameters specific to the transform.
 
             Returns Transformed volume of the same shape as input.
@@ -627,7 +627,7 @@ class DualTransform(BasicTransform):
         apply_to_volumes(volumes: np.ndarray, **params: Any) -> np.ndarray:
             Apply the transform to multiple volumes.
 
-            volumes: Input volumes of shape (N, D, H, W) or (N, D, H, W, C).
+            volumes: Input volumes of shape (N, D, H, W, C).
             **params: Additional parameters specific to the transform.
 
             Returns Transformed volumes in the same format as input.
@@ -810,10 +810,10 @@ class Transform3D(DualTransform):
     volumes and masks, similar to how 2D DualTransforms work with images and masks.
 
     Targets:
-        volume: 3D numpy array of shape (D, H, W) or (D, H, W, C)
-        volumes: Batch of 3D arrays of shape (N, D, H, W) or (N, D, H, W, C)
-        mask: 3D numpy array of shape (D, H, W)
-        masks: Batch of 3D arrays of shape (N, D, H, W)
+        volume: 3D numpy array of shape (D, H, W, C)
+        volumes: Batch of 3D arrays of shape (N, D, H, W, C)
+        mask: 3D numpy array of shape (D, H, W) or (D, H, W, C)
+        masks: Batch of 3D arrays of shape (N, D, H, W) or (N, D, H, W, C)
         keypoints: 3D numpy array of shape (N, 3)
     """
 

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -223,12 +223,17 @@ def test_to_tensor_v2_on_non_contiguous_array():
     assert not non_contiguous_img.flags["C_CONTIGUOUS"]
 
     transform = A.Compose([A.ToTensorV2()], strict=True)
-    transformed = transform(image=non_contiguous_img, masks=[non_contiguous_img] * 2)
+    transformed = transform(image=non_contiguous_img, masks=np.stack([non_contiguous_img] * 2))
 
     # Additional checks to ensure the transformation worked correctly
     assert isinstance(transformed["image"], torch.Tensor)
     assert transformed["image"].shape == (3, 50, 50)  # Shape changed due to slicing
     assert transformed["image"].dtype == torch.uint8
+
+    # Check masks
+    assert isinstance(transformed["masks"], torch.Tensor)
+    assert transformed["masks"].shape == (2, 50, 50, 3)  # (N, H, W, C) - masks remain in original format
+    assert transformed["masks"].dtype == torch.uint8
 
     # Optional: Check that the content is correct
     np_transformed = transformed["image"].numpy()


### PR DESCRIPTION
## Summary by Sourcery

Clean up and streamline transform implementations by standardizing API signatures, tidying up type hints and docstrings, consolidating batch methods, and adjusting tests to match the new array-only input conventions.

Enhancements:
- Simplify ToTensorV2 by removing overloaded methods and list-based mask handling, enforcing a single apply_to_masks signature.
- Harmonize transform interface signatures and docstrings to consistently require a channel dimension for images, masks, and volumes.
- Extend pixel transforms with apply_to_volumes and remove obsolete dimension checks to streamline batch operations.

Tests:
- Update PyTorch transform tests to use stacked numpy masks and validate mask tensor shape and dtype.