### PR TITLE
Cursor/mosaic copypaste instance binding

### DIFF
--- a/albumentations/augmentations/mixing/functional.py
+++ b/albumentations/augmentations/mixing/functional.py
@@ -11,12 +11,17 @@ from warnings import warn
 
 import cv2
 import numpy as np
+from typing_extensions import NotRequired
 
 import albumentations.augmentations.geometric.functional as fgeometric
 from albumentations.augmentations.crops.transforms import Crop
 from albumentations.augmentations.geometric.resize import LongestMaxSize, SmallestMaxSize
 from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, normalize_bboxes
-from albumentations.core.composition import Compose
+from albumentations.core.composition import (
+    _BBOX_INSTANCE_ID,
+    _KP_INSTANCE_ID,
+    Compose,
+)
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.type_definitions import (
     NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS,
@@ -26,14 +31,13 @@ from albumentations.core.type_definitions import (
 
 # Type definition for a processed mosaic item
 class ProcessedMosaicItem(TypedDict):
-    """Single mosaic item (primary or additional) after preprocessing: image, optional mask,
-    bboxes, keypoints with preprocessed annotations.
-    """
+    """Preprocessed Mosaic grid item: cell RGB image, optional semantic mask, optional (N,H,W) instance masks, bboxes, keypoints."""
 
-    image: np.ndarray  # Image is mandatory
-    mask: np.ndarray | None
-    bboxes: np.ndarray | None
-    keypoints: np.ndarray | None
+    image: np.ndarray
+    mask: NotRequired[np.ndarray | None]
+    masks: NotRequired[np.ndarray | None]  # (N, H, W) instance masks aligned with item image
+    bboxes: NotRequired[np.ndarray | None]
+    keypoints: NotRequired[np.ndarray | None]
 
 
 def copy_and_paste_blend(
@@ -445,6 +449,50 @@ def assign_items_to_grid_cells(
     return placement_to_item_index
 
 
+def _ensure_mosaic_bbox_binding_fields(item: dict[str, Any], required_labels: Sequence[str]) -> None:
+    if not required_labels:
+        return
+    arr = item["bboxes"]
+    n_rows = len(arr) if isinstance(arr, np.ndarray) else len(np.asarray(arr))
+    if _BBOX_INSTANCE_ID in required_labels and _BBOX_INSTANCE_ID not in item:
+        item[_BBOX_INSTANCE_ID] = list(range(n_rows))
+    for field in required_labels:
+        if field.startswith("_ibl_bbox_") and field not in item:
+            user_key = field.removeprefix("_ibl_bbox_")
+            if user_key in item:
+                item[field] = item[user_key]
+
+
+def _ensure_mosaic_keypoint_binding_fields(item: dict[str, Any], required_labels: Sequence[str]) -> None:
+    if not required_labels:
+        return
+    kps = np.asarray(item["keypoints"])
+    n_kp = kps.shape[0]
+    if _KP_INSTANCE_ID in required_labels and _KP_INSTANCE_ID not in item:
+        item[_KP_INSTANCE_ID] = [0] * n_kp
+    for field in required_labels:
+        if field.startswith("_ibl_kp_") and field not in item:
+            user_key = field.removeprefix("_ibl_kp_")
+            if user_key in item:
+                item[field] = item[user_key]
+
+
+def _validate_mosaic_item_label_fields(
+    item: dict[str, Any],
+    required_labels: Sequence[str],
+    data_key: str,
+    params_cls_name: str,
+) -> None:
+    missing = [field for field in required_labels if field not in item]
+    if not missing:
+        return
+    raise ValueError(
+        f"Item contains '{data_key}' but is missing required label fields: {missing}. "
+        f"Ensure all label fields declared in {params_cls_name} ({required_labels}) are present "
+        f"in the item dictionary when '{data_key}' is present.",
+    )
+
+
 def _preprocess_item_annotations(
     item: dict[str, Any],
     processor: BboxProcessor | KeypointsProcessor | None,
@@ -455,40 +503,24 @@ def _preprocess_item_annotations(
     """
     original_data = item.get(data_key)
 
-    # Check if processor exists and the relevant data key is in the item
-    if processor and data_key in item and item.get(data_key) is not None:
-        # === Add validation for required label fields ===
-        required_labels = processor.params.label_fields
+    if not (processor and data_key in item and item.get(data_key) is not None):
+        return original_data
 
-        if required_labels and [field for field in required_labels if field not in item]:
-            raise ValueError(
-                f"Item contains '{data_key}' but is missing required label "
-                "fields: {[field for field in required_labels if field not in item]}. "
-                f"Ensure all label fields declared in {type(processor.params).__name__} "
-                f"({required_labels}) are present in the item dictionary when '{data_key}' is present.",
-            )
-        # === End validation ===
+    required_labels = processor.params.label_fields or []
+    if data_key == "bboxes":
+        _ensure_mosaic_bbox_binding_fields(item, required_labels)
+    else:
+        _ensure_mosaic_keypoint_binding_fields(item, required_labels)
 
-        # Create a temporary minimal dict for the processor
-        temp_data = {
-            "image": item["image"],
-            data_key: item[data_key],
-        }
+    _validate_mosaic_item_label_fields(item, required_labels, data_key, type(processor.params).__name__)
 
-        # Add declared label fields if they exist in the item (already validated above)
-        if required_labels:
-            for field in required_labels:
-                # Check again just in case validation logic changes, avoids KeyError
-                if field in item:
-                    temp_data[field] = item[field]
+    temp_data: dict[str, Any] = {"image": item["image"], data_key: item[data_key]}
+    for field in required_labels:
+        if field in item:
+            temp_data[field] = item[field]
 
-        # Preprocess modifies temp_data in-place
-        processor.preprocess(temp_data)
-        # Return the potentially modified data from the temp dict
-        return temp_data.get(data_key)
-
-    # Return original data if no processor or data key wasn't in item
-    return original_data
+    processor.preprocess(temp_data)
+    return temp_data.get(data_key)
 
 
 def preprocess_copy_paste_annotations(
@@ -502,7 +534,7 @@ def preprocess_copy_paste_annotations(
     return _preprocess_item_annotations(item, processor, data_key)
 
 
-def _unpack_label_wrappers(item: dict[str, Any]) -> dict[str, Any]:
+def unpack_label_wrappers(item: dict[str, Any]) -> dict[str, Any]:
     """Unpack `bbox_labels` and `keypoint_labels` wrapper dicts into top-level label fields so processors can find them directly.
 
     Both Mosaic and CopyAndPaste store per-item label values under `bbox_labels` and
@@ -537,7 +569,7 @@ def preprocess_selected_mosaic_items(
     result_data_items: list[ProcessedMosaicItem] = []
 
     for item in selected_raw_items:
-        flat_item = _unpack_label_wrappers(item)
+        flat_item = unpack_label_wrappers(item)
         processed_bboxes = _preprocess_item_annotations(flat_item, bbox_processor, "bboxes")
         processed_keypoints = _preprocess_item_annotations(flat_item, keypoint_processor, "keypoints")
 
@@ -548,6 +580,9 @@ def preprocess_selected_mosaic_items(
             "bboxes": processed_bboxes,  # Already np.ndarray or None
             "keypoints": processed_keypoints,  # Already np.ndarray or None
         }
+        inst_masks = flat_item.get("masks")
+        if inst_masks is not None:
+            processed_item_dict["masks"] = np.copy(np.asarray(inst_masks))
         result_data_items.append(processed_item_dict)
 
     return result_data_items
@@ -614,6 +649,71 @@ def get_opposite_crop_coords(
     return x_min, y_min, x_max, y_max
 
 
+def _mosaic_cell_geometry_compose(
+    cell_shape: tuple[int, int],
+    target_shape: tuple[int, int],
+    fill: float | tuple[float, ...],
+    fill_mask: float | tuple[float, ...],
+    fit_mode: Literal["cover", "contain"],
+    interpolation: int,
+    mask_interpolation: int,
+    cell_position: Literal["top_left", "top_right", "center", "bottom_left", "bottom_right"],
+    *,
+    with_bbox_params: bool,
+    with_keypoint_params: bool,
+) -> Compose:
+    """Construct Albumentations Compose per Mosaic grid cell so RGB, mask, and stacked instance masks share identical resize/crop."""
+    compose_kwargs: dict[str, Any] = {"p": 1.0}
+    if with_bbox_params:
+        compose_kwargs["bbox_params"] = {"coord_format": "albumentations"}
+    if with_keypoint_params:
+        compose_kwargs["keypoint_params"] = {"coord_format": "xy"}
+
+    crop_coords = get_opposite_crop_coords(cell_shape, target_shape, cell_position)
+
+    if fit_mode == "cover":
+        return Compose(
+            [
+                SmallestMaxSize(
+                    max_size_hw=cell_shape,
+                    interpolation=interpolation,
+                    mask_interpolation=mask_interpolation,
+                    p=1.0,
+                ),
+                Crop(
+                    x_min=crop_coords[0],
+                    y_min=crop_coords[1],
+                    x_max=crop_coords[2],
+                    y_max=crop_coords[3],
+                ),
+            ],
+            **compose_kwargs,
+        )
+    if fit_mode == "contain":
+        return Compose(
+            [
+                LongestMaxSize(
+                    max_size_hw=cell_shape,
+                    interpolation=interpolation,
+                    mask_interpolation=mask_interpolation,
+                    p=1.0,
+                ),
+                Crop(
+                    x_min=crop_coords[0],
+                    y_min=crop_coords[1],
+                    x_max=crop_coords[2],
+                    y_max=crop_coords[3],
+                    pad_if_needed=True,
+                    fill=fill,
+                    fill_mask=fill_mask,
+                    p=1.0,
+                ),
+            ],
+            **compose_kwargs,
+        )
+    raise ValueError(f"Invalid fit_mode: {fit_mode}. Must be 'cover' or 'contain'.")
+
+
 def process_cell_geometry(
     cell_shape: tuple[int, int],
     item: ProcessedMosaicItem,
@@ -641,63 +741,24 @@ def process_cell_geometry(
         interpolation (int): Interpolation method for image.
         mask_interpolation (int): Interpolation method for mask.
         cell_position (Literal['top_left', 'top_right', 'center', 'bottom_left', 'bottom_right']): Position
-            of the cell.
+        of the cell.
 
     Returns: (ProcessedMosaicItem): Dictionary containing the geometrically processed image,
         mask, bboxes, and keypoints, fitting the target dimensions.
 
     """
-    # Define the pipeline: PadIfNeeded first, then Crop
-    compose_kwargs: dict[str, Any] = {"p": 1.0}
-    if item.get("bboxes") is not None:
-        compose_kwargs["bbox_params"] = {"coord_format": "albumentations"}
-    if item.get("keypoints") is not None:
-        compose_kwargs["keypoint_params"] = {"coord_format": "xy"}
-
-    crop_coords = get_opposite_crop_coords(cell_shape, target_shape, cell_position)
-
-    if fit_mode == "cover":
-        geom_pipeline = Compose(
-            [
-                SmallestMaxSize(
-                    max_size_hw=cell_shape,
-                    interpolation=interpolation,
-                    mask_interpolation=mask_interpolation,
-                    p=1.0,
-                ),
-                Crop(
-                    x_min=crop_coords[0],
-                    y_min=crop_coords[1],
-                    x_max=crop_coords[2],
-                    y_max=crop_coords[3],
-                ),
-            ],
-            **compose_kwargs,
-        )
-    elif fit_mode == "contain":
-        geom_pipeline = Compose(
-            [
-                LongestMaxSize(
-                    max_size_hw=cell_shape,
-                    interpolation=interpolation,
-                    mask_interpolation=mask_interpolation,
-                    p=1.0,
-                ),
-                Crop(
-                    x_min=crop_coords[0],
-                    y_min=crop_coords[1],
-                    x_max=crop_coords[2],
-                    y_max=crop_coords[3],
-                    pad_if_needed=True,
-                    fill=fill,
-                    fill_mask=fill_mask,
-                    p=1.0,
-                ),
-            ],
-            **compose_kwargs,
-        )
-    else:
-        raise ValueError(f"Invalid fit_mode: {fit_mode}. Must be 'cover' or 'contain'.")
+    geom_pipeline = _mosaic_cell_geometry_compose(
+        cell_shape,
+        target_shape,
+        fill,
+        fill_mask,
+        fit_mode,
+        interpolation,
+        mask_interpolation,
+        cell_position,
+        with_bbox_params=item.get("bboxes") is not None,
+        with_keypoint_params=item.get("keypoints") is not None,
+    )
 
     # Prepare input data for the pipeline
     geom_input: dict[str, Any] = {"image": item["image"]}
@@ -714,14 +775,43 @@ def process_cell_geometry(
     # Apply the pipeline (`force_apply` explicit so **geom_input cannot bind to it under mypy)
     processed_item = geom_pipeline(force_apply=False, **geom_input)
 
-    # Ensure output dict has the same structure as ProcessedMosaicItem
-    # Compose might not return None for missing keys, handle explicitly
-    return {
+    result: ProcessedMosaicItem = {
         "image": processed_item["image"],
         "mask": processed_item.get("mask"),
         "bboxes": processed_item.get("bboxes"),
         "keypoints": processed_item.get("keypoints"),
     }
+
+    raw_masks = item.get("masks")
+    if raw_masks is not None and isinstance(raw_masks, np.ndarray) and raw_masks.size > 0:
+        m = raw_masks
+        if m.ndim == 4 and m.shape[-1] == 1:
+            m = np.squeeze(m, axis=-1)
+        if m.ndim == 3 and m.shape[0] > 0:
+            geom_masks_only = _mosaic_cell_geometry_compose(
+                cell_shape,
+                target_shape,
+                fill,
+                fill_mask,
+                fit_mode,
+                interpolation,
+                mask_interpolation,
+                cell_position,
+                with_bbox_params=False,
+                with_keypoint_params=False,
+            )
+            ref_dtype = item["image"].dtype
+            planes: list[np.ndarray] = []
+            for i in range(m.shape[0]):
+                layer = m[i]
+                img3 = np.stack([layer, layer, layer], axis=-1)
+                if img3.dtype != ref_dtype:
+                    img3 = img3.astype(ref_dtype, copy=False)
+                out_img = geom_masks_only(force_apply=False, image=img3)["image"]
+                planes.append(out_img[..., 0])
+            result["masks"] = np.stack(planes, axis=0)
+
+    return result
 
 
 def shift_cell_coordinates(
@@ -818,6 +908,196 @@ def assemble_mosaic_from_processed_cells(
             canvas[tgt_y1:tgt_y2, tgt_x1:tgt_x2] = segment
 
     return canvas
+
+
+def assemble_mosaic_instance_masks_stack(
+    processed_cells: dict[tuple[int, int, int, int], dict[str, Any]],
+    canvas_hw: tuple[int, int],
+    dtype: np.dtype,
+    fill: float | tuple[float, ...] | None,
+) -> np.ndarray:
+    """One full-canvas mask per instance; iteration order over `processed_cells` matches
+    `Mosaic.apply_to_bboxes` / `apply_to_masks` (dict insertion order).
+    """
+    canvas_h, canvas_w = canvas_hw
+    actual_fill = fill if fill is not None else 0
+    fill_value = np.array(actual_fill, dtype=dtype)
+
+    layers: list[np.ndarray] = []
+    for placement_coords, cell_data in processed_cells.items():
+        stack = cell_data.get("masks")
+        if stack is None or not isinstance(stack, np.ndarray) or stack.size == 0:
+            continue
+        if stack.ndim == 4 and stack.shape[-1] == 1:
+            stack = np.squeeze(stack, axis=-1)
+        if stack.ndim != 3:
+            continue
+        tgt_x1, tgt_y1, tgt_x2, tgt_y2 = placement_coords
+        for i in range(stack.shape[0]):
+            canvas = np.full((canvas_h, canvas_w), fill_value=fill_value, dtype=dtype)
+            segment = stack[i]
+            if segment.ndim == 3 and segment.shape[-1] == 1:
+                segment = segment[..., 0]
+            canvas[tgt_y1:tgt_y2, tgt_x1:tgt_x2] = segment
+            layers.append(canvas)
+
+    if not layers:
+        return np.empty((0, canvas_h, canvas_w), dtype=dtype)
+    return np.stack(layers, axis=0)
+
+
+def _mosaic_cell_local_instance_ids(
+    bb: np.ndarray | None,
+    kp: np.ndarray | None,
+    need_bbox_remap: bool,
+    need_kp_remap: bool,
+    n_bf: int,
+    n_kf: int,
+    bbox_id_idx: int,
+    kp_id_idx: int,
+) -> set[int]:
+    local_ids: set[int] = set()
+    if need_bbox_remap and bb is not None and np.asarray(bb).size > 0 and n_bf > 0:
+        bb_np = np.asarray(bb)
+        n_geo_bb = bb_np.shape[1] - n_bf
+        id_col_bb = n_geo_bb + bbox_id_idx
+        for row in range(bb_np.shape[0]):
+            local_ids.add(int(bb_np[row, id_col_bb]))
+    if need_kp_remap and kp is not None and np.asarray(kp).size > 0 and n_kf > 0:
+        kp_np = np.asarray(kp)
+        n_geo_kp = kp_np.shape[1] - n_kf
+        id_col_kp = n_geo_kp + kp_id_idx
+        for row in range(kp_np.shape[0]):
+            local_ids.add(int(kp_np[row, id_col_kp]))
+    return local_ids
+
+
+def _remap_mosaic_bboxes_column(
+    bb_arr: np.ndarray,
+    need_bbox_remap: bool,
+    n_bf: int,
+    bbox_id_idx: int,
+    local_to_global: dict[int, int],
+) -> None:
+    if not (need_bbox_remap and n_bf > 0):
+        return
+    n_geo_bb = bb_arr.shape[1] - n_bf
+    id_col_bb = n_geo_bb + bbox_id_idx
+    for row in range(bb_arr.shape[0]):
+        lid = int(bb_arr[row, id_col_bb])
+        bb_arr[row, id_col_bb] = float(local_to_global[lid])
+
+
+def _remap_mosaic_keypoints_column(
+    kp_arr: np.ndarray,
+    need_kp_remap: bool,
+    n_kf: int,
+    kp_id_idx: int,
+    local_to_global: dict[int, int],
+) -> None:
+    if not (need_kp_remap and n_kf > 0):
+        return
+    n_geo_kp = kp_arr.shape[1] - n_kf
+    id_col_kp = n_geo_kp + kp_id_idx
+    for row in range(kp_arr.shape[0]):
+        lid = int(kp_arr[row, id_col_kp])
+        if lid in local_to_global:
+            kp_arr[row, id_col_kp] = float(local_to_global[lid])
+
+
+def _remap_one_mosaic_cell_instance_ids(
+    cell: ProcessedMosaicItem,
+    need_bbox_remap: bool,
+    need_kp_remap: bool,
+    n_bf: int,
+    n_kf: int,
+    bbox_id_idx: int,
+    kp_id_idx: int,
+    global_next: int,
+) -> tuple[ProcessedMosaicItem, int]:
+    cell_out: dict[str, Any] = {"image": cell["image"]}
+    if "mask" in cell:
+        cell_out["mask"] = cell["mask"]
+    if "masks" in cell:
+        cell_out["masks"] = cell["masks"]
+
+    bb = cell.get("bboxes")
+    kp = cell.get("keypoints")
+    local_ids = _mosaic_cell_local_instance_ids(
+        bb,
+        kp,
+        need_bbox_remap,
+        need_kp_remap,
+        n_bf,
+        n_kf,
+        bbox_id_idx,
+        kp_id_idx,
+    )
+    local_to_global = {lid: global_next + idx for idx, lid in enumerate(sorted(local_ids))}
+    next_global = global_next + len(local_to_global)
+
+    if bb is not None and np.asarray(bb).size > 0:
+        bb_arr = np.asarray(bb, dtype=np.float32, copy=True)
+        _remap_mosaic_bboxes_column(bb_arr, need_bbox_remap, n_bf, bbox_id_idx, local_to_global)
+        cell_out["bboxes"] = bb_arr
+    else:
+        cell_out["bboxes"] = cell.get(
+            "bboxes",
+            np.empty((0, NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS), dtype=np.float32),
+        )
+
+    if kp is not None and np.asarray(kp).size > 0:
+        kp_arr = np.asarray(kp, dtype=np.float32, copy=True)
+        _remap_mosaic_keypoints_column(kp_arr, need_kp_remap, n_kf, kp_id_idx, local_to_global)
+        cell_out["keypoints"] = kp_arr
+    else:
+        cell_out["keypoints"] = cell.get(
+            "keypoints",
+            np.empty((0, NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS), dtype=np.float32),
+        )
+
+    return cast("ProcessedMosaicItem", cell_out), next_global
+
+
+def remap_mosaic_instance_label_ids(
+    processed_cells: dict[tuple[int, int, int, int], ProcessedMosaicItem],
+    bbox_processor: BboxProcessor | None,
+    keypoint_processor: KeypointsProcessor | None,
+) -> dict[tuple[int, int, int, int], ProcessedMosaicItem]:
+    """Assign globally unique instance id column values per mosaic cell so repack does not
+    merge distinct instances that reused local ids (0..n-1) in different cells.
+    """
+    bbox_fields = bbox_processor.params.label_fields if bbox_processor else None
+    kp_fields = keypoint_processor.params.label_fields if keypoint_processor else None
+
+    need_bbox_remap = bool(bbox_fields and _BBOX_INSTANCE_ID in bbox_fields)
+    need_kp_remap = bool(kp_fields and _KP_INSTANCE_ID in kp_fields)
+    if not need_bbox_remap and not need_kp_remap:
+        return processed_cells
+
+    n_bf = len(bbox_fields) if bbox_fields else 0
+    bbox_id_idx = bbox_fields.index(_BBOX_INSTANCE_ID) if bbox_fields and need_bbox_remap else -1
+
+    n_kf = len(kp_fields) if kp_fields else 0
+    kp_id_idx = kp_fields.index(_KP_INSTANCE_ID) if kp_fields and need_kp_remap else -1
+
+    global_next = 0
+    new_cells: dict[tuple[int, int, int, int], ProcessedMosaicItem] = {}
+
+    for placement, cell in processed_cells.items():
+        cell_out, global_next = _remap_one_mosaic_cell_instance_ids(
+            cell,
+            need_bbox_remap,
+            need_kp_remap,
+            n_bf,
+            n_kf,
+            bbox_id_idx,
+            kp_id_idx,
+            global_next,
+        )
+        new_cells[placement] = cell_out
+
+    return new_cells
 
 
 def process_all_mosaic_geometries(
@@ -993,10 +1273,12 @@ def shift_all_coordinates(
         bboxes_geom = cell_data_geom.get("bboxes")
         keypoints_geom = cell_data_geom.get("keypoints")
 
-        final_cell_data = {
+        final_cell_data: ProcessedMosaicItem = {
             "image": cell_data_geom["image"],
             "mask": cell_data_geom.get("mask"),
         }
+        if "masks" in cell_data_geom:
+            final_cell_data["masks"] = cell_data_geom["masks"]
 
         # Perform shifting if data exists
         if bboxes_geom is not None and bboxes_geom.size > 0:
@@ -1022,6 +1304,6 @@ def shift_all_coordinates(
         else:
             final_cell_data["keypoints"] = np.empty((0, NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS))
 
-        final_processed_cells[placement_coords] = cast("ProcessedMosaicItem", final_cell_data)
+        final_processed_cells[placement_coords] = final_cell_data
 
     return final_processed_cells

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -1037,9 +1037,11 @@ class Mosaic(DualTransform):
         will be replicated to fill the remaining cells. For example, with a 2x2 grid, if only
         one additional image is provided, the mosaic will contain the primary image in two cells
         and the additional image in one cell, with one visible cell selected from these three.
+        Stacked instance masks on the `masks` key (N, H, W) are transformed via `apply_to_masks` like
+        other DualTransforms; `_targets` only lists `Targets` enum values (no `Targets.MASKS`).
 
     Targets:
-        image, mask, masks, bboxes, keypoints
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -540,13 +540,15 @@ class CopyAndPaste(DualTransform):
         items: list[dict[str, Any]],
         pasted_masks: np.ndarray,
         target_image: np.ndarray,
+        instance_ids: list[int],
     ) -> np.ndarray | None:
         """Build a preprocessed bounding-box array from all pasted object items, encoding extra
         label fields through the bbox processor.
 
         Label values are read from `bbox_labels` in each item — a dict mapping
         label field name to the scalar value for that object, e.g.
-        `{"class_id": 3, "is_crowd": 0}`.
+        `{"class_id": 3, "is_crowd": 0}`. With instance binding, internal `_ibl_bbox_*` fields
+        map to user keys; `_bbox_instance_id` is taken from `instance_ids`.
         """
         bbox_processor = cast("BboxProcessor", self.get_processor("bboxes"))
         label_fields = (bbox_processor.params.label_fields or []) if bbox_processor else []
@@ -564,6 +566,18 @@ class CopyAndPaste(DualTransform):
 
             item_labels: dict[str, Any] = item.get("bbox_labels", {})
             for field in label_fields:
+                if field == "_bbox_instance_id":
+                    all_labels[field].append(instance_ids[idx])
+                    continue
+                if field.startswith("_ibl_bbox_"):
+                    user_key = field.removeprefix("_ibl_bbox_")
+                    if user_key not in item_labels:
+                        raise ValueError(
+                            f"CopyAndPaste: missing bbox label field '{user_key}' for pasted object at index {idx}. "
+                            "Provide `bbox_labels` with every field declared in BboxParams.label_fields.",
+                        )
+                    all_labels[field].append(item_labels[user_key])
+                    continue
                 if field not in item_labels:
                     raise ValueError(
                         f"CopyAndPaste: missing bbox label field '{field}' for pasted object at index {idx}. "
@@ -588,17 +602,55 @@ class CopyAndPaste(DualTransform):
 
         return fmixing.preprocess_copy_paste_annotations(donor_item, bbox_processor, "bboxes")
 
+    def _collect_labels_for_one_pasted_keypoint_item(
+        self,
+        item_idx: int,
+        item: dict[str, Any],
+        kp_label_fields: Sequence[str],
+        instance_ids: list[int],
+        num_keypoints: int,
+        all_labels: dict[str, list[Any]],
+    ) -> None:
+        item_labels: dict[str, Any] = item.get("keypoint_labels", {})
+        for field in kp_label_fields:
+            if field == "_kp_instance_id":
+                all_labels[field].extend([instance_ids[item_idx]] * num_keypoints)
+                continue
+            if field.startswith("_ibl_kp_"):
+                user_key = field.removeprefix("_ibl_kp_")
+                if user_key not in item_labels:
+                    raise ValueError(
+                        f"CopyAndPaste: missing keypoint label field '{user_key}' for pasted object at "
+                        f"index {item_idx}. Provide `keypoint_labels` with every field declared in "
+                        "KeypointParams.label_fields.",
+                    )
+                val = item_labels[user_key]
+                field_values = self._keypoint_label_values_for_item(val, num_keypoints, user_key, item_idx)
+                all_labels[field].extend(field_values)
+                continue
+            if field not in item_labels:
+                raise ValueError(
+                    f"CopyAndPaste: missing keypoint label field '{field}' for pasted object at "
+                    f"index {item_idx}. Provide `keypoint_labels` with every field declared in "
+                    "KeypointParams.label_fields.",
+                )
+            val = item_labels[field]
+            field_values = self._keypoint_label_values_for_item(val, num_keypoints, field, item_idx)
+            all_labels[field].extend(field_values)
+
     def _prepare_pasted_keypoints(
         self,
         items: list[dict[str, Any]],
         target_image: np.ndarray,
+        instance_ids: list[int],
     ) -> np.ndarray | None:
         """Build a preprocessed keypoints array from all pasted object items, encoding label
         fields through the keypoint processor.
 
         Label values are read from `keypoint_labels` in each item — a dict mapping
         label field name to scalar or list of values for that object, e.g.
-        `{"joint_name": "left_eye"}` or `{"visibility": [2, 2]}`.
+        `{"joint_name": "left_eye"}` or `{"visibility": [2, 2]}`. With instance binding,
+        `_kp_instance_id` is replicated per keypoint row from `instance_ids`.
         """
         keypoint_processor = cast("KeypointsProcessor", self.get_processor("keypoints"))
         kp_label_fields = (keypoint_processor.params.label_fields or []) if keypoint_processor else []
@@ -614,18 +666,14 @@ class CopyAndPaste(DualTransform):
                 raw = raw[np.newaxis]
             num_keypoints = raw.shape[0]
             all_kps.append(raw)
-
-            item_labels: dict[str, Any] = item.get("keypoint_labels", {})
-            for field in kp_label_fields:
-                if field not in item_labels:
-                    raise ValueError(
-                        f"CopyAndPaste: missing keypoint label field '{field}' for pasted object at "
-                        f"index {item_idx}. Provide `keypoint_labels` with every field declared in "
-                        "KeypointParams.label_fields.",
-                    )
-                val = item_labels[field]
-                field_values = self._keypoint_label_values_for_item(val, num_keypoints, field, item_idx)
-                all_labels[field].extend(field_values)
+            self._collect_labels_for_one_pasted_keypoint_item(
+                item_idx,
+                item,
+                kp_label_fields,
+                instance_ids,
+                num_keypoints,
+                all_labels,
+            )
 
         if not all_kps:
             return None
@@ -649,16 +697,14 @@ class CopyAndPaste(DualTransform):
 
         return fmixing.preprocess_copy_paste_annotations(donor_item, keypoint_processor, "keypoints")
 
-    def get_params_dependent_on_data(
+    def _gather_valid_copy_paste_items(
         self,
-        params: dict[str, Any],
         data: dict[str, Any],
-    ) -> dict[str, Any]:
+        target_shape: tuple[int, int],
+    ) -> tuple[list[dict[str, Any]], list[np.ndarray], np.ndarray] | None:
         metadata = data.get(self.metadata_key)
         if not isinstance(metadata, list) or not metadata:
-            return self._no_op_params()
-
-        target_shape = params["shape"][:2]
+            return None
 
         valid_items: list[dict[str, Any]] = []
         pasted_masks_list: list[np.ndarray] = []
@@ -679,8 +725,20 @@ class CopyAndPaste(DualTransform):
             composite_image[mask_bool] = src_image[mask_bool]
 
         if not valid_items:
+            return None
+        return valid_items, pasted_masks_list, composite_image
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        target_shape = params["shape"][:2]
+        gathered = self._gather_valid_copy_paste_items(data, target_shape)
+        if gathered is None:
             return self._no_op_params()
 
+        valid_items, pasted_masks_list, composite_image = gathered
         pasted_masks = np.stack(pasted_masks_list, axis=0)
         paste_union_mask = np.any(pasted_masks > 0, axis=0)
 
@@ -689,11 +747,23 @@ class CopyAndPaste(DualTransform):
 
         surviving_indices, paste_primary_instance_count = self._compute_surviving_indices(data, paste_union_mask)
 
+        if surviving_indices is not None and surviving_indices.size > 0:
+            next_paste_instance_id = int(np.max(surviving_indices)) + 1
+        else:
+            next_paste_instance_id = 0
+        paste_instance_ids = [next_paste_instance_id + k for k in range(len(valid_items))]
+
         pasted_bboxes = (
-            self._prepare_pasted_bboxes(valid_items, pasted_masks, composite_image) if "bboxes" in data else None
+            self._prepare_pasted_bboxes(valid_items, pasted_masks, composite_image, paste_instance_ids)
+            if "bboxes" in data
+            else None
         )
 
-        pasted_keypoints = self._prepare_pasted_keypoints(valid_items, composite_image) if "keypoints" in data else None
+        pasted_keypoints = (
+            self._prepare_pasted_keypoints(valid_items, composite_image, paste_instance_ids)
+            if "keypoints" in data
+            else None
+        )
 
         donor_mask = None
         for item in valid_items:
@@ -818,8 +888,18 @@ class CopyAndPaste(DualTransform):
         if paste_alpha is None:
             return bboxes
 
+        bbox_processor = cast("BboxProcessor", self.get_processor("bboxes"))
+        bbox_label_fields = bbox_processor.params.label_fields or []
+
         if paste_surviving_indices is not None and bboxes.size > 0:
-            surviving_bboxes = bboxes[paste_surviving_indices]
+            if "_bbox_instance_id" in bbox_label_fields:
+                n_lf = len(bbox_label_fields)
+                id_col = bboxes.shape[1] - n_lf + bbox_label_fields.index("_bbox_instance_id")
+                inst_col = bboxes[:, id_col].astype(np.int64, copy=False)
+                keep = np.isin(inst_col, paste_surviving_indices)
+                surviving_bboxes = bboxes[keep]
+            else:
+                surviving_bboxes = bboxes[paste_surviving_indices]
         else:
             surviving_bboxes = bboxes
 
@@ -842,18 +922,27 @@ class CopyAndPaste(DualTransform):
 
         paste_surviving_indices = params.get("paste_surviving_indices")
         paste_primary_instance_count = params.get("paste_primary_instance_count")
+        keypoint_processor = cast("KeypointsProcessor", self.get_processor("keypoints"))
+        kp_label_fields = keypoint_processor.params.label_fields or []
+
         surviving_keypoints = keypoints
-        aligned = (
-            paste_primary_instance_count is not None
-            and keypoints.size > 0
-            and keypoints.shape[0] == paste_primary_instance_count
-        )
-        if paste_surviving_indices is not None and aligned:
-            survivor_idx = np.asarray(paste_surviving_indices)
-            if survivor_idx.size == 0:
-                surviving_keypoints = keypoints[:0]
-            elif int(survivor_idx.max()) < keypoints.shape[0] and int(survivor_idx.min()) >= 0:
-                surviving_keypoints = keypoints[survivor_idx]
+        if paste_surviving_indices is not None and keypoints.size > 0:
+            if "_kp_instance_id" in kp_label_fields:
+                n_kf = len(kp_label_fields)
+                id_col = keypoints.shape[1] - n_kf + kp_label_fields.index("_kp_instance_id")
+                inst_col = keypoints[:, id_col].astype(np.int64, copy=False)
+                keep = np.isin(inst_col, paste_surviving_indices)
+                surviving_keypoints = keypoints[keep]
+            else:
+                aligned = (
+                    paste_primary_instance_count is not None and keypoints.shape[0] == paste_primary_instance_count
+                )
+                if aligned:
+                    survivor_idx = np.asarray(paste_surviving_indices)
+                    if survivor_idx.size == 0:
+                        surviving_keypoints = keypoints[:0]
+                    elif int(survivor_idx.max()) < keypoints.shape[0] and int(survivor_idx.min()) >= 0:
+                        surviving_keypoints = keypoints[survivor_idx]
 
         if paste_keypoints is not None and paste_keypoints.size > 0:
             if surviving_keypoints.size == 0:
@@ -892,9 +981,9 @@ class Mosaic(DualTransform):
         metadata_key (str): Key in the input dictionary specifying the list of additional data dictionaries
             for the mosaic. Each dictionary in the list should represent one potential additional item.
             Expected keys: 'image' (required, np.ndarray), and optionally 'mask' (np.ndarray),
-            'bboxes' (np.ndarray), 'keypoints' (np.ndarray), and label fields supplied via the
-            `bbox_labels` and `keypoint_labels` wrapper dicts (see Metadata Format below).
-            Default: "mosaic_metadata".
+            'masks' (np.ndarray, stacked instance masks), 'bboxes' (np.ndarray), 'keypoints' (np.ndarray),
+            and label fields supplied via the `bbox_labels` and `keypoint_labels` wrapper dicts
+            (see Metadata Format below). Default: "mosaic_metadata".
         center_range (tuple[float, float]): Range [0.0-1.0] to sample the center point of the mosaic view
             relative to the valid central region of the conceptual large grid. This affects which parts
             of the assembled grid are visible in the final crop. Default: (0.3, 0.7).
@@ -950,7 +1039,7 @@ class Mosaic(DualTransform):
         and the additional image in one cell, with one visible cell selected from these three.
 
     Targets:
-        image, mask, bboxes, keypoints
+        image, mask, masks, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -965,6 +1054,8 @@ class Mosaic(DualTransform):
         Each dict in the metadata list represents one additional image and must contain:
             - image (np.ndarray): Additional image. Required.
             - mask (np.ndarray): Semantic mask for the additional image. Optional.
+            - masks (np.ndarray): Stacked instance masks (N, H, W) for the additional image.
+              Optional; same geometry as image. Use with instance_binding / pipeline masks target.
             - bboxes (np.ndarray): Bounding boxes in the **same coordinate format** as
               `BboxParams.coord_format` declared in `Compose`. Optional.
             - keypoints (np.ndarray): Keypoints in the **same format** as
@@ -1179,6 +1270,19 @@ class Mosaic(DualTransform):
             bbox_processor = cast("BboxProcessor", self.get_processor("bboxes"))
             keypoint_processor = cast("KeypointsProcessor", self.get_processor("keypoints"))
             return fmixing.preprocess_selected_mosaic_items(additional_items, bbox_processor, keypoint_processor)
+        if "masks" in data:
+            out: list[fmixing.ProcessedMosaicItem] = []
+            for item in additional_items:
+                if not isinstance(item, dict) or "image" not in item:
+                    continue
+                flat_item = fmixing.unpack_label_wrappers(item)
+                entry: fmixing.ProcessedMosaicItem = {"image": item["image"]}
+                if flat_item.get("mask") is not None:
+                    entry["mask"] = flat_item["mask"]
+                if flat_item.get("masks") is not None:
+                    entry["masks"] = np.copy(np.asarray(flat_item["masks"]))
+                out.append(entry)
+            return out
         return cast("list[fmixing.ProcessedMosaicItem]", list(additional_items))
 
     def _prepare_final_items(
@@ -1222,12 +1326,26 @@ class Mosaic(DualTransform):
             mask_interpolation=self.mask_interpolation,
         )
 
-        if "bboxes" in data or "keypoints" in data:
+        if "bboxes" in data or "keypoints" in data or "masks" in data:
             processed_cells = fmixing.shift_all_coordinates(processed_cells, canvas_shape=self.target_size)
+            bbox_proc = self.get_processor("bboxes")
+            kp_proc = self.get_processor("keypoints")
+            processed_cells = fmixing.remap_mosaic_instance_label_ids(
+                processed_cells,
+                bbox_proc if isinstance(bbox_proc, BboxProcessor) else None,
+                kp_proc if isinstance(kp_proc, KeypointsProcessor) else None,
+            )
 
         result = {"processed_cells": processed_cells, "target_shape": self._get_target_shape(data["image"].shape)}
         if "mask" in data:
             result["target_mask_shape"] = self._get_target_shape(data["mask"].shape)
+        if "masks" in data:
+            ms = data["masks"].shape
+            # Stacked instance masks are (N, H, W); do not treat N as spatial dim.
+            if len(ms) >= 3:
+                result["target_masks_shape"] = (int(ms[0]), self.target_size[0], self.target_size[1])
+            else:
+                result["target_masks_shape"] = tuple(self._get_target_shape(ms))
         return result
 
     @staticmethod
@@ -1251,12 +1369,18 @@ class Mosaic(DualTransform):
         keypoints = data.get("keypoints")
         if keypoints is not None:
             keypoints = keypoints.copy()
-        return {
+        masks = data.get("masks")
+        if masks is not None:
+            masks = masks.copy()
+        primary: fmixing.ProcessedMosaicItem = {
             "image": data["image"],
             "mask": mask,
             "bboxes": bboxes,
             "keypoints": keypoints,
         }
+        if masks is not None:
+            primary["masks"] = masks
+        return primary
 
     def _get_target_shape(self, np_shape: tuple[int, ...]) -> list[int]:
         target_shape = list(np_shape)
@@ -1294,6 +1418,21 @@ class Mosaic(DualTransform):
             fill=self.fill_mask,
         )
 
+    def apply_to_masks(
+        self,
+        masks: ImageType,
+        processed_cells: dict[tuple[int, int, int, int], dict[str, Any]],
+        target_masks_shape: tuple[int, ...],
+        **params: Any,
+    ) -> ImageType:
+        canvas_hw = (int(target_masks_shape[1]), int(target_masks_shape[2]))
+        return fmixing.assemble_mosaic_instance_masks_stack(
+            processed_cells=processed_cells,
+            canvas_hw=canvas_hw,
+            dtype=masks.dtype,
+            fill=self.fill_mask,
+        )
+
     def apply_to_bboxes(
         self,
         bboxes: np.ndarray,  # Original bboxes - ignored
@@ -1303,8 +1442,8 @@ class Mosaic(DualTransform):
         all_shifted_bboxes = []
 
         for cell_data in processed_cells.values():
-            shifted_bboxes = cell_data["bboxes"]
-            if shifted_bboxes.size > 0:
+            shifted_bboxes = cell_data.get("bboxes")
+            if shifted_bboxes is not None and np.asarray(shifted_bboxes).size > 0:
                 all_shifted_bboxes.append(shifted_bboxes)
 
         bbox_processor = cast("BboxProcessor", self.get_processor("bboxes"))
@@ -1342,8 +1481,8 @@ class Mosaic(DualTransform):
         all_shifted_keypoints = []
 
         for cell_data in processed_cells.values():
-            shifted_keypoints = cell_data["keypoints"]
-            if shifted_keypoints.size > 0:
+            shifted_keypoints = cell_data.get("keypoints")
+            if shifted_keypoints is not None and np.asarray(shifted_keypoints).size > 0:
                 all_shifted_keypoints.append(shifted_keypoints)
 
         if not all_shifted_keypoints:
@@ -1351,7 +1490,15 @@ class Mosaic(DualTransform):
 
         combined_keypoints = np.concatenate(all_shifted_keypoints, axis=0)
 
-        # Filter out keypoints outside the target canvas boundaries
+        keypoint_processor = self.get_processor("keypoints")
+        kp_fields = (
+            keypoint_processor.params.label_fields
+            if isinstance(keypoint_processor, KeypointsProcessor) and keypoint_processor.params.label_fields
+            else []
+        )
+        if "_kp_instance_id" in kp_fields:
+            return combined_keypoints
+
         target_h, target_w = self.target_size
         valid_indices = (
             (combined_keypoints[:, 0] >= 0)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1650,35 +1650,76 @@ class Compose(BaseCompose, HubMixin):
             msg = "_repack_instances requires instance_binding"
             raise RuntimeError(msg)
 
-        if "bboxes" in binding:
-            bbox_ids = data.pop(_BBOX_INSTANCE_ID, [])
+        kp_ids = np.array(data.pop(_KP_INSTANCE_ID, []))
+        bbox_ids = data.pop(_BBOX_INSTANCE_ID, [])
+
+        bboxes_arr = data.get("bboxes")
+        masks_arr = data.get("masks")
+        use_row_aligned_masks = (
+            "bboxes" in binding
+            and "masks" in binding
+            and isinstance(bbox_ids, list)
+            and isinstance(bboxes_arr, np.ndarray)
+            and isinstance(masks_arr, np.ndarray)
+            and len(bbox_ids) == len(bboxes_arr) == len(masks_arr)
+        )
+
+        if use_row_aligned_masks:
+            data["instances"] = [
+                self._repack_one_instance(
+                    data,
+                    binding,
+                    bbox_row_idx=row_idx,
+                    mask_row_idx=row_idx,
+                    kp_group_id=int(bbox_ids[row_idx]),
+                    kp_ids=kp_ids,
+                )
+                for row_idx in range(len(bbox_ids))
+            ]
+        elif "bboxes" in binding:
             surviving_ids = sorted(set(bbox_ids))
+            data["instances"] = [
+                self._repack_one_instance(
+                    data,
+                    binding,
+                    bbox_row_idx=new_idx,
+                    mask_row_idx=old_idx,
+                    kp_group_id=old_idx,
+                    kp_ids=kp_ids,
+                )
+                for new_idx, old_idx in enumerate(surviving_ids)
+            ]
         else:
             surviving_ids = list(range(self._instance_count))
+            data["instances"] = [
+                self._repack_one_instance(
+                    data,
+                    binding,
+                    bbox_row_idx=new_idx,
+                    mask_row_idx=old_idx,
+                    kp_group_id=old_idx,
+                    kp_ids=kp_ids,
+                )
+                for new_idx, old_idx in enumerate(surviving_ids)
+            ]
 
-        kp_ids = np.array(data.pop(_KP_INSTANCE_ID, []))
-
-        data["instances"] = [
-            self._repack_one_instance(data, binding, new_idx, old_idx, kp_ids)
-            for new_idx, old_idx in enumerate(surviving_ids)
-        ]
         self._cleanup_instance_data(data, binding)
 
     def _repack_one_instance(
         self,
         data: dict[str, Any],
         binding: frozenset[str],
-        new_idx: int,
-        old_idx: int,
+        bbox_row_idx: int,
+        mask_row_idx: int,
+        kp_group_id: int,
         kp_ids: np.ndarray,
     ) -> dict[str, Any]:
         inst: dict[str, Any] = {}
-        # Masks are not filtered row-wise with bboxes; stack axis 0 still follows original instance ids.
-        self._repack_mask_into(inst, data, binding, int(old_idx))
-        self._repack_bbox_into(inst, data, binding, new_idx)
-        self._repack_keypoints_into(inst, data, binding, old_idx, kp_ids)
-        self._repack_bbox_labels_into(inst, data, new_idx)
-        self._repack_kp_labels_into(inst, data, binding, old_idx, kp_ids)
+        self._repack_mask_into(inst, data, binding, int(mask_row_idx))
+        self._repack_bbox_into(inst, data, binding, bbox_row_idx)
+        self._repack_keypoints_into(inst, data, binding, kp_group_id, kp_ids)
+        self._repack_bbox_labels_into(inst, data, bbox_row_idx)
+        self._repack_kp_labels_into(inst, data, binding, kp_group_id, kp_ids)
         return inst
 
     def _repack_mask_into(

--- a/docs/design/instance_binding.md
+++ b/docs/design/instance_binding.md
@@ -14,7 +14,14 @@ A new `instance_binding` parameter on `Compose` plus a structured `instances` in
 Users pass `instances` as a list of dicts, each representing one object. Compose unpacks them
 into flat arrays for the existing pipeline, then repacks the survivors into the same format.
 
-No transform changes are required.
+Standard geometric transforms need no special handling. **Mixing transforms that fuse
+multiple sources** (e.g. `Mosaic`, `CopyAndPaste`) must keep instance ids and stacked
+`masks` aligned with the fused geometry: remap `_bbox_instance_id` / `_kp_instance_id`
+across cells or pasted objects, run stacked instance masks through the same placement as
+images, and avoid per-keypoint out-of-bounds drops when `_kp_instance_id` is present (see
+`Mosaic.apply_to_keypoints`). `Compose._repack_instances` uses **row-aligned** mask indexing
+when `len(masks) == len(bboxes) == len(_bbox_instance_id)` so pasted rows with new ids still
+match one mask plane per bbox row.
 
 ## Instance Dict Schema
 

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -1376,3 +1376,134 @@ class TestMixingInstanceBindingRegression:
         r2 = transform(image=image.copy(), instances=instances, mosaic_metadata=[])
         assert len(r1["instances"]) == len(r2["instances"]) == 1
         np.testing.assert_array_equal(r1["instances"][0]["mask"], r2["instances"][0]["mask"])
+
+
+class TestMosaicCopyPasteInstanceBinding:
+    """Mosaic then CopyAndPaste: fused mosaic stack must flow through paste visibility + repack."""
+
+    def test_mosaic_then_copy_paste_masks_bboxes_occluded_primary_dropped_pasted_kept(
+        self,
+        rng_137: np.random.Generator,
+    ) -> None:
+        ch, cw = 48, 48
+        th, tw = ch * 2, cw
+        img_p = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        img_m = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 40, 4, 40)),
+                "bbox": np.array([4, 4, 40, 40], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        mosaic_metadata = [
+            {
+                "image": img_m,
+                "masks": np.stack([_make_mask(ch, cw, (6, 42, 6, 42))]),
+                "bboxes": np.array([[6.0, 6.0, 42.0, 42.0]], dtype=np.float32),
+                "bbox_labels": {"cid": [2]},
+            },
+        ]
+        paste_mask = np.zeros((th, tw), dtype=np.uint8)
+        paste_mask[:ch, :] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((th, tw, 3), 222, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, int(tw), int(ch)],
+            "bbox_labels": {"cid": 900},
+        }
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(2, 1),
+                    target_size=(th, tw),
+                    cell_shape=(ch, cw),
+                    center_range=(0.5, 0.5),
+                    fit_mode="cover",
+                    p=1.0,
+                ),
+                A.CopyAndPaste(min_visibility_after_paste=0.05, p=1.0),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(
+            image=img_p,
+            instances=instances,
+            mosaic_metadata=mosaic_metadata,
+            copy_paste_metadata=[donor],
+        )
+        cids = {int(inst["bbox_labels"]["cid"]) for inst in result["instances"]}
+        assert cids == {2, 900}
+        assert 1 not in cids
+        for inst in result["instances"]:
+            assert inst["mask"].shape == (th, tw)
+
+    def test_mosaic_then_copy_paste_triple_binding_keypoints_follow_survivors(
+        self,
+        rng_137: np.random.Generator,
+    ) -> None:
+        ch, cw = 48, 48
+        th, tw = ch * 2, cw
+        img_p = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        img_m = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 40, 4, 40)),
+                "bbox": np.array([4, 4, 40, 40], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+                "keypoints": np.array([[12.0, 12.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [1]},
+            },
+        ]
+        mosaic_metadata = [
+            {
+                "image": img_m,
+                "masks": np.stack([_make_mask(ch, cw, (6, 42, 6, 42))]),
+                "bboxes": np.array([[6.0, 6.0, 42.0, 42.0]], dtype=np.float32),
+                "bbox_labels": {"cid": [2]},
+                "keypoints": np.array([[24.0, 24.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [2]},
+            },
+        ]
+        paste_mask = np.zeros((th, tw), dtype=np.uint8)
+        paste_mask[:ch, :] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((th, tw, 3), 111, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, int(tw), int(ch)],
+            "bbox_labels": {"cid": 900},
+            "keypoints": np.array([[8.0, 8.0]], dtype=np.float32),
+            "keypoint_labels": {"vis": [9]},
+        }
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(2, 1),
+                    target_size=(th, tw),
+                    cell_shape=(ch, cw),
+                    center_range=(0.5, 0.5),
+                    fit_mode="cover",
+                    p=1.0,
+                ),
+                A.CopyAndPaste(min_visibility_after_paste=0.05, p=1.0),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["vis"]),
+            instance_binding=["masks", "bboxes", "keypoints"],
+            seed=137,
+        )
+        result = transform(
+            image=img_p,
+            instances=instances,
+            mosaic_metadata=mosaic_metadata,
+            copy_paste_metadata=[donor],
+        )
+        assert len(result["instances"]) == 2
+        by_cid = _instances_by_cid(result["instances"])
+        assert set(by_cid) == {2, 900}
+        assert by_cid[2]["keypoints"].shape == (1, 2)
+        assert by_cid[900]["keypoints"].shape == (1, 2)
+        np.testing.assert_array_equal(by_cid[2]["keypoint_labels"]["vis"], np.array([2]))
+        np.testing.assert_array_equal(by_cid[900]["keypoint_labels"]["vis"], np.array([9]))

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -667,3 +667,712 @@ class TestChannelMask:
         result = transform(image=image, instances=instances)
         assert len(result["instances"]) == 2
         assert result["instances"][0]["mask"].shape == (100, 100)
+
+
+class TestMixingTransformsInstanceBinding:
+    def test_mosaic_instance_binding_masks_one_cell(self) -> None:
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(1, 1),
+                    target_size=(64, 64),
+                    cell_shape=(64, 64),
+                    center_range=(0.5, 0.5),
+                    p=1.0,
+                ),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        image = _make_image(64, 64)
+        m1 = _make_mask(64, 64, (10, 40, 10, 40))
+        m2 = _make_mask(64, 64, (45, 60, 45, 60))
+        instances = [
+            {
+                "mask": m1,
+                "bbox": np.array([10, 10, 40, 40], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+            {
+                "mask": m2,
+                "bbox": np.array([45, 45, 60, 60], dtype=np.float32),
+                "bbox_labels": {"cid": 2},
+            },
+        ]
+        result = transform(image=image, instances=instances, mosaic_metadata=[])
+        assert len(result["instances"]) == 2
+        assert result["instances"][0]["mask"].shape == (64, 64)
+        assert result["instances"][1]["mask"].shape == (64, 64)
+
+    def test_mosaic_instance_binding_two_sources_two_instances(self) -> None:
+        ch, cw = 64, 64
+        rng = np.random.default_rng(137)
+        img_p = rng.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        img_m = rng.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 36, 4, 36)),
+                "bbox": np.array([4, 4, 36, 36], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        mosaic_metadata = [
+            {
+                "image": img_m,
+                "masks": np.stack([_make_mask(ch, cw, (8, 44, 8, 44))]),
+                "bboxes": np.array([[8.0, 8.0, 44.0, 44.0]], dtype=np.float32),
+                "bbox_labels": {"cid": [2]},
+            },
+        ]
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(2, 1),
+                    target_size=(ch * 2, cw),
+                    cell_shape=(ch, cw),
+                    center_range=(0.5, 0.5),
+                    fit_mode="cover",
+                    p=1.0,
+                ),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=img_p, instances=instances, mosaic_metadata=mosaic_metadata)
+        assert len(result["instances"]) == 2
+        assert result["instances"][0]["mask"].shape == (ch * 2, cw)
+        assert result["instances"][1]["mask"].shape == (ch * 2, cw)
+        cids = {result["instances"][i]["bbox_labels"]["cid"] for i in range(2)}
+        assert cids == {1, 2}
+
+    def test_copy_paste_instance_binding_keypoints_survive_by_instance_id(self) -> None:
+        image = np.zeros((80, 80, 3), dtype=np.uint8)
+        m0 = _make_mask(80, 80, (5, 30, 5, 30))
+        m1 = _make_mask(80, 80, (50, 75, 50, 75))
+        instances = [
+            {
+                "mask": m0,
+                "bbox": np.array([5, 5, 30, 30], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+                "keypoints": np.array([[10.0, 10.0], [15.0, 15.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [1, 1]},
+            },
+            {
+                "mask": m1,
+                "bbox": np.array([50, 50, 75, 75], dtype=np.float32),
+                "bbox_labels": {"cid": 2},
+                "keypoints": np.array([[60.0, 60.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [2]},
+            },
+        ]
+        paste_mask = np.zeros((80, 80), dtype=np.uint8)
+        paste_mask[:40, :40] = 1
+        obj: dict[str, Any] = {
+            "image": np.full((80, 80, 3), 200, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, 40, 40],
+            "bbox_labels": {"cid": 99},
+            "keypoints": np.array([[20.0, 20.0]], dtype=np.float32),
+            "keypoint_labels": {"vis": [9]},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=0.05, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["vis"]),
+            instance_binding=["masks", "bboxes", "keypoints"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[obj])
+        assert len(result["instances"]) == 2
+        total_kp_rows = sum(inst["keypoints"].shape[0] for inst in result["instances"])
+        assert total_kp_rows == 2
+
+
+# ---------------------------------------------------------------------------
+# Mixing transforms × instance binding — matrix + corner cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rng_137() -> np.random.Generator:
+    return np.random.default_rng(137)
+
+
+def _instances_by_cid(instances: list[dict[str, Any]]) -> dict[Any, dict[str, Any]]:
+    return {inst["bbox_labels"]["cid"]: inst for inst in instances}
+
+
+def _make_mosaic_compose(
+    *,
+    grid_yx: tuple[int, int],
+    target_size: tuple[int, int],
+    cell_shape: tuple[int, int],
+    fit_mode: str = "cover",
+    strict: bool = False,
+    instance_binding: list[str] | None = None,
+    with_keypoints: bool = False,
+) -> A.Compose:
+    binding = instance_binding if instance_binding is not None else ["masks", "bboxes"]
+    kp_params = None
+    if with_keypoints or "keypoints" in binding:
+        kp_params = A.KeypointParams(coord_format="xy", label_fields=["vis"])
+    return A.Compose(
+        [
+            A.Mosaic(
+                grid_yx=grid_yx,
+                target_size=target_size,
+                cell_shape=cell_shape,
+                center_range=(0.5, 0.5),
+                fit_mode=fit_mode,
+                p=1.0,
+            ),
+        ],
+        bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+        keypoint_params=kp_params,
+        instance_binding=binding,
+        seed=137,
+        strict=strict,
+    )
+
+
+def _two_source_mosaic_payload(
+    *,
+    ch: int,
+    cw: int,
+    layout: str,
+    rng: np.random.Generator,
+) -> tuple[
+    np.ndarray,
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    tuple[int, int],
+    tuple[int, int],
+]:
+    """Primary + metadata for a 2-cell mosaic; layout is 'vertical' (2,1) or 'horizontal' (1,2)."""
+    img_p = rng.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+    img_m = rng.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+    instances = [
+        {
+            "mask": _make_mask(ch, cw, (4, 36, 4, 36)),
+            "bbox": np.array([4, 4, 36, 36], dtype=np.float32),
+            "bbox_labels": {"cid": 1},
+        },
+    ]
+    mosaic_metadata = [
+        {
+            "image": img_m,
+            "masks": np.stack([_make_mask(ch, cw, (8, 44, 8, 44))]),
+            "bboxes": np.array([[8.0, 8.0, 44.0, 44.0]], dtype=np.float32),
+            "bbox_labels": {"cid": [2]},
+        },
+    ]
+    if layout == "vertical":
+        target_size, grid_yx = (ch * 2, cw), (2, 1)
+    elif layout == "horizontal":
+        target_size, grid_yx = (ch, cw * 2), (1, 2)
+    else:
+        raise ValueError(layout)
+    return img_p, instances, mosaic_metadata, target_size, grid_yx
+
+
+class TestMosaicInstanceBindingExhaustive:
+    @pytest.mark.parametrize("strict", [False, True], ids=["loose", "strict"])
+    def test_strict_compose_accepts_mosaic_with_masks(self, strict: bool, rng_137: np.random.Generator) -> None:
+        ch, cw = 48, 48
+        transform = _make_mosaic_compose(
+            grid_yx=(1, 1),
+            target_size=(ch, cw),
+            cell_shape=(ch, cw),
+            strict=strict,
+        )
+        image = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (5, 25, 5, 25)),
+                "bbox": np.array([5, 5, 25, 25], dtype=np.float32),
+                "bbox_labels": {"cid": 7},
+            },
+        ]
+        result = transform(image=image, instances=instances, mosaic_metadata=[])
+        assert len(result["instances"]) == 1
+        assert result["instances"][0]["bbox_labels"]["cid"] == 7
+        assert result["instances"][0]["mask"].shape == (ch, cw)
+
+    @pytest.mark.parametrize(
+        ("fit_mode", "layout"),
+        [
+            ("cover", "vertical"),
+            ("cover", "horizontal"),
+            ("contain", "vertical"),
+            ("contain", "horizontal"),
+        ],
+        ids=["cv", "ch", "ktv", "kth"],
+    )
+    def test_two_cell_mosaic_fit_mode_and_layout(
+        self,
+        fit_mode: str,
+        layout: str,
+        rng_137: np.random.Generator,
+    ) -> None:
+        ch, cw = 56, 56
+        img_p, instances, mosaic_metadata, target_size, grid_yx = _two_source_mosaic_payload(
+            ch=ch,
+            cw=cw,
+            layout=layout,
+            rng=rng_137,
+        )
+        transform = _make_mosaic_compose(
+            grid_yx=grid_yx,
+            target_size=target_size,
+            cell_shape=(ch, cw),
+            fit_mode=fit_mode,
+        )
+        result = transform(image=img_p, instances=instances, mosaic_metadata=mosaic_metadata)
+        assert len(result["instances"]) == 2
+        th, tw = target_size
+        for inst in result["instances"]:
+            assert inst["mask"].shape == (th, tw)
+        assert _instances_by_cid(result["instances"]).keys() == {1, 2}
+
+    def test_mosaic_triple_binding_keypoint_counts_per_instance(self, rng_137: np.random.Generator) -> None:
+        ch, cw = 48, 48
+        img_p = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        img_m = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 30, 4, 30)),
+                "bbox": np.array([4, 4, 30, 30], dtype=np.float32),
+                "bbox_labels": {"cid": 10},
+                "keypoints": np.array([[12.0, 12.0], [18.0, 18.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [1, 1]},
+            },
+        ]
+        mosaic_metadata = [
+            {
+                "image": img_m,
+                "masks": np.stack([_make_mask(ch, cw, (6, 40, 6, 40))]),
+                "bboxes": np.array([[6.0, 6.0, 40.0, 40.0]], dtype=np.float32),
+                "bbox_labels": {"cid": [20]},
+                "keypoints": np.array([[22.0, 22.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [2]},
+            },
+        ]
+        transform = _make_mosaic_compose(
+            grid_yx=(2, 1),
+            target_size=(ch * 2, cw),
+            cell_shape=(ch, cw),
+            with_keypoints=True,
+            instance_binding=["masks", "bboxes", "keypoints"],
+        )
+        result = transform(image=img_p, instances=instances, mosaic_metadata=mosaic_metadata)
+        assert len(result["instances"]) == 2
+        by_cid = _instances_by_cid(result["instances"])
+        assert by_cid[10]["keypoints"].shape == (2, 2)
+        assert by_cid[20]["keypoints"].shape == (1, 2)
+        np.testing.assert_array_equal(by_cid[10]["keypoint_labels"]["vis"], np.array([1, 1]))
+        np.testing.assert_array_equal(by_cid[20]["keypoint_labels"]["vis"], np.array([2]))
+
+    def test_mosaic_masks_plus_bboxes_only_no_keypoints_in_binding(self, rng_137: np.random.Generator) -> None:
+        ch, cw = 40, 40
+        img_p = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (5, 25, 5, 25)),
+                "bbox": np.array([5, 5, 25, 25], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+            {
+                "mask": _make_mask(ch, cw, (28, 38, 28, 38)),
+                "bbox": np.array([28, 28, 38, 38], dtype=np.float32),
+                "bbox_labels": {"cid": 2},
+            },
+        ]
+        transform = _make_mosaic_compose(
+            grid_yx=(1, 1),
+            target_size=(ch, cw),
+            cell_shape=(ch, cw),
+            instance_binding=["masks", "bboxes"],
+        )
+        result = transform(image=img_p, instances=instances, mosaic_metadata=[])
+        assert len(result["instances"]) == 2
+        assert "keypoints" not in result["instances"][0]
+
+    def test_mosaic_empty_metadata_replicates_primary_into_both_cells(self, rng_137: np.random.Generator) -> None:
+        """Two cells, no donors: primary is cloned into each cell → two bbox/mask rows after fuse."""
+        ch, cw = 32, 32
+        transform = _make_mosaic_compose(
+            grid_yx=(2, 1),
+            target_size=(ch * 2, cw),
+            cell_shape=(ch, cw),
+        )
+        img = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 20, 4, 20)),
+                "bbox": np.array([4, 4, 20, 20], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        result = transform(image=img, instances=instances, mosaic_metadata=[])
+        assert len(result["instances"]) == 2
+        for inst in result["instances"]:
+            assert inst["mask"].shape == (ch * 2, cw)
+            assert int(inst["bbox_labels"]["cid"]) == 1
+
+    def test_mosaic_zero_instances_returns_empty(self) -> None:
+        transform = _make_mosaic_compose(
+            grid_yx=(1, 1),
+            target_size=(24, 24),
+            cell_shape=(24, 24),
+        )
+        image = np.zeros((24, 24, 3), dtype=np.uint8)
+        result = transform(image=image, instances=[], mosaic_metadata=[])
+        assert result["instances"] == []
+
+    def test_mosaic_chained_with_crop_repacks_instances(self, rng_137: np.random.Generator) -> None:
+        ch, cw = 48, 48
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(1, 1),
+                    target_size=(ch, cw),
+                    cell_shape=(ch, cw),
+                    center_range=(0.5, 0.5),
+                    p=1.0,
+                ),
+                A.Crop(x_min=0, y_min=0, x_max=32, y_max=32, p=1.0),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"], min_area=1),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        image = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (5, 30, 5, 30)),
+                "bbox": np.array([5, 5, 30, 30], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        result = transform(image=image, instances=instances, mosaic_metadata=[])
+        assert len(result["instances"]) >= 1
+        assert result["instances"][0]["mask"].shape == (32, 32)
+
+
+class TestCopyPasteInstanceBindingExhaustive:
+    @pytest.fixture
+    def base_two_instance_payload(self) -> tuple[np.ndarray, list[dict[str, Any]]]:
+        """Shared primary image + two non-overlapping instances for CopyAndPaste matrices."""
+        image = np.zeros((72, 72, 3), dtype=np.uint8)
+        m0 = _make_mask(72, 72, (6, 34, 6, 34))
+        m1 = _make_mask(72, 72, (40, 68, 40, 68))
+        instances = [
+            {
+                "mask": m0,
+                "bbox": np.array([6, 6, 34, 34], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+            {
+                "mask": m1,
+                "bbox": np.array([40, 40, 68, 68], dtype=np.float32),
+                "bbox_labels": {"cid": 2},
+            },
+        ]
+        return image, instances
+
+    def test_masks_bboxes_only_pasted_labels_and_counts(
+        self,
+        base_two_instance_payload: tuple[np.ndarray, list[dict[str, Any]]],
+    ) -> None:
+        image, instances = base_two_instance_payload
+        paste_mask = np.zeros((72, 72), dtype=np.uint8)
+        paste_mask[:28, :28] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((72, 72, 3), 99, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, 28, 28],
+            "bbox_labels": {"cid": 77},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=0.05, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        by_cid = _instances_by_cid(result["instances"])
+        assert 77 in by_cid
+        assert by_cid[77]["bbox_labels"]["cid"] == 77
+        assert len(result["instances"]) >= 2
+
+    @pytest.mark.parametrize("min_vis", [0.0, 0.45, 0.9], ids=["v0", "v045", "v09"])
+    def test_copy_paste_min_visibility_param_survival_matrix(
+        self,
+        base_two_instance_payload: tuple[np.ndarray, list[dict[str, Any]]],
+        min_vis: float,
+    ) -> None:
+        image, instances = base_two_instance_payload
+        paste_mask = np.zeros((72, 72), dtype=np.uint8)
+        paste_mask[:20, :20] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((72, 72, 3), 50, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, 20, 20],
+            "bbox_labels": {"cid": 900},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=min_vis, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        assert len(result["instances"]) >= 1
+        cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
+        assert 900 in cids
+
+    def test_all_primaries_occluded_only_paste_remains(self) -> None:
+        image = np.zeros((64, 64, 3), dtype=np.uint8)
+        full = np.ones((64, 64), dtype=np.uint8)
+        instances = [
+            {
+                "mask": full,
+                "bbox": np.array([0, 0, 64, 64], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        paste_mask = np.ones((64, 64), dtype=np.uint8)
+        donor: dict[str, Any] = {
+            "image": np.full((64, 64, 3), 200, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, 64, 64],
+            "bbox_labels": {"cid": 500},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=0.99, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        assert len(result["instances"]) == 1
+        assert result["instances"][0]["bbox_labels"]["cid"] == 500
+
+    def test_two_donors_distinct_cids_and_mask_stack(self) -> None:
+        image = np.zeros((80, 80, 3), dtype=np.uint8)
+        m0 = _make_mask(80, 80, (50, 78, 50, 78))
+        instances = [
+            {
+                "mask": m0,
+                "bbox": np.array([50, 50, 78, 78], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        d1_mask = np.zeros((80, 80), dtype=np.uint8)
+        d1_mask[0:15, 0:15] = 1
+        d2_mask = np.zeros((80, 80), dtype=np.uint8)
+        d2_mask[0:15, 20:35] = 1
+        meta = [
+            {
+                "image": np.full((80, 80, 3), 10, dtype=np.uint8),
+                "mask": d1_mask,
+                "bbox": [0, 0, 15, 15],
+                "bbox_labels": {"cid": 101},
+            },
+            {
+                "image": np.full((80, 80, 3), 20, dtype=np.uint8),
+                "mask": d2_mask,
+                "bbox": [20, 0, 35, 15],
+                "bbox_labels": {"cid": 102},
+            },
+        ]
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=0.0, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=meta)
+        cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
+        assert {1, 101, 102}.issubset(cids)
+        stacked = np.stack([inst["mask"] for inst in result["instances"]], axis=0)
+        assert stacked.shape[0] == len(result["instances"])
+
+    def test_empty_metadata_no_paste_instances_unchanged_count(self) -> None:
+        image = _make_image(48, 48)
+        instances = [
+            {
+                "mask": _make_mask(48, 48, (5, 30, 5, 30)),
+                "bbox": np.array([5, 5, 30, 30], dtype=np.float32),
+                "bbox_labels": {"cid": 3},
+            },
+        ]
+        transform = A.Compose(
+            [A.CopyAndPaste(p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[])
+        assert len(result["instances"]) == 1
+        assert result["instances"][0]["bbox_labels"]["cid"] == 3
+
+    def test_donor_mask_empty_skipped(self) -> None:
+        image = _make_image(40, 40)
+        instances = [
+            {
+                "mask": _make_mask(40, 40, (5, 25, 5, 25)),
+                "bbox": np.array([5, 5, 25, 25], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        donor: dict[str, Any] = {
+            "image": np.zeros((40, 40, 3), dtype=np.uint8),
+            "mask": np.zeros((40, 40), dtype=np.uint8),
+            "bbox": [0, 0, 1, 1],
+            "bbox_labels": {"cid": 99},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        assert len(result["instances"]) == 1
+
+    def test_triple_binding_assert_pasted_keypoint_row_and_survivor_cids(self) -> None:
+        image = np.zeros((88, 88, 3), dtype=np.uint8)
+        m0 = _make_mask(88, 88, (8, 40, 8, 40))
+        m1 = _make_mask(88, 88, (52, 84, 52, 84))
+        instances = [
+            {
+                "mask": m0,
+                "bbox": np.array([8, 8, 40, 40], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+                "keypoints": np.array([[12.0, 12.0], [20.0, 20.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [1, 1]},
+            },
+            {
+                "mask": m1,
+                "bbox": np.array([52, 52, 84, 84], dtype=np.float32),
+                "bbox_labels": {"cid": 2},
+                "keypoints": np.array([[70.0, 70.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [2]},
+            },
+        ]
+        paste_mask = np.zeros((88, 88), dtype=np.uint8)
+        paste_mask[:44, :44] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((88, 88, 3), 123, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, 44, 44],
+            "bbox_labels": {"cid": 999},
+            "keypoints": np.array([[22.0, 22.0], [30.0, 30.0]], dtype=np.float32),
+            "keypoint_labels": {"vis": [8, 8]},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=0.05, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["vis"]),
+            instance_binding=["masks", "bboxes", "keypoints"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        by_cid = _instances_by_cid(result["instances"])
+        assert 999 in by_cid
+        assert by_cid[999]["keypoints"].shape[0] == 2
+        np.testing.assert_array_equal(by_cid[999]["keypoint_labels"]["vis"], np.array([8, 8]))
+        assert 2 in by_cid
+        assert by_cid[2]["keypoints"].shape[0] == 1
+
+    def test_copy_paste_min_visibility_one_excludes_all_primaries(self) -> None:
+        """min_visibility_after_paste=1.0 requires untouched masks — any overlap removes instance."""
+        image = np.zeros((56, 56, 3), dtype=np.uint8)
+        m = _make_mask(56, 56, (10, 46, 10, 46))
+        instances = [
+            {
+                "mask": m,
+                "bbox": np.array([10, 10, 46, 46], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        paste = np.zeros((56, 56), dtype=np.uint8)
+        paste[20:30, 20:30] = 1
+        donor: dict[str, Any] = {
+            "image": np.ones((56, 56, 3), dtype=np.uint8),
+            "mask": paste,
+            "bbox": [20, 20, 30, 30],
+            "bbox_labels": {"cid": 88},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=1.0, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        assert len(result["instances"]) == 1
+        assert int(result["instances"][0]["bbox_labels"]["cid"]) == 88
+
+    @pytest.mark.parametrize("dtype_mask", [np.uint8, np.int32], ids=["u8", "i32"])
+    def test_copy_paste_mask_dtype_variants(self, dtype_mask: np.dtype) -> None:
+        image = np.zeros((50, 50, 3), dtype=np.uint8)
+        m = np.zeros((50, 50), dtype=dtype_mask)
+        m[10:30, 10:30] = 1
+        instances = [
+            {
+                "mask": m,
+                "bbox": np.array([10, 10, 30, 30], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        paste = np.zeros((50, 50), dtype=dtype_mask)
+        paste[:12, :12] = 1
+        donor: dict[str, Any] = {
+            "image": np.ones((50, 50, 3), dtype=np.uint8),
+            "mask": paste,
+            "bbox": [0, 0, 12, 12],
+            "bbox_labels": {"cid": 2},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=0.0, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        assert len(result["instances"]) == 2
+
+
+class TestMixingInstanceBindingRegression:
+    def test_mosaic_then_horizontal_flip_deterministic_seed(self, rng_137: np.random.Generator) -> None:
+        ch, cw = 40, 40
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(1, 1),
+                    target_size=(ch, cw),
+                    cell_shape=(ch, cw),
+                    p=1.0,
+                ),
+                A.HorizontalFlip(p=1.0),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        image = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (5, 25, 5, 30)),
+                "bbox": np.array([5, 5, 30, 25], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        r1 = transform(image=image.copy(), instances=instances, mosaic_metadata=[])
+        r2 = transform(image=image.copy(), instances=instances, mosaic_metadata=[])
+        assert len(r1["instances"]) == len(r2["instances"]) == 1
+        np.testing.assert_array_equal(r1["instances"][0]["mask"], r2["instances"][0]["mask"])


### PR DESCRIPTION
## Summary by Sourcery

Extend Mosaic and CopyAndPaste transforms to fully support instance-binding semantics across images, bboxes, keypoints, and stacked instance masks, ensuring consistent instance IDs through mixing and repacking while adding comprehensive tests and documentation updates.

New Features:
- Support stacked instance masks in Mosaic metadata and targets, propagating them through cell geometry processing and final mosaic assembly.
- Assign globally unique instance IDs across Mosaic cells and CopyAndPaste donors so instance binding can safely track objects across mixed sources.

Bug Fixes:
- Ensure CopyAndPaste and Mosaic correctly filter and repack bboxes and keypoints by instance ID when instance binding is enabled, preventing misaligned annotations or dropped keypoints.
- Avoid dropping keypoints outside canvas in Mosaic when instance IDs are present, relying on instance-based filtering instead.

Enhancements:
- Refactor mosaic preprocessing utilities to share label-unpacking logic and to validate or synthesize required binding-specific label fields for bboxes and keypoints.
- Improve CopyAndPaste label collection logic to handle binding-specific internal label fields and to centralize keypoint label extraction.
- Update Compose instance repacking to support row-aligned mask stacks when masks and bboxes share one row per instance, maintaining alignment after mixing transforms.

Documentation:
- Document the additional responsibilities of mixing transforms under instance binding, including instance ID remapping, stacked mask handling, and keypoint retention behavior in Mosaic.

Tests:
- Add extensive test coverage for Mosaic, CopyAndPaste, and their combinations under instance binding, including keypoints, various fit modes and layouts, multiple donors, visibility thresholds, dtype variants, and regression cases for determinism and occlusion handling.