### PR TITLE
Enabled obb in Mosaic

### DIFF
--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -726,9 +726,9 @@ class Mosaic(DualTransform):
         if not all_shifted_bboxes:
             # Preserve correct column count for empty result
             if bbox_processor.params.bbox_type == "obb":
-                num_cols = max(bboxes.shape[1] if bboxes.size > 0 else 5, 5)
+                num_cols = max(bboxes.shape[1] if bboxes.ndim > 1 else 5, 5)
             else:
-                num_cols = max(bboxes.shape[1] if bboxes.size > 0 else 4, 4)
+                num_cols = max(bboxes.shape[1] if bboxes.ndim > 1 else 4, 4)
             return np.empty((0, num_cols), dtype=bboxes.dtype)
 
         # Concatenate (these are absolute pixel coordinates)

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -1121,8 +1121,9 @@ def filter_bboxes(
         # Preserve shape: OBB needs 5+ columns, HBB needs 4+ columns
         if bbox_type == "obb":
             num_cols = max(bboxes.shape[1] if bboxes.ndim > 1 else BBOX_OBB_MIN_COLUMNS, BBOX_OBB_MIN_COLUMNS)
-            return np.array([], dtype=np.float32).reshape(0, num_cols)
-        return np.array([], dtype=np.float32).reshape(0, 4)
+        else:
+            num_cols = max(bboxes.shape[1] if bboxes.ndim > 1 else 4, 4)
+        return np.array([], dtype=np.float32).reshape(0, num_cols)
 
     # Calculate areas of bounding boxes before clipping in pixels
     denormalized_box_areas = calculate_bbox_areas_in_pixels(bboxes, shape)
@@ -1163,7 +1164,9 @@ def filter_bboxes(
     filtered_bboxes = clipped_bboxes[mask]
 
     if len(filtered_bboxes) == 0:
-        return np.array([], dtype=np.float32).reshape(0, 4)
+        # Preserve column count from input
+        num_cols = max(bboxes.shape[1], BBOX_OBB_MIN_COLUMNS) if bbox_type == "obb" else max(bboxes.shape[1], 4)
+        return np.array([], dtype=np.float32).reshape(0, num_cols)
 
     # Normalize angles for OBB
     if bbox_type == "obb" and filtered_bboxes.shape[1] >= BBOX_OBB_MIN_COLUMNS:

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -828,7 +828,7 @@ def test_check_bboxes_additional_columns():
             0,
             0,
             0,
-            np.array([]).reshape(0, 4),
+            np.array([]).reshape(0, 5),  # Preserve 5 columns from input
         ),
         (
             np.array([]),

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -403,6 +403,94 @@ def test_mosaic_obb_empty_result() -> None:
     assert result["bboxes"].shape == (0, 5)
 
 
+def test_mosaic_obb_empty_with_labels() -> None:
+    """Test Mosaic with OBB preserves label columns when empty."""
+    target_size = (100, 100)
+    grid_yx = (1, 1)
+    cell_shape = (100, 100)
+
+    img_primary = np.ones((*target_size, 3), dtype=np.uint8)
+    # Empty bboxes array in OBB format WITH label column (6 columns total)
+    bboxes_primary = np.empty((0, 6), dtype=np.float32)
+    bbox_classes_primary = []
+
+    transform = Compose(
+        [
+            Mosaic(
+                target_size=target_size,
+                cell_shape=cell_shape,
+                grid_yx=grid_yx,
+                p=1.0,
+            ),
+        ],
+        bbox_params=BboxParams(
+            coord_format="albumentations",
+            bbox_type="obb",
+            label_fields=["bbox_classes"],
+            min_area=0.0,
+            min_visibility=0.0,
+        ),
+        seed=137,
+    )
+
+    data = {
+        "image": img_primary,
+        "bboxes": bboxes_primary,
+        "bbox_classes": bbox_classes_primary,
+        "mosaic_metadata": [],
+    }
+
+    result = transform(**data)
+
+    # Should preserve 6 columns (5 for OBB + 1 for label)
+    assert result["bboxes"].shape == (0, 6), f"Expected (0, 6), got {result['bboxes'].shape}"
+    assert len(result["bbox_classes"]) == 0
+
+
+def test_mosaic_hbb_empty_with_labels() -> None:
+    """Test Mosaic with HBB preserves label columns when empty."""
+    target_size = (100, 100)
+    grid_yx = (1, 1)
+    cell_shape = (100, 100)
+
+    img_primary = np.ones((*target_size, 3), dtype=np.uint8)
+    # Empty bboxes array in HBB format WITH label column (5 columns total)
+    bboxes_primary = np.empty((0, 5), dtype=np.float32)
+    bbox_classes_primary = []
+
+    transform = Compose(
+        [
+            Mosaic(
+                target_size=target_size,
+                cell_shape=cell_shape,
+                grid_yx=grid_yx,
+                p=1.0,
+            ),
+        ],
+        bbox_params=BboxParams(
+            coord_format="albumentations",
+            bbox_type="hbb",
+            label_fields=["bbox_classes"],
+            min_area=0.0,
+            min_visibility=0.0,
+        ),
+        seed=137,
+    )
+
+    data = {
+        "image": img_primary,
+        "bboxes": bboxes_primary,
+        "bbox_classes": bbox_classes_primary,
+        "mosaic_metadata": [],
+    }
+
+    result = transform(**data)
+
+    # Should preserve 5 columns (4 for HBB + 1 for label)
+    assert result["bboxes"].shape == (0, 5), f"Expected (0, 5), got {result['bboxes'].shape}"
+    assert len(result["bbox_classes"]) == 0
+
+
 def test_mosaic_simplified_deterministic() -> None:
     """Test Mosaic with fixed parameters, albumentations format, no labels."""
     target_size = (100, 100)


### PR DESCRIPTION
## Summary by Sourcery

Add oriented bounding box (OBB) support and correct empty-output handling for Mosaic transforms while tightening bbox filtering to always respect bbox type and clipping settings.

New Features:
- Support Mosaic transforms with oriented bounding boxes (OBB) alongside existing horizontal bounding boxes (HBB).

Enhancements:
- Ensure bbox filtering consistently receives the bbox type and clip settings from BboxProcessor, including during Mosaic and input clipping workflows.
- Preserve the correct bounding box column count when Mosaic returns an empty bbox result for both HBB and OBB modes.

Tests:
- Add Mosaic test coverage for OBB support, including basic usage, metadata-driven mosaics, and empty-result scenarios.
- Update bbox filtering tests to pass explicit bbox types to the filter_bboxes helper.