### PR TITLE
chore(release): bump version to 2.0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,8 @@ conda_build/
 
 .ruff_cache/
 
+uv.lock
+
 data/
 
 notebooks/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,7 +114,7 @@ repos:
         language: system
         files: ^(pyproject\.toml|conda\.recipe/meta\.yaml|tools/check_conda_dependencies\.py)$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.2
     hooks:
       - id: ruff
         exclude: '__pycache__/'

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -366,7 +366,7 @@ class BboxProcessor(DataProcessor):
         from albumentations.core.composition import BaseCompose
         from albumentations.core.transforms_interface import DualTransform, ImageOnlyTransform
 
-        unsupported = []
+        unsupported: list[str] = []
 
         def check_transform(transform: object) -> None:
             # Skip ImageOnly (they don't touch bboxes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [ "setuptools>=45", "wheel" ]
 [project]
 name = "albumentationsx"
 
-version = "2.0.17"
+version = "2.0.18"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volumes, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows."
 readme = "README.md"


### PR DESCRIPTION
- Update ruff pre-commit to v0.15.2
- Add explicit type hint for unsupported list in BboxProcessor
- Add uv.lock to .gitignore

## Summary by Sourcery

Bump the library and tooling versions and tighten typing for bbox transform validation.

Enhancements:
- Add an explicit type hint for the unsupported transforms list in BboxProcessor to improve type safety.

Build:
- Update the ruff pre-commit hook to version v0.15.2.
- Bump the package version to 2.0.18 in pyproject.toml.

Chores:
- Ignore uv.lock in version control.