### PR TITLE
fix: break circular import for __version__

### DIFF
--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,14 +1,6 @@
-from importlib.metadata import metadata
-
-try:
-    _metadata = metadata("albumentationsx")
-    __version__ = _metadata["Version"]
-    __author__ = _metadata["Author"]
-    __maintainer__ = _metadata["Maintainer"]
-except Exception:  # noqa: BLE001
-    __version__ = "unknown"
-    __author__ = "Vladimir Iglovikov"
-    __maintainer__ = "Vladimir Iglovikov"
+from albumentations._version import __author__ as __author__
+from albumentations._version import __maintainer__ as __maintainer__
+from albumentations._version import __version__ as __version__
 
 # Check for OpenCV at import time
 try:

--- a/albumentations/_version.py
+++ b/albumentations/_version.py
@@ -1,0 +1,11 @@
+from importlib.metadata import metadata
+
+try:
+    _metadata = metadata("albumentationsx")
+    __version__ = _metadata["Version"]
+    __author__ = _metadata["Author"]
+    __maintainer__ = _metadata["Maintainer"]
+except Exception:  # noqa: BLE001
+    __version__ = "unknown"
+    __author__ = "Vladimir Iglovikov"
+    __maintainer__ = "Vladimir Iglovikov"

--- a/albumentations/core/analytics/collectors.py
+++ b/albumentations/core/analytics/collectors.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from albumentations import __version__ as albumentationsx_version
+from albumentations._version import __version__ as albumentationsx_version
 from albumentations.core.analytics.events import ComposeInitEvent
 
 if TYPE_CHECKING:

--- a/albumentations/core/serialization.py
+++ b/albumentations/core/serialization.py
@@ -25,7 +25,7 @@ except ImportError:
     yaml_available = False
 
 
-from albumentations import __version__
+from albumentations._version import __version__
 
 __all__ = ["from_dict", "load", "save", "to_dict"]
 


### PR DESCRIPTION
## Summary
- Move version/author/maintainer metadata into `albumentations/_version.py` so internal modules can import `__version__` without triggering full package initialization
- Fixes circular import: `serialization.py` and `analytics/collectors.py` imported `from albumentations import __version__`, which triggered `__init__.py` → `augmentations/__init__.py` → full transform tree → back to `serialization.py`
- `__init__.py` now re-exports from `_version.py`

## Test plan
- [x] All 9663 tests pass
- [x] Pre-commit hooks pass
- [x] `python -c "import albumentations; print(albumentations.__version__)"` works
- [x] `python -c "import albumentations.augmentations.geometric.functional"` works (was broken before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract version metadata into a dedicated module and update internal imports to avoid circular initialization when accessing __version__.

Bug Fixes:
- Resolve circular import caused by modules importing __version__ from the top-level package during initialization.

Enhancements:
- Introduce an internal _version module that centralizes package version and author metadata and is re-exported by the package __init__ for external use.