### PR TITLE
feat(blur): add ModeFilter transform

### DIFF
--- a/.cursor/skills/add-transform/SKILL.md
+++ b/.cursor/skills/add-transform/SKILL.md
@@ -103,6 +103,7 @@ class MyTransform(DualTransform):  # or ImageOnlyTransform / NoOp
 - **`fill` not `fill_value`**, **`fill_mask` not `fill_mask_value`**
 - **`border_mode`** not `mode` or `pad_mode`
 - **NO default values in `InitSchema`** (except Pydantic discriminator fields)
+- **Range parameters are always `tuple[T, T]`**, never `T | tuple[T, T]` — no union with a scalar. Users always pass a tuple.
 - **NO default argument values in `apply_*` methods** (other than `self`, `**params`)
 - **All randomness in `get_params` or `get_params_dependent_on_data`**, never in `apply_*`
 - Use **`self.py_random`** for simple random ops, **`self.random_generator`** only when numpy arrays needed

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [InvertImg](https://explore.albumentations.ai/transform/InvertImg)
 - [LensFlare](https://explore.albumentations.ai/transform/LensFlare)
 - [MedianBlur](https://explore.albumentations.ai/transform/MedianBlur)
+- [ModeFilter](https://explore.albumentations.ai/transform/ModeFilter)
 - [MotionBlur](https://explore.albumentations.ai/transform/MotionBlur)
 - [MultiplicativeNoise](https://explore.albumentations.ai/transform/MultiplicativeNoise)
 - [Normalize](https://explore.albumentations.ai/transform/Normalize)

--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -19,14 +19,16 @@ from albucore import (
     float32_io,
     preserve_channel_dim,
     reduce_sum,
+    uint8_io,
 )
 from pydantic import ValidationInfo
+from scipy.stats import mode as scipy_mode
 
 from albumentations.augmentations.geometric.functional import scale
 from albumentations.augmentations.pixel.functional import convolve
 from albumentations.core.type_definitions import EIGHT, ImageType
 
-__all__ = ["box_blur", "central_zoom", "defocus", "glass_blur", "zoom_blur"]
+__all__ = ["box_blur", "central_zoom", "defocus", "glass_blur", "mode_filter", "zoom_blur"]
 
 
 @preserve_channel_dim
@@ -172,6 +174,31 @@ def zoom_blur(img: ImageType, zoom_factors: np.ndarray | Sequence[int]) -> Image
         out += central_zoom(img, zoom_factor)
 
     return (img + out) * np.float32(1.0 / (len(zoom_factors) + 1))
+
+
+@uint8_io
+def mode_filter(img: np.ndarray, kernel_size: int) -> np.ndarray:
+    """Replace each pixel with the most frequent value (mode) in its local square neighborhood,
+    computed per channel; ties broken by smallest value (scipy default).
+
+    Args:
+        img (np.ndarray): Input image (uint8 after @uint8_io conversion).
+        kernel_size (int): Side length of the square neighborhood (must be odd, ≥ 3).
+
+    Returns:
+        np.ndarray: Filtered image with the same shape and dtype as the input.
+
+    """
+    pad = kernel_size // 2
+    num_channels = img.shape[-1]
+    result = np.empty_like(img)
+    for channel_idx in range(num_channels):
+        channel = img[:, :, channel_idx]
+        padded = np.pad(channel, pad, mode="reflect")
+        windows = np.lib.stride_tricks.sliding_window_view(padded, (kernel_size, kernel_size))
+        flat = windows.reshape(windows.shape[0], windows.shape[1], -1)
+        result[:, :, channel_idx] = scipy_mode(flat, axis=-1, keepdims=False).mode
+    return result
 
 
 def _ensure_min_value(result: tuple[int, int], min_value: int, field_name: str | None) -> tuple[int, int]:

--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -176,29 +176,28 @@ def zoom_blur(img: ImageType, zoom_factors: np.ndarray | Sequence[int]) -> Image
     return (img + out) * np.float32(1.0 / (len(zoom_factors) + 1))
 
 
+@preserve_channel_dim
 @uint8_io
-def mode_filter(img: np.ndarray, kernel_size: int) -> np.ndarray:
+def mode_filter(img: ImageType, kernel_size: int) -> ImageType:
     """Replace each pixel with the most frequent value (mode) in its local square neighborhood,
     computed per channel; ties broken by smallest value (scipy default).
 
     Args:
-        img (np.ndarray): Input image (uint8 after @uint8_io conversion).
+        img (ImageType): Input image (uint8 after @uint8_io conversion).
         kernel_size (int): Side length of the square neighborhood (must be odd, ≥ 3).
 
     Returns:
-        np.ndarray: Filtered image with the same shape and dtype as the input.
+        ImageType: Filtered image with the same shape and dtype as the input.
 
     """
     pad = kernel_size // 2
-    num_channels = img.shape[-1]
-    result = np.empty_like(img)
-    for channel_idx in range(num_channels):
-        channel = img[:, :, channel_idx]
-        padded = np.pad(channel, pad, mode="reflect")
-        windows = np.lib.stride_tricks.sliding_window_view(padded, (kernel_size, kernel_size))
-        flat = windows.reshape(windows.shape[0], windows.shape[1], -1)
-        result[:, :, channel_idx] = scipy_mode(flat, axis=-1, keepdims=False).mode
-    return result
+    padded = np.pad(img, ((pad, pad), (pad, pad), (0, 0)), mode="reflect")
+    # Slide a (kernel_size, kernel_size, 1) window over the padded HWC image.
+    # Output shape: (H, W, C, kernel_size, kernel_size, 1)
+    windows = np.lib.stride_tricks.sliding_window_view(padded, (kernel_size, kernel_size, 1))
+    # Flatten neighborhood into trailing axis: (H, W, C, kernel_size * kernel_size)
+    flat = windows.reshape(windows.shape[0], windows.shape[1], windows.shape[2], -1)
+    return scipy_mode(flat, axis=-1, keepdims=False).mode.astype(img.dtype, copy=False)
 
 
 def _ensure_min_value(result: tuple[int, int], min_value: int, field_name: str | None) -> tuple[int, int]:

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -589,9 +589,9 @@ class ModeFilter(ImageOnlyTransform):
     (deterministic, scipy.stats.mode default). Border pixels use reflect padding.
 
     Args:
-        kernel_range (tuple[int, int] | int): Range of square kernel sizes to sample from.
-            Both bounds must be odd integers ≥ 3. Even values are silently bumped to the
-            next odd number. Pass a single int to fix the kernel size. Default: (3, 7).
+        kernel_range (tuple[int, int]): Range of square kernel sizes to sample from.
+            Both bounds must be odd integers ≥ 3. Even values raise a UserWarning and
+            are automatically bumped to the next odd number. Default: (3, 7).
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -630,24 +630,24 @@ class ModeFilter(ImageOnlyTransform):
     """
 
     class InitSchema(BaseTransformInitSchema):
-        kernel_range: tuple[int, int] | int
+        kernel_range: tuple[int, int]
 
         @field_validator("kernel_range")
         @classmethod
         def _validate_kernel_range(
             cls,
-            value: tuple[int, int] | int,
+            value: tuple[int, int],
             info: ValidationInfo,
         ) -> tuple[int, int]:
             return fblur.process_blur_limit(value, info, min_value=3)
 
     def __init__(
         self,
-        kernel_range: tuple[int, int] | int = (3, 7),
+        kernel_range: tuple[int, int] = (3, 7),
         p: float = 0.5,
     ) -> None:
         super().__init__(p=p)
-        self.kernel_range = cast("tuple[int, int]", kernel_range)
+        self.kernel_range = kernel_range
 
     def apply(self, img: ImageType, kernel_size: int, **params: Any) -> ImageType:
         return fblur.mode_filter(img, kernel_size)

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -41,6 +41,7 @@ __all__ = [
     "GaussianBlur",
     "GlassBlur",
     "MedianBlur",
+    "ModeFilter",
     "MotionBlur",
     "ZoomBlur",
 ]
@@ -570,6 +571,95 @@ class MedianBlur(Blur):
 
     def apply(self, img: ImageType, kernel: int, **params: Any) -> ImageType:
         return median_blur(img, kernel)
+
+
+class ModeFilter(ImageOnlyTransform):
+    """Replace each pixel with the most frequent value (mode) in its local neighborhood,
+    computed per channel. Useful for quantised, palette-like, or cartoon imagery.
+
+    Unlike median blur (order-statistic) or box blur (averaging), mode filtering is
+    frequency-based: it picks the value that appears most often in the window. This
+    preserves and expands dominant flat regions while suppressing isolated outliers, making
+    it well-suited for palette-like, synthetic, or segmentation-style imagery.
+
+    For float32 images the operation is performed in uint8 space (via @uint8_io); quantisation
+    is intentional — mode is meaningless for continuous-valued signals.
+
+    Tie-breaking: when multiple values share the highest frequency, the smallest is chosen
+    (deterministic, scipy.stats.mode default). Border pixels use reflect padding.
+
+    Args:
+        kernel_range (tuple[int, int] | int): Range of square kernel sizes to sample from.
+            Both bounds must be odd integers ≥ 3. Even values are silently bumped to the
+            next odd number. Pass a single int to fix the kernel size. Default: (3, 7).
+        p (float): Probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image, volume
+
+    Image types:
+        uint8, float32
+
+    Number of channels:
+        Any
+
+    Examples:
+        >>> import numpy as np
+        >>> import albumentations as A
+        >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        >>> mask = np.random.randint(0, 2, (100, 100), dtype=np.uint8)
+        >>> bboxes = np.array([[10, 10, 50, 50]], dtype=np.float32)
+        >>> bbox_labels = [1]
+        >>> keypoints = np.array([[20, 30]], dtype=np.float32)
+        >>> keypoint_labels = [0]
+        >>>
+        >>> transform = A.Compose([
+        ...     A.ModeFilter(kernel_range=(3, 7), p=1.0)
+        ... ], bbox_params=A.BboxParams(coord_format='pascal_voc', label_fields=['bbox_labels']),
+        ...    keypoint_params=A.KeypointParams(coord_format='xy', label_fields=['keypoint_labels']))
+        >>>
+        >>> result = transform(
+        ...     image=image,
+        ...     mask=mask,
+        ...     bboxes=bboxes,
+        ...     bbox_labels=bbox_labels,
+        ...     keypoints=keypoints,
+        ...     keypoint_labels=keypoint_labels,
+        ... )
+
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        kernel_range: tuple[int, int] | int
+
+        @field_validator("kernel_range")
+        @classmethod
+        def _validate_kernel_range(
+            cls,
+            value: tuple[int, int] | int,
+            info: ValidationInfo,
+        ) -> tuple[int, int]:
+            return fblur.process_blur_limit(value, info, min_value=3)
+
+    def __init__(
+        self,
+        kernel_range: tuple[int, int] | int = (3, 7),
+        p: float = 0.5,
+    ) -> None:
+        super().__init__(p=p)
+        self.kernel_range = cast("tuple[int, int]", kernel_range)
+
+    def apply(self, img: ImageType, kernel_size: int, **params: Any) -> ImageType:
+        return fblur.mode_filter(img, kernel_size)
+
+    def get_params(self) -> dict[str, Any]:
+        kernel_size = fblur.sample_odd_from_range(
+            self.py_random,
+            self.kernel_range[0],
+            self.kernel_range[1],
+        )
+        self.applied_config = {"kernel_range": kernel_size}
+        return {"kernel_size": kernel_size}
 
 
 class GaussianBlur(ImageOnlyTransform):

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -28,6 +28,7 @@ AUGMENTATION_CLS_PARAMS = [
     [A.Blur, {"blur_limit": (3, 5)}],
     [A.MotionBlur, {"blur_limit": (3, 5)}],
     [A.MedianBlur, {"blur_limit": (3, 5)}],
+    [A.ModeFilter, {"kernel_range": (3, 5)}],
     [A.GaussianBlur, {"blur_limit": (3, 5)}],
     [
         A.GaussNoise,

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -303,11 +303,14 @@ def test_mode_filter_apply_to_images_parity(dtype: np.dtype, num_channels: int, 
     [
         ((3, 3), (3, 3)),
         ((5, 7), (5, 7)),
+        ((4, 6), (5, 7)),  # even values bumped to next odd with a UserWarning
     ],
 )
 def test_mode_filter_kernel_range_stored(
     kernel_range_input: tuple[int, int],
     kernel_range_stored: tuple[int, int],
 ) -> None:
-    aug = A.ModeFilter(kernel_range=kernel_range_input, p=1.0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        aug = A.ModeFilter(kernel_range=kernel_range_input, p=1.0)
     assert aug.kernel_range == kernel_range_stored

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -242,3 +242,72 @@ def test_gaussian_blur_matches_pil():
     # Assert reasonable absolute differences
     assert mean_diff < 10, f"Average absolute difference too high: {mean_diff:.2f}"
     assert max_diff < 83, f"Maximum absolute difference too high: {max_diff:.2f}"
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
+@pytest.mark.parametrize("kernel_size", [3, 5, 7])
+def test_mode_filter_output_shape_and_dtype(dtype: np.dtype, num_channels: int, kernel_size: int) -> None:
+    rng = np.random.default_rng(137)
+    shape = (64, 64, num_channels)
+    if dtype == np.uint8:
+        image = rng.integers(0, 256, shape, dtype=np.uint8)
+    else:
+        image = rng.random(shape, dtype=np.float32)
+
+    transform = A.Compose([A.ModeFilter(kernel_range=(kernel_size, kernel_size), p=1.0)])
+    result = transform(image=image)["image"]
+
+    assert result.shape == image.shape
+    assert result.dtype == dtype
+
+
+def test_mode_filter_constant_image_passes_through() -> None:
+    """A constant-valued image should be unchanged: mode of identical values is that value."""
+    image = np.full((32, 32, 3), fill_value=137, dtype=np.uint8)
+    transform = A.Compose([A.ModeFilter(kernel_range=(5, 5), p=1.0)])
+    result = transform(image=image)["image"]
+    np.testing.assert_array_equal(result, image)
+
+
+def test_mode_filter_constant_image_float32_passes_through() -> None:
+    image = np.full((32, 32, 3), fill_value=0.5, dtype=np.float32)
+    transform = A.Compose([A.ModeFilter(kernel_range=(5, 5), p=1.0)])
+    result = transform(image=image)["image"]
+    # After uint8_io round-trip (0.5 → 127 → ~0.498), check within quantisation tolerance
+    np.testing.assert_allclose(result, image, atol=1.0 / 255)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
+@pytest.mark.parametrize("kernel_size", [3, 5, 7])
+def test_mode_filter_apply_to_images_parity(dtype: np.dtype, num_channels: int, kernel_size: int) -> None:
+    """Batch processing via images= must match per-image processing."""
+    rng = np.random.default_rng(137)
+    shape = (32, 32, num_channels)
+    if dtype == np.uint8:
+        images = rng.integers(0, 256, (4, *shape), dtype=np.uint8)
+    else:
+        images = rng.random((4, *shape), dtype=np.float32)
+
+    transform = A.Compose([A.ModeFilter(kernel_range=(kernel_size, kernel_size), p=1.0)])
+
+    batch_result = transform(images=images)["images"]
+    per_image_results = np.stack([transform(image=img)["image"] for img in images])
+
+    np.testing.assert_array_equal(batch_result, per_image_results)
+
+
+@pytest.mark.parametrize(
+    "kernel_range_input, kernel_range_stored",
+    [
+        ((3, 3), (3, 3)),
+        ((5, 7), (5, 7)),
+    ],
+)
+def test_mode_filter_kernel_range_stored(
+    kernel_range_input: tuple[int, int],
+    kernel_range_stored: tuple[int, int],
+) -> None:
+    aug = A.ModeFilter(kernel_range=kernel_range_input, p=1.0)
+    assert aug.kernel_range == kernel_range_stored


### PR DESCRIPTION
Replaces each pixel with the most frequent value (mode) in its local square neighborhood, computed independently per channel.

- Functional layer: sliding_window_view + scipy.stats.mode (vectorized C) with reflect padding and @uint8_io for float32 round-trip
- Transform: kernel_range parameter (odd integers ≥ 3, even values bumped), reuses process_blur_limit / sample_odd_from_range from blur functional
- Distinct from MedianBlur: frequency-based vs order-statistic; preserves and expands dominant flat regions, useful for cartoon/palette/quantised imagery
- Tests: shape/dtype, constant-image identity, batch parity, kernel_range storage
- Registered in aug_definitions.py and README pixel-level transforms table

Made-with: Cursor

## Summary by Sourcery

Add a new pixel-level ModeFilter blur transform that applies a per-channel mode-based neighborhood filter and integrate it into the blur functional API, documentation, and test suites.

New Features:
- Introduce a ModeFilter image transform that replaces each pixel with the most frequent value in its local neighborhood using a configurable kernel range.

Enhancements:
- Expose a mode_filter functional that performs uint8-based, per-channel mode filtering with reflect padding and sliding window computation.
- Register ModeFilter in augmentation definitions so it participates in generic transform coverage tests.

Documentation:
- Document the ModeFilter transform in the README pixel-level transforms table.

Tests:
- Add tests covering ModeFilter output shape and dtype, behavior on constant images, batch vs per-image parity, and kernel_range configuration persistence.