### PR TITLE
feat: add apply_to_images to PixelDropout

### DIFF
--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -304,6 +304,15 @@ class PixelDropout(DualTransform):
     ) -> np.ndarray:
         return fpixel.pixel_dropout(img, drop_mask, drop_values)
 
+    def apply_to_images(
+        self,
+        images: np.ndarray,
+        drop_mask: np.ndarray,
+        drop_values: np.ndarray,
+        **params: Any,
+    ) -> np.ndarray:
+        return self.apply(images, drop_mask, drop_values, **params)
+
     def apply_to_mask(
         self,
         mask: np.ndarray,


### PR DESCRIPTION
## Summary by Sourcery

Add batch processing support to PixelDropout by introducing apply_to_images and validate it with a new unit test.

New Features:
- Add apply_to_images method to PixelDropout to support batch image dropout.

Tests:
- Add unit test for PixelDropout.apply_to_images to verify batch dropout behavior.