### PR TITLE
refactor(geometric): replace cv2.resize with albucore.resize

### DIFF
--- a/.cursor/skills/review-transform/SKILL.md
+++ b/.cursor/skills/review-transform/SKILL.md
@@ -51,11 +51,12 @@ Run these checks in order. Report issues with severity: 🔴 Critical, 🟡 Impo
 
 Priority order to check:
 1. **`cv2.LUT`** used for pixel lookup operations (fastest)
-2. **`cv2` over numpy** for image ops where applicable (except resize: use **`albucore.resize`**, not `cv2.resize` — enforced by pre-commit)
-3. **Vectorized numpy** instead of Python loops
-4. **In-place ops** where safe (avoid unnecessary `.copy()`)
-5. No repeated array allocations in tight loops
-6. Expensive computations cached in `get_params` / `get_params_dependent_on_data`
+2. **`albucore.resize` not `cv2.resize`** for image resizing (handles 5+ channels, INTER_AREA, etc.)
+3. **`cv2` over numpy** for image ops where applicable
+4. **Vectorized numpy** instead of Python loops
+5. **In-place ops** where safe (avoid unnecessary `.copy()`)
+6. No repeated array allocations in tight loops
+7. Expensive computations cached in `get_params` / `get_params_dependent_on_data`
 
 Flag any violations with a concrete speedup suggestion.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Install all dependencies
       run: |
         uv pip install wheel
+        uv pip install .  # project first so albucore etc. from pyproject.toml
         uv pip install -r requirements-dev.txt
-        uv pip install .
 
     - name: Run PyTest with coverage
       run: pytest -n auto --cov=albumentations --cov-branch --cov-report=xml
@@ -78,8 +78,8 @@ jobs:
 
     - name: Install all requirements
       run: |
+        uv pip install .  # project first so albucore etc. from pyproject.toml
         uv pip install -r requirements-dev.txt
-        uv pip install .
 
     - name: Run checks
       run: pre-commit run --files $(find albumentations -type f)

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -243,7 +243,7 @@ def crop_and_pad(
 
     if keep_size:
         rows, cols = image_shape[:2]
-        return fgeometric.resize_cv2(img, (rows, cols), interpolation)
+        return fgeometric.resize(img, (rows, cols), interpolation)
 
     return img
 

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -13,7 +13,6 @@ from functools import lru_cache
 from typing import Any, Literal, cast
 from warnings import warn
 
-import albucore
 import cv2
 import numpy as np
 from albucore import (
@@ -27,6 +26,9 @@ from albucore import (
     to_float,
     vflip,
     warp_perspective,
+)
+from albucore import (
+    resize as albucore_resize,
 )
 
 # Optional dependencies
@@ -368,7 +370,6 @@ def _get_resize_backend() -> str:
     return "opencv"
 
 
-@preserve_channel_dim
 def resize(
     img: ImageType,
     target_shape: tuple[int, int],
@@ -394,9 +395,13 @@ def resize(
     if target_shape == img.shape[:2]:
         return img
 
+    height, width = target_shape
+    if img.ndim == 2:
+        return cv2.resize(img, (width, height), interpolation=interpolation)
+
     backend = _get_resize_backend()
     if backend == "opencv":
-        return resize_cv2(img, target_shape, interpolation)
+        return albucore_resize(img, (width, height), interpolation=interpolation)
     if backend == "pyvips":
         return resize_pyvips(img, target_shape, interpolation)
     if backend == "pillow":
@@ -453,29 +458,6 @@ def resize_pyvips(
     )
 
     return resized_img_vips.numpy().astype(original_dtype)
-
-
-def resize_cv2(
-    img: ImageType,
-    target_shape: tuple[int, int],
-    interpolation: int,
-) -> np.ndarray:
-    """Resize an image to the specified dimensions using albucore.
-
-    This function resizes an input image to the target shape using the specified interpolation method.
-
-    Args:
-        img (np.ndarray): Input image to resize.
-        target_shape (tuple[int, int]): Target (height, width) dimensions.
-        interpolation (int): Interpolation method to use (cv2 interpolation flag).
-            Examples: cv2.INTER_LINEAR, cv2.INTER_CUBIC, cv2.INTER_NEAREST, etc.
-
-    Returns:
-        np.ndarray: Resized image with shape target_shape + original channel dimensions.
-
-    """
-    height, width = target_shape[:2]
-    return albucore.resize(img, dsize=(width, height), interpolation=interpolation)
 
 
 def resize_pil(
@@ -2086,7 +2068,7 @@ def upscale_distortion_maps(
     scale_y = small_h / h
     scale_x = small_w / w
 
-    # Upscale the maps (2D float32: use cv2.resize for coordinate semantics; albucore.resize differs)
+    # Upscale the maps (2D float32)
     map_x_scaled = cv2.resize(map_x, (w, h), interpolation=interpolation)
     map_y_scaled = cv2.resize(map_y, (w, h), interpolation=interpolation)
 

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -9,12 +9,11 @@ from typing import Any, Literal, cast
 
 import cv2
 import numpy as np
-from albucore import batch_transform
 from pydantic import Field, field_validator, model_validator
 from typing_extensions import Self
 
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
-from albumentations.core.type_definitions import ALL_TARGETS, ImageType, VolumeType
+from albumentations.core.type_definitions import ALL_TARGETS, ImageType
 from albumentations.core.utils import to_tuple
 
 from . import functional as fgeometric
@@ -430,22 +429,6 @@ class MaxSizeTransform(DualTransform):
         **params: Any,
     ) -> np.ndarray:
         return fgeometric.keypoints_scale(keypoints, scale, scale)
-
-    @batch_transform("spatial")
-    def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
-        return self.apply(images, *args, **params)
-
-    @batch_transform("spatial")
-    def apply_to_volumes(self, volumes: VolumeType, *args: Any, **params: Any) -> VolumeType:
-        return self.apply(volumes, *args, **params)
-
-    @batch_transform("spatial")
-    def apply_to_mask3d(self, mask3d: VolumeType, *args: Any, **params: Any) -> VolumeType:
-        return self.apply_to_mask(mask3d, *args, **params)
-
-    @batch_transform("spatial")
-    def apply_to_masks3d(self, masks3d: VolumeType, *args: Any, **params: Any) -> VolumeType:
-        return self.apply_to_mask(masks3d, *args, **params)
 
 
 class LongestMaxSize(MaxSizeTransform):

--- a/albumentations/augmentations/mixing/domain_adaptation.py
+++ b/albumentations/augmentations/mixing/domain_adaptation.py
@@ -9,10 +9,11 @@ like histograms, frequency spectra, or overall pixel distributions.
 from collections.abc import Sequence
 from typing import Annotated, Any, Literal, cast
 
+import cv2
 import numpy as np
-from albucore import resize
 from pydantic import AfterValidator, field_validator
 
+from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.mixing.domain_adaptation_functional import (
     adapt_pixel_distribution,
     apply_histogram,
@@ -469,7 +470,7 @@ class FDA(BaseDomainAdaptation):
         height, width = params["shape"][:2]
 
         # Resize the target image to match the input image dimensions
-        target_image_resized = resize(target_image, dsize=(width, height))
+        target_image_resized = fgeometric.resize(target_image, (height, width), cv2.INTER_LINEAR)
 
         return {"target_image": target_image_resized, "beta": self.py_random.uniform(*self.beta_limit)}
 

--- a/albumentations/augmentations/mixing/domain_adaptation_functional.py
+++ b/albumentations/augmentations/mixing/domain_adaptation_functional.py
@@ -18,7 +18,6 @@ from albucore import (
     from_float,
     get_num_channels,
     preserve_channel_dim,
-    resize,
     to_float,
     uint8_io,
 )
@@ -425,7 +424,7 @@ def adapt_pixel_distribution(
         ref = np.squeeze(ref)
 
     if img.shape != ref.shape:
-        ref = resize(ref, dsize=(img.shape[1], img.shape[0]), interpolation=cv2.INTER_AREA)
+        ref = fgeometric.resize(ref, img.shape[:2], cv2.INTER_AREA)
 
     original_dtype = img.dtype
 
@@ -588,7 +587,7 @@ def apply_histogram(img: ImageType, reference_image: ImageType, blend_ratio: flo
     """
     # Resize reference image only if necessary
     if img.shape[:2] != reference_image.shape[:2]:
-        reference_image = resize(reference_image, dsize=(img.shape[1], img.shape[0]))
+        reference_image = fgeometric.resize(reference_image, img.shape[:2], cv2.INTER_LINEAR)
 
     reference_image = reference_image.reshape(img.shape)
 

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -12,10 +12,10 @@ from typing import Annotated, Any, Literal, cast
 
 import cv2
 import numpy as np
-from albucore import resize
 from pydantic import AfterValidator, model_validator
 from typing_extensions import Self
 
+from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.mixing import functional as fmixing
 from albumentations.core.bbox_utils import BboxProcessor, check_bboxes, denormalize_bboxes, filter_bboxes
 from albumentations.core.keypoints_utils import KeypointsProcessor
@@ -167,11 +167,11 @@ class OverlayElements(DualTransform):
 
             if "mask" in metadata:
                 mask = metadata["mask"]
-                mask = resize(mask, dsize=(x_max - x_min, y_max - y_min), interpolation=cv2.INTER_NEAREST)
+                mask = fgeometric.resize(mask, (y_max - y_min, x_max - x_min), cv2.INTER_NEAREST)
             else:
                 mask = np.ones((y_max - y_min, x_max - x_min), dtype=np.uint8)
 
-            overlay_image = resize(overlay_image, dsize=(x_max - x_min, y_max - y_min), interpolation=cv2.INTER_AREA)
+            overlay_image = fgeometric.resize(overlay_image, (y_max - y_min, x_max - x_min), cv2.INTER_AREA)
             offset = (y_min, x_min)
 
             if len(bbox) == LENGTH_RAW_BBOX and "bbox_id" in metadata:
@@ -180,7 +180,7 @@ class OverlayElements(DualTransform):
                 bbox = (x_min, y_min, x_max, y_max, *bbox[4:])
         else:
             if image_height < overlay_height or image_width < overlay_width:
-                overlay_image = resize(overlay_image, dsize=(image_width, image_height), interpolation=cv2.INTER_AREA)
+                overlay_image = fgeometric.resize(overlay_image, (image_height, image_width), cv2.INTER_AREA)
                 overlay_height, overlay_width = overlay_image.shape[:2]
 
             mask = metadata["mask"] if "mask" in metadata else np.ones_like(overlay_image, dtype=np.uint8)

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -38,7 +38,6 @@ from albucore import (
     preserve_channel_dim,
     reshape_ndhwc_channel,
     reshape_xhwc_channel,
-    resize,
     restore_ndhwc_channel,
     restore_xhwc_channel,
     sz_lut,
@@ -1720,12 +1719,8 @@ def downscale(
     """
     height, width = img.shape[:2]
 
-    downscaled = resize(
-        img,
-        dsize=(int(width * scale), int(height * scale)),
-        interpolation=down_interpolation,
-    )
-    return resize(downscaled, dsize=(width, height), interpolation=up_interpolation)
+    downscaled = fgeometric.resize(img, (int(height * scale), int(width * scale)), down_interpolation)
+    return fgeometric.resize(downscaled, (height, width), up_interpolation)
 
 
 def noop(input_obj: Any, **params: Any) -> Any:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=4.13.0.92
-    - albucore==0.0.39
+    - albucore==0.0.41
 
 suggests:
   - pytorch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "albucore==0.0.39",
+  "albucore==0.0.41",
   "numpy>=1.24.4",
   "pydantic>=2.12.4",
   "pyyaml",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
-albu-spec>=0.0.2
+albu-spec>=0.0.4
 deepdiff>=8.0.1
 eval-type-backport
 google-docstring-parser>=0.0.9
 hypothesis>=6.0.0
-opencv-python-headless>=4.9.0.80
+opencv-python-headless>=4.13.0.92
 pre_commit>=4.5.1
 pytest>=9.0.2
 pytest-randomly>=3.15.0
@@ -15,7 +15,7 @@ requests>=2.31.0
 scikit-image
 scikit-learn
 tomli>=2.0.1
-torch>=2.3.1
-torchvision>=0.18.1
+torch>=2.10.0
+torchvision>=0.25.0
 types-PyYAML
 types-setuptools

--- a/tests/functional/test_geometric.py
+++ b/tests/functional/test_geometric.py
@@ -3,6 +3,7 @@ import os
 import cv2
 import numpy as np
 import pytest
+from albucore import resize as albucore_resize
 
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.geometric.functional import (
@@ -698,10 +699,10 @@ def test_memory_efficiency(random_generator):
         ((150, 100), (150, 200)),
     ],
 )
-def test_resize_cv2(input_shape, target_shape):
+def test_albucore_resize(input_shape, target_shape):
     img = np.random.randint(0, 255, (*input_shape, 3), dtype=np.uint8)
 
-    resized = fgeometric.resize_cv2(img, target_shape, interpolation=0)
+    resized = albucore_resize(img, (target_shape[1], target_shape[0]), interpolation=0)
 
     assert resized.shape == (*target_shape, 3)
 
@@ -715,11 +716,11 @@ def test_resize_cv2(input_shape, target_shape):
         ((150, 100), (150, 200)),
     ],
 )
-def test_resize_cv2_2d_mask(input_shape, target_shape):
-    """Test that resize_cv2 handles 2D arrays (masks) correctly."""
+def test_albucore_resize_2d_mask(input_shape, target_shape):
+    """Test that albucore.resize handles 2D arrays (masks) correctly."""
     mask = np.random.randint(0, 2, input_shape, dtype=np.uint8)
 
-    resized = fgeometric.resize_cv2(mask, target_shape, interpolation=cv2.INTER_NEAREST)
+    resized = albucore_resize(mask, (target_shape[1], target_shape[0]), interpolation=cv2.INTER_NEAREST)
 
     assert resized.shape == target_shape
     assert resized.ndim == 2
@@ -754,9 +755,9 @@ def test_resize_pyvips(input_shape, target_shape):
 def test_resize_cv2_vs_pyvips(input_shape, target_shape, interpolation):
     img = np.random.randint(0, 255, (*input_shape, 3), dtype=np.uint8)
 
-    resized_cv2 = fgeometric.resize_cv2(img, target_shape, interpolation=interpolation)
+    resized_opencv = albucore_resize(img, (target_shape[1], target_shape[0]), interpolation=interpolation)
     resized_pyvips = fgeometric.resize_pyvips(img, target_shape, interpolation=interpolation)
-    np.testing.assert_allclose(resized_cv2, resized_pyvips, atol=1)
+    np.testing.assert_allclose(resized_opencv, resized_pyvips, atol=1)
 
 
 @pytest.mark.xfail(reason="Pillow and OpenCV have different interpolation implementations")
@@ -772,9 +773,9 @@ def test_resize_cv2_vs_pyvips(input_shape, target_shape, interpolation):
 def test_resize_cv2_vs_pillow(input_shape, target_shape, interpolation):
     img = np.random.randint(0, 255, (*input_shape, 3), dtype=np.uint8)
 
-    resized_cv2 = fgeometric.resize_cv2(img, target_shape, interpolation=interpolation)
+    resized_opencv = albucore_resize(img, (target_shape[1], target_shape[0]), interpolation=interpolation)
     resized_pil = fgeometric.resize_pil(img, target_shape, interpolation=interpolation)
-    np.testing.assert_allclose(resized_cv2, resized_pil, atol=1)
+    np.testing.assert_allclose(resized_opencv, resized_pil, atol=1)
 
 
 @pytest.mark.skipif(not _PIL_AVAILABLE, reason="pillow is not installed")

--- a/tests/test_domain_adaptation.py
+++ b/tests/test_domain_adaptation.py
@@ -3,10 +3,12 @@ import pytest
 from skimage.exposure import match_histograms as skimage_match_histograms
 from skimage.metrics import structural_similarity as ssim
 
+import albumentations as A
 from albumentations.augmentations.mixing.domain_adaptation_functional import (
     PCA,
     MinMaxScaler,
     StandardScaler,
+    adapt_pixel_distribution,
     apply_histogram,
 )
 from albumentations.augmentations.mixing.domain_adaptation_functional import match_histograms as our_match_histograms
@@ -439,3 +441,74 @@ def test_match_histograms_different_shapes():
     reference = generate_random_image((50, 50, 3), np.uint8)
     result = our_match_histograms(source, reference)
     assert result.shape == source.shape
+
+
+# ── 5-channel tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("num_channels", [5, 6])
+def test_apply_histogram_5plus_channels(num_channels):
+    rng = np.random.default_rng(137)
+    img = rng.integers(0, 256, (100, 100, num_channels), dtype=np.uint8)
+    ref = rng.integers(0, 256, (80, 80, num_channels), dtype=np.uint8)
+    result = apply_histogram(img, ref, blend_ratio=0.5)
+    assert result.shape == img.shape
+    assert result.dtype == img.dtype
+
+
+@pytest.mark.parametrize("num_channels", [5, 6])
+@pytest.mark.parametrize("transform_type", ["pca", "standard", "minmax"])
+def test_adapt_pixel_distribution_5plus_channels(num_channels, transform_type):
+    rng = np.random.default_rng(137)
+    img = rng.integers(0, 256, (100, 100, num_channels), dtype=np.uint8)
+    ref = rng.integers(0, 256, (80, 80, num_channels), dtype=np.uint8)
+    result = adapt_pixel_distribution(img, ref, transform_type=transform_type, weight=0.5)
+    assert result.shape == img.shape
+    assert result.dtype == img.dtype
+
+
+@pytest.mark.parametrize("num_channels", [5, 6])
+def test_histogram_matching_transform_5plus_channels(num_channels):
+    rng = np.random.default_rng(137)
+    image = rng.integers(0, 256, (100, 100, num_channels), dtype=np.uint8)
+    reference = rng.integers(0, 256, (100, 100, num_channels), dtype=np.uint8)
+    transform = A.HistogramMatching(
+        blend_ratio=(0.5, 0.5),
+        metadata_key="hm_metadata",
+        p=1.0,
+    )
+    result = transform(image=image, hm_metadata=[reference])["image"]
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype
+
+
+@pytest.mark.parametrize("num_channels", [5, 6])
+def test_fda_transform_5plus_channels(num_channels):
+    rng = np.random.default_rng(137)
+    image = rng.integers(0, 256, (100, 100, num_channels), dtype=np.uint8)
+    reference = rng.integers(0, 256, (120, 120, num_channels), dtype=np.uint8)
+    transform = A.FDA(
+        beta_limit=(0.05, 0.05),
+        metadata_key="fda_metadata",
+        p=1.0,
+    )
+    result = transform(image=image, fda_metadata=[reference])["image"]
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype
+
+
+@pytest.mark.parametrize("num_channels", [5, 6])
+@pytest.mark.parametrize("transform_type", ["pca", "standard", "minmax"])
+def test_pixel_distribution_adaptation_transform_5plus_channels(num_channels, transform_type):
+    rng = np.random.default_rng(137)
+    image = rng.integers(0, 256, (100, 100, num_channels), dtype=np.uint8)
+    reference = rng.integers(0, 256, (80, 80, num_channels), dtype=np.uint8)
+    transform = A.PixelDistributionAdaptation(
+        transform_type=transform_type,
+        blend_ratio=(0.5, 0.5),
+        metadata_key="pda_metadata",
+        p=1.0,
+    )
+    result = transform(image=image, pda_metadata=[reference])["image"]
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype

--- a/tests/test_resize_area_downscale.py
+++ b/tests/test_resize_area_downscale.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 import albumentations as A
+import albumentations.augmentations.geometric.functional as fgeometric
 
 
 def get_downscale_image():
@@ -179,3 +180,42 @@ class TestAreaForDownscaleOutput:
             result2["image"],
             err_msg="Upscale outputs differ with/without area_for_downscale",
         )
+
+
+# ── cv2.resize channel-count behaviour (documents OpenCV 4.13 limitation) ────
+
+WORKING_INTERPOLATIONS = [
+    cv2.INTER_LINEAR,
+    cv2.INTER_NEAREST,
+    cv2.INTER_CUBIC,
+    cv2.INTER_LANCZOS4,
+]
+
+
+@pytest.mark.parametrize("num_channels", [5, 6])
+@pytest.mark.parametrize("interpolation", WORKING_INTERPOLATIONS)
+def test_cv2_resize_works_for_5plus_channels(num_channels, interpolation):
+    """cv2.resize succeeds for 5+ channels with all interpolations except INTER_AREA."""
+    img = np.zeros((100, 100, num_channels), dtype=np.uint8)
+    result = cv2.resize(img, (50, 50), interpolation=interpolation)
+    assert result.shape == (50, 50, num_channels)
+
+
+@pytest.mark.parametrize("num_channels", [5, 6])
+def test_cv2_resize_inter_area_fails_for_5plus_channels_non_integer_scale(num_channels):
+    """cv2.resize raises for INTER_AREA + 5+ channels when the scale is non-integer (OpenCV 4.13 limitation).
+
+    Integer scale factors (e.g. 100->50, exact 2x) happen to work, but non-integer
+    scale factors (e.g. 100->37) hit the cn<=4 assertion in the INTER_AREA path.
+    """
+    img = np.zeros((100, 100, num_channels), dtype=np.uint8)
+    with pytest.raises(cv2.error):
+        cv2.resize(img, (37, 37), interpolation=cv2.INTER_AREA)
+
+
+@pytest.mark.parametrize("num_channels", [5, 6])
+def test_fgeometric_resize_handles_inter_area_for_5plus_channels(num_channels):
+    """fgeometric.resize (via albucore.resize) handles INTER_AREA for 5+ channels via chunking."""
+    img = np.zeros((100, 100, num_channels), dtype=np.uint8)
+    result = fgeometric.resize(img, (37, 37), interpolation=cv2.INTER_AREA)
+    assert result.shape == (37, 37, num_channels)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -276,8 +276,7 @@ def test_resize_with_additional_targets_mask():
     """Test that Resize works correctly with additional_targets for 2D masks.
 
     Regression test for issue where 2D masks passed via additional_targets
-    would fail with IndexError in resize_cv2 due to maybe_process_in_chunks
-    expecting 3D arrays.
+    would fail with IndexError due to chunking expecting 3D arrays.
     """
     image = np.zeros((256, 256, 3), dtype=np.uint8)
     mask = np.ones((256, 256), dtype=np.uint8)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -143,7 +143,6 @@ def get_filtered_transforms(
     except_augmentations=None,
     exclude_base_classes=None,
 ):
-
     custom_arguments = custom_arguments or {}
     except_augmentations = except_augmentations or set()
     exclude_base_classes = exclude_base_classes or ()

--- a/tools/check_cv2_geometric_forbidden.py
+++ b/tools/check_cv2_geometric_forbidden.py
@@ -1,11 +1,16 @@
-"""Pre-commit hook: forbid cv2.warpAffine, warpPerspective, copyMakeBorder, remap, resize in albumentations.
+"""Pre-commit hook: forbid raw cv2 geometric ops in albumentations/.
 
-These must use albucore equivalents (warp_affine, warp_perspective, copy_make_border, remap, resize)
-for multi-channel support and consistent behavior.
+Use albucore equivalents for multi-channel support:
+  cv2.resize        → albucore.resize
+  cv2.warpAffine    → albucore.warp_affine
+  cv2.warpPerspective → albucore.warp_perspective
+  cv2.copyMakeBorder → albucore.copy_make_border
+  cv2.remap         → albucore.remap
 
 Allowlist:
-- cv2.remap in functional.py: 2D data (mask/single channel); albucore.remap expects (H,W,C).
-- cv2.resize in geometric/functional.py: 2D map upscaling; albucore.resize differs for 2D float.
+- cv2.remap in geometric/functional.py and pixel/functional.py: 2D data only.
+- cv2.resize in geometric/functional.py: upscale_distortion_maps uses 2D float32 maps,
+  not images, so albucore.resize does not apply there.
 """
 
 from __future__ import annotations
@@ -16,11 +21,11 @@ from pathlib import Path
 
 # Forbidden in albumentations/ (use albucore instead). Keys for allowlist.
 FORBIDDEN: list[tuple[str, str]] = [
+    (r"cv2\.resize\s*\(", "resize"),
     (r"cv2\.warpAffine\s*\(", "warpAffine"),
     (r"cv2\.warpPerspective\s*\(", "warpPerspective"),
     (r"cv2\.copyMakeBorder\s*\(", "copyMakeBorder"),
     (r"cv2\.remap\s*\(", "remap"),
-    (r"cv2\.resize\s*\(", "resize"),
 ]
 
 # (path, forbidden_key) — allow forbidden_key in path. Key is the cv2 method name.
@@ -28,7 +33,7 @@ ALLOWLIST: list[tuple[str, str]] = [
     # 2D remap: remap_keypoints_via_mask (int16 mask), _distort_channel (single channel)
     ("albumentations/augmentations/geometric/functional.py", "remap"),
     ("albumentations/augmentations/pixel/functional.py", "remap"),
-    # 2D float distortion maps: albucore.resize semantics differ from cv2 for 2D
+    # upscale_distortion_maps: resizes 2D float32 coordinate maps, not images
     ("albumentations/augmentations/geometric/functional.py", "resize"),
 ]
 
@@ -78,7 +83,7 @@ def main() -> int:
         errors.extend(_scan_file(path, root))
 
     if errors:
-        print("Forbidden cv2 usage (use albucore: warp_affine, warp_perspective, copy_make_border, remap, resize):")
+        print("Forbidden cv2 usage (use albucore: resize, warp_affine, warp_perspective, copy_make_border, remap):")
         for rel, line_no, content in errors:
             print(f"  {rel}:{line_no}: {content[:80]}{'...' if len(content) > 80 else ''}")
         return 1


### PR DESCRIPTION
- Use albucore.resize in resize_cv2, mixing (OverlayElements, domain adaptation), and pixel downscale; remove maybe_process_in_chunks for resize.
- Keep cv2.resize only for 2D distortion map upscaling in upscale_distortion_maps (albucore semantics differ for 2D float).
- Add cv2.resize to pre-commit forbidden list and allowlist geometric/functional.py for the 2D map case.
- Update review-transform skill to mention albucore.resize.

Made-with: Cursor

## Summary by Sourcery

Replace remaining geometric and mixing image resizing logic to use albucore.resize instead of cv2.resize, with a narrow exception for 2D distortion maps, and enforce this policy via tooling and documentation updates.

Enhancements:
- Standardize image resizing in geometric, pixel, mixing, and domain adaptation functions on albucore.resize for consistency and performance.
- Preserve cv2.resize usage only for 2D float distortion map upscaling where albucore semantics differ.

Build:
- Extend the cv2 forbidden-check script to flag cv2.resize usage while allowlisting the specific geometric distortion map case and updating the violation message.

Documentation:
- Update internal review guidelines to recommend albucore.resize instead of cv2.resize for resize operations.