### PR TITLE
Cleanup warnings

### DIFF
--- a/tests/test_compose_operators.py
+++ b/tests/test_compose_operators.py
@@ -382,10 +382,10 @@ def test_compose_subtract_type_validation():
     [
         (None, None),
         (BboxParams(format="pascal_voc", label_fields=["bbox_labels"]), None),
-        (None, KeypointParams(format="xy", label_fields=["keypoint_labels"])),
+        (None, KeypointParams(format="xy")),
         (
             BboxParams(format="pascal_voc", label_fields=["bbox_labels"]),
-            KeypointParams(format="xy", label_fields=["keypoint_labels"])
+            KeypointParams(format="xy")
         ),
     ]
 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -927,17 +927,16 @@ def test_sequential_multiple_transformations(image, aug):
             },
         ],
         [
-            dict(keypoint_params=A.KeypointParams(format="xy", label_fields=["class_labels"])),
+            dict(keypoint_params=A.KeypointParams(format="xy")),
             {
                 "image": np.empty([100, 100, 3], dtype=np.uint8),
                 "keypoints": np.array([[10, 20]]),
-                "class_labels": [1],
             },
         ],
         [
             dict(
                 bbox_params=A.BboxParams(format="yolo", label_fields=["class_labels_1"]),
-                keypoint_params=A.KeypointParams(format="xy", label_fields=["class_labels_2"]),
+                keypoint_params=A.KeypointParams(format="xy"),
             ),
             {
                 "image": np.empty([100, 100, 3], dtype=np.uint8),
@@ -945,7 +944,6 @@ def test_sequential_multiple_transformations(image, aug):
                 "bboxes": np.array([[0.5, 0.5, 0.1, 0.1]]),
                 "class_labels_1": [1],
                 "keypoints": np.array([[10, 20]]),
-                "class_labels_2": [1],
             },
         ],
     ],

--- a/tests/test_hub_mixin.py
+++ b/tests/test_hub_mixin.py
@@ -15,11 +15,11 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-class TestTransform(HubMixin):
-    """Test class for HubMixin."""
+class DummyTransform(HubMixin):
+    """Dummy class for testing HubMixin."""
 
     def __init__(self):
-        """Initialize test transform."""
+        """Initialize dummy transform."""
         pass
 
 
@@ -46,10 +46,10 @@ def test_windows_path_handling(path_string, expected_posix):
         mock_download.return_value = "config.json"
 
         # Also mock _from_pretrained to avoid file operations
-        with patch.object(TestTransform, "_from_pretrained") as mock_from_pretrained:
+        with patch.object(DummyTransform, "_from_pretrained") as mock_from_pretrained:
             mock_from_pretrained.return_value = "mocked_transform"
 
-            transform = TestTransform()
+            transform = DummyTransform()
             transform.from_pretrained(path_string)
 
             # Check that the repo_id argument was properly formatted
@@ -65,12 +65,12 @@ def test_real_windows_paths():
     with patch("albumentations.core.hub_mixin.hf_hub_download") as mock_download:
         mock_download.return_value = "mocked_file_path"
 
-        with patch.object(TestTransform, "_from_pretrained") as mock_from_pretrained:
+        with patch.object(DummyTransform, "_from_pretrained") as mock_from_pretrained:
             mock_from_pretrained.return_value = "mocked_transform"
 
             # Use a Windows-style path string
             windows_path = "C:\\Users\\test\\models\\my_model"
-            TestTransform.from_pretrained(windows_path)
+            DummyTransform.from_pretrained(windows_path)
 
             # Verify the repo_id
             repo_id = mock_download.call_args[1]["repo_id"]

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -982,7 +982,7 @@ def test_grid_shuffle_3d_with_keypoints():
 
     transform = A.Compose([
         A.GridShuffle3D(grid_zyx=(2, 2, 2), p=1.0)
-    ], keypoint_params=A.KeypointParams(format='xyz', label_fields=['keypoint_labels']))
+    ], keypoint_params=A.KeypointParams(format='xyz'))
 
     # Use seed for reproducibility
     np.random.seed(137)
@@ -1001,7 +1001,7 @@ def test_grid_shuffle_3d_with_keypoints():
         assert 0 <= kp[1] < 100  # y
         assert 0 <= kp[2] < 10   # z
 
-    # Check that labels are preserved
+    # Check that labels are passed through (no label swapping for grid shuffle)
     assert transformed['keypoint_labels'] == keypoint_labels
 
 


### PR DESCRIPTION
## Summary by Sourcery

Clean up numerical warnings in stain processing routines and refresh tests to align with updated API

Enhancements:
- Suppress divide/invalid/overflow warnings in fit_transform, fit, and apply_he_stain_augmentation by wrapping computations in np.errstate

Tests:
- Rename TestTransform to DummyTransform and update related hub mixin tests
- Remove deprecated label_fields parameters from KeypointParams usages across core, compose operators, and 3D transform tests