### PR TITLE
Feature/pillow resize backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
         language: system
         files: setup.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.10
+    rev: v0.13.0
     hooks:
       - id: ruff
         exclude: '__pycache__/'
@@ -105,7 +105,7 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+    rev: v1.18.1
     hooks:
       - id: mypy
         files: ^albumentations/

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -1487,7 +1487,7 @@ class _BaseRandomSizedCrop(DualTransform):
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
         ]
-        area_for_downscale: Literal[None, "image", "image_mask"]
+        area_for_downscale: Literal["image", "image_mask"] | None
 
     def __init__(
         self,
@@ -1510,7 +1510,7 @@ class _BaseRandomSizedCrop(DualTransform):
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
         ] = cv2.INTER_NEAREST,
-        area_for_downscale: Literal[None, "image", "image_mask"] = None,
+        area_for_downscale: Literal["image", "image_mask"] | None = None,
         p: float = 1.0,
     ):
         super().__init__(p=p)
@@ -1735,7 +1735,7 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
         min_max_height: OnePlusIntRangeType
         w2h_ratio: Annotated[float, Field(gt=0)]
         size: Annotated[tuple[int, int], AfterValidator(check_range_bounds(1, None))]
-        area_for_downscale: Literal[None, "image", "image_mask"]
+        area_for_downscale: Literal["image", "image_mask"] | None
 
     def __init__(
         self,
@@ -1760,7 +1760,7 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
         ] = cv2.INTER_NEAREST,
-        area_for_downscale: Literal[None, "image", "image_mask"] = None,
+        area_for_downscale: Literal["image", "image_mask"] | None = None,
         p: float = 1.0,
     ):
         super().__init__(
@@ -1925,7 +1925,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
         ]
-        area_for_downscale: Literal[None, "image", "image_mask"]
+        area_for_downscale: Literal["image", "image_mask"] | None
 
     def __init__(
         self,
@@ -1950,7 +1950,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
         ] = cv2.INTER_NEAREST,
-        area_for_downscale: Literal[None, "image", "image_mask"] = None,
+        area_for_downscale: Literal["image", "image_mask"] | None = None,
         p: float = 1.0,
     ):
         super().__init__(

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -268,6 +268,8 @@ def resize(
         return resize_cv2(img, target_shape, interpolation)
     if backend == "pyvips":
         return resize_pyvips(img, target_shape, interpolation)
+    if backend == "pillow":
+        return resize_pil(img, target_shape, interpolation)
 
     raise NotImplementedError(f"The provided backend '{backend}' is not supported yet.")
 
@@ -363,32 +365,80 @@ def resize_pil(
     Args:
         img (np.ndarray): The input image as a NumPy array.
         target_shape (tuple[int, int]): The desired output shape (height, width).
-        interpolation (int): The PIL interpolation filter to use.
-            0: NEAREST
-            1: LANCZOS (alias of ANTIALIAS filter)
-            2: BILINEAR
-            3: BICUBIC
-            4: BOX
-            5: HAMMING
+        interpolation (int): The cv2 interpolation flag that will be mapped to PIL interpolation.
+            Maps cv2 constants to PIL.Image.Resampling constants.
 
     Returns:
         np.ndarray: The resized image as a NumPy array.
 
     """
-    # At this stage, the library's installation and importability have already been verified.
     from PIL import Image
 
     target_height, target_width = target_shape
     original_dtype = img.dtype
 
-    pil_img = Image.fromarray(img)
+    # Map cv2 interpolation constants to PIL.Image.Resampling constants
+    cv2_to_pil_interpolation = {
+        cv2.INTER_NEAREST: Image.Resampling.NEAREST,
+        cv2.INTER_NEAREST_EXACT: Image.Resampling.NEAREST,  # PIL doesn't have exact variant
+        cv2.INTER_LINEAR: Image.Resampling.BILINEAR,
+        cv2.INTER_CUBIC: Image.Resampling.BICUBIC,
+        cv2.INTER_AREA: Image.Resampling.BOX,  # BOX is similar to INTER_AREA for downscaling
+        cv2.INTER_LANCZOS4: Image.Resampling.LANCZOS,
+        cv2.INTER_LINEAR_EXACT: Image.Resampling.BILINEAR,  # PIL doesn't have exact variant
+    }
 
-    resized_pil_img = pil_img.resize(
-        (target_width, target_height),
-        resample=interpolation,
-    )
+    pil_interpolation = cv2_to_pil_interpolation.get(interpolation)
+    if pil_interpolation is None:
+        # Fallback to BILINEAR for unknown interpolation methods
+        warn(f"Interpolation method {interpolation} is not supported by PIL backend, using BILINEAR", stacklevel=2)
+        pil_interpolation = Image.Resampling.BILINEAR
 
-    return np.array(resized_pil_img, dtype=original_dtype)
+    # Convert numpy array to PIL Image
+    # Images always have ndim=3 in albumentations
+    if img.ndim != 3:
+        raise ValueError(f"Expected 3D array, got shape: {img.shape}")
+
+    num_channels = img.shape[2]
+
+    if num_channels == 1:
+        # Grayscale image (H, W, 1) -> squeeze to (H, W) for PIL
+        pil_img = Image.fromarray(img[:, :, 0], mode="L")
+        resized_pil_img = pil_img.resize(
+            (target_width, target_height),
+            resample=pil_interpolation,
+        )
+        # Convert back to (H, W, 1)
+        result = np.array(resized_pil_img)[:, :, np.newaxis]
+    elif num_channels == 3:
+        # RGB image
+        pil_img = Image.fromarray(img, mode="RGB")
+        resized_pil_img = pil_img.resize(
+            (target_width, target_height),
+            resample=pil_interpolation,
+        )
+        result = np.array(resized_pil_img)
+    elif num_channels == 4:
+        # RGBA image
+        pil_img = Image.fromarray(img, mode="RGBA")
+        resized_pil_img = pil_img.resize(
+            (target_width, target_height),
+            resample=pil_interpolation,
+        )
+        result = np.array(resized_pil_img)
+    else:
+        # For other channel counts, process each channel separately
+        channels = []
+        for i in range(num_channels):
+            channel_img = Image.fromarray(img[:, :, i], mode="L")
+            resized_channel = channel_img.resize(
+                (target_width, target_height),
+                resample=pil_interpolation,
+            )
+            channels.append(np.array(resized_channel))
+        result = np.stack(channels, axis=-1)
+
+    return result.astype(original_dtype)
 
 
 @preserve_channel_dim

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -7,7 +7,6 @@ bounding boxes and keypoints.
 
 from __future__ import annotations
 
-import importlib
 import math
 import os
 from collections import defaultdict
@@ -25,6 +24,21 @@ from albucore import (
     preserve_channel_dim,
     vflip,
 )
+
+# Optional dependencies
+try:
+    from PIL import Image
+
+    _PIL_AVAILABLE = True
+except ImportError:
+    _PIL_AVAILABLE = False
+
+try:
+    import pyvips
+
+    _PYVIPS_AVAILABLE = True
+except ImportError:
+    _PYVIPS_AVAILABLE = False
 
 from albumentations.augmentations.utils import angle_2pi_range, handle_empty_array
 from albumentations.core.bbox_utils import (
@@ -220,19 +234,12 @@ def keypoints_d4(
     raise ValueError(f"Invalid group member: {group_member}")
 
 
-def _can_import(library_name: str) -> bool:
-    try:
-        return importlib.import_module(library_name) is not None
-    except ImportError:
-        return False
-
-
 @lru_cache(maxsize=1)
 def _get_resize_backend() -> str:
-    env_backend = os.environ.get("ALBUMENTATIONS_RESIZE", default="opencv").lower()
-    if env_backend == "pyvips" and _can_import("pyvips"):
+    env_backend = os.environ.get("ALBUMENTATIONS_RESIZE", "opencv").lower()
+    if env_backend == "pyvips" and _PYVIPS_AVAILABLE:
         return env_backend
-    if env_backend == "pillow" and _can_import("PIL"):
+    if env_backend == "pillow" and _PIL_AVAILABLE:
         return env_backend
     return "opencv"
 
@@ -296,7 +303,6 @@ def resize_pyvips(
 
     """
     # At this stage, the library's installation and importability have already been verified.
-    import pyvips
 
     height, width = img.shape[:2]
     target_height, target_width = target_shape
@@ -372,8 +378,6 @@ def resize_pil(
         np.ndarray: The resized image as a NumPy array.
 
     """
-    from PIL import Image
-
     target_height, target_width = target_shape
     original_dtype = img.dtype
 

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -125,7 +125,7 @@ class RandomScale(DualTransform):
 
     class InitSchema(BaseTransformInitSchema):
         scale_limit: tuple[float, float] | float
-        area_for_downscale: Literal[None, "image", "image_mask"]
+        area_for_downscale: Literal["image", "image_mask"] | None
         interpolation: Literal[
             cv2.INTER_NEAREST,
             cv2.INTER_NEAREST_EXACT,
@@ -171,7 +171,7 @@ class RandomScale(DualTransform):
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
         ] = cv2.INTER_NEAREST,
-        area_for_downscale: Literal[None, "image", "image_mask"] = None,
+        area_for_downscale: Literal["image", "image_mask"] | None = None,
         p: float = 0.5,
     ):
         super().__init__(p=p)
@@ -326,7 +326,7 @@ class MaxSizeTransform(DualTransform):
     class InitSchema(BaseTransformInitSchema):
         max_size: int | list[int] | None
         max_size_hw: tuple[int | None, int | None] | None
-        area_for_downscale: Literal[None, "image", "image_mask"]
+        area_for_downscale: Literal["image", "image_mask"] | None
         interpolation: Literal[
             cv2.INTER_NEAREST,
             cv2.INTER_NEAREST_EXACT,
@@ -376,7 +376,7 @@ class MaxSizeTransform(DualTransform):
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
         ] = cv2.INTER_NEAREST,
-        area_for_downscale: Literal[None, "image", "image_mask"] = None,
+        area_for_downscale: Literal["image", "image_mask"] | None = None,
         p: float = 1,
     ):
         super().__init__(p=p)
@@ -760,7 +760,7 @@ class Resize(DualTransform):
     class InitSchema(BaseTransformInitSchema):
         height: int = Field(ge=1)
         width: int = Field(ge=1)
-        area_for_downscale: Literal[None, "image", "image_mask"]
+        area_for_downscale: Literal["image", "image_mask"] | None
         interpolation: Literal[
             cv2.INTER_NEAREST,
             cv2.INTER_NEAREST_EXACT,
@@ -802,7 +802,7 @@ class Resize(DualTransform):
             cv2.INTER_LANCZOS4,
             cv2.INTER_LINEAR_EXACT,
         ] = cv2.INTER_NEAREST,
-        area_for_downscale: Literal[None, "image", "image_mask"] = None,
+        area_for_downscale: Literal["image", "image_mask"] | None = None,
         p: float = 1,
     ):
         super().__init__(p=p)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ classifiers = [
 
 dynamic = [ "dependencies" ]
 optional-dependencies.hub = [ "huggingface-hub" ]
+optional-dependencies.pillow = [ "pillow" ]
 optional-dependencies.pytorch = [ "torch" ]
 
 optional-dependencies.pyvips = [ "pyvips[binary]" ]

--- a/tests/functional/test_geometric.py
+++ b/tests/functional/test_geometric.py
@@ -674,3 +674,90 @@ def test_resize_cv2_vs_pillow(input_shape, target_shape, interpolation):
     resized_cv2 = fgeometric.resize_cv2(img, target_shape, interpolation=interpolation)
     resized_pil = fgeometric.resize_pil(img, target_shape, interpolation=interpolation)
     np.testing.assert_allclose(resized_cv2, resized_pil, atol=1)
+
+
+@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.parametrize("interpolation", [
+    cv2.INTER_NEAREST,
+    cv2.INTER_LINEAR,
+    cv2.INTER_CUBIC,
+    cv2.INTER_AREA,
+    cv2.INTER_LANCZOS4,
+])
+@pytest.mark.parametrize("input_shape,target_shape", [
+    ((100, 100), (50, 75)),  # Downscale with different aspect ratio
+    ((50, 50), (100, 150)),   # Upscale with different aspect ratio
+])
+def test_resize_pil_with_cv2_interpolation_constants(input_shape, target_shape, interpolation):
+    """Test that resize_pil correctly maps cv2 interpolation constants to PIL."""
+    img = np.random.randint(0, 255, (*input_shape, 3), dtype=np.uint8)
+
+    # This should not raise an error
+    resized = fgeometric.resize_pil(img, target_shape, interpolation=interpolation)
+
+    # Check output shape
+    assert resized.shape[:2] == target_shape
+    assert resized.shape[2] == 3
+    assert resized.dtype == np.uint8
+
+
+@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.parametrize("num_channels", [1, 3, 4, 5, 10])
+def test_resize_pil_different_channel_counts(num_channels):
+    """Test that resize_pil handles different channel counts correctly."""
+    input_shape = (100, 100, num_channels)
+    target_shape = (50, 75)
+
+    img = np.random.randint(0, 255, input_shape, dtype=np.uint8)
+
+    resized = fgeometric.resize_pil(img, target_shape, interpolation=cv2.INTER_LINEAR)
+
+    assert resized.shape == (*target_shape, num_channels)
+    assert resized.dtype == np.uint8
+
+
+@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+def test_resize_backend_selection():
+    """Test that the resize function correctly selects backends based on environment variable."""
+    img = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
+    target_shape = (50, 75)
+
+    # Clear the cache to ensure fresh backend selection
+    fgeometric._get_resize_backend.cache_clear()
+
+    # Test default backend (opencv)
+    os.environ.pop("ALBUMENTATIONS_RESIZE", None)
+    fgeometric._get_resize_backend.cache_clear()
+    backend = fgeometric._get_resize_backend()
+    assert backend == "opencv"
+
+    resized_default = fgeometric.resize(img, target_shape, cv2.INTER_LINEAR)
+    assert resized_default.shape == (*target_shape, 3)
+
+    # Test pillow backend
+    os.environ["ALBUMENTATIONS_RESIZE"] = "pillow"
+    fgeometric._get_resize_backend.cache_clear()
+    backend = fgeometric._get_resize_backend()
+    assert backend == "pillow"
+
+    resized_pillow = fgeometric.resize(img, target_shape, cv2.INTER_LINEAR)
+    assert resized_pillow.shape == (*target_shape, 3)
+
+    # Clean up
+    os.environ.pop("ALBUMENTATIONS_RESIZE", None)
+    fgeometric._get_resize_backend.cache_clear()
+
+
+@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_resize_pil_preserves_dtype(dtype):
+    """Test that resize_pil preserves the input dtype."""
+    img = np.random.rand(100, 100, 3).astype(dtype)
+    if dtype == np.uint8:
+        img = (img * 255).astype(np.uint8)
+
+    target_shape = (50, 75)
+    resized = fgeometric.resize_pil(img, target_shape, interpolation=cv2.INTER_LINEAR)
+
+    assert resized.dtype == dtype
+    assert resized.shape == (*target_shape, 3)

--- a/tests/functional/test_geometric.py
+++ b/tests/functional/test_geometric.py
@@ -4,7 +4,8 @@ import pytest
 
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.geometric.functional import (
-    _can_import,
+    _PIL_AVAILABLE,
+    _PYVIPS_AVAILABLE,
     from_distance_maps,
     to_distance_maps,
 )
@@ -635,7 +636,7 @@ def test_resize_cv2(input_shape, target_shape):
 
     assert resized.shape == (*target_shape, 3)
 
-@pytest.mark.skipif(not _can_import("pyvips"), reason="pyvips is not installed")
+@pytest.mark.skipif(not _PYVIPS_AVAILABLE, reason="pyvips is not installed")
 @pytest.mark.parametrize("input_shape,target_shape", [
     ((100, 100), (200, 200)),
     ((200, 200), (100, 100)),
@@ -648,7 +649,7 @@ def test_resize_pyvips(input_shape, target_shape):
     assert resized.shape == (*target_shape, 3)
 
 @pytest.mark.xfail(reason="pyvips and OpenCV have different interpolation implementations")
-@pytest.mark.skipif(not _can_import("pyvips"), reason="pyvips is not installed")
+@pytest.mark.skipif(not _PYVIPS_AVAILABLE, reason="pyvips is not installed")
 @pytest.mark.parametrize("interpolation", [0, 1, 2])
 @pytest.mark.parametrize("input_shape,target_shape", [
     ((100, 100), (200, 200)),
@@ -662,7 +663,7 @@ def test_resize_cv2_vs_pyvips(input_shape, target_shape, interpolation):
     np.testing.assert_allclose(resized_cv2, resized_pyvips, atol=1)
 
 @pytest.mark.xfail(reason="Pillow and OpenCV have different interpolation implementations")
-@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.skipif(not _PIL_AVAILABLE, reason="pillow is not installed")
 @pytest.mark.parametrize("interpolation", [0, 1, 2])
 @pytest.mark.parametrize("input_shape,target_shape", [
     ((100, 100), (200, 200)),
@@ -676,7 +677,7 @@ def test_resize_cv2_vs_pillow(input_shape, target_shape, interpolation):
     np.testing.assert_allclose(resized_cv2, resized_pil, atol=1)
 
 
-@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.skipif(not _PIL_AVAILABLE, reason="pillow is not installed")
 @pytest.mark.parametrize("interpolation", [
     cv2.INTER_NEAREST,
     cv2.INTER_LINEAR,
@@ -701,7 +702,7 @@ def test_resize_pil_with_cv2_interpolation_constants(input_shape, target_shape, 
     assert resized.dtype == np.uint8
 
 
-@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.skipif(not _PIL_AVAILABLE, reason="pillow is not installed")
 @pytest.mark.parametrize("num_channels", [1, 3, 4, 5, 10])
 def test_resize_pil_different_channel_counts(num_channels):
     """Test that resize_pil handles different channel counts correctly."""
@@ -716,7 +717,7 @@ def test_resize_pil_different_channel_counts(num_channels):
     assert resized.dtype == np.uint8
 
 
-@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.skipif(not _PIL_AVAILABLE, reason="pillow is not installed")
 def test_resize_backend_selection():
     """Test that the resize function correctly selects backends based on environment variable."""
     img = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
@@ -748,7 +749,7 @@ def test_resize_backend_selection():
     fgeometric._get_resize_backend.cache_clear()
 
 
-@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.skipif(not _PIL_AVAILABLE, reason="pillow is not installed")
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 def test_resize_pil_preserves_dtype(dtype):
     """Test that resize_pil preserves the input dtype."""

--- a/tests/functional/test_geometric.py
+++ b/tests/functional/test_geometric.py
@@ -647,6 +647,7 @@ def test_resize_pyvips(input_shape, target_shape):
     resized = fgeometric.resize_pyvips(img, target_shape, interpolation=0)
     assert resized.shape == (*target_shape, 3)
 
+@pytest.mark.xfail(reason="pyvips and OpenCV have different interpolation implementations")
 @pytest.mark.skipif(not _can_import("pyvips"), reason="pyvips is not installed")
 @pytest.mark.parametrize("interpolation", [0, 1, 2])
 @pytest.mark.parametrize("input_shape,target_shape", [
@@ -659,3 +660,17 @@ def test_resize_cv2_vs_pyvips(input_shape, target_shape, interpolation):
     resized_cv2 = fgeometric.resize_cv2(img, target_shape, interpolation=interpolation)
     resized_pyvips = fgeometric.resize_pyvips(img, target_shape, interpolation=interpolation)
     np.testing.assert_allclose(resized_cv2, resized_pyvips, atol=1)
+
+@pytest.mark.xfail(reason="Pillow and OpenCV have different interpolation implementations")
+@pytest.mark.skipif(not _can_import("PIL"), reason="pillow is not installed")
+@pytest.mark.parametrize("interpolation", [0, 1, 2])
+@pytest.mark.parametrize("input_shape,target_shape", [
+    ((100, 100), (200, 200)),
+    ((200, 200), (100, 100)),
+])
+def test_resize_cv2_vs_pillow(input_shape, target_shape, interpolation):
+    img = np.random.randint(0, 255, (*input_shape, 3), dtype=np.uint8)
+
+    resized_cv2 = fgeometric.resize_cv2(img, target_shape, interpolation=interpolation)
+    resized_pil = fgeometric.resize_pil(img, target_shape, interpolation=interpolation)
+    np.testing.assert_allclose(resized_cv2, resized_pil, atol=1)


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new Pillow-based image resize backend alongside OpenCV and PyVips, improve resize logic to skip no-op operations, and expand test coverage and dependency configurations accordingly

New Features:
- Add a Pillow-based resize backend that can be selected via the ALBUMENTATIONS_RESIZE environment variable

Enhancements:
- Skip resizing when the input image already matches the target dimensions
- Clean up redundant early returns in existing resize implementations

Build:
- Upgrade pre-commit hook versions: ruff to v0.13.0 and mypy to v1.18.1
- Add Pillow to optional dependencies in pyproject.toml

Tests:
- Add tests for Pillow backend including interpolation mapping, handling of various channel counts, dtype preservation, and backend selection
- Mark cross-backend interpolation comparison tests as xfail for PyVips and Pillow due to implementation differences