### PR TITLE
chore(release): bump version to 2.0.19

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,7 +114,7 @@ repos:
         language: system
         files: ^(pyproject\.toml|conda\.recipe/meta\.yaml|tools/check_conda_dependencies\.py)$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.4
     hooks:
       - id: ruff
         exclude: '__pycache__/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [ "setuptools>=45", "wheel" ]
 [project]
 name = "albumentationsx"
 
-version = "2.0.18"
+version = "2.0.19"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volumes, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows."
 readme = "README.md"


### PR DESCRIPTION
- Update pyproject.toml version
- Bump ruff pre-commit from v0.15.2 to v0.15.4

Made-with: Cursor

## Summary by Sourcery

Bump the package version to 2.0.19 and update the Ruff pre-commit hook to the latest patch release.

Build:
- Update pyproject.toml project version from 2.0.18 to 2.0.19.

CI:
- Upgrade Ruff pre-commit hook from v0.15.2 to v0.15.4 in the pre-commit configuration.