### PR TITLE
Feat/instance binding

### DIFF
--- a/.cursor/skills/validate-and-fix/SKILL.md
+++ b/.cursor/skills/validate-and-fix/SKILL.md
@@ -22,3 +22,8 @@ description: After completing code changes, runs tests and pre-commit, then iter
 - **Never** suppress with `# noqa: E501` or add `E501` to `pyproject.toml` ignore list.
 - **Fix**: Split the line at a word or operator boundary. For docstrings, wrap to the next line — the
   Google format allows multi-line short descriptions. For code, break at `(`, `,`, or `+`.
+
+### C901 / PLR0912 Function too complex / too many branches
+- **Never** suppress with `# noqa: C901`, `# noqa: PLR0912`, or raise the limits in `pyproject.toml`.
+- **Fix**: Extract private helper methods that each own a single concern. If a function exceeds the
+  limit it is doing too many things and must be split.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ on:
       - '**.md'
       - 'benchmark/**'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   test_and_lint:
     name: Test and lint
@@ -27,7 +24,7 @@ jobs:
       fail-fast: true
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install uv and set Python version ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7
       with:
@@ -75,7 +72,7 @@ jobs:
         python-version: ["3.10"]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install uv and set Python version ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build_release_artifacts:
     runs-on: ubuntu-latest
@@ -14,7 +11,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -110,7 +107,7 @@ jobs:
         )
 
     - name: Upload distribution artifacts for PyPI
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pypi-distributions
         path: |
@@ -119,7 +116,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload release artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: release-artifacts
         path: |
@@ -149,7 +146,7 @@ jobs:
       contents: read
     steps:
     - name: Download distribution artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: pypi-distributions
         path: dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,12 @@ AlbumentationsX is a high-performance computer vision augmentation library. We p
 - **Never** add `E501` to `pyproject.toml` ignores or use `# noqa: E501`.
 - Long lines must be split at a word/operator boundary. Docstrings can wrap — Google format allows multi-line short descriptions.
 
+### Code Complexity
+
+- Ruff enforces McCabe complexity (`C901`, limit 10) and branch count (`PLR0912`, limit 12).
+- **Never** suppress with `# noqa: C901`, `# noqa: PLR0912`, or raise the limits in `pyproject.toml`.
+- **Fix**: Extract private helper methods — a function over the limit is doing too many things.
+
 ### Code Patterns
 
 ```python

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -276,9 +276,8 @@ class BboxParams(Params):
         )
 
     def make_empty_bboxes_array(self) -> np.ndarray:
-        """Return (0,C) float32 empty bboxes: four cols HBB, five OBB internally; use when bbox list
-        is empty so preprocess ndarray column count stays valid.
-
+        """Build an empty (0, C) float32 bboxes ndarray for an empty instance list; C is HBB width or
+        minimum OBB columns for preprocess.
         """
         cols = NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS if self.bbox_type == "hbb" else BBOX_OBB_MIN_COLUMNS
         return np.array([], dtype=np.float32).reshape(0, cols)

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -275,6 +275,14 @@ class BboxParams(Params):
             f" clip_after_transform={self.clip_after_transform})"
         )
 
+    def make_empty_bboxes_array(self) -> np.ndarray:
+        """Return (0,C) float32 empty bboxes: C is four for HBB or five for OBB internally; use when
+        the bbox list is empty so preprocess receives a valid column count.
+
+        """
+        cols = NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS if self.bbox_type == "hbb" else BBOX_OBB_MIN_COLUMNS
+        return np.array([], dtype=np.float32).reshape(0, cols)
+
 
 class BboxProcessor(DataProcessor):
     """DataProcessor for bboxes: conversion, validation, clipping, filtering. Uses
@@ -322,6 +330,8 @@ class BboxProcessor(DataProcessor):
 
     """
 
+    params: BboxParams
+
     def __init__(self, params: BboxParams, additional_targets: dict[str, str] | None = None):
         super().__init__(params, additional_targets)
 
@@ -340,8 +350,7 @@ class BboxProcessor(DataProcessor):
         """Create an empty bbox array (0 rows, 4 or 5 cols for hbb/obb). Call when the user
         passes an empty list for bboxes so the pipeline has a valid array shape.
         """
-        cols = NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS if self.params.bbox_type == "hbb" else BBOX_OBB_MIN_COLUMNS
-        return np.array([], dtype=np.float32).reshape(0, cols)
+        return self.params.make_empty_bboxes_array()
 
     def ensure_data_valid(self, data: dict[str, Any]) -> None:
         """Validate that data contains all params.label_fields; raises ValueError if any are

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -276,8 +276,8 @@ class BboxParams(Params):
         )
 
     def make_empty_bboxes_array(self) -> np.ndarray:
-        """Return (0,C) float32 empty bboxes: C is four for HBB or five for OBB internally; use when
-        the bbox list is empty so preprocess receives a valid column count.
+        """Return (0,C) float32 empty bboxes: four cols HBB, five OBB internally; use when bbox list
+        is empty so preprocess ndarray column count stays valid.
 
         """
         cols = NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS if self.bbox_type == "hbb" else BBOX_OBB_MIN_COLUMNS

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1408,6 +1408,35 @@ class Compose(BaseCompose, HubMixin):
     def _get_user_kp_label_fields(self) -> list[str]:
         return list(self._kp_label_map.values())
 
+    def _reserved_keys_for_instance_unpack(self, binding: frozenset[str]) -> frozenset[str]:
+        """Return keys instance unpack assigns to pipeline data: mask targets, bboxes, keypoints, and
+        internal label columns used when repacking instances.
+        """
+        keys: set[str] = set()
+        if "masks" in binding:
+            keys.add("masks")
+        elif "mask" in binding:
+            keys.add("mask")
+        if "bboxes" in binding:
+            keys.update({_BBOX_INSTANCE_ID, "bboxes"})
+        if "keypoints" in binding:
+            keys.update({_KP_INSTANCE_ID, "keypoints"})
+        keys.update(self._bbox_label_map)
+        keys.update(self._kp_label_map)
+        return frozenset(keys)
+
+    def _reject_instance_unpack_key_collisions(self, data: dict[str, Any], binding: frozenset[str]) -> None:
+        reserved = self._reserved_keys_for_instance_unpack(binding)
+        collisions = sorted(reserved & data.keys())
+        if not collisions:
+            return
+        joined = ", ".join(collisions)
+        msg = (
+            f"Passing `instances` would overwrite existing data keys: {joined}. "
+            "Omit those keys from the input when using instance_binding."
+        )
+        raise ValueError(msg)
+
     def _unpack_instances(self, data: dict[str, Any]) -> None:
         binding = self._instance_binding
         if binding is None:
@@ -1417,6 +1446,8 @@ class Compose(BaseCompose, HubMixin):
         instances = data.pop("instances")
         if not isinstance(instances, (list, tuple)):
             raise TypeError("instances must be a list of dicts")
+
+        self._reject_instance_unpack_key_collisions(data, binding)
 
         num_instances = len(instances)
         self._instance_count = num_instances

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1481,13 +1481,10 @@ class Compose(BaseCompose, HubMixin):
         if not isinstance(kp_proc_unpack, KeypointsProcessor):
             return
         kp_params = kp_proc_unpack.params
-        empty_kp = kp_params.make_empty_keypoints_array()
-        num_cols = empty_kp.shape[1]
-        default_empty = np.zeros((0, num_cols), dtype=np.float32)
         all_kps: list[np.ndarray] = []
         all_ids: list[int] = []
         for idx, inst in enumerate(instance_dicts):
-            kps = inst.get("keypoints", default_empty)
+            kps = inst["keypoints"]
             count = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
             if count > 0:
                 all_kps.append(np.asarray(kps, dtype=np.float32))
@@ -1562,7 +1559,9 @@ class Compose(BaseCompose, HubMixin):
     ) -> None:
         if "keypoints" not in binding:
             return
-        kps = inst.get("keypoints", np.zeros((0, 2), dtype=np.float32))
+        if "keypoints" not in inst:
+            raise ValueError(f"instances[{idx}] missing required key 'keypoints'")
+        kps = inst["keypoints"]
         num_kps = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
         if not (kp_label_fields and num_kps > 0):
             return
@@ -1610,7 +1609,8 @@ class Compose(BaseCompose, HubMixin):
         kp_ids: np.ndarray,
     ) -> dict[str, Any]:
         inst: dict[str, Any] = {}
-        self._repack_mask_into(inst, data, binding, new_idx)
+        # Masks are not filtered row-wise with bboxes; stack axis 0 still follows original instance ids.
+        self._repack_mask_into(inst, data, binding, int(old_idx))
         self._repack_bbox_into(inst, data, binding, new_idx)
         self._repack_keypoints_into(inst, data, binding, old_idx, kp_ids)
         self._repack_bbox_labels_into(inst, data, new_idx)
@@ -1622,16 +1622,16 @@ class Compose(BaseCompose, HubMixin):
         inst: dict[str, Any],
         data: dict[str, Any],
         binding: frozenset[str],
-        new_idx: int,
+        original_instance_idx: int,
     ) -> None:
         if "masks" in binding and "masks" in data:
-            mask = data["masks"][new_idx]
+            mask = data["masks"][original_instance_idx]
             added = hasattr(self, "_added_channel_dim") and self._added_channel_dim.get("masks")
             if added and mask.shape[-1] == 1:
                 mask = np.squeeze(mask, axis=-1)
             inst["mask"] = mask
         elif "mask" in binding and "mask" in data:
-            inst["mask"] = data["mask"][:, :, new_idx]
+            inst["mask"] = data["mask"][:, :, original_instance_idx]
 
     def _repack_bbox_into(
         self,

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1187,6 +1187,8 @@ class Compose(BaseCompose, HubMixin):
         """
         if self._instance_binding and "instances" in data and self.main_compose:
             self._unpack_instances(data)
+        elif self._instance_binding and self.main_compose and isinstance(data, dict):
+            self._require_instance_binding_data_present(data)
 
         # Always validate shapes if is_check_shapes is True, regardless of strict mode
         if self.is_check_shapes:
@@ -1407,6 +1409,26 @@ class Compose(BaseCompose, HubMixin):
 
     def _get_user_kp_label_fields(self) -> list[str]:
         return list(self._kp_label_map.values())
+
+    def _require_instance_binding_data_present(self, data: dict[str, Any]) -> None:
+        """Ensure instance_binding calls pass `instances` for unpack or already-unpacked data with mask tensors
+        and internal instance-id columns for nested preprocess.
+        """
+        binding = self._instance_binding
+        if binding is None:
+            return
+        if "masks" in binding and "masks" not in data:
+            msg = "`instances` must be provided when using instance_binding with `masks`."
+            raise ValueError(msg)
+        if "mask" in binding and "mask" not in data:
+            msg = "`instances` must be provided when using instance_binding with `mask`."
+            raise ValueError(msg)
+        if "bboxes" in binding and _BBOX_INSTANCE_ID not in data:
+            msg = "`instances` must be provided when using instance_binding with `bboxes`."
+            raise ValueError(msg)
+        if "keypoints" in binding and _KP_INSTANCE_ID not in data:
+            msg = "`instances` must be provided when using instance_binding with `keypoints`."
+            raise ValueError(msg)
 
     def _reserved_keys_for_instance_unpack(self, binding: frozenset[str]) -> frozenset[str]:
         """Return keys instance unpack assigns to pipeline data: mask targets, bboxes, keypoints, and
@@ -1959,9 +1981,9 @@ class Compose(BaseCompose, HubMixin):
                 kp_params = KeypointParams(
                     coord_format=kp.coord_format,
                     label_fields=user_fields,
-                    remove_invisible=True,
+                    remove_invisible=kp.remove_invisible,
                     angle_in_degrees=kp.angle_in_degrees,
-                    check_each_transform=True,
+                    check_each_transform=kp.check_each_transform,
                     label_mapping=kp.label_mapping or None,
                 )
             else:

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -17,6 +17,7 @@ from typing import Any, Union, cast, get_args, get_origin
 
 import cv2
 import numpy as np
+from numpy.typing import NDArray
 
 from .analytics.collectors import collect_pipeline_info, get_environment_info
 
@@ -140,6 +141,10 @@ IMAGE_KEYS = {"image", "images"}
 CHECK_BBOX_PARAM = {"bboxes"}
 CHECK_KEYPOINTS_PARAM = {"keypoints"}
 VOLUME_KEYS = {"volume", "volumes"}
+
+_VALID_INSTANCE_BINDING_TARGETS = frozenset({"mask", "masks", "bboxes", "keypoints"})
+_BBOX_INSTANCE_ID = "_bbox_instance_id"
+_KP_INSTANCE_ID = "_kp_instance_id"
 
 
 class BaseCompose(Serializable):
@@ -798,7 +803,7 @@ class Compose(BaseCompose, HubMixin):
 
     """
 
-    def __init__(
+    def __init__(  # noqa: C901
         self,
         transforms: TransformsSeqType,
         bbox_params: dict[str, Any] | BboxParams | None = None,
@@ -811,6 +816,7 @@ class Compose(BaseCompose, HubMixin):
         seed: int | None = None,
         save_applied_params: bool = False,
         telemetry: bool = True,
+        instance_binding: Sequence[str] | None = None,
     ):
         # Store the original base seed for worker context recalculation
         self._base_seed = seed
@@ -852,9 +858,14 @@ class Compose(BaseCompose, HubMixin):
         for proc in self.processors.values():
             proc.ensure_transforms_valid(self.transforms)
 
+        self._instance_binding = self._setup_instance_binding(instance_binding)
+
         self.add_targets(additional_targets)
         if not self.transforms:  # if no transforms -> do nothing, all keys will be available
             self._available_keys.update(AVAILABLE_KEYS)
+
+        if self._instance_binding:
+            self._available_keys.add("instances")
 
         self.is_check_args = True
         self.strict = strict
@@ -928,6 +939,58 @@ class Compose(BaseCompose, HubMixin):
 
         for transform in self.transforms:
             check_transform(transform)
+
+    def _setup_instance_binding(self, instance_binding: Sequence[str] | None) -> frozenset[str] | None:
+        self._bbox_label_map: dict[str, str] = {}
+        self._kp_label_map: dict[str, str] = {}
+
+        if instance_binding is None:
+            return None
+
+        targets = frozenset(instance_binding)
+
+        if len(targets) < 2:
+            raise ValueError("instance_binding must contain at least 2 targets")
+
+        invalid = targets - _VALID_INSTANCE_BINDING_TARGETS
+        if invalid:
+            raise ValueError(
+                f"Invalid instance_binding targets: {invalid}. "
+                f"Valid targets: {sorted(_VALID_INSTANCE_BINDING_TARGETS)}",
+            )
+
+        if "mask" in targets and "masks" in targets:
+            raise ValueError("instance_binding cannot contain both 'mask' and 'masks'")
+
+        if "bboxes" in targets and "bboxes" not in self.processors:
+            raise ValueError("bbox_params must be set when 'bboxes' is in instance_binding")
+
+        if "keypoints" in targets and "keypoints" not in self.processors:
+            raise ValueError("keypoint_params must be set when 'keypoints' is in instance_binding")
+
+        if "bboxes" in targets:
+            bbox_proc = self.processors["bboxes"]
+            user_fields = list(bbox_proc.params.label_fields or [])
+            internal_fields = [f"_ibl_bbox_{f}" for f in user_fields]
+            self._bbox_label_map = dict(zip(internal_fields, user_fields, strict=True))
+            internal_fields.append(_BBOX_INSTANCE_ID)
+            bbox_proc.params.label_fields = internal_fields
+
+        if "keypoints" in targets:
+            kp_proc = self.processors["keypoints"]
+            if not isinstance(kp_proc, KeypointsProcessor):
+                msg = "expected keypoints processor"
+                raise TypeError(msg)
+            kp_params = kp_proc.params
+            user_fields = list(kp_params.label_fields or [])
+            internal_fields = [f"_ibl_kp_{f}" for f in user_fields]
+            self._kp_label_map = dict(zip(internal_fields, user_fields, strict=True))
+            internal_fields.append(_KP_INSTANCE_ID)
+            kp_params.label_fields = internal_fields
+            kp_params.remove_invisible = False
+            kp_params.check_each_transform = False
+
+        return targets
 
     def _set_processors_for_transforms(self, transforms: TransformsSeqType) -> None:
         for transform in transforms:
@@ -1115,6 +1178,9 @@ class Compose(BaseCompose, HubMixin):
         """Preprocess input data before applying transforms. Validates shapes (if
         is_check_shapes), validates data keys (if strict), ensures contiguous, adds channels.
         """
+        if self._instance_binding and "instances" in data and self.main_compose:
+            self._unpack_instances(data)
+
         # Always validate shapes if is_check_shapes is True, regardless of strict mode
         if self.is_check_shapes:
             shapes, volume_shapes = self._gather_shapes_from_data(data)
@@ -1285,6 +1351,9 @@ class Compose(BaseCompose, HubMixin):
             for p in self.processors.values():
                 p.postprocess(data)
 
+            if self._instance_binding and hasattr(self, "_instance_count"):
+                self._repack_instances(data)
+
             # Remove channel dimensions that were added during preprocessing
             self._remove_grayscale_channels(data)
 
@@ -1321,19 +1390,232 @@ class Compose(BaseCompose, HubMixin):
                             # Mask tensor with shape (..., H, W, 1) -> (..., H, W)
                             data[key] = torch.squeeze(value, dim=-1)
 
+    def _get_user_bbox_label_fields(self) -> list[str]:
+        return list(self._bbox_label_map.values())
+
+    def _get_user_kp_label_fields(self) -> list[str]:
+        return list(self._kp_label_map.values())
+
+    def _unpack_instances(self, data: dict[str, Any]) -> None:  # noqa: C901, PLR0912
+        binding = self._instance_binding
+        if binding is None:
+            msg = "_unpack_instances requires instance_binding"
+            raise RuntimeError(msg)
+
+        instances = data.pop("instances")
+        if not isinstance(instances, (list, tuple)):
+            raise TypeError("instances must be a list of dicts")
+
+        num_instances = len(instances)
+        self._instance_count = num_instances
+        self._instance_kp_counts: list[int] = []
+
+        if num_instances == 0:
+            if "masks" in binding:
+                data["masks"] = np.empty((0, 0, 0), dtype=np.uint8)
+            if "bboxes" in binding:
+                data["bboxes"] = np.zeros((0, 4), dtype=np.float32)
+                data[_BBOX_INSTANCE_ID] = []
+            if "keypoints" in binding:
+                data["keypoints"] = np.zeros((0, 2), dtype=np.float32)
+                data[_KP_INSTANCE_ID] = []
+            for internal_name in self._bbox_label_map:
+                data[internal_name] = []
+            for internal_name in self._kp_label_map:
+                data[internal_name] = []
+            return
+
+        instance_dicts = self._validate_instances(instances)
+
+        if "masks" in binding:
+            data["masks"] = np.stack([inst["mask"] for inst in instance_dicts])
+        elif "mask" in binding:
+            data["mask"] = np.stack([inst["mask"] for inst in instance_dicts], axis=-1)
+
+        if "bboxes" in binding:
+            data["bboxes"] = np.array([inst["bbox"] for inst in instance_dicts], dtype=np.float32)
+            data[_BBOX_INSTANCE_ID] = list(range(num_instances))
+
+        if "keypoints" in binding:
+            all_kps: list[np.ndarray] = []
+            all_ids: list[int] = []
+            for idx, inst in enumerate(instance_dicts):
+                kps = inst.get("keypoints", np.zeros((0, 2), dtype=np.float32))
+                count = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
+                self._instance_kp_counts.append(count)
+                if count > 0:
+                    all_kps.append(np.asarray(kps, dtype=np.float32))
+                    all_ids.extend([idx] * count)
+            data["keypoints"] = np.concatenate(all_kps) if all_kps else np.zeros((0, 2), dtype=np.float32)
+            data[_KP_INSTANCE_ID] = all_ids
+
+        for internal_name, user_name in self._bbox_label_map.items():
+            data[internal_name] = [inst.get("bbox_labels", {})[user_name] for inst in instance_dicts]
+
+        for internal_name, user_name in self._kp_label_map.items():
+            flat: list[Any] = []
+            for inst in instance_dicts:
+                kp_labels = inst.get("keypoint_labels", {})
+                values = kp_labels.get(user_name, [])
+                flat.extend(values)
+            data[internal_name] = flat
+
+    def _validate_instances(self, instances: Sequence[Any]) -> list[dict[str, Any]]:  # noqa: C901, PLR0912
+        binding = self._instance_binding
+        if binding is None:
+            msg = "_validate_instances requires instance_binding"
+            raise RuntimeError(msg)
+
+        bbox_label_fields = self._get_user_bbox_label_fields()
+        kp_label_fields = self._get_user_kp_label_fields()
+        normalized: list[dict[str, Any]] = []
+
+        for idx, inst in enumerate(instances):
+            if not isinstance(inst, dict):
+                raise TypeError(f"instances[{idx}] must be a dict, got {type(inst).__name__}")
+
+            mask_key = "masks" if "masks" in binding else ("mask" if "mask" in binding else None)
+            if mask_key is not None and "mask" not in inst:
+                raise ValueError(f"instances[{idx}] missing required key 'mask'")
+
+            if "bboxes" in binding and "bbox" not in inst:
+                raise ValueError(f"instances[{idx}] missing required key 'bbox'")
+
+            if "bboxes" in binding and bbox_label_fields:
+                inst_labels = inst.get("bbox_labels")
+                if inst_labels is None:
+                    raise ValueError(f"instances[{idx}] missing 'bbox_labels'")
+                missing = set(bbox_label_fields) - set(inst_labels)
+                if missing:
+                    raise ValueError(
+                        f"instances[{idx}]['bbox_labels'] missing keys: {missing}. Expected: {bbox_label_fields}",
+                    )
+
+            if "keypoints" in binding:
+                kps = inst.get("keypoints", np.zeros((0, 2), dtype=np.float32))
+                num_kps = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
+
+                if kp_label_fields and num_kps > 0:
+                    kp_labels = inst.get("keypoint_labels")
+                    if kp_labels is None:
+                        raise ValueError(f"instances[{idx}] missing 'keypoint_labels'")
+                    missing = set(kp_label_fields) - set(kp_labels)
+                    if missing:
+                        raise ValueError(
+                            f"instances[{idx}]['keypoint_labels'] missing keys: {missing}. Expected: {kp_label_fields}",
+                        )
+                    for field in kp_label_fields:
+                        if len(kp_labels[field]) != num_kps:
+                            raise ValueError(
+                                f"instances[{idx}]['keypoint_labels']['{field}'] has "
+                                f"{len(kp_labels[field])} values but keypoints has {num_kps} rows",
+                            )
+
+            normalized.append(inst)
+
+        return normalized
+
+    def _repack_instances(self, data: dict[str, Any]) -> None:  # noqa: C901, PLR0912
+        binding = self._instance_binding
+        if binding is None:
+            msg = "_repack_instances requires instance_binding"
+            raise RuntimeError(msg)
+
+        if "bboxes" in binding:
+            bbox_ids = data.pop(_BBOX_INSTANCE_ID, [])
+            surviving_ids = sorted(set(bbox_ids))
+        else:
+            surviving_ids = list(range(self._instance_count))
+
+        kp_ids = np.array(data.pop(_KP_INSTANCE_ID, []))
+
+        instances: list[dict[str, Any]] = []
+        for new_idx, old_idx in enumerate(surviving_ids):
+            inst: dict[str, Any] = {}
+
+            if "masks" in binding and "masks" in data:
+                mask = data["masks"][new_idx]
+                if hasattr(self, "_added_channel_dim") and self._added_channel_dim.get("masks") and mask.shape[-1] == 1:
+                    mask = np.squeeze(mask, axis=-1)
+                inst["mask"] = mask
+            elif "mask" in binding and "mask" in data:
+                inst["mask"] = data["mask"][:, :, new_idx]
+
+            if "bboxes" in binding and "bboxes" in data:
+                inst["bbox"] = data["bboxes"][new_idx]
+
+            if "keypoints" in binding and "keypoints" in data:
+                if kp_ids.size > 0:
+                    kp_mask = kp_ids == old_idx
+                    inst["keypoints"] = data["keypoints"][kp_mask]
+                else:
+                    inst["keypoints"] = np.zeros((0, 2), dtype=np.float32)
+
+            if self._bbox_label_map:
+                inst["bbox_labels"] = {}
+                for internal_name, user_name in self._bbox_label_map.items():
+                    if internal_name in data:
+                        inst["bbox_labels"][user_name] = data[internal_name][new_idx]
+
+            if self._kp_label_map and "keypoints" in binding:
+                inst["keypoint_labels"] = {}
+                for internal_name, user_name in self._kp_label_map.items():
+                    if internal_name in data:
+                        field_values = data[internal_name]
+                        if kp_ids.size > 0:
+                            kp_mask = kp_ids == old_idx
+                            inst["keypoint_labels"][user_name] = [
+                                field_values[i] for i, keep in enumerate(kp_mask) if keep
+                            ]
+                        else:
+                            inst["keypoint_labels"][user_name] = []
+
+            instances.append(inst)
+
+        data["instances"] = instances
+
+        for key in ["masks", "bboxes", "keypoints"]:
+            if key in binding:
+                data.pop(key, None)
+        for internal_name in self._bbox_label_map:
+            data.pop(internal_name, None)
+        for internal_name in self._kp_label_map:
+            data.pop(internal_name, None)
+
+    def _clean_params_dict(
+        self,
+        params_dict: dict[str, Any] | None,
+        label_map: dict[str, str],
+    ) -> dict[str, Any] | None:
+        if params_dict is None or not self._instance_binding:
+            return params_dict
+        label_fields = params_dict.get("label_fields")
+        if label_fields:
+            user_fields = [label_map.get(f, f) for f in label_fields if f not in {_BBOX_INSTANCE_ID, _KP_INSTANCE_ID}]
+            params_dict = {**params_dict, "label_fields": user_fields}
+        return params_dict
+
     def to_dict_private(self) -> dict[str, Any]:
         dictionary = super().to_dict_private()
         bbox_processor = self.processors.get("bboxes")
         keypoints_processor = self.processors.get("keypoints")
         dictionary.update(
             {
-                "bbox_params": bbox_processor.params.to_dict_private() if bbox_processor else None,
-                "keypoint_params": (keypoints_processor.params.to_dict_private() if keypoints_processor else None),
+                "bbox_params": self._clean_params_dict(
+                    bbox_processor.params.to_dict_private() if bbox_processor else None,
+                    self._bbox_label_map,
+                ),
+                "keypoint_params": self._clean_params_dict(
+                    keypoints_processor.params.to_dict_private() if keypoints_processor else None,
+                    self._kp_label_map,
+                ),
                 "additional_targets": self.additional_targets,
                 "is_check_shapes": self.is_check_shapes,
                 "seed": getattr(self, "_base_seed", None),
             },
         )
+        if self._instance_binding:
+            dictionary["instance_binding"] = sorted(self._instance_binding)
         return dictionary
 
     def get_dict_with_id(self) -> dict[str, Any]:
@@ -1349,13 +1631,21 @@ class Compose(BaseCompose, HubMixin):
         keypoints_processor = self.processors.get("keypoints")
         dictionary.update(
             {
-                "bbox_params": bbox_processor.params.to_dict_private() if bbox_processor else None,
-                "keypoint_params": (keypoints_processor.params.to_dict_private() if keypoints_processor else None),
+                "bbox_params": self._clean_params_dict(
+                    bbox_processor.params.to_dict_private() if bbox_processor else None,
+                    self._bbox_label_map,
+                ),
+                "keypoint_params": self._clean_params_dict(
+                    keypoints_processor.params.to_dict_private() if keypoints_processor else None,
+                    self._kp_label_map,
+                ),
                 "additional_targets": self.additional_targets,
                 "params": None,
                 "is_check_shapes": self.is_check_shapes,
             },
         )
+        if self._instance_binding:
+            dictionary["instance_binding"] = sorted(self._instance_binding)
         return dictionary
 
     @staticmethod
@@ -1478,9 +1768,47 @@ class Compose(BaseCompose, HubMixin):
         bbox_processor = self.processors.get("bboxes")
         keypoints_processor = self.processors.get("keypoints")
 
+        bbox_params: BboxParams | None = None
+        if bbox_processor:
+            bp = cast("BboxParams", bbox_processor.params)
+            if self._instance_binding:
+                user_fields = list(self._bbox_label_map.values()) or None
+                bbox_params = BboxParams(
+                    coord_format=bp.coord_format,
+                    label_fields=user_fields,
+                    bbox_type=bp.bbox_type,
+                    min_area=bp.min_area,
+                    min_visibility=bp.min_visibility,
+                    min_width=bp.min_width,
+                    min_height=bp.min_height,
+                    check_each_transform=bp.check_each_transform,
+                    clip_bboxes_on_input=bp.clip_bboxes_on_input,
+                    filter_invalid_bboxes=bp.filter_invalid_bboxes,
+                    max_accept_ratio=bp.max_accept_ratio,
+                    clip_after_transform=bp.clip_after_transform,
+                )
+            else:
+                bbox_params = bp
+
+        kp_params: KeypointParams | None = None
+        if keypoints_processor:
+            kp = cast("KeypointParams", keypoints_processor.params)
+            if self._instance_binding:
+                user_fields = list(self._kp_label_map.values()) or None
+                kp_params = KeypointParams(
+                    coord_format=kp.coord_format,
+                    label_fields=user_fields,
+                    remove_invisible=True,
+                    angle_in_degrees=kp.angle_in_degrees,
+                    check_each_transform=True,
+                    label_mapping=kp.label_mapping or None,
+                )
+            else:
+                kp_params = kp
+
         return {
-            "bbox_params": bbox_processor.params if bbox_processor else None,
-            "keypoint_params": keypoints_processor.params if keypoints_processor else None,
+            "bbox_params": bbox_params,
+            "keypoint_params": kp_params,
             "additional_targets": self.additional_targets,
             "p": self.p,
             "is_check_shapes": self.is_check_shapes,
@@ -1489,6 +1817,7 @@ class Compose(BaseCompose, HubMixin):
             "seed": getattr(self, "_base_seed", None),
             "save_applied_params": getattr(self, "save_applied_params", False),
             "telemetry": getattr(self, "telemetry", True),
+            "instance_binding": sorted(self._instance_binding) if self._instance_binding else None,
         }
 
 
@@ -1636,7 +1965,7 @@ class SomeOf(BaseCompose):
                 data = self.check_data_post_transform(data)
         return data
 
-    def _get_idx(self) -> np.ndarray[np.int_]:
+    def _get_idx(self) -> NDArray[np.int_]:
         # Use uniform probability for selection, ignore individual p values here
         idx = self.random_generator.choice(
             len(self.transforms),
@@ -1698,7 +2027,7 @@ class RandomOrder(SomeOf):
         # Initialize using SomeOf's logic (which now does uniform selection setup)
         super().__init__(transforms=transforms, n=n, replace=replace, p=p)
 
-    def _get_idx(self) -> np.ndarray[np.int_]:
+    def _get_idx(self) -> NDArray[np.int_]:
         # Perform uniform random selection without replacement, like SomeOf
         # Crucially, DO NOT sort the indices here to maintain random order.
         return self.random_generator.choice(
@@ -1809,7 +2138,7 @@ class SelectiveChannelTransform(BaseCompose):
 
             for t in self.transforms:
                 sub_data = {"image": sub_image}
-                sub_image = t(**sub_data)["image"]
+                sub_image = t(force_apply=False, **sub_data)["image"]
                 self._track_transform_params(t, sub_data)
 
             transformed_channels = cv2.split(sub_image)
@@ -1878,8 +2207,18 @@ class ReplayCompose(Compose):
         is_check_shapes: bool = True,
         save_key: str = "replay",
         seed: int | None = None,
+        instance_binding: Sequence[str] | None = None,
     ):
-        super().__init__(transforms, bbox_params, keypoint_params, additional_targets, p, is_check_shapes, seed=seed)
+        super().__init__(
+            transforms,
+            bbox_params,
+            keypoint_params,
+            additional_targets,
+            p,
+            is_check_shapes,
+            seed=seed,
+            instance_binding=instance_binding,
+        )
         self.set_deterministic(True, save_key=save_key)
         self.save_key = save_key
         self._available_keys.add(save_key)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1045,14 +1045,24 @@ class Compose(BaseCompose, HubMixin):
         if not need_to_run:
             return data
 
-        self.preprocess(data)
+        try:
+            self.preprocess(data)
+            for t in self.transforms:
+                data = t(**data)
+                self._track_transform_params(t, data)
+                data = self.check_data_post_transform(data)
 
-        for t in self.transforms:
-            data = t(**data)
-            self._track_transform_params(t, data)
-            data = self.check_data_post_transform(data)
+            return self.postprocess(data)
+        finally:
+            # Clear per-call unpack/repack flags if preprocess or a transform raised mid-call.
+            if self.main_compose and self._instance_binding:
+                self._clear_instance_binding_call_state_if_pending()
 
-        return self.postprocess(data)
+    def _clear_instance_binding_call_state_if_pending(self) -> None:
+        if getattr(self, "_repack_after_processors", False):
+            del self._repack_after_processors
+        if hasattr(self, "_instance_count"):
+            delattr(self, "_instance_count")
 
     @staticmethod
     def from_applied_transforms(
@@ -1479,7 +1489,8 @@ class Compose(BaseCompose, HubMixin):
             return
         kp_proc_unpack = self.processors["keypoints"]
         if not isinstance(kp_proc_unpack, KeypointsProcessor):
-            return
+            msg = "expected keypoints processor"
+            raise TypeError(msg)
         kp_params = kp_proc_unpack.params
         all_kps: list[np.ndarray] = []
         all_ids: list[int] = []
@@ -1890,7 +1901,7 @@ class Compose(BaseCompose, HubMixin):
         bbox_params: BboxParams | None = None
         if bbox_processor:
             bp = cast("BboxParams", bbox_processor.params)
-            if self._instance_binding:
+            if self._instance_binding and "bboxes" in self._instance_binding:
                 user_fields = list(self._bbox_label_map.values()) or None
                 bbox_params = BboxParams(
                     coord_format=bp.coord_format,
@@ -1912,7 +1923,7 @@ class Compose(BaseCompose, HubMixin):
         kp_params: KeypointParams | None = None
         if keypoints_processor:
             kp = cast("KeypointParams", keypoints_processor.params)
-            if self._instance_binding:
+            if self._instance_binding and "keypoints" in self._instance_binding:
                 user_fields = list(self._kp_label_map.values()) or None
                 kp_params = KeypointParams(
                     coord_format=kp.coord_format,

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -7,6 +7,7 @@ proper data flow and maintaining consistent behavior across the augmentation pip
 """
 
 import contextlib
+import copy
 import inspect
 import random
 import types
@@ -932,54 +933,61 @@ class Compose(BaseCompose, HubMixin):
     def _setup_instance_binding(self, instance_binding: Sequence[str] | None) -> frozenset[str] | None:
         self._bbox_label_map: dict[str, str] = {}
         self._kp_label_map: dict[str, str] = {}
-
         if instance_binding is None:
             return None
-
         targets = frozenset(instance_binding)
+        self._validate_instance_binding_targets(targets)
+        self._apply_bbox_instance_binding(targets)
+        self._apply_keypoints_instance_binding(targets)
+        return targets
 
+    def _validate_instance_binding_targets(self, targets: frozenset[str]) -> None:
         if len(targets) < 2:
             raise ValueError("instance_binding must contain at least 2 targets")
-
         invalid = targets - _VALID_INSTANCE_BINDING_TARGETS
         if invalid:
             raise ValueError(
                 f"Invalid instance_binding targets: {invalid}. "
                 f"Valid targets: {sorted(_VALID_INSTANCE_BINDING_TARGETS)}",
             )
-
         if "mask" in targets and "masks" in targets:
             raise ValueError("instance_binding cannot contain both 'mask' and 'masks'")
-
         if "bboxes" in targets and "bboxes" not in self.processors:
             raise ValueError("bbox_params must be set when 'bboxes' is in instance_binding")
-
         if "keypoints" in targets and "keypoints" not in self.processors:
             raise ValueError("keypoint_params must be set when 'keypoints' is in instance_binding")
 
-        if "bboxes" in targets:
-            bbox_proc = self.processors["bboxes"]
-            user_fields = list(bbox_proc.params.label_fields or [])
-            internal_fields = [f"_ibl_bbox_{f}" for f in user_fields]
-            self._bbox_label_map = dict(zip(internal_fields, user_fields, strict=True))
-            internal_fields.append(_BBOX_INSTANCE_ID)
-            bbox_proc.params.label_fields = internal_fields
+    def _apply_bbox_instance_binding(self, targets: frozenset[str]) -> None:
+        if "bboxes" not in targets:
+            return
+        bbox_proc = self.processors["bboxes"]
+        if not isinstance(bbox_proc, BboxProcessor):
+            msg = "expected bbox processor"
+            raise TypeError(msg)
+        bbox_proc.params = copy.deepcopy(bbox_proc.params)
+        bbox_params = bbox_proc.params
+        user_fields = list(bbox_params.label_fields or [])
+        internal_fields = [f"_ibl_bbox_{f}" for f in user_fields]
+        self._bbox_label_map = dict(zip(internal_fields, user_fields, strict=True))
+        internal_fields.append(_BBOX_INSTANCE_ID)
+        bbox_params.label_fields = internal_fields
 
-        if "keypoints" in targets:
-            kp_proc = self.processors["keypoints"]
-            if not isinstance(kp_proc, KeypointsProcessor):
-                msg = "expected keypoints processor"
-                raise TypeError(msg)
-            kp_params = kp_proc.params
-            user_fields = list(kp_params.label_fields or [])
-            internal_fields = [f"_ibl_kp_{f}" for f in user_fields]
-            self._kp_label_map = dict(zip(internal_fields, user_fields, strict=True))
-            internal_fields.append(_KP_INSTANCE_ID)
-            kp_params.label_fields = internal_fields
-            kp_params.remove_invisible = False
-            kp_params.check_each_transform = False
-
-        return targets
+    def _apply_keypoints_instance_binding(self, targets: frozenset[str]) -> None:
+        if "keypoints" not in targets:
+            return
+        kp_proc = self.processors["keypoints"]
+        if not isinstance(kp_proc, KeypointsProcessor):
+            msg = "expected keypoints processor"
+            raise TypeError(msg)
+        kp_proc.params = copy.deepcopy(kp_proc.params)
+        kp_params = kp_proc.params
+        user_fields = list(kp_params.label_fields or [])
+        internal_fields = [f"_ibl_kp_{f}" for f in user_fields]
+        self._kp_label_map = dict(zip(internal_fields, user_fields, strict=True))
+        internal_fields.append(_KP_INSTANCE_ID)
+        kp_params.label_fields = internal_fields
+        kp_params.remove_invisible = False
+        kp_params.check_each_transform = False
 
     def _set_processors_for_transforms(self, transforms: TransformsSeqType) -> None:
         for transform in transforms:
@@ -1340,8 +1348,13 @@ class Compose(BaseCompose, HubMixin):
             for p in self.processors.values():
                 p.postprocess(data)
 
-            if self._instance_binding and hasattr(self, "_instance_count"):
-                self._repack_instances(data)
+            if self._instance_binding and getattr(self, "_repack_after_processors", False):
+                try:
+                    self._repack_instances(data)
+                finally:
+                    del self._repack_after_processors
+                    if hasattr(self, "_instance_count"):
+                        delattr(self, "_instance_count")
 
             # Remove channel dimensions that were added during preprocessing
             self._remove_grayscale_channels(data)
@@ -1397,10 +1410,10 @@ class Compose(BaseCompose, HubMixin):
 
         num_instances = len(instances)
         self._instance_count = num_instances
-        self._instance_kp_counts: list[int] = []
 
         if num_instances == 0:
             self._init_empty_instance_data(data, binding)
+            self._repack_after_processors = True
             return
 
         instance_dicts = self._validate_instances(instances)
@@ -1409,15 +1422,24 @@ class Compose(BaseCompose, HubMixin):
         self._unpack_keypoints(data, binding, instance_dicts)
         self._unpack_bbox_labels(data, instance_dicts)
         self._unpack_kp_labels(data, instance_dicts)
+        self._repack_after_processors = True
 
     def _init_empty_instance_data(self, data: dict[str, Any], binding: frozenset[str]) -> None:
         if "masks" in binding:
             data["masks"] = np.empty((0, 0, 0), dtype=np.uint8)
         if "bboxes" in binding:
-            data["bboxes"] = np.zeros((0, 4), dtype=np.float32)
+            bbox_proc = self.processors["bboxes"]
+            if isinstance(bbox_proc, BboxProcessor):
+                data["bboxes"] = bbox_proc.params.make_empty_bboxes_array()
+            else:
+                data["bboxes"] = np.zeros((0, 4), dtype=np.float32)
             data[_BBOX_INSTANCE_ID] = []
         if "keypoints" in binding:
-            data["keypoints"] = np.zeros((0, 2), dtype=np.float32)
+            kp_proc_init = self.processors["keypoints"]
+            if not isinstance(kp_proc_init, KeypointsProcessor):
+                msg = "expected keypoints processor"
+                raise TypeError(msg)
+            data["keypoints"] = kp_proc_init.params.make_empty_keypoints_array()
             data[_KP_INSTANCE_ID] = []
         for internal_name in self._bbox_label_map:
             data[internal_name] = []
@@ -1455,16 +1477,22 @@ class Compose(BaseCompose, HubMixin):
     ) -> None:
         if "keypoints" not in binding:
             return
+        kp_proc_unpack = self.processors["keypoints"]
+        if not isinstance(kp_proc_unpack, KeypointsProcessor):
+            return
+        kp_params = kp_proc_unpack.params
+        empty_kp = kp_params.make_empty_keypoints_array()
+        num_cols = empty_kp.shape[1]
+        default_empty = np.zeros((0, num_cols), dtype=np.float32)
         all_kps: list[np.ndarray] = []
         all_ids: list[int] = []
         for idx, inst in enumerate(instance_dicts):
-            kps = inst.get("keypoints", np.zeros((0, 2), dtype=np.float32))
+            kps = inst.get("keypoints", default_empty)
             count = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
-            self._instance_kp_counts.append(count)
             if count > 0:
                 all_kps.append(np.asarray(kps, dtype=np.float32))
                 all_ids.extend([idx] * count)
-        data["keypoints"] = np.concatenate(all_kps) if all_kps else np.zeros((0, 2), dtype=np.float32)
+        data["keypoints"] = np.concatenate(all_kps) if all_kps else kp_params.make_empty_keypoints_array()
         data[_KP_INSTANCE_ID] = all_ids
 
     def _unpack_bbox_labels(self, data: dict[str, Any], instance_dicts: list[dict[str, Any]]) -> None:
@@ -1628,7 +1656,11 @@ class Compose(BaseCompose, HubMixin):
         if kp_ids.size > 0:
             inst["keypoints"] = data["keypoints"][kp_ids == old_idx]
         else:
-            inst["keypoints"] = np.zeros((0, 2), dtype=np.float32)
+            kp_proc = self.processors.get("keypoints")
+            if isinstance(kp_proc, KeypointsProcessor):
+                inst["keypoints"] = kp_proc.params.make_empty_keypoints_array()
+            else:
+                inst["keypoints"] = np.zeros((0, 2), dtype=np.float32)
 
     def _repack_bbox_labels_into(self, inst: dict[str, Any], data: dict[str, Any], new_idx: int) -> None:
         if not self._bbox_label_map:
@@ -1661,7 +1693,7 @@ class Compose(BaseCompose, HubMixin):
                 inst["keypoint_labels"][user_name] = []
 
     def _cleanup_instance_data(self, data: dict[str, Any], binding: frozenset[str]) -> None:
-        for key in ["masks", "bboxes", "keypoints"]:
+        for key in ("mask", "masks", "bboxes", "keypoints"):
             if key in binding:
                 data.pop(key, None)
         for internal_name in self._bbox_label_map:

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -803,7 +803,7 @@ class Compose(BaseCompose, HubMixin):
 
     """
 
-    def __init__(  # noqa: C901
+    def __init__(
         self,
         transforms: TransformsSeqType,
         bbox_params: dict[str, Any] | BboxParams | None = None,
@@ -818,23 +818,51 @@ class Compose(BaseCompose, HubMixin):
         telemetry: bool = True,
         instance_binding: Sequence[str] | None = None,
     ):
-        # Store the original base seed for worker context recalculation
         self._base_seed = seed
-
-        # Get effective seed considering worker context
-        effective_seed = self._get_effective_seed(seed)
-
         super().__init__(
             transforms=transforms,
             p=p,
             mask_interpolation=mask_interpolation,
-            seed=effective_seed,
+            seed=self._get_effective_seed(seed),
             save_applied_params=save_applied_params,
         )
 
-        # Store telemetry parameter
         self.telemetry = telemetry
+        self._resolve_processors(bbox_params, keypoint_params)
 
+        for proc in self.processors.values():
+            proc.ensure_transforms_valid(self.transforms)
+
+        self._instance_binding = self._setup_instance_binding(instance_binding)
+
+        self.add_targets(additional_targets)
+        if not self.transforms:  # if no transforms -> do nothing, all keys will be available
+            self._available_keys.update(AVAILABLE_KEYS)
+        if self._instance_binding:
+            self._available_keys.add("instances")
+
+        self.is_check_args = True
+        self.strict = strict
+        self.is_check_shapes = is_check_shapes
+        self.check_each_transform = tuple(  # processors that check after each transform
+            proc for proc in self.processors.values() if getattr(proc.params, "check_each_transform", False)
+        )
+        self._set_check_args_for_transforms(self.transforms)
+        self._set_processors_for_transforms(self.transforms)
+
+        self.save_applied_params = save_applied_params
+        self._images_was_list = False
+        self._masks_was_list = False
+        self._last_torch_seed: int | None = None
+
+        # Telemetry runs after nested composes so main_compose=False is already set on them.
+        self._maybe_send_telemetry(telemetry)
+
+    def _resolve_processors(
+        self,
+        bbox_params: dict[str, Any] | BboxParams | None,
+        keypoint_params: dict[str, Any] | KeypointParams | None,
+    ) -> None:
         if bbox_params:
             if isinstance(bbox_params, dict):
                 b_params = BboxParams(**bbox_params)
@@ -855,52 +883,13 @@ class Compose(BaseCompose, HubMixin):
                 raise ValueError(msg)
             self.processors["keypoints"] = KeypointsProcessor(k_params)
 
-        for proc in self.processors.values():
-            proc.ensure_transforms_valid(self.transforms)
-
-        self._instance_binding = self._setup_instance_binding(instance_binding)
-
-        self.add_targets(additional_targets)
-        if not self.transforms:  # if no transforms -> do nothing, all keys will be available
-            self._available_keys.update(AVAILABLE_KEYS)
-
-        if self._instance_binding:
-            self._available_keys.add("instances")
-
-        self.is_check_args = True
-        self.strict = strict
-
-        self.is_check_shapes = is_check_shapes
-        self.check_each_transform = tuple(  # processors that checks after each transform
-            proc for proc in self.processors.values() if getattr(proc.params, "check_each_transform", False)
-        )
-        self._set_check_args_for_transforms(self.transforms)
-
-        self._set_processors_for_transforms(self.transforms)
-
-        self.save_applied_params = save_applied_params
-        self._images_was_list = False
-        self._masks_was_list = False
-        self._last_torch_seed: int | None = None
-
-        # Track telemetry after nested composes are processed
-        # This ensures nested composes have main_compose=False from disable_check_args_private
-        if self.main_compose and settings.telemetry_enabled:
-            with contextlib.suppress(Exception):
-                client = get_telemetry_client()
-
-                # Collect telemetry data
-                env_info = get_environment_info()
-                pipeline_info = collect_pipeline_info(self)
-
-                # Combine all data
-                telemetry_data = {
-                    **env_info,
-                    **pipeline_info,
-                }
-
-                # Always call the client, let it decide based on telemetry parameter
-                client.track_compose_init(telemetry_data, telemetry=telemetry)
+    def _maybe_send_telemetry(self, telemetry: bool) -> None:
+        if not (self.main_compose and settings.telemetry_enabled):
+            return
+        with contextlib.suppress(Exception):
+            client = get_telemetry_client()
+            telemetry_data = {**get_environment_info(), **collect_pipeline_info(self)}
+            client.track_compose_init(telemetry_data, telemetry=telemetry)
 
     @property
     def strict(self) -> bool:
@@ -1396,7 +1385,7 @@ class Compose(BaseCompose, HubMixin):
     def _get_user_kp_label_fields(self) -> list[str]:
         return list(self._kp_label_map.values())
 
-    def _unpack_instances(self, data: dict[str, Any]) -> None:  # noqa: C901, PLR0912
+    def _unpack_instances(self, data: dict[str, Any]) -> None:
         binding = self._instance_binding
         if binding is None:
             msg = "_unpack_instances requires instance_binding"
@@ -1411,56 +1400,85 @@ class Compose(BaseCompose, HubMixin):
         self._instance_kp_counts: list[int] = []
 
         if num_instances == 0:
-            if "masks" in binding:
-                data["masks"] = np.empty((0, 0, 0), dtype=np.uint8)
-            if "bboxes" in binding:
-                data["bboxes"] = np.zeros((0, 4), dtype=np.float32)
-                data[_BBOX_INSTANCE_ID] = []
-            if "keypoints" in binding:
-                data["keypoints"] = np.zeros((0, 2), dtype=np.float32)
-                data[_KP_INSTANCE_ID] = []
-            for internal_name in self._bbox_label_map:
-                data[internal_name] = []
-            for internal_name in self._kp_label_map:
-                data[internal_name] = []
+            self._init_empty_instance_data(data, binding)
             return
 
         instance_dicts = self._validate_instances(instances)
+        self._unpack_masks(data, binding, instance_dicts)
+        self._unpack_bboxes(data, binding, instance_dicts, num_instances)
+        self._unpack_keypoints(data, binding, instance_dicts)
+        self._unpack_bbox_labels(data, instance_dicts)
+        self._unpack_kp_labels(data, instance_dicts)
 
+    def _init_empty_instance_data(self, data: dict[str, Any], binding: frozenset[str]) -> None:
+        if "masks" in binding:
+            data["masks"] = np.empty((0, 0, 0), dtype=np.uint8)
+        if "bboxes" in binding:
+            data["bboxes"] = np.zeros((0, 4), dtype=np.float32)
+            data[_BBOX_INSTANCE_ID] = []
+        if "keypoints" in binding:
+            data["keypoints"] = np.zeros((0, 2), dtype=np.float32)
+            data[_KP_INSTANCE_ID] = []
+        for internal_name in self._bbox_label_map:
+            data[internal_name] = []
+        for internal_name in self._kp_label_map:
+            data[internal_name] = []
+
+    def _unpack_masks(
+        self,
+        data: dict[str, Any],
+        binding: frozenset[str],
+        instance_dicts: list[dict[str, Any]],
+    ) -> None:
         if "masks" in binding:
             data["masks"] = np.stack([inst["mask"] for inst in instance_dicts])
         elif "mask" in binding:
             data["mask"] = np.stack([inst["mask"] for inst in instance_dicts], axis=-1)
 
-        if "bboxes" in binding:
-            data["bboxes"] = np.array([inst["bbox"] for inst in instance_dicts], dtype=np.float32)
-            data[_BBOX_INSTANCE_ID] = list(range(num_instances))
+    def _unpack_bboxes(
+        self,
+        data: dict[str, Any],
+        binding: frozenset[str],
+        instance_dicts: list[dict[str, Any]],
+        num_instances: int,
+    ) -> None:
+        if "bboxes" not in binding:
+            return
+        data["bboxes"] = np.array([inst["bbox"] for inst in instance_dicts], dtype=np.float32)
+        data[_BBOX_INSTANCE_ID] = list(range(num_instances))
 
-        if "keypoints" in binding:
-            all_kps: list[np.ndarray] = []
-            all_ids: list[int] = []
-            for idx, inst in enumerate(instance_dicts):
-                kps = inst.get("keypoints", np.zeros((0, 2), dtype=np.float32))
-                count = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
-                self._instance_kp_counts.append(count)
-                if count > 0:
-                    all_kps.append(np.asarray(kps, dtype=np.float32))
-                    all_ids.extend([idx] * count)
-            data["keypoints"] = np.concatenate(all_kps) if all_kps else np.zeros((0, 2), dtype=np.float32)
-            data[_KP_INSTANCE_ID] = all_ids
+    def _unpack_keypoints(
+        self,
+        data: dict[str, Any],
+        binding: frozenset[str],
+        instance_dicts: list[dict[str, Any]],
+    ) -> None:
+        if "keypoints" not in binding:
+            return
+        all_kps: list[np.ndarray] = []
+        all_ids: list[int] = []
+        for idx, inst in enumerate(instance_dicts):
+            kps = inst.get("keypoints", np.zeros((0, 2), dtype=np.float32))
+            count = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
+            self._instance_kp_counts.append(count)
+            if count > 0:
+                all_kps.append(np.asarray(kps, dtype=np.float32))
+                all_ids.extend([idx] * count)
+        data["keypoints"] = np.concatenate(all_kps) if all_kps else np.zeros((0, 2), dtype=np.float32)
+        data[_KP_INSTANCE_ID] = all_ids
 
+    def _unpack_bbox_labels(self, data: dict[str, Any], instance_dicts: list[dict[str, Any]]) -> None:
         for internal_name, user_name in self._bbox_label_map.items():
             data[internal_name] = [inst.get("bbox_labels", {})[user_name] for inst in instance_dicts]
 
+    def _unpack_kp_labels(self, data: dict[str, Any], instance_dicts: list[dict[str, Any]]) -> None:
         for internal_name, user_name in self._kp_label_map.items():
             flat: list[Any] = []
             for inst in instance_dicts:
-                kp_labels = inst.get("keypoint_labels", {})
-                values = kp_labels.get(user_name, [])
-                flat.extend(values)
+                flat.extend(inst.get("keypoint_labels", {}).get(user_name, []))
             data[internal_name] = flat
 
-    def _validate_instances(self, instances: Sequence[Any]) -> list[dict[str, Any]]:  # noqa: C901, PLR0912
+    def _validate_instances(self, instances: Sequence[Any]) -> list[dict[str, Any]]:
         binding = self._instance_binding
         if binding is None:
             msg = "_validate_instances requires instance_binding"
@@ -1473,49 +1491,69 @@ class Compose(BaseCompose, HubMixin):
         for idx, inst in enumerate(instances):
             if not isinstance(inst, dict):
                 raise TypeError(f"instances[{idx}] must be a dict, got {type(inst).__name__}")
-
-            mask_key = "masks" if "masks" in binding else ("mask" if "mask" in binding else None)
-            if mask_key is not None and "mask" not in inst:
-                raise ValueError(f"instances[{idx}] missing required key 'mask'")
-
-            if "bboxes" in binding and "bbox" not in inst:
-                raise ValueError(f"instances[{idx}] missing required key 'bbox'")
-
-            if "bboxes" in binding and bbox_label_fields:
-                inst_labels = inst.get("bbox_labels")
-                if inst_labels is None:
-                    raise ValueError(f"instances[{idx}] missing 'bbox_labels'")
-                missing = set(bbox_label_fields) - set(inst_labels)
-                if missing:
-                    raise ValueError(
-                        f"instances[{idx}]['bbox_labels'] missing keys: {missing}. Expected: {bbox_label_fields}",
-                    )
-
-            if "keypoints" in binding:
-                kps = inst.get("keypoints", np.zeros((0, 2), dtype=np.float32))
-                num_kps = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
-
-                if kp_label_fields and num_kps > 0:
-                    kp_labels = inst.get("keypoint_labels")
-                    if kp_labels is None:
-                        raise ValueError(f"instances[{idx}] missing 'keypoint_labels'")
-                    missing = set(kp_label_fields) - set(kp_labels)
-                    if missing:
-                        raise ValueError(
-                            f"instances[{idx}]['keypoint_labels'] missing keys: {missing}. Expected: {kp_label_fields}",
-                        )
-                    for field in kp_label_fields:
-                        if len(kp_labels[field]) != num_kps:
-                            raise ValueError(
-                                f"instances[{idx}]['keypoint_labels']['{field}'] has "
-                                f"{len(kp_labels[field])} values but keypoints has {num_kps} rows",
-                            )
-
+            self._validate_instance_mask(inst, idx, binding)
+            self._validate_instance_bbox(inst, idx, binding, bbox_label_fields)
+            self._validate_instance_keypoints(inst, idx, binding, kp_label_fields)
             normalized.append(inst)
 
         return normalized
 
-    def _repack_instances(self, data: dict[str, Any]) -> None:  # noqa: C901, PLR0912
+    def _validate_instance_mask(self, inst: dict[str, Any], idx: int, binding: frozenset[str]) -> None:
+        has_mask_binding = "masks" in binding or "mask" in binding
+        if has_mask_binding and "mask" not in inst:
+            raise ValueError(f"instances[{idx}] missing required key 'mask'")
+
+    def _validate_instance_bbox(
+        self,
+        inst: dict[str, Any],
+        idx: int,
+        binding: frozenset[str],
+        bbox_label_fields: list[str],
+    ) -> None:
+        if "bboxes" not in binding:
+            return
+        if "bbox" not in inst:
+            raise ValueError(f"instances[{idx}] missing required key 'bbox'")
+        if not bbox_label_fields:
+            return
+        inst_labels = inst.get("bbox_labels")
+        if inst_labels is None:
+            raise ValueError(f"instances[{idx}] missing 'bbox_labels'")
+        missing = set(bbox_label_fields) - set(inst_labels)
+        if missing:
+            raise ValueError(
+                f"instances[{idx}]['bbox_labels'] missing keys: {missing}. Expected: {bbox_label_fields}",
+            )
+
+    def _validate_instance_keypoints(
+        self,
+        inst: dict[str, Any],
+        idx: int,
+        binding: frozenset[str],
+        kp_label_fields: list[str],
+    ) -> None:
+        if "keypoints" not in binding:
+            return
+        kps = inst.get("keypoints", np.zeros((0, 2), dtype=np.float32))
+        num_kps = kps.shape[0] if isinstance(kps, np.ndarray) else len(kps)
+        if not (kp_label_fields and num_kps > 0):
+            return
+        kp_labels = inst.get("keypoint_labels")
+        if kp_labels is None:
+            raise ValueError(f"instances[{idx}] missing 'keypoint_labels'")
+        missing = set(kp_label_fields) - set(kp_labels)
+        if missing:
+            raise ValueError(
+                f"instances[{idx}]['keypoint_labels'] missing keys: {missing}. Expected: {kp_label_fields}",
+            )
+        for field in kp_label_fields:
+            if len(kp_labels[field]) != num_kps:
+                raise ValueError(
+                    f"instances[{idx}]['keypoint_labels']['{field}'] has "
+                    f"{len(kp_labels[field])} values but keypoints has {num_kps} rows",
+                )
+
+    def _repack_instances(self, data: dict[str, Any]) -> None:
         binding = self._instance_binding
         if binding is None:
             msg = "_repack_instances requires instance_binding"
@@ -1529,51 +1567,100 @@ class Compose(BaseCompose, HubMixin):
 
         kp_ids = np.array(data.pop(_KP_INSTANCE_ID, []))
 
-        instances: list[dict[str, Any]] = []
-        for new_idx, old_idx in enumerate(surviving_ids):
-            inst: dict[str, Any] = {}
+        data["instances"] = [
+            self._repack_one_instance(data, binding, new_idx, old_idx, kp_ids)
+            for new_idx, old_idx in enumerate(surviving_ids)
+        ]
+        self._cleanup_instance_data(data, binding)
 
-            if "masks" in binding and "masks" in data:
-                mask = data["masks"][new_idx]
-                if hasattr(self, "_added_channel_dim") and self._added_channel_dim.get("masks") and mask.shape[-1] == 1:
-                    mask = np.squeeze(mask, axis=-1)
-                inst["mask"] = mask
-            elif "mask" in binding and "mask" in data:
-                inst["mask"] = data["mask"][:, :, new_idx]
+    def _repack_one_instance(
+        self,
+        data: dict[str, Any],
+        binding: frozenset[str],
+        new_idx: int,
+        old_idx: int,
+        kp_ids: np.ndarray,
+    ) -> dict[str, Any]:
+        inst: dict[str, Any] = {}
+        self._repack_mask_into(inst, data, binding, new_idx)
+        self._repack_bbox_into(inst, data, binding, new_idx)
+        self._repack_keypoints_into(inst, data, binding, old_idx, kp_ids)
+        self._repack_bbox_labels_into(inst, data, new_idx)
+        self._repack_kp_labels_into(inst, data, binding, old_idx, kp_ids)
+        return inst
 
-            if "bboxes" in binding and "bboxes" in data:
-                inst["bbox"] = data["bboxes"][new_idx]
+    def _repack_mask_into(
+        self,
+        inst: dict[str, Any],
+        data: dict[str, Any],
+        binding: frozenset[str],
+        new_idx: int,
+    ) -> None:
+        if "masks" in binding and "masks" in data:
+            mask = data["masks"][new_idx]
+            added = hasattr(self, "_added_channel_dim") and self._added_channel_dim.get("masks")
+            if added and mask.shape[-1] == 1:
+                mask = np.squeeze(mask, axis=-1)
+            inst["mask"] = mask
+        elif "mask" in binding and "mask" in data:
+            inst["mask"] = data["mask"][:, :, new_idx]
 
-            if "keypoints" in binding and "keypoints" in data:
-                if kp_ids.size > 0:
-                    kp_mask = kp_ids == old_idx
-                    inst["keypoints"] = data["keypoints"][kp_mask]
-                else:
-                    inst["keypoints"] = np.zeros((0, 2), dtype=np.float32)
+    def _repack_bbox_into(
+        self,
+        inst: dict[str, Any],
+        data: dict[str, Any],
+        binding: frozenset[str],
+        new_idx: int,
+    ) -> None:
+        if "bboxes" in binding and "bboxes" in data:
+            inst["bbox"] = data["bboxes"][new_idx]
 
-            if self._bbox_label_map:
-                inst["bbox_labels"] = {}
-                for internal_name, user_name in self._bbox_label_map.items():
-                    if internal_name in data:
-                        inst["bbox_labels"][user_name] = data[internal_name][new_idx]
+    def _repack_keypoints_into(
+        self,
+        inst: dict[str, Any],
+        data: dict[str, Any],
+        binding: frozenset[str],
+        old_idx: int,
+        kp_ids: np.ndarray,
+    ) -> None:
+        if "keypoints" not in binding or "keypoints" not in data:
+            return
+        if kp_ids.size > 0:
+            inst["keypoints"] = data["keypoints"][kp_ids == old_idx]
+        else:
+            inst["keypoints"] = np.zeros((0, 2), dtype=np.float32)
 
-            if self._kp_label_map and "keypoints" in binding:
-                inst["keypoint_labels"] = {}
-                for internal_name, user_name in self._kp_label_map.items():
-                    if internal_name in data:
-                        field_values = data[internal_name]
-                        if kp_ids.size > 0:
-                            kp_mask = kp_ids == old_idx
-                            inst["keypoint_labels"][user_name] = [
-                                field_values[i] for i, keep in enumerate(kp_mask) if keep
-                            ]
-                        else:
-                            inst["keypoint_labels"][user_name] = []
+    def _repack_bbox_labels_into(self, inst: dict[str, Any], data: dict[str, Any], new_idx: int) -> None:
+        if not self._bbox_label_map:
+            return
+        inst["bbox_labels"] = {
+            user_name: data[internal_name][new_idx]
+            for internal_name, user_name in self._bbox_label_map.items()
+            if internal_name in data
+        }
 
-            instances.append(inst)
+    def _repack_kp_labels_into(
+        self,
+        inst: dict[str, Any],
+        data: dict[str, Any],
+        binding: frozenset[str],
+        old_idx: int,
+        kp_ids: np.ndarray,
+    ) -> None:
+        if not (self._kp_label_map and "keypoints" in binding):
+            return
+        inst["keypoint_labels"] = {}
+        for internal_name, user_name in self._kp_label_map.items():
+            if internal_name not in data:
+                continue
+            field_values = data[internal_name]
+            if kp_ids.size > 0:
+                kp_mask = kp_ids == old_idx
+                inst["keypoint_labels"][user_name] = [field_values[i] for i, keep in enumerate(kp_mask) if keep]
+            else:
+                inst["keypoint_labels"][user_name] = []
 
-        data["instances"] = instances
-
+    def _cleanup_instance_data(self, data: dict[str, Any], binding: frozenset[str]) -> None:
         for key in ["masks", "bboxes", "keypoints"]:
             if key in binding:
                 data.pop(key, None)

--- a/albumentations/core/keypoints_utils.py
+++ b/albumentations/core/keypoints_utils.py
@@ -191,6 +191,13 @@ class KeypointParams(Params):
             f" check_each_transform={self.check_each_transform}, label_mapping={self.label_mapping})"
         )
 
+    def make_empty_keypoints_array(self) -> np.ndarray:
+        """Return (0,K) float32 empty keypoints; K=len(coord_format). Empty-list inputs get ndarray width
+        matching user format before preprocess converts coordinates.
+
+        """
+        return np.array([], dtype=np.float32).reshape(0, len(self.coord_format))
+
 
 class KeypointsProcessor(DataProcessor):
     """DataProcessor for keypoints: conversion, validation, filtering. Uses KeypointParams
@@ -207,6 +214,8 @@ class KeypointsProcessor(DataProcessor):
 
     """
 
+    params: KeypointParams
+
     def __init__(self, params: KeypointParams, additional_targets: dict[str, str] | None = None):
         super().__init__(params, additional_targets)
         # Store encoded mappings for transforms - will be populated during preprocessing
@@ -215,6 +224,9 @@ class KeypointsProcessor(DataProcessor):
     @property
     def default_data_name(self) -> str:
         return "keypoints"
+
+    def _create_empty_keypoints_array(self) -> np.ndarray:
+        return self.params.make_empty_keypoints_array()
 
     def ensure_data_valid(self, data: dict[str, Any]) -> None:
         """Validate that data has all params.label_fields; raises ValueError if any are

--- a/albumentations/core/keypoints_utils.py
+++ b/albumentations/core/keypoints_utils.py
@@ -192,9 +192,8 @@ class KeypointParams(Params):
         )
 
     def make_empty_keypoints_array(self) -> np.ndarray:
-        """Return (0,K) float32 empty keypoints; K=len(coord_format). Use when list empty so width
-        matches user format before coordinate preprocess.
-
+        """Build an empty (0, K) float32 keypoints ndarray for an empty instance list so column width matches
+        coord_format before coordinate preprocessing.
         """
         return np.array([], dtype=np.float32).reshape(0, len(self.coord_format))
 

--- a/albumentations/core/keypoints_utils.py
+++ b/albumentations/core/keypoints_utils.py
@@ -192,8 +192,8 @@ class KeypointParams(Params):
         )
 
     def make_empty_keypoints_array(self) -> np.ndarray:
-        """Return (0,K) float32 empty keypoints; K=len(coord_format). Empty-list inputs get ndarray width
-        matching user format before preprocess converts coordinates.
+        """Return (0,K) float32 empty keypoints; K=len(coord_format). Use when list empty so width
+        matches user format before coordinate preprocess.
 
         """
         return np.array([], dtype=np.float32).reshape(0, len(self.coord_format))

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -27,6 +27,13 @@ These guidelines represent our current best practices, developed through experie
 - Long strings (docstrings, comments, expressions) must be split across multiple lines at a word or operator boundary.
 - For docstrings, wrap to the next line — the Google docstring format allows multi-line short descriptions.
 
+### Code Complexity
+
+- Ruff enforces McCabe complexity (`C901`, limit 10) and branch count (`PLR0912`, limit 12).
+- **Never** suppress these with `# noqa: C901`, `# noqa: PLR0912`, or any other inline suppression.
+- **Never** raise the limit in `pyproject.toml`.
+- **Fix**: Extract private helper methods that each own a single concern. A function over the limit is a signal it is doing too many things and should be split.
+
 ### Pre-commit Hooks
 
 We use pre-commit hooks to maintain consistent code quality. These hooks automatically check and format your code before each commit.

--- a/docs/design/instance_binding.md
+++ b/docs/design/instance_binding.md
@@ -31,7 +31,7 @@ No transform changes are required.
 Which keys are required depends on `instance_binding`:
 - `"masks"` or `"mask"` → requires `"mask"` key
 - `"bboxes"` → requires `"bbox"` key
-- `"keypoints"` → requires `"keypoints"` key
+- `"keypoints"` → requires `"keypoints"` key (use a zero-row array such as `np.empty((0, 2))` for no points)
 
 `bbox_labels` / `keypoint_labels` are present when the corresponding `Params.label_fields`
 are non-empty. They use nested dicts to avoid name collisions (both bbox and keypoint can

--- a/docs/design/instance_binding.md
+++ b/docs/design/instance_binding.md
@@ -62,7 +62,8 @@ Valid targets: `"mask"`, `"masks"`, `"bboxes"`, `"keypoints"`. Minimum 2. `"mask
 7. Inject hidden label fields: `_bbox_instance_id = [0..N-1]`,
    `_kp_instance_id = [0,0,..,1,1,..]` (one per keypoint row).
 
-Then the existing processor `preprocess` hstacks these label columns onto the arrays.
+Then the existing processor `preprocess` horizontally stacks (`numpy.hstack`) these label
+columns onto the arrays.
 
 ## Postprocessing (Repack)
 

--- a/docs/design/instance_binding.md
+++ b/docs/design/instance_binding.md
@@ -1,0 +1,86 @@
+# Instance Binding
+
+## Problem
+
+Albumentations treats `masks`, `bboxes`, and `keypoints` as independent targets. When bbox
+filtering removes an instance (e.g., after a crop makes it too small), the corresponding mask
+and keypoints stay behind, causing index misalignment. Pose estimation models also expect a
+fixed number of keypoints per surviving instance, but `filter_keypoints` may drop individual
+out-of-bounds keypoints independently.
+
+## Solution
+
+A new `instance_binding` parameter on `Compose` plus a structured `instances` input format.
+Users pass `instances` as a list of dicts, each representing one object. Compose unpacks them
+into flat arrays for the existing pipeline, then repacks the survivors into the same format.
+
+No transform changes are required.
+
+## Instance Dict Schema
+
+```python
+{
+    "mask": np.ndarray,                      # (H, W) binary mask
+    "bbox": np.ndarray,                      # (4,) or (5+,) per coord format
+    "keypoints": np.ndarray,                 # (K, C) e.g. (K, 2) for xy
+    "bbox_labels": {"class": "cat", ...},    # scalars, keys = BboxParams.label_fields
+    "keypoint_labels": {"name": [...], ...}, # lists len==K, keys = KeypointParams.label_fields
+}
+```
+
+Which keys are required depends on `instance_binding`:
+- `"masks"` or `"mask"` → requires `"mask"` key
+- `"bboxes"` → requires `"bbox"` key
+- `"keypoints"` → requires `"keypoints"` key
+
+`bbox_labels` / `keypoint_labels` are present when the corresponding `Params.label_fields`
+are non-empty. They use nested dicts to avoid name collisions (both bbox and keypoint can
+have a `"class"` field).
+
+## Compose Parameter
+
+```python
+A.Compose(
+    transforms,
+    bbox_params=...,
+    keypoint_params=...,
+    instance_binding=["masks", "bboxes", "keypoints"],
+)
+```
+
+Valid targets: `"mask"`, `"masks"`, `"bboxes"`, `"keypoints"`. Minimum 2. `"mask"` and
+`"masks"` are mutually exclusive.
+
+## Preprocessing (Unpack)
+
+1. Pop `data["instances"]` list.
+2. Stack masks → `data["masks"]` `(N,H,W)` or concat as channels → `data["mask"]` `(H,W,C)`.
+3. Stack bboxes → `data["bboxes"]` `(N,4+)`.
+4. Concatenate keypoints → `data["keypoints"]` `(M,C)`.
+5. Flatten `bbox_labels` → `data[field_name]` as list of N scalars.
+6. Flatten `keypoint_labels` → `data[field_name]` as concatenated list of M values.
+7. Inject hidden label fields: `_bbox_instance_id = [0..N-1]`,
+   `_kp_instance_id = [0,0,..,1,1,..]` (one per keypoint row).
+
+Then the existing processor `preprocess` hstacks these label columns onto the arrays.
+
+## Postprocessing (Repack)
+
+1. Processor `postprocess` runs (filter, format convert, split label fields back out).
+2. Read surviving `_bbox_instance_id` values → determine which instances survived.
+3. Index `masks` and `keypoints` by surviving IDs.
+4. Rebuild instance dicts with masks, bboxes, keypoints, and label dicts.
+5. Remove flat arrays and hidden fields from `data`; set `data["instances"]`.
+
+## Anchor
+
+- When `"bboxes"` is bound, bbox filtering (min_area, min_visibility, etc.) drives
+  instance removal.
+- When `"bboxes"` is not bound, nothing drives removal; binding only enforces
+  correspondence.
+
+## Keypoint Behavior
+
+When keypoints are bound, `remove_invisible` and `check_each_transform` on
+`KeypointParams` are forced to `False`. Keypoints may land outside image bounds; the only
+removal is via instance survival.

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -513,6 +515,64 @@ class TestSerialization:
         bbox_params = params["bbox_params"]
         assert "_bbox_instance_id" not in (bbox_params.label_fields or [])
         assert params["instance_binding"] == ["bboxes", "masks"]
+
+    def test_get_init_params_masks_keypoints_preserves_bbox_params(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["name"]),
+            instance_binding=["masks", "keypoints"],
+        )
+
+        params = transform._get_init_params()
+        assert params["bbox_params"].label_fields == ["class_id"]
+
+    def test_get_init_params_masks_bboxes_preserves_keypoint_params(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=A.KeypointParams(
+                coord_format="xy",
+                label_fields=["name"],
+                remove_invisible=False,
+                check_each_transform=False,
+            ),
+            instance_binding=["masks", "bboxes"],
+        )
+
+        params = transform._get_init_params()
+        assert params["keypoint_params"].label_fields == ["name"]
+        assert params["keypoint_params"].remove_invisible is False
+        assert params["keypoint_params"].check_each_transform is False
+
+
+class TestInstanceBindingCallState:
+    def test_state_cleared_when_transform_raises(self) -> None:
+        def boom(img: np.ndarray, **kwargs: Any) -> np.ndarray:
+            msg = "intentional"
+            raise RuntimeError(msg)
+
+        transform = A.Compose(
+            [A.NoOp(p=1), A.Lambda(image=boom, p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(),
+                "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                "keypoints": np.array([[20.0, 20.0]], dtype=np.float32),
+            },
+        ]
+
+        with pytest.raises(RuntimeError, match="intentional"):
+            transform(image=image, instances=instances)
+
+        assert not getattr(transform, "_repack_after_processors", False)
+        assert not hasattr(transform, "_instance_count")
 
 
 class TestChannelMask:

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -1,0 +1,442 @@
+import numpy as np
+import pytest
+
+import albumentations as A
+
+
+def _make_image(height: int = 100, width: int = 100) -> np.ndarray:
+    return np.random.default_rng(137).integers(0, 256, (height, width, 3), dtype=np.uint8)
+
+
+def _make_mask(height: int = 100, width: int = 100, region: tuple[int, int, int, int] | None = None) -> np.ndarray:
+    mask = np.zeros((height, width), dtype=np.uint8)
+    if region is not None:
+        y1, y2, x1, x2 = region
+        mask[y1:y2, x1:x2] = 1
+    return mask
+
+
+class TestInstanceBindingInit:
+    def test_valid_binding(self) -> None:
+        t = A.Compose(
+            [A.HorizontalFlip(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["masks", "bboxes"],
+        )
+        assert t._instance_binding == frozenset({"masks", "bboxes"})
+
+    def test_binding_requires_at_least_two(self) -> None:
+        with pytest.raises(ValueError, match="at least 2"):
+            A.Compose(
+                [A.HorizontalFlip(p=1)],
+                bbox_params=A.BboxParams(coord_format="pascal_voc"),
+                instance_binding=["bboxes"],
+            )
+
+    def test_invalid_target_name(self) -> None:
+        with pytest.raises(ValueError, match="Invalid instance_binding"):
+            A.Compose(
+                [A.HorizontalFlip(p=1)],
+                instance_binding=["masks", "invalid_target"],
+            )
+
+    def test_mask_and_masks_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError, match="both 'mask' and 'masks'"):
+            A.Compose(
+                [A.HorizontalFlip(p=1)],
+                bbox_params=A.BboxParams(coord_format="pascal_voc"),
+                instance_binding=["mask", "masks", "bboxes"],
+            )
+
+    def test_bboxes_requires_bbox_params(self) -> None:
+        with pytest.raises(ValueError, match="bbox_params must be set"):
+            A.Compose(
+                [A.HorizontalFlip(p=1)],
+                instance_binding=["masks", "bboxes"],
+            )
+
+    def test_keypoints_requires_keypoint_params(self) -> None:
+        with pytest.raises(ValueError, match="keypoint_params must be set"):
+            A.Compose(
+                [A.HorizontalFlip(p=1)],
+                bbox_params=A.BboxParams(coord_format="pascal_voc"),
+                instance_binding=["masks", "bboxes", "keypoints"],
+            )
+
+    def test_none_binding(self) -> None:
+        t = A.Compose([A.HorizontalFlip(p=1)])
+        assert t._instance_binding is None
+
+
+class TestUnpackRepack:
+    def test_basic_roundtrip(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 50, 10, 50)),
+                "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                "keypoints": np.array([[20.0, 20.0], [30.0, 30.0]], dtype=np.float32),
+                "bbox_labels": {"class_id": "cat"},
+            },
+            {
+                "mask": _make_mask(region=(60, 90, 60, 90)),
+                "bbox": np.array([60, 60, 90, 90], dtype=np.float32),
+                "keypoints": np.array([[70.0, 70.0]], dtype=np.float32),
+                "bbox_labels": {"class_id": "dog"},
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert len(result["instances"]) == 2
+        assert result["instances"][0]["mask"].shape == (100, 100)
+        assert result["instances"][0]["bbox_labels"]["class_id"] == "cat"
+        assert result["instances"][1]["bbox_labels"]["class_id"] == "dog"
+        assert result["instances"][0]["keypoints"].shape == (2, 2)
+        assert result["instances"][1]["keypoints"].shape == (1, 2)
+
+    def test_variable_keypoints_per_instance(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 50, 10, 50)),
+                "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                "keypoints": np.array([[20.0, 20.0]] * 17, dtype=np.float32),
+            },
+            {
+                "mask": _make_mask(region=(60, 90, 60, 90)),
+                "bbox": np.array([60, 60, 90, 90], dtype=np.float32),
+                "keypoints": np.array([[70.0, 70.0]], dtype=np.float32),
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert result["instances"][0]["keypoints"].shape == (17, 2)
+        assert result["instances"][1]["keypoints"].shape == (1, 2)
+
+
+class TestBboxFiltering:
+    def test_removed_bbox_removes_mask_and_keypoints(self) -> None:
+        transform = A.Compose(
+            [A.Crop(x_min=0, y_min=0, x_max=55, y_max=55, p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"], min_area=1),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 50, 10, 50)),
+                "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                "keypoints": np.array([[20.0, 20.0], [30.0, 30.0]], dtype=np.float32),
+                "bbox_labels": {"class_id": "cat"},
+            },
+            {
+                "mask": _make_mask(region=(60, 90, 60, 90)),
+                "bbox": np.array([60, 60, 90, 90], dtype=np.float32),
+                "keypoints": np.array([[70.0, 70.0]], dtype=np.float32),
+                "bbox_labels": {"class_id": "dog"},
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert len(result["instances"]) == 1
+        assert result["instances"][0]["bbox_labels"]["class_id"] == "cat"
+        assert result["instances"][0]["keypoints"].shape[0] == 2
+
+    def test_all_bboxes_removed(self) -> None:
+        transform = A.Compose(
+            [A.Crop(x_min=40, y_min=40, x_max=60, y_max=60, p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", min_area=100),
+            instance_binding=["masks", "bboxes"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 20, 10, 20)),
+                "bbox": np.array([10, 10, 20, 20], dtype=np.float32),
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert result["instances"] == []
+
+
+class TestEmptyInput:
+    def test_empty_instances_list(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["masks", "bboxes"],
+        )
+
+        image = _make_image()
+        result = transform(image=image, instances=[])
+        assert result["instances"] == []
+
+    def test_instance_with_zero_keypoints(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 50, 10, 50)),
+                "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                "keypoints": np.zeros((0, 2), dtype=np.float32),
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert len(result["instances"]) == 1
+        assert result["instances"][0]["keypoints"].shape == (0, 2)
+
+
+class TestKeypoints:
+    def test_out_of_bounds_keypoints_preserved(self) -> None:
+        transform = A.Compose(
+            [A.Crop(x_min=20, y_min=20, x_max=80, y_max=80, p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(20, 80, 20, 80)),
+                "bbox": np.array([20, 20, 80, 80], dtype=np.float32),
+                "keypoints": np.array(
+                    [
+                        [50.0, 50.0],
+                        [5.0, 5.0],
+                    ],
+                    dtype=np.float32,
+                ),
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert len(result["instances"]) == 1
+        assert result["instances"][0]["keypoints"].shape[0] == 2
+
+
+class TestOverlappingLabelNames:
+    def test_same_label_name_bbox_and_keypoint(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class"]),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["class"]),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 50, 10, 50)),
+                "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                "keypoints": np.array([[20.0, 20.0], [30.0, 30.0]], dtype=np.float32),
+                "bbox_labels": {"class": "cat"},
+                "keypoint_labels": {"class": ["left_eye", "right_eye"]},
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert result["instances"][0]["bbox_labels"]["class"] == "cat"
+        assert result["instances"][0]["keypoint_labels"]["class"] == ["left_eye", "right_eye"]
+
+
+class TestValidation:
+    def test_missing_mask(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["masks", "bboxes"],
+        )
+
+        image = _make_image()
+        with pytest.raises(ValueError, match="missing required key 'mask'"):
+            transform(
+                image=image,
+                instances=[{"bbox": np.array([10, 10, 50, 50], dtype=np.float32)}],
+            )
+
+    def test_missing_bbox(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["masks", "bboxes"],
+        )
+
+        image = _make_image()
+        with pytest.raises(ValueError, match="missing required key 'bbox'"):
+            transform(
+                image=image,
+                instances=[{"mask": _make_mask()}],
+            )
+
+    def test_missing_bbox_labels(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+            instance_binding=["masks", "bboxes"],
+        )
+
+        image = _make_image()
+        with pytest.raises(ValueError, match="missing 'bbox_labels'"):
+            transform(
+                image=image,
+                instances=[
+                    {
+                        "mask": _make_mask(),
+                        "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                    },
+                ],
+            )
+
+    def test_missing_bbox_label_key(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id", "score"]),
+            instance_binding=["masks", "bboxes"],
+        )
+
+        image = _make_image()
+        with pytest.raises(ValueError, match="missing keys"):
+            transform(
+                image=image,
+                instances=[
+                    {
+                        "mask": _make_mask(),
+                        "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                        "bbox_labels": {"class_id": "cat"},
+                    },
+                ],
+            )
+
+    def test_keypoint_label_length_mismatch(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["name"]),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        with pytest.raises(ValueError, match="values but keypoints has"):
+            transform(
+                image=image,
+                instances=[
+                    {
+                        "mask": _make_mask(),
+                        "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                        "keypoints": np.array([[20.0, 20.0], [30.0, 30.0]], dtype=np.float32),
+                        "keypoint_labels": {"name": ["left_eye"]},
+                    },
+                ],
+            )
+
+
+class TestWithoutBboxes:
+    def test_masks_and_keypoints_only(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 50, 10, 50)),
+                "keypoints": np.array([[20.0, 20.0], [30.0, 30.0]], dtype=np.float32),
+            },
+            {
+                "mask": _make_mask(region=(60, 90, 60, 90)),
+                "keypoints": np.array([[70.0, 70.0]], dtype=np.float32),
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert len(result["instances"]) == 2
+
+
+class TestSerialization:
+    def test_to_dict_excludes_hidden_fields(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        d = transform.to_dict_private()
+        bbox_label_fields = d["bbox_params"]["label_fields"]
+        kp_label_fields = d["keypoint_params"]["label_fields"]
+
+        assert "_bbox_instance_id" not in bbox_label_fields
+        assert "_ibl_bbox_class_id" not in bbox_label_fields
+        assert "_kp_instance_id" not in kp_label_fields
+        assert "class_id" in bbox_label_fields
+        assert d["instance_binding"] == ["bboxes", "keypoints", "masks"]
+
+    def test_to_dict_omits_binding_when_none(self) -> None:
+        transform = A.Compose([A.NoOp(p=1)])
+        d = transform.to_dict_private()
+        assert "instance_binding" not in d
+
+    def test_get_init_params_clean(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+            instance_binding=["masks", "bboxes"],
+        )
+
+        params = transform._get_init_params()
+        bbox_params = params["bbox_params"]
+        assert "_bbox_instance_id" not in (bbox_params.label_fields or [])
+        assert params["instance_binding"] == ["bboxes", "masks"]
+
+
+class TestChannelMask:
+    def test_mask_channel_binding(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["mask", "bboxes"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 50, 10, 50)),
+                "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+            },
+            {
+                "mask": _make_mask(region=(60, 90, 60, 90)),
+                "bbox": np.array([60, 60, 90, 90], dtype=np.float32),
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        assert len(result["instances"]) == 2
+        assert result["instances"][0]["mask"].shape == (100, 100)

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -347,6 +347,16 @@ class TestOverlappingLabelNames:
 
 
 class TestValidation:
+    def test_missing_instances_key(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["masks", "bboxes"],
+        )
+        image = _make_image()
+        with pytest.raises(ValueError, match="`instances` must be provided"):
+            transform(image=image)
+
     def test_missing_mask(self) -> None:
         transform = A.Compose(
             [A.NoOp(p=1)],
@@ -544,6 +554,43 @@ class TestSerialization:
         assert params["keypoint_params"].label_fields == ["name"]
         assert params["keypoint_params"].remove_invisible is False
         assert params["keypoint_params"].check_each_transform is False
+
+    def test_get_init_params_keypoints_binding_reflects_runtime_flags(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=A.KeypointParams(
+                coord_format="xy",
+                remove_invisible=True,
+                check_each_transform=True,
+            ),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+        params = transform._get_init_params()
+        kp = params["keypoint_params"]
+        assert kp.remove_invisible is False
+        assert kp.check_each_transform is False
+
+
+class TestNestedComposeInstanceBinding:
+    def test_inner_compose_preprocess_after_unpack(self) -> None:
+        inner = A.Compose([A.NoOp(p=1)])
+        transform = A.Compose(
+            [inner],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["masks", "bboxes"],
+        )
+        image = _make_image()
+        out = transform(
+            image=image,
+            instances=[
+                {
+                    "mask": _make_mask(),
+                    "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                },
+            ],
+        )
+        assert len(out["instances"]) == 1
 
 
 class TestInstanceUnpackCollisions:

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -546,6 +546,28 @@ class TestSerialization:
         assert params["keypoint_params"].check_each_transform is False
 
 
+class TestInstanceUnpackCollisions:
+    def test_rejects_existing_masks_key(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["masks", "bboxes"],
+        )
+        image = _make_image()
+        existing = np.zeros((1, 100, 100), dtype=np.uint8)
+        with pytest.raises(ValueError, match="would overwrite existing data keys"):
+            transform(
+                image=image,
+                masks=existing,
+                instances=[
+                    {
+                        "mask": _make_mask(),
+                        "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                    },
+                ],
+            )
+
+
 class TestInstanceBindingCallState:
     def test_state_cleared_when_transform_raises(self) -> None:
         def boom(img: np.ndarray, **kwargs: Any) -> np.ndarray:

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -210,6 +210,63 @@ class TestEmptyInput:
         assert len(result["instances"]) == 1
         assert result["instances"][0]["keypoints"].shape == (0, 2)
 
+    def test_zero_keypoints_with_label_fields_no_keypoint_labels_required(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["name"]),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+
+        image = _make_image()
+        instances = [
+            {
+                "mask": _make_mask(region=(10, 50, 10, 50)),
+                "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                "keypoints": np.empty((0, 2), dtype=np.float32),
+                "bbox_labels": {"class_id": 1},
+            },
+        ]
+
+        result = transform(image=image, instances=instances)
+        np.testing.assert_array_equal(
+            result["instances"][0]["keypoints"],
+            np.empty((0, 2), dtype=np.float32),
+        )
+
+    def test_empty_instances_obb_bbox_processor_shape(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", bbox_type="obb"),
+            instance_binding=["masks", "bboxes"],
+        )
+        image = _make_image()
+        result = transform(image=image, instances=[])
+        assert result["instances"] == []
+
+
+class TestParamsIsolation:
+    def test_shared_bbox_params_not_mutated_by_instance_binding(self) -> None:
+        shared = A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"])
+        A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=shared,
+            instance_binding=["masks", "bboxes"],
+        )
+        assert shared.label_fields == ["class_id"]
+
+    def test_shared_keypoint_params_not_mutated_by_instance_binding(self) -> None:
+        shared = A.KeypointParams(coord_format="xy", remove_invisible=True, check_each_transform=True)
+        A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=shared,
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+        assert shared.remove_invisible is True
+        assert shared.check_each_transform is True
+        assert shared.label_fields is None
+
 
 class TestKeypoints:
     def test_out_of_bounds_keypoints_preserved(self) -> None:

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -158,6 +158,28 @@ class TestBboxFiltering:
         assert result["instances"][0]["bbox_labels"]["class_id"] == "cat"
         assert result["instances"][0]["keypoints"].shape[0] == 2
 
+    def test_mask_repack_uses_original_instance_index(self) -> None:
+        """When instance 0 is bbox-filtered but instance 1 survives, mask must index stack by old id."""
+        transform = A.Compose(
+            [A.Crop(x_min=40, y_min=40, x_max=60, y_max=60, p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", min_area=1),
+            instance_binding=["masks", "bboxes"],
+        )
+        image = _make_image()
+        instances = [
+            {
+                "mask": np.zeros((100, 100), dtype=np.uint8),
+                "bbox": np.array([10.0, 10.0, 15.0, 15.0], dtype=np.float32),
+            },
+            {
+                "mask": _make_mask(region=(42, 58, 42, 58)),
+                "bbox": np.array([45.0, 45.0, 55.0, 55.0], dtype=np.float32),
+            },
+        ]
+        result = transform(image=image, instances=instances)
+        assert len(result["instances"]) == 1
+        assert result["instances"][0]["mask"].sum() > 50
+
     def test_all_bboxes_removed(self) -> None:
         transform = A.Compose(
             [A.Crop(x_min=40, y_min=40, x_max=60, y_max=60, p=1)],
@@ -349,6 +371,25 @@ class TestValidation:
             transform(
                 image=image,
                 instances=[{"mask": _make_mask()}],
+            )
+
+    def test_missing_keypoints_when_bound(self) -> None:
+        transform = A.Compose(
+            [A.NoOp(p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+        image = _make_image()
+        with pytest.raises(ValueError, match="missing required key 'keypoints'"):
+            transform(
+                image=image,
+                instances=[
+                    {
+                        "mask": _make_mask(),
+                        "bbox": np.array([10, 10, 50, 50], dtype=np.float32),
+                    },
+                ],
             )
 
     def test_missing_bbox_labels(self) -> None:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -39,12 +39,14 @@ def reset_telemetry_client():
 class TestTelemetrySettings:
     """Test telemetry settings management."""
 
-    def test_telemetry_enabled_by_default(self):
-        """Test that telemetry is enabled by default."""
-        # Create fresh settings instance
+    def test_telemetry_enabled_by_default(self, tmp_path, monkeypatch):
+        """Test that telemetry is enabled by default (no file, no opt-out env)."""
+        monkeypatch.delenv("ALBUMENTATIONS_NO_TELEMETRY", raising=False)
+        monkeypatch.delenv("ALBUMENTATIONS_OFFLINE", raising=False)
         from albumentations.core.analytics.settings import SettingsManager
 
-        test_settings = SettingsManager()
+        # Isolated path: avoid shared get_cache_dir()/settings.json from other workers or CI cache
+        test_settings = SettingsManager(settings_file=tmp_path / "telemetry_default.json")
         assert test_settings.telemetry_enabled is True
 
     def test_telemetry_disable_via_settings(self):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -734,7 +734,7 @@ class TestComplexPipelines:
         ("ALBUMENTATIONS_OFFLINE", "1", False),
     ],
 )
-def test_environment_variables(monkeypatch, env_var, env_value, expected):
+def test_environment_variables(monkeypatch, env_var, env_value, expected, tmp_path):
     """Test various environment variable configurations."""
     # Clear all relevant env vars first
     for var in ["ALBUMENTATIONS_NO_TELEMETRY", "ALBUMENTATIONS_OFFLINE"]:
@@ -746,7 +746,8 @@ def test_environment_variables(monkeypatch, env_var, env_value, expected):
     # Create new settings instance to pick up env vars
     from albumentations.core.analytics.settings import SettingsManager
 
-    test_settings = SettingsManager()
+    # Isolate from shared cache settings.json (e.g. CI may persist telemetry: false).
+    test_settings = SettingsManager(settings_file=tmp_path / "telemetry_env_settings.json")
 
     assert test_settings.telemetry_enabled == expected
 


### PR DESCRIPTION
## Summary by Sourcery

Add instance-aware binding for masks, bounding boxes, and keypoints in Compose, plus supporting refactors, documentation, and tests.

New Features:
- Introduce an instance_binding option on Compose and ReplayCompose that accepts an instances list input and keeps masks, bboxes, keypoints, and their labels aligned across transforms and filtering.
- Support both per-instance mask stacks (masks) and multi-channel masks (mask) as binding options, with validation of required keys and label fields.
- Expose instance_binding configuration through Compose serialization and initialization helpers while preserving the public bbox/keypoint params API.

Bug Fixes:
- Ensure nested transforms inside channel-wise compositions invoke sub-transforms without force_apply so individual transform probabilities are respected.

Enhancements:
- Refactor Compose initialization by extracting helper methods for processor setup, telemetry, and instance binding to reduce complexity and improve maintainability.
- Adjust bbox and keypoint parameter handling so internal instance-binding metadata is stripped out in serialized configs and init params.
- Tighten type hints for internal selection indices in SomeOf/OneOf to use NDArray[np.int_].

Documentation:
- Document the new instance binding design and instance schema in a dedicated design doc.
- Clarify coding guidelines and Claude assistant skills around function complexity limits (C901/PLR0912) and preferred refactoring strategies.

Tests:
- Add a comprehensive test suite for instance binding covering initialization, unpack/repack behavior, bbox-driven filtering, keypoint handling, empty inputs, overlapping label names, validation failures, and serialization behavior.