### PR TITLE
Feat/apply to images batch optimizations

### DIFF
--- a/.cursor/skills/add-transform/SKILL.md
+++ b/.cursor/skills/add-transform/SKILL.md
@@ -109,46 +109,33 @@ class MyTransform(DualTransform):  # or ImageOnlyTransform / NoOp
 
 ## 4. Add batch optimization (`apply_to_images`)
 
-If the transform's `apply()` processes each channel identically (convolutions, geometric warps, element-wise ops):
+Override `apply_to_images` only if you can beat the default per-image loop. Priority patterns:
 
-```python
-class MyTransform(ImageOnlyTransform):
-    _supports_grayscale_batch_as_multichannel = True
-    # Base class automatically handles grayscale batches (N,H,W,1) → (H,W,N) → apply → reshape back
-```
-
-If the transform pre-computes expensive resources (kernels, LUTs, gradient maps), override `apply_to_images`:
-
+**Pre-compute expensive setup once per batch** (kernels, LUTs, gradient maps):
 ```python
 def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
-    kernel = create_kernel(params["size"])  # compute once
-    apply_fn = lambda img: convolve(img, kernel)
-
-    if images.shape[-1] == 1:
-        num_images, height, width, _ = images.shape
-        multi_ch = images.reshape(num_images, height, width).transpose(1, 2, 0)
-        result = convolve(multi_ch, kernel)
-        return result.transpose(2, 0, 1)[..., np.newaxis]
-
-    return self._apply_to_batch(images, apply_fn)
+    kernel = create_kernel(params["size"])  # once, not N times
+    return self._apply_to_batch(images, lambda img: convolve(img, kernel))
 ```
 
-For `DualTransform`s with channel-independent geometric ops, also override `apply_to_masks`:
-
+**Direct 4D indexing** for simple array ops:
 ```python
-def apply_to_masks(self, masks: ImageType, *args: Any, **params: Any) -> ImageType:
-    if masks.size == 0:
-        return masks
-    if masks.ndim == 3:
-        result = self.apply_to_mask(masks.transpose(1, 2, 0), **params)
-        return result.transpose(2, 0, 1)
-    return self._apply_to_batch(masks, lambda m: self.apply_to_mask(m, **params))
+def apply_to_images(self, images: ImageType, channels_to_drop: list[int], **params: Any) -> ImageType:
+    result = images.copy()
+    result[:, :, :, channels_to_drop] = self.fill
+    return result
 ```
 
-Key rules:
-- Images are always `(N, H, W, C)` — never check `ndim == 4`
-- `np.ascontiguousarray` is NOT needed — functional layer handles contiguity
-- Check `images.shape[-1] == 1` for the grayscale fast path
+**Pre-allocated loop** as fallback when params vary per image:
+```python
+def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
+    result = np.empty_like(images)
+    for i, image in enumerate(images):
+        result[i] = self.apply(image, **params)
+    return result
+```
+
+> **DO NOT** reshape `(N,H,W,1)` to `(H,W,N)` to call cv2 once — this is 2–4× slower in practice (transpose → non-contiguous copy + cv2 sequential channel processing).
 
 ## 5. Export the transform
 
@@ -195,9 +182,7 @@ Check edge cases: uint8, float32, single channel, multichannel.
 - [ ] All random ops in `get_params` / `get_params_dependent_on_data`
 - [ ] Using `self.py_random` or `self.random_generator` (not `np.random` / `random`)
 - [ ] `ImageType` for image type hints
-- [ ] `_supports_grayscale_batch_as_multichannel = True` if transform is channel-independent
 - [ ] Custom `apply_to_images` if expensive setup can be shared across batch
-- [ ] `apply_to_masks` override for DualTransform with channel-independent geometric ops
 - [ ] Docstring has `Args`, `Targets`, `Image types`, `Examples` sections
 - [ ] Examples section uses plural "Examples" (not "Example")
 - [ ] Exported in `albumentations/__init__.py`

--- a/.cursor/skills/benchmark/SKILL.md
+++ b/.cursor/skills/benchmark/SKILL.md
@@ -91,7 +91,7 @@ Compose single:
 
 ## Template: Batch (apply_to_images)
 
-When benchmarking batch optimizations (grayscale reshape trick, kernel pre-computation):
+When benchmarking batch optimizations (kernel pre-computation, 4D indexing, pre-allocated loops):
 
 ```python
 import timeit
@@ -123,4 +123,4 @@ for batch_size in BATCH_SIZES:
 - Test **both uint8 and float32** if the change affects dtype handling
 - A **>5% regression** on any combination requires justification or rework
 - If adding a new transform, benchmark against the equivalent naive numpy implementation
-- For batch optimizations, compare grayscale (1-channel) vs RGB (3-channel) to verify the reshape trick gives speedup
+- For batch optimizations, compare 1-channel vs 3-channel to verify speedup holds across channel counts

--- a/.cursor/skills/review-transform/SKILL.md
+++ b/.cursor/skills/review-transform/SKILL.md
@@ -60,11 +60,9 @@ Priority order to check:
 
 ### Batch Optimization Checks
 
-- [ ] **`_supports_grayscale_batch_as_multichannel = True`** set if transform processes channels identically (convolutions, geometric warps, element-wise ops)
 - [ ] **Custom `apply_to_images`** if expensive setup (kernels, LUTs, gradient maps) can be computed once per batch
-- [ ] **`apply_to_masks` override** for DualTransform with channel-independent geometric ops (Affine, Rotate, Resize)
 - [ ] **No redundant `ndim == 4` checks** on images — they're always 4D in batch context
-- [ ] **No unnecessary `np.ascontiguousarray`** — functional layer handles contiguity
+- [ ] **No reshape trick**: Do NOT reshape `(N,H,W,1)` to `(H,W,N)` for cv2 — 2–4× slower due to non-contiguous copy + sequential channel processing
 
 Flag any violations with a concrete speedup suggestion.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,44 +88,40 @@ def __init__(self, brightness: float | tuple[float, float] = 0.2):
 6. **Remove dead code** - unused code impacts performance and maintainability
 7. Apply decorators `@uint8_io` or `@float32_io` for type consistency
 
-### Batch Optimization (`apply_to_images` / `apply_to_masks`)
+### Batch Optimization (`apply_to_images`)
 
-Images in batch mode are always `(N, H, W, C)` — never 3D. Masks are `(N, H, W)`.
+Images in batch mode are always `(N, H, W, C)` — never check `ndim == 4`, it's always true.
 
-#### Grayscale Batch Reshape Trick
+#### Patterns (in order of impact)
 
-For channel-independent transforms (filters, geometric warps), grayscale batches `(N, H, W, 1)` can be reshaped to `(H, W, N)` — treating N images as one multi-channel image — processed with a single `apply()` call, then reshaped back. This avoids the Python loop entirely.
-
-- Set `_supports_grayscale_batch_as_multichannel = True` on the transform class
-- The base `apply_to_images` in `BasicTransform` handles this automatically
-- For custom `apply_to_images`, check `images.shape[-1] == 1` (no `ndim == 4` — it's always 4)
-- `np.ascontiguousarray` is NOT needed — the functional layer handles contiguity internally
-- Works with: `cv2.filter2D`, `cv2.GaussianBlur`, `albucore.warp_affine`, `albucore.resize`, `albucore.median_blur`, `albucore.warp_perspective`, and any per-channel operation
+1. **Pre-compute expensive setup once** — kernels, LUTs, gradient maps computed per-batch instead of per-image:
 
 ```python
-class MyBlur(ImageOnlyTransform):
-    _supports_grayscale_batch_as_multichannel = True
-    # Base class handles grayscale batches automatically via _apply_grayscale_batch_as_multichannel
+def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
+    kernel = create_kernel(params["size"])  # computed once for the whole batch
+    return self._apply_to_batch(images, lambda img: convolve(img, kernel))
 ```
 
-For `DualTransform`s, also override `apply_to_masks` with the same trick for `(N, H, W)` → `(H, W, N)`:
+2. **Direct 4D indexing** for simple array operations instead of per-image loops:
 
 ```python
-def apply_to_masks(self, masks: ImageType, *args: Any, **params: Any) -> ImageType:
-    if masks.size == 0:
-        return masks
-    if masks.ndim == 3:
-        multi_ch = masks.transpose(1, 2, 0)
-        result = self.apply_to_mask(multi_ch, **params)
-        return result.transpose(2, 0, 1)
-    return self._apply_to_batch(masks, lambda mask: self.apply_to_mask(mask, **params))
+def apply_to_images(self, images: ImageType, channels_to_drop: list[int], **params: Any) -> ImageType:
+    result = images.copy()
+    result[:, :, :, channels_to_drop] = self.fill  # vectorized over N
+    return result
 ```
 
-#### Other Batch Patterns
+3. **Pre-allocated loop** — `np.empty_like` + enumerate avoids per-call allocation:
 
-- **Pre-compute expensive resources** (kernels, LUTs, gradient maps) once in `apply_to_images`, then apply per-image
-- **Direct 4D indexing** for simple operations: `result[:, :, :, channels] = fill` instead of per-image loops
-- **Pre-allocated loop** (`np.empty_like` + loop) when no better option exists — still faster than the default `_apply_to_batch` which may copy
+```python
+def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
+    result = np.empty_like(images)
+    for i, image in enumerate(images):
+        result[i] = self.apply(image, **params)
+    return result
+```
+
+> **DO NOT** reshape `(N,H,W,1)` to `(H,W,N)` to call cv2 once — benchmarks show this is 2–4× **slower** because: (1) the transpose creates non-contiguous memory requiring a copy, and (2) cv2 processes channels sequentially, so N-channel is not N× faster than 1-channel.
 
 ### Random Number Generation
 
@@ -247,9 +243,9 @@ Examples:
 - Creating unnecessary array copies instead of in-place operations
 - Repeated array allocations in tight loops
 - Dead code and unused imports
-- Missing `_supports_grayscale_batch_as_multichannel = True` on channel-independent transforms
 - Missing custom `apply_to_images` when expensive setup can be shared across a batch
 - Redundant `ndim == 4` checks on images (they're always 4D in batch context)
+- Reshaping `(N,H,W,1)` to `(H,W,N)` for cv2 — transpose creates non-contiguous memory, cv2 doesn't parallelize channels, net result is slower
 
 ### Memory Issues
 

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -148,8 +148,6 @@ class Blur(ImageOnlyTransform):
 
     """
 
-    _supports_grayscale_batch_as_multichannel = True
-
     class InitSchema(BlurInitSchema):
         pass
 
@@ -710,8 +708,6 @@ class GaussianBlur(ImageOnlyTransform):
 
     """
 
-    _supports_grayscale_batch_as_multichannel = True
-
     class InitSchema(BaseTransformInitSchema):
         sigma_limit: Annotated[
             tuple[float, float] | float,
@@ -1148,8 +1144,6 @@ class AdvancedBlur(ImageOnlyTransform):
 
     """
 
-    _supports_grayscale_batch_as_multichannel = True
-
     class InitSchema(BlurInitSchema):
         sigma_x_limit: NonNegativeFloatRangeType
         sigma_y_limit: NonNegativeFloatRangeType
@@ -1376,17 +1370,7 @@ class Defocus(ImageOnlyTransform):
 
     def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
         kernel = fblur.create_defocus_kernel(params["radius"], params["alias_blur"])
-
-        def apply_fn(img: ImageType) -> ImageType:
-            return fpixel.convolve(img, kernel)
-
-        if images.shape[-1] == 1:
-            num_images, height, width, _ = images.shape
-            multi_ch = images.reshape(num_images, height, width).transpose(1, 2, 0)
-            result = fpixel.convolve(multi_ch, kernel)
-            return result.transpose(2, 0, 1)[..., np.newaxis]
-
-        return self._apply_to_batch(images, apply_fn)
+        return self._apply_to_batch(images, lambda img: fpixel.convolve(img, kernel))
 
     def get_params(self) -> dict[str, Any]:
         return {
@@ -1507,9 +1491,6 @@ class ZoomBlur(ImageOnlyTransform):
         return fblur.zoom_blur(img, zoom_factors)
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
-        if images.shape[-1] == 1:
-            return self._apply_grayscale_batch_as_multichannel(images, **params)
-
         result = np.empty_like(images)
         for i, image in enumerate(images):
             result[i] = self.apply(image, **params)

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -756,8 +756,6 @@ class Resize(DualTransform):
 
     """
 
-    _supports_grayscale_batch_as_multichannel = True
-
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
 
@@ -835,15 +833,6 @@ class Resize(DualTransform):
             interpolation = cv2.INTER_AREA
 
         return fgeometric.resize(mask, (self.height, self.width), interpolation=interpolation)
-
-    def apply_to_masks(self, masks: ImageType, *args: Any, **params: Any) -> ImageType:
-        if masks.size == 0:
-            return masks
-        if masks.ndim == 3:
-            multi_ch = masks.transpose(1, 2, 0)
-            result = self.apply_to_mask(multi_ch, **params)
-            return result.transpose(2, 0, 1)
-        return self._apply_to_batch(masks, lambda mask: self.apply_to_mask(mask, **params))
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
         return fgeometric.resize_bboxes(

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -341,7 +341,6 @@ class Rotate(DualTransform):
 
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
-    _supports_grayscale_batch_as_multichannel = True
 
     class InitSchema(RotateInitSchema):
         rotate_method: Literal["largest_box", "ellipse"]
@@ -435,15 +434,6 @@ class Rotate(DualTransform):
         if self.crop_border:
             return fcrops.crop(img_out, x_min, y_min, x_max, y_max)
         return img_out
-
-    def apply_to_masks(self, masks: ImageType, *args: Any, **params: Any) -> ImageType:
-        if masks.size == 0:
-            return masks
-        if masks.ndim == 3:
-            multi_ch = masks.transpose(1, 2, 0)
-            result = self.apply_to_mask(multi_ch, **params)
-            return result.transpose(2, 0, 1)
-        return self._apply_to_batch(masks, lambda mask: self.apply_to_mask(mask, **params))
 
     def apply_to_bboxes(
         self,

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -526,8 +526,6 @@ class Affine(DualTransform):
 
     """
 
-    _supports_grayscale_batch_as_multichannel = True
-
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
 
@@ -727,15 +725,6 @@ class Affine(DualTransform):
             border_value=self.fill_mask,
             dsize=(width, height),
         )
-
-    def apply_to_masks(self, masks: ImageType, *args: Any, **params: Any) -> ImageType:
-        if masks.size == 0:
-            return masks
-        if masks.ndim == 3:
-            multi_ch = masks.transpose(1, 2, 0)
-            result = self.apply_to_mask(multi_ch, **params)
-            return result.transpose(2, 0, 1)
-        return self._apply_to_batch(masks, lambda mask: self.apply_to_mask(mask, **params))
 
     def apply_to_bboxes(
         self,

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -3127,8 +3127,6 @@ class Downscale(ImageOnlyTransform):
 
     """
 
-    _supports_grayscale_batch_as_multichannel = True
-
     class InitSchema(BaseTransformInitSchema):
         interpolation_pair: dict[
             Literal["downscale", "upscale"],
@@ -3726,9 +3724,6 @@ class Sharpen(ImageOnlyTransform):
         return fpixel.sharpen_gaussian(img, alpha, self.kernel_size, self.sigma)
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
-        if images.shape[-1] == 1:
-            return self._apply_grayscale_batch_as_multichannel(images, **params)
-
         result = np.empty_like(images)
         for i, image in enumerate(images):
             result[i] = self.apply(image, **params)
@@ -3786,8 +3781,6 @@ class Emboss(ImageOnlyTransform):
         - Application of Emboss Filtering in Image Processing: https://www.researchgate.net/publication/303412455_Application_of_Emboss_Filtering_in_Image_Processing
 
     """
-
-    _supports_grayscale_batch_as_multichannel = True
 
     class InitSchema(BaseTransformInitSchema):
         alpha: Annotated[tuple[float, float], AfterValidator(check_range_bounds(0, 1))]
@@ -4069,8 +4062,6 @@ class RingingOvershoot(ImageOnlyTransform):
         - Digital Image Processing: Rafael C. Gonzalez and Richard E. Woods, 4th Edition
 
     """
-
-    _supports_grayscale_batch_as_multichannel = True
 
     class InitSchema(BlurInitSchema):
         blur_limit: tuple[int, int] | int

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -83,8 +83,6 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
     interpolation: int
     fill: tuple[float, ...] | float
     fill_mask: tuple[float, ...] | float | None
-    _supports_grayscale_batch_as_multichannel: bool = False
-
     # replay mode params
     deterministic: bool = False
     save_key = "replay"
@@ -401,17 +399,6 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
         return np.require(result, requirements=["C_CONTIGUOUS"]) if ensure_contiguous else result
 
-    def _apply_grayscale_batch_as_multichannel(self, images: ImageType, **params: Any) -> ImageType:
-        """Reshape (N, H, W, 1) grayscale batch to (H, W, N), apply once, reshape back.
-
-        Uses zero-copy views for both reshapes. The apply function handles
-        contiguity internally when needed (e.g. cv2.filter2D copies the input).
-        """
-        num_images, height, width, _ = images.shape
-        multi_ch = images.reshape(num_images, height, width).transpose(1, 2, 0)
-        result = self.apply(multi_ch, **params)
-        return result.transpose(2, 0, 1)[..., np.newaxis]
-
     def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
         """Apply transform on images.
 
@@ -426,9 +413,6 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             ImageType: Transformed images as numpy array in the same format as input
 
         """
-        if self._supports_grayscale_batch_as_multichannel and images.shape[-1] == 1:
-            return self._apply_grayscale_batch_as_multichannel(images, **params)
-
         return self._apply_to_batch(images, lambda img: self.apply(img, **params))
 
     def apply_to_volume(self, volume: VolumeType, *args: Any, **params: Any) -> VolumeType:

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -421,43 +421,36 @@ class UniformParams(NoiseParamsBase):
 
 This rule is enforced by a pre-commit hook that will flag any violations during development.
 
-### Batch Performance (`apply_to_images` / `apply_to_masks`)
+### Batch Performance (`apply_to_images`)
 
-Images in batch mode are always `(N, H, W, C)`. Masks are `(N, H, W)`. Never check `ndim == 4` — it's always true.
+Images in batch mode are always `(N, H, W, C)`. Never check `ndim == 4` — it's always true.
 
-#### Grayscale Batch Reshape Trick
+Override `apply_to_images` when you can do better than the default per-image loop:
 
-For transforms where each channel is processed identically (convolutions, geometric warps), grayscale batches `(N, H, W, 1)` can be reshaped to `(H, W, N)`, processed with a single `apply()` call, then reshaped back:
-
-```python
-class MyFilter(ImageOnlyTransform):
-    _supports_grayscale_batch_as_multichannel = True
-    # BasicTransform.apply_to_images handles this automatically
-```
-
-The base class checks `_supports_grayscale_batch_as_multichannel and images.shape[-1] == 1` and calls `_apply_grayscale_batch_as_multichannel`.
-
-Compatible operations: `cv2.filter2D`, `cv2.GaussianBlur`, `albucore.warp_affine`, `albucore.resize`, `albucore.median_blur`, `albucore.warp_perspective`.
-
-`np.ascontiguousarray` is NOT needed — functional layer handles contiguity internally.
-
-For `DualTransform`s, also override `apply_to_masks`:
+1. **Pre-compute expensive setup once** (kernels, LUTs, gradient maps):
 
 ```python
-def apply_to_masks(self, masks, *args, **params):
-    if masks.size == 0:
-        return masks
-    if masks.ndim == 3:
-        result = self.apply_to_mask(masks.transpose(1, 2, 0), **params)
-        return result.transpose(2, 0, 1)
-    return self._apply_to_batch(masks, lambda m: self.apply_to_mask(m, **params))
+def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
+    kernel = create_kernel(params["size"])  # once per batch
+    return self._apply_to_batch(images, lambda img: convolve(img, kernel))
 ```
 
-#### Other Batch Patterns
+2. **Direct 4D indexing** for simple array ops:
 
-- **Pre-compute expensive resources** (kernels, LUTs, gradient maps) once in `apply_to_images`, apply per-image
-- **Direct 4D indexing**: `result[:, :, :, channels] = fill` instead of looping
-- **Pre-allocated loop**: `np.empty_like` + enumerate loop as a fallback
+```python
+result = images.copy()
+result[:, :, :, channels] = fill  # vectorized across N
+```
+
+3. **Pre-allocated loop** to avoid repeated allocations:
+
+```python
+result = np.empty_like(images)
+for i, image in enumerate(images):
+    result[i] = self.apply(image, **params)
+```
+
+> **Anti-pattern**: Do NOT reshape `(N,H,W,1)` to `(H,W,N)` to call a cv2 function once — transpose yields non-contiguous memory (requiring a full copy), and cv2 processes channels sequentially so an N-channel call is not faster than N single-channel calls. Benchmarks show 2–4× regression.
 
 ### Coordinate Systems
 


### PR DESCRIPTION
Optimization | 256² | 512² | 1024²
-- | -- | -- | --
Defocus kernel precompute | 1.02x | 1.00x | 1.00x
ChannelDropout 4D indexing | 1.28x | ~1.0x | ~1.0x
Pre-alloc loop | 1.02x | 1.02x | 1.02x
Illumination gradient precompute | 1.26x | 1.30x | 1.34x

## Summary by Sourcery

Optimize batch image transforms by introducing shared precomputation and clarifying batch best practices.

New Features:
- Add creation helpers for illumination and defocus kernels/gradients to reuse across batch operations.
- Implement custom apply_to_images overrides for several transforms to support batch-optimized execution.

Enhancements:
- Refine default batch application to avoid unnecessary contiguity enforcement during per-image loops.
- Document patterns and anti-patterns for efficient apply_to_images implementations across contributor guides, skills, and benchmarking templates.
- Factor defocus kernel construction into a reusable function for use in both single-image and batched paths.

Documentation:
- Expand contributor and internal skills documentation with concrete guidelines and examples for batch-optimized transforms and benchmarking.