### PR TITLE
feat(geometric): add apply_to_images and apply_to_masks to Affine

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -709,6 +709,26 @@ class Affine(DualTransform):
             dsize=(width, height),
         )
 
+    def apply_to_images(
+        self,
+        images: ImageType,
+        matrix: np.ndarray,
+        output_shape: tuple[int, int],
+        **params: Any,
+    ) -> ImageType:
+        height, width = output_shape
+        result = np.empty((len(images), height, width, images.shape[3]), dtype=images.dtype)
+        for i, image in enumerate(images):
+            result[i] = warp_affine(
+                image,
+                matrix,
+                flags=self.interpolation,
+                border_mode=self.border_mode,
+                border_value=self.fill,
+                dsize=(width, height),
+            )
+        return result
+
     def apply_to_mask(
         self,
         mask: ImageType,
@@ -725,6 +745,26 @@ class Affine(DualTransform):
             border_value=self.fill_mask,
             dsize=(width, height),
         )
+
+    def apply_to_masks(
+        self,
+        masks: ImageType,
+        matrix: np.ndarray,
+        output_shape: tuple[int, int],
+        **params: Any,
+    ) -> ImageType:
+        height, width = output_shape
+        result = np.empty((len(masks), height, width, masks.shape[3]), dtype=masks.dtype)
+        for i, mask in enumerate(masks):
+            result[i] = warp_affine(
+                mask,
+                matrix,
+                flags=self.mask_interpolation,
+                border_mode=self.border_mode,
+                border_value=self.fill_mask,
+                dsize=(width, height),
+            )
+        return result
 
     def apply_to_bboxes(
         self,


### PR DESCRIPTION
Closes #15

## Summary

- Add `apply_to_images` to `Affine` for optimized batch image processing
- Add `apply_to_masks` to `Affine` for optimized batch mask processing

## Motivation

The base class `_apply_to_batch` fallback processes the **first image to infer output shape** before pre-allocating the result array. `Affine` already computes `output_shape` once in `get_params_dependent_on_data` (including the `fit_output=True` case), so that shape-detection step is redundant. Custom implementations skip it and allocate directly:

```python
result = np.empty((len(images), height, width, images.shape[3]), dtype=images.dtype)

## Summary by Sourcery

Add optimized batch affine transformation methods for images and masks that reuse precomputed output shapes.

New Features:
- Introduce apply_to_images on Affine to perform batched affine warping of images using a known output shape.
- Introduce apply_to_masks on Affine to perform batched affine warping of masks using a known output shape.