### PR TITLE
Add apply_to_images support to HueSaturationValue and add unit test

### DIFF
--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -1639,11 +1639,13 @@ class HueSaturationValue(ImageOnlyTransform):
         sat_shift_limit: tuple[float, float] | float = (-30, 30),
         val_shift_limit: tuple[float, float] | float = (-20, 20),
         p: float = 0.5,
+        apply_to_images: bool = False,
     ):
         super().__init__(p=p)
         self.hue_shift_limit = cast("tuple[float, float]", hue_shift_limit)
         self.sat_shift_limit = cast("tuple[float, float]", sat_shift_limit)
         self.val_shift_limit = cast("tuple[float, float]", val_shift_limit)
+        self._apply_to_images_flag = apply_to_images
 
     def apply(
         self,
@@ -1664,6 +1666,20 @@ class HueSaturationValue(ImageOnlyTransform):
             "sat_shift": self.py_random.uniform(*self.sat_shift_limit),
             "val_shift": self.py_random.uniform(*self.val_shift_limit),
         }
+
+    def apply_to_images(self, images: Sequence[np.ndarray], **params: Any) -> list[np.ndarray]:
+        """Apply the Hue-Saturation-Value (HSV) transformation to a list of images.
+
+        Args:
+            images: Sequence of images to augment.
+            **params: Additional transformation parameters
+                (hue_shift, sat_shift, val_shift) sampled for this augmentation.
+
+        Returns:
+            list[np.ndarray]: Augmented images.
+
+        """
+        return [self.apply(img, **params) for img in images]
 
 
 class Solarize(ImageOnlyTransform):

--- a/tests/test_hsv_apply_to_images.py
+++ b/tests/test_hsv_apply_to_images.py
@@ -1,0 +1,33 @@
+import numpy as np
+import albumentations as A
+
+def test_hsv_apply_to_images_list():
+    img1 = np.ones((32, 32, 3), dtype=np.uint8) * 100
+    img2 = np.ones((32, 32, 3), dtype=np.uint8) * 150
+
+    # force apply with p=1.0 and enable apply_to_images
+    aug = A.HueSaturationValue(apply_to_images=True, p=1.0)
+
+    out = aug(images=[img1, img2])
+
+    # Support both API styles (some transforms return dict with 'images' key)
+    if isinstance(out, dict) and "images" in out:
+        images_out = out["images"]
+    else:
+        images_out = out
+
+    assert isinstance(images_out, (list, tuple))
+    assert len(images_out) == 2
+    assert images_out[0].shape == img1.shape
+    assert images_out[1].shape == img2.shape
+
+    # If two identical images are passed, outputs should be identical because we sample params once
+    same1 = np.copy(img1)
+    same2 = np.copy(img1)
+    out_same = aug(images=[same1, same2])
+    if isinstance(out_same, dict) and "images" in out_same:
+        images_same = out_same["images"]
+    else:
+        images_same = out_same
+
+    assert np.array_equal(images_same[0], images_same[1])


### PR DESCRIPTION
- Implement apply_to_images method in HueSaturationValue.
- Add tests/test_hsv_apply_to_images.py to verify consistent augmentation.

## Summary by Sourcery

Enable batch HSV augmentation by adding apply_to_images support to HueSaturationValue and add tests to ensure consistent transformations across image lists

New Features:
- Add apply_to_images flag and method to HueSaturationValue to support batch augmentation with consistent parameters

Tests:
- Add unit tests to verify consistent HSV augmentation across multiple images when using apply_to_images