### PR TITLE
Feat/tta inverse transforms

### DIFF
--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -35,6 +35,7 @@ from albumentations.core.transforms_interface import (
 )
 from albumentations.core.type_definitions import (
     ALL_TARGETS,
+    D4_INVERSE,
     ImageType,
     VolumeType,
     d4_group_elements,
@@ -49,17 +50,6 @@ __all__ = [
     "Transpose",
     "VerticalFlip",
 ]
-
-_D4_INVERSE: dict[str, Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]] = {
-    "e": "e",
-    "r90": "r270",
-    "r180": "r180",
-    "r270": "r90",
-    "v": "v",
-    "h": "h",
-    "t": "t",
-    "hvt": "hvt",
-}
 
 
 class VerticalFlip(DualTransform):
@@ -600,7 +590,7 @@ class D4(DualTransform):
             raise ValueError(
                 "Cannot invert D4 with random group_element. Set group_element explicitly for TTA.",
             )
-        return D4(p=1, group_element=_D4_INVERSE[self.group_element])
+        return D4(p=1, group_element=D4_INVERSE[self.group_element])
 
 
 class SquareSymmetry(D4):
@@ -680,4 +670,4 @@ class SquareSymmetry(D4):
             raise ValueError(
                 "Cannot invert SquareSymmetry with random group_element. Set group_element explicitly for TTA.",
             )
-        return SquareSymmetry(p=1, group_element=_D4_INVERSE[self.group_element])
+        return SquareSymmetry(p=1, group_element=D4_INVERSE[self.group_element])

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -23,6 +23,7 @@ from albumentations.core.transforms_interface import (
 )
 from albumentations.core.type_definitions import (
     ALL_TARGETS,
+    C4_INVERSE,
     ImageType,
     VolumeType,
     c4_group_elements,
@@ -33,13 +34,6 @@ from . import functional as fgeometric
 __all__ = ["RandomRotate90", "Rotate", "SafeRotate"]
 
 SMALL_NUMBER = 1e-10
-
-_C4_INVERSE: dict[str, Literal["e", "r90", "r180", "r270"]] = {
-    "e": "e",
-    "r90": "r270",
-    "r180": "r180",
-    "r270": "r90",
-}
 
 
 class RandomRotate90(DualTransform):
@@ -138,8 +132,8 @@ class RandomRotate90(DualTransform):
         >>> predictions = []
         >>> for element in c4_group_elements:
         ...     aug = A.RandomRotate90(p=1.0, group_element=element)
-        ...     aug_image = aug(image=image)
-        ...     pred_mask = np.zeros_like(mask)  # placeholder for model output
+        ...     aug_image = aug(image=image)["image"]
+        ...     pred_mask = np.zeros((100, 100, 1), dtype=np.uint8)  # placeholder for model output
         ...     restored = aug.inverse()(image=pred_mask)["image"]
         ...     predictions.append(restored)
 
@@ -231,7 +225,7 @@ class RandomRotate90(DualTransform):
             raise ValueError(
                 "Cannot invert RandomRotate90 with random group_element. Set group_element explicitly for TTA.",
             )
-        return RandomRotate90(p=1, group_element=_C4_INVERSE[self.group_element])
+        return RandomRotate90(p=1, group_element=C4_INVERSE[self.group_element])
 
 
 class RotateInitSchema(BaseTransformInitSchema):

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -290,8 +290,9 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         before inference, then apply its inverse to the predicted mask to bring it back to
         the original image space.
 
-        Only group-based transforms with a fixed ``group_element`` support this operation
-        (D4, RandomRotate90, HorizontalFlip, VerticalFlip, Transpose).
+        Only transforms that override ``inverse()`` support this operation, typically
+        group-based transforms with a fixed ``group_element`` (e.g., D4, RandomRotate90,
+        HorizontalFlip, VerticalFlip, Transpose).
 
         Raises:
             NotImplementedError: If the transform does not support inversion.
@@ -299,7 +300,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         """
         raise NotImplementedError(
             f"{self.__class__.__name__} does not support inverse(). "
-            "Only group-based transforms (D4, RandomRotate90, flips) support TTA inversion.",
+            "Only transforms that override `inverse()` can be used for TTA inversion.",
         )
 
     def should_apply(self, force_apply: bool = False) -> bool:

--- a/albumentations/core/type_definitions.py
+++ b/albumentations/core/type_definitions.py
@@ -8,7 +8,7 @@ and provide a centralized location for commonly used values.
 """
 
 from enum import Enum
-from typing import TypeAlias, TypeVar
+from typing import Literal, TypeAlias, TypeVar
 
 import cv2
 import numpy as np
@@ -38,8 +38,15 @@ c4_group_elements = ["e", "r90", "r180", "r270"]
 # Inverse tables for TTA: applying element then its inverse yields identity.
 # Rotations: r90 and r270 are mutual inverses; r180 and e are self-inverse.
 # Reflections in D4 are all self-inverse.
-C4_INVERSE: dict[str, str] = {"e": "e", "r90": "r270", "r180": "r180", "r270": "r90"}
-D4_INVERSE: dict[str, str] = {
+C4GroupElement: TypeAlias = Literal["e", "r90", "r180", "r270"]
+D4GroupElement: TypeAlias = Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]
+C4_INVERSE: dict[C4GroupElement, C4GroupElement] = {
+    "e": "e",
+    "r90": "r270",
+    "r180": "r180",
+    "r270": "r90",
+}
+D4_INVERSE: dict[D4GroupElement, D4GroupElement] = {
     "e": "e",
     "r90": "r270",
     "r180": "r180",

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2080,6 +2080,7 @@ def test_d4_inverse_roundtrip(group_element: str) -> None:
     augmented = aug(image=image)["image"]
     restored = aug.inverse()(image=augmented)["image"]
     np.testing.assert_array_equal(restored, image)
+    assert isinstance(aug.inverse(), A.D4)
 
 
 @pytest.mark.parametrize("group_element", ["e", "r90", "r180", "r270", "v", "hvt", "h", "t"])


### PR DESCRIPTION
## Summary by Sourcery

Add explicit inverse support for group-based geometric transforms to enable TTA-friendly roundtrips and document their usage.

Enhancements:
- Introduce an inverse() API on BasicTransform and implement it for D4, SquareSymmetry, RandomRotate90, HorizontalFlip, VerticalFlip, and Transpose using group inverse lookup tables.
- Expose C4 and D4 inverse maps in type_definitions for consistent inverse element resolution across transforms.

Documentation:
- Expand transform docstrings and examples to describe inverse() semantics and show TTA workflows that apply a transform, run inference, and invert predictions.

Tests:
- Add roundtrip tests verifying that D4, SquareSymmetry, RandomRotate90, flips, and Transpose followed by their inverse restore the original image and that inverse() raises when required parameters like group_element are not set.