### PR TITLE
Enabled obb in Mosaic

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [LongestMaxSize](https://explore.albumentations.ai/transform/LongestMaxSize)                     | ✓     | ✓    | ✓            | ✓            | ✓         | ✓      | ✓      |
 | [MaskDropout](https://explore.albumentations.ai/transform/MaskDropout)                           | ✓     | ✓    | ✓            |              | ✓         | ✓      | ✓      |
 | [Morphological](https://explore.albumentations.ai/transform/Morphological)                       | ✓     | ✓    | ✓            |              | ✓         | ✓      | ✓      |
-| [Mosaic](https://explore.albumentations.ai/transform/Mosaic)                                     | ✓     | ✓    | ✓            |              | ✓         |        |        |
+| [Mosaic](https://explore.albumentations.ai/transform/Mosaic)                                     | ✓     | ✓    | ✓            | ✓            | ✓         |        |        |
 | [NoOp](https://explore.albumentations.ai/transform/NoOp)                                         | ✓     | ✓    | ✓            | ✓            | ✓         | ✓      | ✓      |
 | [OpticalDistortion](https://explore.albumentations.ai/transform/OpticalDistortion)               | ✓     | ✓    | ✓            | ✓            | ✓         | ✓      | ✓      |
 | [OverlayElements](https://explore.albumentations.ai/transform/OverlayElements)                   | ✓     | ✓    |              |              |           |        |        |

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -355,9 +355,9 @@ class Mosaic(DualTransform):
     Image types:
         uint8, float32
 
-
     Supported bboxes:
-        hbb
+        hbb, obb
+
     Reference:
         YOLOv4: Optimal Speed and Accuracy of Object Detection: https://arxiv.org/pdf/2004.10934
 
@@ -460,6 +460,7 @@ class Mosaic(DualTransform):
     """
 
     _targets = (Targets.IMAGE, Targets.MASK, Targets.BBOXES, Targets.KEYPOINTS)
+    _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
 
     class InitSchema(BaseTransformInitSchema):
         grid_yx: tuple[int, int]


### PR DESCRIPTION
## Summary by Sourcery

Enable oriented bounding box (obb) support for the Mosaic augmentation and update its documentation accordingly.

New Features:
- Allow the Mosaic transform to work with both horizontal and oriented bounding boxes.

Documentation:
- Document obb support for Mosaic in the README transform capabilities table.