### PR TITLE
Added CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,32 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+        informational: false
+    patch:
+      default:
+        target: auto
+        threshold: 0.5%
+        informational: false
+
+comment:
+  layout: "reach,diff,flags,tree,footer"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+
+ignore:
+  - "tests/**/*"
+  - "**/__pycache__/**/*"
+  - "setup.py"
+  - "tools/**/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,17 @@ jobs:
         uv pip install --system -r requirements-dev.txt
         uv pip install --system .
 
-    - name: Run PyTest
-      run: pytest
+    - name: Run PyTest with coverage
+      run: pytest --cov --cov-branch --cov-report=xml
+
+    - name: Upload coverage reports to Codecov
+      if: matrix.operating-system == 'ubuntu-latest' && matrix.python-version == '3.10'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: albumentations-team/AlbumentationsX
+        files: ./coverage.xml
+        fail_ci_if_error: true
 
   check_code_formatting_types:
     name: Check code formatting with ruff and mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,24 @@ test-framework = "pytest"
 ignore-paths = [  ]
 formatter-cmds = [ "ruff check --exit-zero --fix $file", "ruff format $file" ]
 
+[tool.coverage.run]
+source = ["albumentations"]
+omit = [
+    "*/tests/*",
+    "*/test_*.py",
+    "*/__pycache__/*",
+    "*/site-packages/*",
+]
+branch = true
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
+
+[tool.coverage.xml]
+output = "coverage.xml"
+
 [tool.google_docstring_parser]
 paths = [ "albumentations", "tools" ] # Directories or files to scan
 require_param_types = true            # Require parameter types in docstrings


### PR DESCRIPTION
## Summary by Sourcery

Integrate coverage reporting with Codecov in the CI pipeline and configure test coverage collection for the project.

Build:
- Configure coverage.py settings in pyproject.toml to generate XML coverage reports for the albumentations package.

CI:
- Update GitHub Actions CI to run pytest with coverage and upload coverage reports to Codecov only on a specific OS/Python matrix job.

Chores:
- Add a Codecov configuration file to enforce coverage thresholds, reporting behavior, and ignore patterns.