### PR TITLE
feat: Add apply_to_images to ZoomBlur (#16)

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -1487,6 +1487,14 @@ class ZoomBlur(ImageOnlyTransform):
     ) -> np.ndarray:
         return fblur.zoom_blur(img, zoom_factors)
 
+    def apply_to_images(self, images: np.ndarray, zoom_factors: np.ndarray, **params: Any) -> np.ndarray:
+        out = np.empty_like(images)
+
+        for i, image in enumerate(images):
+            out[i] = self.apply(image, zoom_factors, **params)
+
+        return out
+
     def get_params(self) -> dict[str, Any]:
         step_factor = self.py_random.uniform(*self.step_factor)
         max_factor = max(1 + step_factor, self.py_random.uniform(*self.max_factor))

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -994,6 +994,31 @@ def test_motion_blur_allow_shifted_true():
     assert len(unique_kernels) > 1, "allow_shifted=True should produce some variation in kernel positions"
 
 
+@pytest.mark.parametrize("images", [
+    cv2.randu(np.zeros((2, 228, 256, 1), dtype=np.uint8), 0, 255),
+    cv2.randu(np.zeros((2, 228, 256, 1), dtype=np.float32), 0, 1),
+    cv2.randu(np.zeros((2, 228, 256, 3), dtype=np.uint8), 0, 255),
+    cv2.randu(np.zeros((2, 228, 256, 3), dtype=np.float32), 0, 1),
+])
+def test_batched_zoom_blur(images: np.ndarray):
+    max_factor=(1.15, 1.25)
+    step_factor=0.02
+
+    aug = A.ZoomBlur(max_factor, step_factor, p=1.0)
+    zoom_factors = aug.get_params()["zoom_factors"]
+
+    actual = aug.apply_to_images(images, zoom_factors)
+
+    assert actual.shape == images.shape
+    assert actual.dtype == images.dtype
+
+    expected = aug(image=images[0])["image"]
+    assert not np.array_equal(images[0], expected)
+
+    expected = aug(image=images[-1])["image"]
+    assert not np.array_equal(images[1], expected)
+
+
 @pytest.mark.parametrize(
     "augmentation",
     [


### PR DESCRIPTION
This PR adds the *apply_to_images* method to the ZoomBlur transform, closing issue #16. 

A new test, test_batched_zoom_blur, was added to verify the functionality across different image dtypes and channel counts.