### PR TITLE
Renamed options for clip_boxes_after_transform

### DIFF
--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -87,16 +87,11 @@ class BboxParams(Params):
             will be filtered out. For example, if max_accept_ratio=3.0, boxes with width:height or height:width ratios
             greater than 3:1 will be removed. Set to None to disable aspect ratio filtering. Default: None.
 
-        clip_after_transform (Literal[None, "geometry"]): Controls how bounding boxes are clipped AFTER EACH TRANSFORM
-            in the augmentation pipeline. This is different from `clip_bboxes_on_input` which only runs once before
-            the pipeline. Options:
-            - None: No clipping after transforms. Boxes may temporarily go outside [0, 1] bounds.
-                   Use for lenient pipelines where boxes may go outside temporarily (e.g., crop then pad).
-            - "geometry": Clip based on actual geometry (default).
-                         For HBB: clips (x_min, y_min, x_max, y_max) to [0, 1]. Fast, current behavior.
-                         For OBB: clips all 4 rotated corners to [0, 1] and returns a wrapping
-                                axis-aligned bounding box (angle set to 0), without cv2.minAreaRect refit.
-            Default: "geometry".
+        clip_after_transform (bool): If True, clip bounding boxes to image bounds AFTER EACH TRANSFORM in the
+            augmentation pipeline. If False, boxes may temporarily go outside [0, 1] bounds. This is different
+            from `clip_bboxes_on_input` which only runs once before the pipeline. When True: for HBB, clips
+            (x_min, y_min, x_max, y_max) to [0, 1]; for OBB, clips all 4 rotated corners to [0, 1] and returns
+            a wrapping axis-aligned bounding box (angle set to 0). Default: True.
 
     Note:
         The processing order for bounding boxes is:
@@ -104,7 +99,7 @@ class BboxParams(Params):
         2. Clip boxes to image boundaries (if clip_bboxes_on_input=True) - PRE-PIPELINE, fixes invalid input
         3. Filter invalid boxes (if filter_invalid_bboxes=True)
         4. Apply transformations
-        5. After each transform: clip (if clip_after_transform is set) and filter boxes based on
+        5. After each transform: clip (if clip_after_transform=True) and filter boxes based on
            min_area, min_visibility, min_width, min_height
         6. Convert back to the original format
 
@@ -133,17 +128,17 @@ class BboxParams(Params):
         ...     max_accept_ratio=5.0,  # Filter boxes with aspect ratio > 5:1
         ...     clip_bboxes_on_input=True
         ... )
-        >>> # Create BboxParams for OBB with geometry-based clipping after transforms
+        >>> # Create BboxParams for OBB with clipping after transforms
         >>> bbox_params = BboxParams(
         ...     coord_format='albumentations',
         ...     bbox_type='obb',
-        ...     clip_after_transform='geometry',  # Clip all corners inside bounds
+        ...     clip_after_transform=True,  # Clip all corners inside bounds
         ... )
         >>> # Create BboxParams with lenient clipping (allows temporary excursions)
         >>> bbox_params = BboxParams(
         ...     coord_format='yolo',
         ...     clip_bboxes_on_input=True,  # Fix input errors
-        ...     clip_after_transform=None  # Allow boxes to go outside temporarily
+        ...     clip_after_transform=False  # Allow boxes to go outside temporarily
         ... )
         >>> # Create BboxParams for cxcywh (center + wh in pixels)
         >>> bbox_params = BboxParams(
@@ -175,7 +170,7 @@ class BboxParams(Params):
         # Clipping parameters
         clip_bboxes_on_input: bool
         filter_invalid_bboxes: bool
-        clip_after_transform: Literal["geometry"] | None
+        clip_after_transform: bool
 
         # Other
         check_each_transform: bool
@@ -193,7 +188,7 @@ class BboxParams(Params):
         filter_invalid_bboxes: bool = False,
         max_accept_ratio: float | None = None,
         clip_bboxes_on_input: bool = False,
-        clip_after_transform: Literal["geometry"] | None = "geometry",
+        clip_after_transform: bool = True,
     ):
         # Validate all parameters using InitSchema
         validated = self.InitSchema(
@@ -508,8 +503,8 @@ class BboxProcessor(DataProcessor):
             shape (tuple[int, int] | tuple[int, int, int]): Shape to check against.
 
         """
-        # Skip validation if clip_after_transform=None (boxes may be outside [0, 1])
-        if self.params.clip_after_transform is not None:
+        # Skip validation if clip_after_transform=False (boxes may be outside [0, 1])
+        if self.params.clip_after_transform:
             check_bboxes(data)
 
     def convert_from_albumentations(
@@ -558,7 +553,7 @@ class BboxProcessor(DataProcessor):
                 min_visibility=0,
                 min_width=0,
                 min_height=0,
-                clip_after_transform="geometry",
+                clip_after_transform=True,
             )
             check_bboxes(data_np)
             return data_np
@@ -1097,7 +1092,7 @@ def filter_bboxes(
     min_width: float = 1.0,
     min_height: float = 1.0,
     max_accept_ratio: float | None = None,
-    clip_after_transform: Literal["geometry"] | None = "geometry",
+    clip_after_transform: bool = True,
 ) -> np.ndarray:
     """Remove bounding boxes that either lie outside of the visible area by more than min_visibility
     or whose area in pixels is under the threshold set by `min_area`. Also crops boxes to final image size.
@@ -1113,10 +1108,8 @@ def filter_bboxes(
         min_height (float): Minimum height of a bounding box in pixels. Default: 0.0.
         max_accept_ratio (float | None): Maximum allowed aspect ratio, calculated as max(width/height, height/width).
             Boxes with higher ratios will be filtered out. Default: None.
-        clip_after_transform (Literal[None, "geometry"]): How to clip bounding boxes to image bounds.
-            - None: No clipping, boxes may extend outside [0, 1].
-            - "geometry": Clip based on actual geometry (HBB: coords, OBB: corners).
-            Default: "geometry".
+        clip_after_transform (bool): If True, clip bounding boxes to image bounds (HBB: coords, OBB: corners).
+            If False, boxes may extend outside [0, 1]. Default: True.
 
     Returns:
         np.ndarray: Filtered bounding boxes.
@@ -1136,7 +1129,7 @@ def filter_bboxes(
     denormalized_box_areas = calculate_bbox_areas_in_pixels(bboxes, shape)
 
     # Clip bounding boxes based on clip_after_transform
-    clipped_bboxes = bboxes if clip_after_transform is None else clip_bboxes_geometry(bboxes, shape, bbox_type)
+    clipped_bboxes = bboxes if not clip_after_transform else clip_bboxes_geometry(bboxes, shape, bbox_type)
 
     # Calculate areas of clipped bounding boxes in pixels
     clipped_box_areas = calculate_bbox_areas_in_pixels(clipped_bboxes, shape)

--- a/docs/design/bounding_boxes.md
+++ b/docs/design/bounding_boxes.md
@@ -175,19 +175,19 @@ BboxParams(clip_bboxes_on_input=True)  # Fix invalid input coordinates (e.g., YO
 
 **Deprecated**: The `clip` parameter is deprecated. Use `clip_bboxes_on_input` instead for clarity.
 
-#### `clip_after_transform: Literal[None, 'geometry'] = 'geometry'`
+#### `clip_after_transform: bool = True`
 Controls how bboxes are clipped **after each transform** in the pipeline:
 
-- `None`: No clipping after transforms. Boxes may temporarily go outside [0, 1] bounds.
-  - Use for lenient pipelines (e.g., crop then pad)
-  - Boxes can have negative coords or coords > 1
-
-- `'geometry'`: Clip based on actual geometry (default)
+- `True` (default): Clip based on actual geometry.
   - **For HBB**: Clips `(x_min, y_min, x_max, y_max)` to [0, 1]. Fast, current behavior.
   - **For OBB**: Clips all 4 rotated corners to [0, 1] and returns axis-aligned wrapping box.
     - Ensures all corners are inside bounds
     - Sets angle to 0 (result is axis-aligned after clipping)
     - Does NOT use `cv2.minAreaRect` - that's only for rotations
+
+- `False`: No clipping after transforms. Boxes may temporarily go outside [0, 1] bounds.
+  - Use for lenient pipelines (e.g., crop then pad)
+  - Boxes can have negative coords or coords > 1
 
 **Example configurations:**
 
@@ -195,15 +195,15 @@ Controls how bboxes are clipped **after each transform** in the pipeline:
 # Strict: clip input errors AND after each transform
 BboxParams(
     bbox_format='yolo',
-    clip_bboxes_on_input=True,     # Fix input errors once
-    clip_after_transform='geometry' # Clip after each transform
+    clip_bboxes_on_input=True,  # Fix input errors once
+    clip_after_transform=True,  # Clip after each transform
 )
 
 # Lenient: allow temporary excursions
 BboxParams(
     bbox_format='albumentations',
-    clip_bboxes_on_input=True,    # Fix input errors once
-    clip_after_transform=None      # Allow boxes outside [0,1] during pipeline
+    clip_bboxes_on_input=True,   # Fix input errors once
+    clip_after_transform=False,  # Allow boxes outside [0,1] during pipeline
 )
 ```
 
@@ -227,7 +227,7 @@ If `True`, removes bboxes with invalid coordinates (e.g., x_min >= x_max) during
 3. Apply Transforms (Compose)
    For each transform:
      - Execute transform.apply_to_bboxes()
-     - Apply clipping (if clip_after_transform is set)
+     - Apply clipping (if clip_after_transform=True)
      - Filter by min_area, min_visibility, min_width, min_height
    ↓
 4. Postprocess (BboxProcessor.postprocess)
@@ -289,7 +289,7 @@ After **each** transform, `Compose` applies filtering (in `filter_bboxes()`):
 
 ```python
 # 1. Apply clip_after_transform
-if clip_after_transform == 'geometry':
+if clip_after_transform:
     if bbox_type == 'hbb':
         # Clip coordinates to [0, 1]
         bbox[0] = max(0.0, min(1.0, bbox[0]))  # x_min
@@ -352,11 +352,11 @@ BboxParams(coord_format='yolo', clip_bboxes_on_input=True)
 
 ```python
 # Example: Crop that moves bbox outside bounds
-BboxParams(clip_after_transform='geometry')
+BboxParams(clip_after_transform=True)
 # After crop: [-0.1, -0.1, 1.1, 1.1]  # Outside bounds
-# After clip: [0.0, 0.0, 1.0, 1.0]    # Clipped to [0, 1]
+# After clip: [0.0, 0.0, 1.0, 1.0]   # Clipped to [0, 1]
 
-BboxParams(clip_after_transform=None)
+BboxParams(clip_after_transform=False)
 # After crop: [-0.1, -0.1, 1.1, 1.1]  # Left as-is
 # Later transform (e.g., pad) may bring it back inside
 ```
@@ -366,10 +366,10 @@ BboxParams(clip_after_transform=None)
 | Scenario | `clip_bboxes_on_input` | `clip_after_transform` |
 |----------|------------------------|------------------------|
 | Fix malformed input | ✅ `True` | N/A |
-| Strict bounds enforcement | Optional | `'geometry'` |
-| Lenient pipeline (crop→pad) | Optional | `None` |
-| OBB with accurate geometry | Optional | `'geometry'` |
-| Performance critical (HBB only) | Optional | `'geometry'` (fast) |
+| Strict bounds enforcement | Optional | `True` |
+| Lenient pipeline (crop→pad) | Optional | `False` |
+| OBB with accurate geometry | Optional | `True` |
+| Performance critical (HBB only) | Optional | `True` (fast) |
 
 ---
 
@@ -508,10 +508,10 @@ bbox_params = A.BboxParams(
 
 ```python
 # Strict pipeline - always keep boxes in bounds
-bbox_params = A.BboxParams(clip_after_transform='geometry')
+bbox_params = A.BboxParams(clip_after_transform=True)
 
 # Lenient pipeline - allow temporary excursions
-bbox_params = A.BboxParams(clip_after_transform=None)
+bbox_params = A.BboxParams(clip_after_transform=False)
 ```
 
 ### 4. Set Meaningful Filters
@@ -614,20 +614,20 @@ for bbox in test_cases:
 bbox_params = A.BboxParams(
     bbox_format='yolo',
     bbox_type='hbb',
-    clip_after_transform='geometry',  # Fast for HBB
+    clip_after_transform=True,  # Fast for HBB
 )
 
 # For OBB with accurate geometry (slower):
 bbox_params = A.BboxParams(
     bbox_format='albumentations',
     bbox_type='obb',
-    clip_after_transform='geometry',  # Refits boxes, may change angle
+    clip_after_transform=True,  # Refits boxes, may change angle
 )
 
 # For maximum performance (careful!):
 bbox_params = A.BboxParams(
     bbox_format='albumentations',
-    clip_after_transform=None,  # No clipping after transforms
+    clip_after_transform=False,  # No clipping after transforms
 )
 ```
 

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -664,7 +664,7 @@ def test_obb_rot90_updates_corners():
     ],
 )
 def test_bbox_processor_roundtrip_with_angle_and_labels(bbox_format, bboxes, labels, expected_angle):
-    params = BboxParams(coord_format=bbox_format, label_fields=["labels"], bbox_type="obb", clip_after_transform=None)
+    params = BboxParams(coord_format=bbox_format, label_fields=["labels"], bbox_type="obb", clip_after_transform=False)
     processor = BboxProcessor(params)
 
     data = {
@@ -702,7 +702,7 @@ def test_cxcywh_obb_compose_roundtrip():
     bboxes = [(50, 50, 30, 40, 45.0)]
     aug = A.Compose(
         [A.RandomRotate90(p=1.0)],
-        bbox_params=A.BboxParams(coord_format="cxcywh", bbox_type="obb", clip_after_transform=None),
+        bbox_params=A.BboxParams(coord_format="cxcywh", bbox_type="obb", clip_after_transform=False),
         strict=True,
         seed=137,
     )
@@ -2394,11 +2394,11 @@ def test_bbox_processor_clip_and_filter():
     "bbox_type,clip_after_transform,bboxes,expected_count",
     [
         # OBB: invalid box should be filtered
-        ("obb", "geometry", [[0.1, 0.1, 0.05, 0.2, 0.0], [0.3, 0.3, 0.5, 0.5, 45.0]], 1),
-        # OBB with clip_after_transform=None: should not clamp during filtering
-        ("obb", None, [[0.3, 0.3, 0.5, 0.5, 45.0]], 1),
-        # HBB with clip_after_transform=None: should not clamp during filtering
-        ("hbb", None, [[0.1, 0.1, 0.05, 0.2], [0.3, 0.3, 0.5, 0.5]], 1),
+        ("obb", True, [[0.1, 0.1, 0.05, 0.2, 0.0], [0.3, 0.3, 0.5, 0.5, 45.0]], 1),
+        # OBB with clip_after_transform=False: should not clamp during filtering
+        ("obb", False, [[0.3, 0.3, 0.5, 0.5, 45.0]], 1),
+        # HBB with clip_after_transform=False: should not clamp during filtering
+        ("hbb", False, [[0.1, 0.1, 0.05, 0.2], [0.3, 0.3, 0.5, 0.5]], 1),
     ],
 )
 def test_bbox_processor_filter_invalid_respects_params(bbox_type, clip_after_transform, bboxes, expected_count):


### PR DESCRIPTION
## Summary by Sourcery

Standardize bounding box clipping configuration by simplifying the clip_after_transform option from a string/None union to a boolean flag and updating all usages accordingly.

Bug Fixes:
- Ensure bbox clipping and validation logic consistently respect the clip_after_transform flag when disabled.

Enhancements:
- Simplify BboxParams API by replacing the Literal[None,'geometry'] clip_after_transform option with a boolean, defaulting to True, and updating associated documentation and examples for clarity.

Documentation:
- Revise bounding box design documentation to describe clip_after_transform as a boolean flag, with updated examples and behavioral descriptions.

Tests:
- Adjust bounding box tests to use the boolean clip_after_transform flag and verify behavior for both enabled and disabled clipping modes.