### PR TITLE
feat: add support for multiple resize backends

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ dynamic = [ "dependencies" ]
 optional-dependencies.hub = [ "huggingface-hub" ]
 optional-dependencies.pytorch = [ "torch" ]
 
-optional-dependencies.pyvips = [ "pyvips" ]
+optional-dependencies.pyvips = [ "pyvips[binary]" ]
 optional-dependencies.text = [ "pillow" ]
 urls.Homepage = "https://albumentations.ai"
 


### PR DESCRIPTION
## Summary by Sourcery

Allow configuring the image resize backend (defaulting to OpenCV) and prepare for PyVips support and update project configuration accordingly.

New Features:
- Support selecting resize backend via ALBUMENTATIONS_RESIZE environment variable
- Include pyvips as optional dependency for resize backend

Enhancements:
- Refactor resize implementation into generic resize function delegating to backend-specific implementations

Documentation:
- Include pyvips in optional dependencies in pyproject.toml

## Summary by Sourcery

Introduce configurable image resize backends and add optional PyVips support

New Features:
- Allow selecting the image resize backend via ALBUMENTATIONS_RESIZE environment variable
- Add a PyVips-based resize implementation as an optional backend

Enhancements:
- Refactor the generic resize function to delegate to backend-specific implementations

Documentation:
- Include pyvips in optional dependencies in pyproject.toml