### PR TITLE
Fix in crops transorm pipeline. Update AtLeastOneBBoxRandomCrop

### DIFF
--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -3237,7 +3237,7 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
             bboxes = denormalize_bboxes(bboxes, shape=(image_height, image_width))
 
             # Pick a bbox amongst all possible as our reference bbox.
-            reference_bbox = self.py_random.choice(bboxes)
+            reference_bbox = self.py_random.choice(bboxes.tolist())
 
             bbox_x1, bbox_y1, bbox_x2, bbox_y2 = reference_bbox[:4]
 


### PR DESCRIPTION
There was a bug in the crop processing pipeline in `AtLeastOneBBoxRandomCrop` with `python<=3.11`

Current Implementation:

https://github.com/albumentations-team/AlbumentationsX/blob/6c12afc19b7e477508131d94bd4cccd99cf03f39/albumentations/augmentations/crops/transforms.py#L3080

The problem lies in the sampling function:

https://github.com/albumentations-team/AlbumentationsX/blob/6c12afc19b7e477508131d94bd4cccd99cf03f39/albumentations/augmentations/crops/transforms.py#L3240

The nature of the problem is, previsously called `denormalize_bboxes` returns `np.ndarray`. Then in `self.py_random.choice` the sequence is tested for non-emptiness with `if not seq`. For a `np.ndarray` this produces an error:

```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

The newer Python versions are sutable for this pipeline because, they contain updated implementation of the sampler function. Starting from `Python3.12` the random.Random(seed).choice() function treats `numpy` arrays more accuartely:

```
    def choice(self, seq):
        """Choose a random element from a non-empty sequence."""

        # As an accommodation for NumPy, we don't use "if not seq"
        # because bool(numpy.array()) raises a ValueError.
        if not len(seq):
            raise IndexError('Cannot choose from an empty sequence')
        return seq[self._randbelow(len(seq))]
```

Basing on this I suggest passing `bboxes.tolist()` into the sampler function in order to maintain compatibility to older Python versions:

`reference_bbox = self.py_random.choice(bboxes.tolist())`

## Summary by Sourcery

Ensure AtLeastOneBBoxRandomCrop works on Python ≤3.11 by converting numpy arrays of bounding boxes to lists before sampling to avoid ambiguous truth-value errors.

Bug Fixes:
- Fix ValueError in AtLeastOneBBoxRandomCrop when selecting a reference bounding box on Python versions ≤3.11

Enhancements:
- Convert bounding boxes to Python lists before using random.choice to maintain compatibility with older Python implementations