### PR TITLE
Bugfix in resize_cv2

### DIFF
--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -351,6 +351,10 @@ def resize_cv2(
 
     """
     height, width = target_shape[:2]
+    # Handle 2D arrays (masks) directly without chunking
+    if img.ndim == 2:
+        return cv2.resize(img, (width, height), interpolation=interpolation)
+
     resize_fn = maybe_process_in_chunks(
         cv2.resize,
         dsize=(width, height),

--- a/tests/functional/test_geometric.py
+++ b/tests/functional/test_geometric.py
@@ -636,6 +636,21 @@ def test_resize_cv2(input_shape, target_shape):
 
     assert resized.shape == (*target_shape, 3)
 
+@pytest.mark.parametrize("input_shape,target_shape", [
+    ((100, 100), (200, 200)),
+    ((256, 256), (512, 512)),
+    ((200, 200), (100, 100)),
+    ((150, 100), (150, 200)),
+])
+def test_resize_cv2_2d_mask(input_shape, target_shape):
+    """Test that resize_cv2 handles 2D arrays (masks) correctly."""
+    mask = np.random.randint(0, 2, input_shape, dtype=np.uint8)
+
+    resized = fgeometric.resize_cv2(mask, target_shape, interpolation=cv2.INTER_NEAREST)
+
+    assert resized.shape == target_shape
+    assert resized.ndim == 2
+
 @pytest.mark.skipif(not _PYVIPS_AVAILABLE, reason="pyvips is not installed")
 @pytest.mark.parametrize("input_shape,target_shape", [
     ((100, 100), (200, 200)),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -272,6 +272,28 @@ def test_additional_targets_for_image_only(augmentation_cls, params):
         np.testing.assert_array_equal(aug1, aug2)
 
 
+def test_resize_with_additional_targets_mask():
+    """Test that Resize works correctly with additional_targets for 2D masks.
+
+    Regression test for issue where 2D masks passed via additional_targets
+    would fail with IndexError in resize_cv2 due to maybe_process_in_chunks
+    expecting 3D arrays.
+    """
+    image = np.zeros((256, 256, 3), dtype=np.uint8)
+    mask = np.ones((256, 256), dtype=np.uint8)
+
+    transform = A.Compose(
+        [A.Resize(height=512, width=512)],
+        additional_targets={"semantic_mask": "mask"},
+    )
+
+    augmented = transform(image=image, semantic_mask=mask)
+
+    assert augmented["image"].shape == (512, 512, 3)
+    assert augmented["semantic_mask"].shape == (512, 512)
+    assert augmented["semantic_mask"].ndim == 2
+
+
 def test_image_invert():
     for _ in range(10):
         # test for np.uint8 dtype


### PR DESCRIPTION
Fixes: https://github.com/albumentations-team/AlbumentationsX/issues/95

## Summary by Sourcery

Fix resize_cv2 to properly handle 2D mask arrays and add regression tests to cover mask resizing in augmentations and functional APIs

Bug Fixes:
- Handle 2D arrays in resize_cv2 by bypassing chunk processing to prevent IndexError

Tests:
- Add a regression test for resizing 2D masks via additional_targets in Compose
- Add parametrized tests for resize_cv2 to verify correct behavior on 2D mask inputs