### PR TITLE
feat: add apply_to_images to HueSaturationValue (#55)

### DIFF
--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -1658,6 +1658,10 @@ class HueSaturationValue(ImageOnlyTransform):
             raise TypeError(msg)
         return fpixel.shift_hsv(img, hue_shift, sat_shift, val_shift)
 
+    def apply_to_images(self, images: np.ndarray, hue_shift: int, sat_shift: int, val_shift: int, **params: Any) -> np.ndarray:
+        return np.stack([self.apply(img, hue_shift=hue_shift, sat_shift=sat_shift, val_shift=val_shift, **params)
+            for img in images], axis=0)
+        
     def get_params(self) -> dict[str, float]:
         return {
             "hue_shift": self.py_random.uniform(*self.hue_shift_limit),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -446,6 +446,46 @@ def test_batched_multiplicative_noise(images: np.ndarray):
     assert not np.array_equal(images[1], expected)
     np.testing.assert_allclose(actual[1], expected)
 
+@pytest.mark.parametrize("images", [
+    cv2.randu(np.zeros((2, 256, 320, 1), dtype=np.uint8), 0, 255),
+    cv2.randu(np.zeros((2, 256, 320, 1), dtype=np.float32), 0, 1),
+    cv2.randu(np.zeros((2, 256, 320, 3), dtype=np.uint8), 0, 255),
+    cv2.randu(np.zeros((2, 256, 320, 3), dtype=np.float32), 0, 1),
+])
+def test_batched_hue_saturation_value(images: np.ndarray):
+    # Fixed params so results are deterministic across single/batch paths
+    hue_shift=10
+    sat_shift=20
+    val_shift=-15
+
+    aug = A.HueSaturationValue(p=1)
+    
+    actual = aug.apply_to_images(images,
+        hue_shift=hue_shift,
+        sat_shift=sat_shift,
+        val_shift=val_shift,)
+    assert actual.shape == images.shape
+
+    expected0 = aug.apply(
+        images[0],
+        hue_shift=hue_shift,
+        sat_shift=sat_shift,
+        val_shift=val_shift,
+    )
+    expected1 = aug.apply(
+        images[1],
+        hue_shift=hue_shift,
+        sat_shift=sat_shift,
+        val_shift=val_shift,
+    )
+
+    # Ensure transform changed something (sanity check)
+    assert not np.array_equal(images[0], expected0)
+    assert not np.array_equal(images[1], expected1)
+
+    # Batch must equal per-image results
+    np.testing.assert_allclose(actual[0], expected0)
+    np.testing.assert_allclose(actual[1], expected1)
 
 @pytest.mark.parametrize(
     "image",


### PR DESCRIPTION
added apply to images for HueSaturationValue and testing

## Summary by Sourcery

Add batch processing capability to the HueSaturationValue transform and include tests to validate its behavior.

New Features:
- Add apply_to_images method to HueSaturationValue to support batch augmentation.

Tests:
- Add tests for batched HueSaturationValue to ensure consistency with single-image transform.