### PR TITLE
Added test for docstrings

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -90,7 +90,7 @@ class Blur(ImageOnlyTransform):
           reduce noise but also reduce image detail.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -449,7 +449,7 @@ class MedianBlur(Blur):
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -596,7 +596,7 @@ class GaussianBlur(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -773,7 +773,7 @@ class GlassBlur(ImageOnlyTransform):
             Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1136,7 +1136,7 @@ class AdvancedBlur(ImageOnlyTransform):
         https://arxiv.org/abs/2107.10833
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1264,7 +1264,7 @@ class Defocus(ImageOnlyTransform):
             Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1391,7 +1391,7 @@ class ZoomBlur(ImageOnlyTransform):
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -644,6 +644,9 @@ class RandomCrop(BaseCropAndPad):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         If pad_if_needed is True and crop size exceeds image dimensions, the image will be padded
         before applying the random crop.
@@ -827,6 +830,9 @@ class CenterCrop(BaseCropAndPad):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - If pad_if_needed is False and crop size exceeds image dimensions, it will raise a CropSizeError.
         - If pad_if_needed is True and crop size exceeds image dimensions, the image will be padded.
@@ -1008,6 +1014,9 @@ class Crop(BaseCropAndPad):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - The crop coordinates are applied as follows: x_min <= x < x_max and y_min <= y < y_max.
         - If pad_if_needed is False and crop region extends beyond image boundaries, it will be clipped.
@@ -1230,6 +1239,9 @@ class CropNonEmptyMaskIfExists(BaseCrop):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - If a mask is provided, the transform will try to crop an area containing non-zero (or non-ignored) pixels.
         - If no suitable area is found in the mask or no mask is provided, it will perform a random crop.
@@ -1698,6 +1710,9 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - The crop size is randomly selected for each execution within the range specified by 'min_max_height'.
         - The aspect ratio of the crop is determined by the 'w2h_ratio' parameter.
@@ -1885,6 +1900,9 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - This transform attempts to crop a random area with an aspect ratio and relative size
           specified by 'ratio' and 'scale' parameters. If it fails to find a suitable crop after
@@ -2083,6 +2101,9 @@ class RandomCropNearBBox(BaseCrop):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Examples:
         >>> aug = Compose([RandomCropNearBBox(max_part_shift=(0.1, 0.5), cropping_bbox_key='test_bbox')],
         >>>              bbox_params=BboxParams("pascal_voc"))
@@ -2176,6 +2197,9 @@ class BBoxSafeRandomCrop(BaseCrop):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Raises:
         CropSizeError: If requested crop size exceeds image dimensions
 
@@ -2330,6 +2354,9 @@ class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - This transform ensures that all bounding boxes in the original image are fully contained within the
           cropped area. If it's not possible to find such a crop (e.g., when bounding boxes are too spread out),
@@ -2592,6 +2619,9 @@ class CropAndPad(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - This transform will never crop images below a height or width of 1.
         - When using pixel values (px), the image will be cropped/padded by exactly that many pixels.
@@ -3018,6 +3048,9 @@ class RandomCropFromBorders(BaseCrop):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - The actual amount of cropping for each side is randomly chosen between 0 and
           the specified maximum for each application of the transform.
@@ -3177,6 +3210,9 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Raises:
         CropSizeError: If requested crop size exceeds image dimensions
 

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -57,6 +57,9 @@ class CoarseDropout(BaseDropout):
     Image types:
         uint8, float32
 
+    Supported bboxes:
+        hbb
+
     Note:
         - The actual number and size of dropout regions are randomly chosen within the specified ranges for each
             application.
@@ -212,6 +215,9 @@ class Erasing(BaseDropout):
 
     Image types:
         uint8, float32
+
+    Supported bboxes:
+        hbb
 
     Note:
         - The transform attempts to find valid erasing parameters up to 10 times.
@@ -395,6 +401,9 @@ class ConstrainedCoarseDropout(BaseDropout):
 
     Image types:
         uint8, float32
+
+    Supported bboxes:
+        hbb
 
     Requires one of:
         - 'mask' key with segmentation mask where:

--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -56,6 +56,9 @@ class GridDropout(BaseDropout):
     Image types:
         uint8, float32
 
+    Supported bboxes:
+        hbb
+
     Note:
         - If both unit_size_range and holes_number_xy are None, the grid size is calculated based on the image size.
         - The actual number of dropped regions may differ slightly from holes_number_xy due to rounding.

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -49,6 +49,9 @@ class MaskDropout(DualTransform):
     Image types:
         uint8, float32
 
+    Supported bboxes:
+        hbb
+
     Note:
         - The mask should be a single-channel image where 0 represents the background and non-zero values represent
           different object instances.

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -254,6 +254,9 @@ class PixelDropout(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Note:
         - When applied to bounding boxes, this transform may cause some boxes to have zero area
           if all pixels within the box are dropped. Such boxes will be removed.

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -60,7 +60,11 @@ class XYMasking(BaseDropout):
     Image types:
         uint8, float32
 
-    Note: Either `max_x_length` or `max_y_length` or both must be defined.
+    Supported bboxes:
+        hbb
+
+    Note:
+        Either `max_x_length` or `max_y_length` or both must be defined.
 
     """
 

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -332,6 +332,15 @@ class ElasticTransform(BaseDistortion):
     The transform works by generating random displacement fields and applying them to the input.
     These fields are smoothed using a Gaussian filter to create more natural-looking distortions.
 
+    Targets:
+        image, mask, bboxes, keypoints, volume, mask3d
+
+    Image types:
+        uint8, float32
+
+    Supported bboxes:
+        hbb
+
     Args:
         alpha (float): Scaling factor for the random displacement fields. Higher values result in
             more pronounced distortions. Default: 1.0
@@ -546,6 +555,9 @@ class PiecewiseAffine(BaseDistortion):
     Image types:
         uint8, float32
 
+    Supported bboxes:
+        hbb
+
     Note:
         - This augmentation is very slow. Consider using `ElasticTransform` instead, which is at least 10x faster.
         - The augmentation may not always produce visible effects, especially with small scale values.
@@ -727,6 +739,9 @@ class OpticalDistortion(BaseDistortion):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Note:
         - The distortion is applied using OpenCV's initUndistortRectifyMap and remap functions.
         - The distortion coefficient (k) is randomly sampled from the distort_limit range.
@@ -881,6 +896,9 @@ class GridDistortion(BaseDistortion):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Note:
         - The same distortion is applied to all targets (image, mask, bboxes, keypoints)
           to maintain consistency.
@@ -1075,6 +1093,9 @@ class ThinPlateSpline(BaseDistortion):
 
     Image types:
         uint8, float32
+
+    Supported bboxes:
+        hbb
 
     Note:
         - The transformation preserves smoothness and continuity

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -61,6 +61,9 @@ class VerticalFlip(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - This transform flips the image upside down. The top of the image becomes the bottom and vice versa.
         - The dimensions of the image remain unchanged.
@@ -152,6 +155,9 @@ class HorizontalFlip(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Examples:
         >>> import numpy as np
         >>> import albumentations as A
@@ -237,6 +243,9 @@ class Transpose(DualTransform):
 
     Image types:
         uint8, float32
+
+    Supported bboxes:
+        hbb, obb
 
     Note:
         - The dimensions of the output will be swapped compared to the input. For example,
@@ -350,6 +359,9 @@ class D4(DualTransform):
 
     Image types:
         uint8, float32
+
+    Supported bboxes:
+        hbb, obb
 
     Note:
         - This transform is particularly useful for augmenting data that does not have a clear orientation,
@@ -524,6 +536,9 @@ class SquareSymmetry(D4):
 
     Image types:
         uint8, float32
+
+    Supported bboxes:
+        hbb, obb
 
     Note:
         - This transform is particularly useful for augmenting data that does not have a clear orientation,

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -50,6 +50,9 @@ class RandomScale(DualTransform):
     Image types:
         uint8, float32
 
+    Supported bboxes:
+        hbb
+
     Note:
         - The output image size is different from the input image size.
         - Scale factor is sampled independently per image side (width and height).
@@ -473,6 +476,9 @@ class LongestMaxSize(MaxSizeTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Note:
         - This transform scales images based on their longest side:
             * If the longest side is **smaller** than max_size: the image will be **upscaled** (scale > 1.0)
@@ -593,6 +599,9 @@ class SmallestMaxSize(MaxSizeTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Note:
         - This transform scales images based on their smallest side:
             * If the smallest side is **smaller** than max_size: the image will be **upscaled** (scale > 1.0)
@@ -700,6 +709,9 @@ class Resize(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Examples:
         >>> import numpy as np
         >>> import albumentations as A

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -73,6 +73,9 @@ class RandomRotate90(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Examples:
         >>> import numpy as np
         >>> import albumentations as A
@@ -205,6 +208,9 @@ class Rotate(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - The rotation angle is randomly selected for each execution within the range specified by 'limit'.
         - When 'crop_border' is False, the output image will have the same size as the input, potentially
@@ -521,6 +527,9 @@ class SafeRotate(Affine):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         - The rotation is performed around the center of the image.
         - After rotation, the image is scaled to fit within the original frame, which may cause some distortion.

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -91,6 +91,9 @@ class Perspective(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Note:
         This transformation creates a perspective effect by randomly moving the four corners of the image.
         The amount of movement is controlled by the 'scale' parameter.
@@ -448,6 +451,9 @@ class Affine(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     References:
         Towards Rotation Invariance in Object Detection: https://arxiv.org/abs/2109.13488
 
@@ -925,6 +931,9 @@ class ShiftScaleRotate(Affine):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb, obb
     Examples:
         >>> import numpy as np
         >>> import albumentations as A
@@ -1137,6 +1146,9 @@ class GridElasticDeform(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Number of channels:
         1, 3
 
@@ -1343,6 +1355,9 @@ class RandomGridShuffle(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Note:
         - This transform maintains consistency across all targets. If applied to an image and its corresponding
           mask or keypoints, the same shuffling will be applied to all.
@@ -1532,6 +1547,9 @@ class Morphological(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     References:
         Nougat: https://github.com/facebookresearch/nougat
 

--- a/albumentations/augmentations/mixing/domain_adaptation.py
+++ b/albumentations/augmentations/mixing/domain_adaptation.py
@@ -51,7 +51,7 @@ class BaseDomainAdaptation(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -217,7 +217,7 @@ class HistogramMatching(BaseDomainAdaptation):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -345,7 +345,7 @@ class FDA(BaseDomainAdaptation):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -525,7 +525,7 @@ class PixelDistributionAdaptation(BaseDomainAdaptation):
         p (float): The probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -355,6 +355,9 @@ class Mosaic(DualTransform):
     Image types:
         uint8, float32
 
+
+    Supported bboxes:
+        hbb
     Reference:
         YOLOv4: Optimal Speed and Accuracy of Object Detection: https://arxiv.org/pdf/2004.10934
 

--- a/albumentations/augmentations/other/lambda_transform.py
+++ b/albumentations/augmentations/other/lambda_transform.py
@@ -52,6 +52,9 @@ class Lambda(NoOp):
     Image types:
         uint8, float32
 
+    Supported bboxes:
+        hbb, obb
+
     Number of channels:
         Any
 

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -148,7 +148,7 @@ class Normalize(ImageOnlyTransform):
         p (float): Probability of applying the transform. Defaults to 1.0.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -270,7 +270,7 @@ class ImageCompression(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -359,7 +359,7 @@ class RandomSnow(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -501,7 +501,7 @@ class RandomGravel(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -681,7 +681,7 @@ class RandomRain(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -841,7 +841,7 @@ class RandomFog(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1025,7 +1025,7 @@ class RandomSunFlare(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1277,7 +1277,7 @@ class RandomShadow(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1442,7 +1442,7 @@ class RandomToneCurve(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1595,7 +1595,7 @@ class HueSaturationValue(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1684,7 +1684,7 @@ class Solarize(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -1778,7 +1778,7 @@ class Posterize(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -2460,7 +2460,7 @@ class ChannelShuffle(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Number of channels:
         Any
@@ -4239,7 +4239,7 @@ class Spatter(ImageOnlyTransform):
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -4463,7 +4463,7 @@ class ChromaticAberration(ImageOnlyTransform):
             Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -4682,7 +4682,7 @@ class PlanckianJitter(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -4862,7 +4862,7 @@ class ShotNoise(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -5220,7 +5220,7 @@ class RGBShift(AdditiveNoise):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -5337,7 +5337,7 @@ class SaltAndPepper(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -5496,7 +5496,7 @@ class PlasmaBrightnessContrast(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -5669,7 +5669,7 @@ class PlasmaShadow(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -5864,7 +5864,7 @@ class Illumination(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -6048,7 +6048,7 @@ class AutoContrast(ImageOnlyTransform):
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32
@@ -6150,7 +6150,7 @@ class HEStain(ImageOnlyTransform):
             Default: False
 
     Targets:
-        image
+        image, volume
 
     Number of channels:
         3
@@ -6451,7 +6451,7 @@ class Dithering(ImageOnlyTransform):
         p(float): Probability of applying this transform. Default: 0.5
 
     Targets:
-        image
+        image, volume
 
     Image types:
         uint8, float32

--- a/albumentations/augmentations/spectrogram/transform.py
+++ b/albumentations/augmentations/spectrogram/transform.py
@@ -42,6 +42,9 @@ class TimeReverse(HorizontalFlip):
     Image types:
         uint8, float32
 
+    Supported bboxes:
+        hbb, obb
+
     Number of channels:
         Any
 
@@ -96,6 +99,9 @@ class TimeMasking(XYMasking):
 
     Image types:
         uint8, float32
+
+    Supported bboxes:
+        hbb
 
     Number of channels:
         Any
@@ -168,6 +174,9 @@ class FrequencyMasking(XYMasking):
 
     Image types:
         uint8, float32
+
+    Supported bboxes:
+        hbb
 
     Number of channels:
         Any

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -905,6 +905,12 @@ class NoOp(DualTransform):
     Targets:
         image, mask, bboxes, keypoints, volume, mask3d
 
+    Image types:
+        uint8, float32
+
+    Supported bboxes:
+        hbb, obb
+
     Examples:
         >>> import numpy as np
         >>> import albumentations as A

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 albu-spec>=0.0.2
 deepdiff>=8.0.1
 eval-type-backport
+google-docstring-parser>=0.0.9
 opencv-python-headless>=4.9.0.80
 pre_commit>=4.5.1
 pytest>=9.0.2

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,130 @@
+"""Tests to validate that transform docstrings match their actual properties."""
+
+import pytest
+from google_docstring_parser import parse_google_docstring
+
+from albumentations.core.type_definitions import Targets
+from tests.utils import get_all_valid_transforms
+
+
+def parse_targets_from_docstring(docstring_targets: str) -> set[str]:
+    """Parse targets from docstring format to set of lowercase strings."""
+    if not docstring_targets:
+        return set()
+
+    # Split by comma and clean up
+    targets = [t.strip().lower() for t in docstring_targets.split(",")]
+    return set(targets)
+
+
+def get_class_targets(cls) -> set[str]:
+    """Get targets from class _targets property as lowercase strings."""
+    if not hasattr(cls, "_targets"):
+        return set()
+
+    targets = cls._targets
+    if isinstance(targets, tuple):
+        # Convert Targets enum to lowercase string names
+        return {t.name.lower() for t in targets}
+    elif isinstance(targets, Targets):
+        return {targets.name.lower()}
+
+    return set()
+
+
+def parse_bbox_types_from_docstring(docstring_bbox_types: str | None) -> set[str]:
+    """Parse bbox types from docstring format to set of strings."""
+    if not docstring_bbox_types:
+        return set()
+
+    # Split by comma and clean up
+    bbox_types = [t.strip().lower() for t in docstring_bbox_types.split(",")]
+    return set(bbox_types)
+
+
+def get_class_bbox_types(cls) -> set[str]:
+    """Get bbox types from class _supported_bbox_types property."""
+    if not hasattr(cls, "_supported_bbox_types"):
+        return set()
+
+    bbox_types = cls._supported_bbox_types
+    if isinstance(bbox_types, frozenset):
+        return set(bbox_types)
+    elif isinstance(bbox_types, set):
+        return bbox_types
+
+    return set()
+
+
+@pytest.mark.parametrize("transform_cls", get_all_valid_transforms())
+def test_docstring_targets_match_class_property(transform_cls):
+    """Test that 'Targets:' in docstring matches _targets class property."""
+    transform_name = transform_cls.__name__
+    docstring = transform_cls.__doc__
+
+    if not docstring:
+        pytest.skip(f"{transform_name} has no docstring")
+
+    parsed = parse_google_docstring(docstring)
+    docstring_targets_str = parsed.get("Targets")
+
+    # Parse targets from docstring
+    docstring_targets = parse_targets_from_docstring(docstring_targets_str)
+
+    # Get targets from class property
+    class_targets = get_class_targets(transform_cls)
+
+    if not docstring_targets:
+        pytest.skip(f"{transform_name} has no 'Targets:' section in docstring")
+
+    if not class_targets:
+        pytest.skip(f"{transform_name} has no _targets property")
+
+    # Check they match
+    assert docstring_targets == class_targets, (
+        f"{transform_name}: Docstring targets {docstring_targets} "
+        f"don't match class _targets {class_targets}"
+    )
+
+
+@pytest.mark.parametrize("transform_cls", get_all_valid_transforms())
+def test_docstring_bbox_types_match_class_property(transform_cls):
+    """Test that 'Supported bboxes:' in docstring matches _supported_bbox_types class property."""
+    transform_name = transform_cls.__name__
+    docstring = transform_cls.__doc__
+
+    if not docstring:
+        pytest.skip(f"{transform_name} has no docstring")
+
+    parsed = parse_google_docstring(docstring)
+    docstring_bbox_types_str = parsed.get("Supported bboxes")
+
+    # Parse bbox types from docstring
+    docstring_bbox_types = parse_bbox_types_from_docstring(docstring_bbox_types_str)
+
+    # Get bbox types from class property
+    class_bbox_types = get_class_bbox_types(transform_cls)
+
+    # Only check if the transform supports bboxes
+    class_targets = get_class_targets(transform_cls)
+    supports_bboxes = "bboxes" in class_targets
+
+    if supports_bboxes:
+        # If transform supports bboxes, it should have bbox types defined
+        if class_bbox_types:
+            # If class has _supported_bbox_types, docstring should document it
+            assert docstring_bbox_types, (
+                f"{transform_name} supports bboxes and has _supported_bbox_types={class_bbox_types}, "
+                f"but docstring has no 'Supported bboxes:' section"
+            )
+
+            # Check they match
+            assert docstring_bbox_types == class_bbox_types, (
+                f"{transform_name}: Docstring bbox types {docstring_bbox_types} "
+                f"don't match class _supported_bbox_types {class_bbox_types}"
+            )
+    else:
+        # If transform doesn't support bboxes, it shouldn't have bbox types in docstring
+        assert not docstring_bbox_types, (
+            f"{transform_name} doesn't support bboxes but has 'Supported bboxes: {docstring_bbox_types_str}' in docstring"
+        )


### PR DESCRIPTION
## Summary by Sourcery

Align transform docstrings with their actual targets and supported bbox types and add automated tests to enforce this consistency.

Documentation:
- Update multiple transform docstrings to correctly list supported targets (including volumes) and bbox formats such as hbb and obb.

Tests:
- Add tests that compare each transform's documented 'Targets' and 'Supported bboxes' against its _targets and _supported_bbox_types properties.