### PR TITLE
feat: add apply_to_images to MultiplicativeNoise

### DIFF
--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -3236,6 +3236,9 @@ class MultiplicativeNoise(ImageOnlyTransform):
     ) -> np.ndarray:
         return multiply(img, multiplier)
 
+    def apply_to_images(self, images: np.ndarray, multiplier: float | np.ndarray, **kwargs: Any) -> np.ndarray:
+        return self.apply(images, multiplier, **kwargs)
+
     def get_params_dependent_on_data(
         self,
         params: dict[str, Any],

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -424,6 +424,25 @@ def test_crop_non_empty_mask():
     _test_crop(mask_6, crop_6, aug_6, n=10)
     _test_crops(np.stack([mask_2, mask_1]), np.stack([crop_2, crop_1]), aug_1, n=1)
 
+@pytest.mark.parametrize("images", [
+    cv2.randu(np.zeros((2, 256, 320, 1), dtype=np.uint8), 0, 255),
+    cv2.randu(np.zeros((2, 256, 320, 1), dtype=np.float32), 0, 1),
+    cv2.randu(np.zeros((2, 256, 320, 3), dtype=np.uint8), 0, 255),
+    cv2.randu(np.zeros((2, 256, 320, 3), dtype=np.float32), 0, 1),
+])
+def test_batched_multiplicative_noise(images: np.ndarray):
+    m = 0.5
+    aug = A.MultiplicativeNoise((m, m), p=1)
+
+    actual = aug.apply_to_images(images, m)
+
+    assert actual.shape == images.shape
+    for act, original in zip(actual, images):
+        expected = aug(image=original)["image"]
+
+        assert not np.array_equal(original, expected)
+        np.testing.assert_allclose(act, expected)
+
 
 @pytest.mark.parametrize(
     "image",

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -437,11 +437,14 @@ def test_batched_multiplicative_noise(images: np.ndarray):
     actual = aug.apply_to_images(images, m)
 
     assert actual.shape == images.shape
-    for act, original in zip(actual, images):
-        expected = aug(image=original)["image"]
 
-        assert not np.array_equal(original, expected)
-        np.testing.assert_allclose(act, expected)
+    expected = aug(image=images[0])["image"]
+    assert not np.array_equal(images[0], expected)
+    np.testing.assert_allclose(actual[0], expected)
+
+    expected = aug(image=images[1])["image"]
+    assert not np.array_equal(images[1], expected)
+    np.testing.assert_allclose(actual[1], expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #48.

## Summary by Sourcery

Enable batched application of MultiplicativeNoise by introducing an apply_to_images method and corresponding unit tests

New Features:
- Add apply_to_images method to MultiplicativeNoise to support batch processing of images

Tests:
- Add test_batched_multiplicative_noise to verify batched multiplicative noise application