### PR TITLE
Feature: added apply_to_images function to MotionBlur augmentation

### DIFF
--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -408,8 +408,8 @@ class MotionBlur(Blur):
     def apply(self, img: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
         return fpixel.convolve(img, kernel=kernel)
 
-    def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
-        return np.stack([self.apply(img, *args, **params) for img in images])
+    def apply_to_images(self, images: np.ndarray, **params: Any) -> np.ndarray:
+        return np.stack([self.apply(img, **params) for img in images])
 
     def get_params(self) -> dict[str, Any]:
         ksize = fblur.sample_odd_from_range(

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -259,4 +259,4 @@ def test_motion_blur_apply_to_images():
     transformed = transform.apply_to_images(images, kernel=kernel)
 
     assert transformed.shape == images.shape
-    assert np.all([not np.array_equal(im, tr) for im, tr in zip(images, transformed, strict=False)])
+    assert np.any(transformed != images)


### PR DESCRIPTION
This branch adds the `apply_to_images` function to `MotionBlur` augmentation. The function has been implemented as a NumPy stack over a list comprehension applying the `apply` function of `MotionBlur` class to the images in the batch.

In implementing this feature, I evaluated different approaches:
- _standard method_: the chosen approach (list comprehension `apply` -> np.stack)
- _height fold vectorization_: performs a folding between batch and height dimensions, then applies `apply` to the resulting array - (B, H, W, C) -> (B * H, W, C)
- _channel fold vectorization_: performs a folding between channel and batch dimensions, then applies `apply` to the resulting array - (B, H, W, C) -> (H, W, C, B) -> (H, W, C * B) 

The two vectorization approaches had different problems:
- folding over height dimension causes the motion blur kernel to be applied across images, as the convolution is computed over neighbor pixels
- folding over channel dimension might create problems when dealing very large batches of images, as OpenCV supports at most images with 512 channels

On top of that, I launched the following script to evaluate the performance of the three approaches, both on small and large batches:
- the fastest method was the height fold vectorization
- the standard method, while not being the fastest, was the second fastest, close enough to the height fold vectorization method 

**Benchmarking script**
```python
from typing import Any
from albucore import ImageType
import albumentations as A
import numpy as np
import timeit

transform = A.MotionBlur(p=1.0, blur_limit=21, angle_range=(0, 0), direction_range=(1.0, 1.0))

kernel = transform.get_params()["kernel"]


def apply_to_images_standard(images: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
    return np.stack([transform.apply(img, kernel=kernel, **params) for img in images])


def apply_to_images_height_fold(images: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
    # assume the img argument to have shape (N, H, W, C)
    batch_size, height, width, channels = images.shape

    # fold across height
    images = images.reshape(batch_size * height, width, channels)

    # apply the transformation to the folded image
    transformed = transform.apply(images, kernel=kernel, **params)

    # revert folding
    return transformed.reshape(batch_size, height, width, channels)


def apply_to_images_channel_fold(images: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
    # assume the img argument to have shape (N, H, W, C)
    batch_size, height, width, channels = images.shape

    # transpose
    images = images.transpose(1, 2, 3, 0)

    # fold across channels
    images = images.reshape(height, width, channels * batch_size)

    # apply the transformation to the folded image
    transformed = transform.apply(images, kernel=kernel, **params)

    # revert folding and transpose
    return transformed.reshape(height, width, channels, batch_size).transpose(3, 0, 1, 2)


# create a small and large batch of images
small = np.random.randint(low=0, high=255, size=(2, 100, 100, 3), dtype=np.uint8)
large = np.random.randint(low=0, high=255, size=(128, 100, 100, 3), dtype=np.uint8)


def benchmark(images, kernel, callable):
    return callable(images, kernel=kernel)


n_runs = 1000
execution_time_height_fold_small = timeit.timeit(lambda: benchmark(small, kernel, apply_to_images_height_fold),
                                                 number=n_runs)
execution_time_channel_fold_small = timeit.timeit(lambda: benchmark(small, kernel, apply_to_images_channel_fold),
                                                  number=n_runs)
execution_time_standard_small = timeit.timeit(lambda: benchmark(small, kernel, apply_to_images_standard),
                                              number=n_runs)

execution_time_height_fold_large = timeit.timeit(lambda: benchmark(large, kernel, apply_to_images_height_fold),
                                                 number=n_runs)
execution_time_channel_fold_large = timeit.timeit(lambda: benchmark(large, kernel, apply_to_images_channel_fold),
                                                  number=n_runs)
execution_time_standard_large = timeit.timeit(lambda: benchmark(large, kernel, apply_to_images_standard),
                                              number=n_runs)

print(f"Num. runs: {n_runs}")
print()
print(f"Vectorized height fold small (avg): {execution_time_height_fold_small / n_runs * 1000:.2f} ms")
print(f"Vectorized channel fold small (avg): {execution_time_channel_fold_small / n_runs * 1000:.2f} ms")
print(f"Standard small (avg): {execution_time_standard_small / n_runs * 1000:.2f} ms")
print()
print(f"Vectorized height fold large (avg): {execution_time_height_fold_large / n_runs * 1000:.6f} ms")
print(f"Vectorized channel fold large (avg): {execution_time_channel_fold_large / n_runs * 1000:.6f} ms")
print(f"Standard large (avg): {execution_time_standard_large / n_runs * 1000:.2f} ms")
```

**Benchmarking results**
```
Num. runs: 1000

Vectorized height fold small (avg): 0.03 ms
Vectorized channel fold small (avg): 0.22 ms
Standard small (avg): 0.04 ms

Vectorized height fold large (avg): 1.718952 ms
Vectorized channel fold large (avg): 12.811071 ms
Standard large (avg): 2.56 ms
```

**Changelog**
- added `apply_to_images` method to `MotionBlur` class to perform motion blur augmentation on a batch of images
- added `test_motion_blur_apply_to_images` test in `tests/test_blur.py` checking if the transformation is applied, the shapes of input and output batches are the same and the transformation produces images different from the original ones

## Summary by Sourcery

Add batch-processing support for MotionBlur and cover it with tests.

New Features:
- Introduce an apply_to_images method on MotionBlur to apply motion blur to batches of images.

Tests:
- Add a MotionBlur batch application test to verify output shape and that transformed images differ from inputs.