### PR TITLE
Cursor/add enhance transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [Dithering](https://explore.albumentations.ai/transform/Dithering)
 - [Downscale](https://explore.albumentations.ai/transform/Downscale)
 - [Emboss](https://explore.albumentations.ai/transform/Emboss)
+- [Enhance](https://explore.albumentations.ai/transform/Enhance)
 - [Equalize](https://explore.albumentations.ai/transform/Equalize)
 - [FDA](https://explore.albumentations.ai/transform/FDA)
 - [FancyPCA](https://explore.albumentations.ai/transform/FancyPCA)

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -3195,8 +3195,15 @@ def generate_enhance_matrix(mode: Literal["edge", "detail"], alpha: float) -> np
     Returns:
         np.ndarray: A `(3, 3)` float32 convolution kernel.
 
+    Raises:
+        ValueError: If `mode` is not one of the supported enhancement modes.
+
     """
-    return (1.0 - alpha) * _ENHANCE_IDENTITY + alpha * _ENHANCE_KERNELS[mode]
+    if mode not in _ENHANCE_KERNELS:
+        msg = f"Unsupported enhance mode: {mode!r}. Supported modes are: {tuple(_ENHANCE_KERNELS)}"
+        raise ValueError(msg)
+    kernel = (1.0 - alpha) * _ENHANCE_IDENTITY + alpha * _ENHANCE_KERNELS[mode]
+    return kernel.astype(np.float32, copy=False)
 
 
 def apply_salt_and_pepper(

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -3149,6 +3149,56 @@ def sharpen_gaussian(
     return add_weighted(img, 1.0 + alpha, blurred, -alpha)
 
 
+# Native Albumentations equivalents of Pillow's enhancement filters. Each kernel is
+# normalized so its weights sum to 1 (DC-preserving). With the blend formula
+#     K(alpha) = (1 - alpha) * I + alpha * E
+# alpha=0 leaves the image untouched, alpha=1 reproduces the Pillow preset, and
+# larger alpha overshoots into stronger variants. For "edge" specifically, alpha=2
+# reproduces Pillow's EDGE_ENHANCE_MORE.
+_ENHANCE_KERNELS: dict[str, np.ndarray] = {
+    "edge": np.array(
+        [
+            [-0.5, -0.5, -0.5],
+            [-0.5, 5.0, -0.5],
+            [-0.5, -0.5, -0.5],
+        ],
+        dtype=np.float32,
+    ),
+    "detail": np.array(
+        [
+            [0.0, -1.0 / 6.0, 0.0],
+            [-1.0 / 6.0, 10.0 / 6.0, -1.0 / 6.0],
+            [0.0, -1.0 / 6.0, 0.0],
+        ],
+        dtype=np.float32,
+    ),
+}
+
+_ENHANCE_IDENTITY = np.array(
+    [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+    dtype=np.float32,
+)
+
+
+def generate_enhance_matrix(mode: Literal["edge", "detail"], alpha: float) -> np.ndarray:
+    """Build a Pillow-inspired 3x3 enhancement kernel via `(1 - alpha) * I + alpha * E`,
+    where E is selected by `mode` (edge or detail). Apply via `convolve`.
+
+    Args:
+        mode (Literal['edge', 'detail']): Which native enhancement operator to use.
+            - "edge": crispens contours; alpha=1 matches Pillow's EDGE_ENHANCE,
+              alpha=2 matches Pillow's EDGE_ENHANCE_MORE.
+            - "detail": mild local detail boost; alpha=1 matches Pillow's DETAIL.
+        alpha (float): Blend strength. 0 returns the identity kernel; 1 returns the
+            full preset; values >1 push past the preset for a stronger effect.
+
+    Returns:
+        np.ndarray: A `(3, 3)` float32 convolution kernel.
+
+    """
+    return (1.0 - alpha) * _ENHANCE_IDENTITY + alpha * _ENHANCE_KERNELS[mode]
+
+
 def apply_salt_and_pepper(
     img: ImageType,
     salt_mask: np.ndarray,

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -621,6 +621,9 @@ class Enhance(ImageOnlyTransform):
 
     def get_params(self) -> dict[str, Any]:
         alpha = self.py_random.uniform(*self.alpha_range)
+        # Record the resolved scalar (not the range) for replay/debug, per the
+        # applied_config contract documented on get_applied_config.
+        self.applied_config = {"alpha_range": alpha}
         return {"enhance_matrix": fpixel.generate_enhance_matrix(self.mode, alpha)}
 
     def apply(

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -41,6 +41,7 @@ from albumentations.core.type_definitions import ImageType, VolumeType
 __all__ = [
     "Dithering",
     "Emboss",
+    "Enhance",
     "Halftone",
     "InvertImg",
     "LensFlare",
@@ -342,9 +343,11 @@ class Sharpen(ImageOnlyTransform):
         - Gaussian blur: https://en.wikipedia.org/wiki/Gaussian_blur
 
     See Also:
-        - Blur: For Gaussian blurring
-        - UnsharpMask: Alternative sharpening method
-        - RandomBrightnessContrast: For adjusting image contrast
+        - Enhance: Compact Pillow-inspired preset family (edge/detail) for milder, more
+          targeted local enhancement than broad Sharpen.
+        - UnsharpMask: Alternative sharpening method.
+        - Blur: For Gaussian blurring.
+        - RandomBrightnessContrast: For adjusting image contrast.
 
     """
 
@@ -521,6 +524,115 @@ class Emboss(ImageOnlyTransform):
         **params: Any,
     ) -> ImageType:
         return fpixel.convolve(img, emboss_matrix)
+
+
+class Enhance(ImageOnlyTransform):
+    """Mild Pillow-inspired local enhancement (edge or detail) blended with the original via
+    alpha. Use for subtle contour or detail boost milder than Sharpen.
+
+    A native Albumentations implementation of the Pillow `EDGE_ENHANCE` / `EDGE_ENHANCE_MORE`
+    and `DETAIL` filter family. The enhanced image is computed via a small 3x3 convolution and
+    then blended with the original:
+
+        output = (1 - alpha) * image + alpha * enhanced_image
+
+    Equivalently, the convolution is applied with the precomputed kernel
+    `K(alpha) = (1 - alpha) * I + alpha * E` where `E` is the mode-specific kernel.
+    Because each `E` sums to 1, `K(alpha)` also sums to 1 and brightness is preserved.
+
+    For `mode="edge"`, `alpha=1` reproduces Pillow's `EDGE_ENHANCE` and `alpha=2`
+    reproduces `EDGE_ENHANCE_MORE`. For `mode="detail"`, `alpha=1` reproduces Pillow's
+    `DETAIL`. Values of `alpha` between 0 and 1 give milder presets; values above 1
+    overshoot for stronger effects.
+
+    Args:
+        mode (Literal['edge', 'detail']): Which native enhancement operator to use.
+            - "edge": crispens contours and boundaries (Pillow EDGE_ENHANCE family).
+            - "detail": mild local detail / fine-structure boost (Pillow DETAIL).
+            Default: "edge".
+        alpha_range (tuple[float, float]): Range from which the blend strength `alpha` is
+            sampled uniformly per call. `alpha=0` is no-op, `alpha=1` is the full Pillow
+            preset, `alpha>1` overshoots into a stronger variant. Must be non-decreasing
+            with non-negative values. Default: (0.5, 1.0).
+        p (float): Probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image, volume
+
+    Image types:
+        uint8, float32
+
+    Number of channels:
+        Any
+
+    Note:
+        - Edge handling follows the rest of Albumentations (cv2 `BORDER_REFLECT_101`),
+          which differs slightly from Pillow's clamping at borders.
+        - For uint8 inputs the output saturates to `[0, 255]`; for float32 it is clipped
+          to `[0, 1]` by `convolve`.
+
+    Examples:
+        >>> import numpy as np
+        >>> import albumentations as A
+        >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        >>>
+        >>> # Edge enhancement, mild to Pillow-EDGE_ENHANCE strength
+        >>> transform = A.Compose([A.Enhance(mode="edge", alpha_range=(0.5, 1.0), p=1.0)])
+        >>> result = transform(image=image)["image"]
+        >>>
+        >>> # Stronger edge variant (alpha=2 matches Pillow EDGE_ENHANCE_MORE)
+        >>> transform = A.Compose([A.Enhance(mode="edge", alpha_range=(1.0, 2.0), p=1.0)])
+        >>> result = transform(image=image)["image"]
+        >>>
+        >>> # Subtle detail / fine-structure boost
+        >>> transform = A.Compose([A.Enhance(mode="detail", alpha_range=(0.5, 1.0), p=1.0)])
+        >>> result = transform(image=image)["image"]
+
+    References:
+        Pillow ImageFilter (EDGE_ENHANCE, EDGE_ENHANCE_MORE, DETAIL):
+            https://pillow.readthedocs.io/en/stable/reference/ImageFilter.html
+
+    See Also:
+        - Sharpen: Broader high-frequency sharpening (kernel-Laplacian or unsharp-mask).
+          Use when you need a continuous, configurable sharpening primitive rather than
+          a compact preset family.
+        - UnsharpMask: Classic unsharp-mask sharpening with explicit blur radius.
+        - Emboss: Directional edge highlight for stylization rather than enhancement.
+
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        mode: Literal["edge", "detail"]
+        alpha_range: Annotated[
+            tuple[float, float],
+            AfterValidator(check_range_bounds(0, None)),
+            AfterValidator(nondecreasing),
+        ]
+
+    def __init__(
+        self,
+        mode: Literal["edge", "detail"] = "edge",
+        alpha_range: tuple[float, float] = (0.5, 1.0),
+        p: float = 0.5,
+    ):
+        super().__init__(p=p)
+        self.mode = mode
+        self.alpha_range = alpha_range
+
+    def get_params(self) -> dict[str, Any]:
+        alpha = self.py_random.uniform(*self.alpha_range)
+        return {"enhance_matrix": fpixel.generate_enhance_matrix(self.mode, alpha)}
+
+    def apply(
+        self,
+        img: ImageType,
+        enhance_matrix: np.ndarray,
+        **params: Any,
+    ) -> ImageType:
+        return fpixel.convolve(img, enhance_matrix)
+
+    def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
+        return self._apply_to_batch_same_shape(images, lambda image: self.apply(image, **params))
 
 
 class Superpixels(ImageOnlyTransform):

--- a/tests/aug_definitions.py
+++ b/tests/aug_definitions.py
@@ -235,6 +235,8 @@ AUGMENTATION_CLS_PARAMS = [
     ],
     [A.Sharpen, {"alpha": [0.2, 0.5], "lightness": [0.5, 1.0]}],
     [A.Emboss, {"alpha": [0.2, 0.5], "strength": [0.5, 1.0]}],
+    [A.Enhance, {"mode": "edge", "alpha_range": (0.5, 1.0)}],
+    [A.Enhance, {"mode": "detail", "alpha_range": (0.5, 1.0)}],
     [A.RandomToneCurve, {"scale": 0.2, "per_channel": False}],
     [A.RandomToneCurve, {"scale": 0.3, "per_channel": True}],
     [

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1642,3 +1642,98 @@ def test_sharpen_apply_to_volumes(dtype, method):
 
     expected = np.stack([transform(volume=volumes[i])["volume"] for i in range(volumes.shape[0])])
     np.testing.assert_array_equal(transformed, expected)
+
+
+@pytest.mark.parametrize("mode", ["edge", "detail"])
+def test_enhance_alpha_zero_is_identity(mode):
+    image = np.random.RandomState(137).randint(0, 256, (64, 64, 3), dtype=np.uint8)
+    transform = A.Compose([A.Enhance(mode=mode, alpha_range=(0.0, 0.0), p=1.0)])
+    np.testing.assert_array_equal(transform(image=image)["image"], image)
+
+
+@pytest.mark.parametrize("mode", ["edge", "detail"])
+def test_enhance_kernel_matches_pillow_preset(mode):
+    """alpha=1 must reproduce the Pillow preset kernel exactly (DC-preserving)."""
+    expected = {
+        "edge": np.array(
+            [[-0.5, -0.5, -0.5], [-0.5, 5.0, -0.5], [-0.5, -0.5, -0.5]],
+            dtype=np.float32,
+        ),
+        "detail": np.array(
+            [
+                [0.0, -1.0 / 6.0, 0.0],
+                [-1.0 / 6.0, 10.0 / 6.0, -1.0 / 6.0],
+                [0.0, -1.0 / 6.0, 0.0],
+            ],
+            dtype=np.float32,
+        ),
+    }[mode]
+    np.testing.assert_allclose(
+        fpixel.generate_enhance_matrix(mode, 1.0),
+        expected,
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(fpixel.generate_enhance_matrix(mode, 1.0).sum(), 1.0, rtol=1e-6)
+
+
+def test_enhance_edge_alpha_two_matches_edge_enhance_more():
+    """alpha=2 with mode=edge must reproduce Pillow's EDGE_ENHANCE_MORE kernel."""
+    expected = np.array(
+        [[-1.0, -1.0, -1.0], [-1.0, 9.0, -1.0], [-1.0, -1.0, -1.0]],
+        dtype=np.float32,
+    )
+    np.testing.assert_allclose(fpixel.generate_enhance_matrix("edge", 2.0), expected, rtol=1e-6)
+
+
+@pytest.mark.parametrize("mode", ["edge", "detail"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
+def test_enhance_preserves_shape_and_dtype(mode, dtype, num_channels):
+    rng = np.random.RandomState(137)
+    shape = (64, 64) if num_channels == 1 else (64, 64, num_channels)
+    if dtype == np.uint8:
+        image = rng.randint(0, 256, shape, dtype=np.uint8)
+    else:
+        image = rng.random(shape).astype(np.float32)
+
+    transform = A.Compose([A.Enhance(mode=mode, alpha_range=(0.5, 1.5), p=1.0)])
+    result = transform(image=image)["image"]
+
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype
+    if dtype == np.float32:
+        assert result.min() >= 0.0
+        assert result.max() <= 1.0
+
+
+@pytest.mark.parametrize("mode", ["edge", "detail"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_enhance_apply_to_images_matches_per_image(mode, dtype):
+    rng = np.random.RandomState(137)
+    shape = (3, 48, 48, 3)
+    if dtype == np.uint8:
+        images = rng.randint(0, 256, shape, dtype=np.uint8)
+    else:
+        images = rng.random(shape).astype(np.float32)
+
+    transform = A.Compose([A.Enhance(mode=mode, alpha_range=(0.7, 0.7), p=1.0)])
+
+    batched = transform(images=images)["images"]
+    per_image = np.stack([transform(image=images[i])["image"] for i in range(images.shape[0])])
+
+    assert batched.shape == images.shape
+    assert batched.dtype == images.dtype
+    np.testing.assert_array_equal(batched, per_image)
+
+
+@pytest.mark.parametrize(
+    ("mode", "alpha_range"),
+    [
+        ("invalid", (0.5, 1.0)),
+        ("edge", (-0.1, 0.5)),
+        ("edge", (1.0, 0.5)),
+    ],
+)
+def test_enhance_invalid_params_raise(mode, alpha_range):
+    with pytest.raises(Exception):
+        A.Enhance(mode=mode, alpha_range=alpha_range, p=1.0)

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1737,3 +1737,38 @@ def test_enhance_apply_to_images_matches_per_image(mode, dtype):
 def test_enhance_invalid_params_raise(mode, alpha_range):
     with pytest.raises(Exception):
         A.Enhance(mode=mode, alpha_range=alpha_range, p=1.0)
+
+
+@pytest.mark.parametrize(
+    ("mode", "alpha", "pil_filter_name"),
+    [
+        ("edge", 1.0, "EDGE_ENHANCE"),
+        ("edge", 2.0, "EDGE_ENHANCE_MORE"),
+        ("detail", 1.0, "DETAIL"),
+    ],
+)
+def test_enhance_matches_pillow_interior(mode, alpha, pil_filter_name):
+    """Enhance must reproduce PIL's preset on interior pixels (within 1 LSB).
+
+    Border pixels are excluded because cv2 defaults to BORDER_REFLECT_101 while
+    PIL uses replicate at borders. Integer-only kernel (EDGE_ENHANCE_MORE) is
+    bit-exact; fractional kernels can differ by 1 LSB due to rounding mode.
+    """
+    pytest.importorskip("PIL")
+    from PIL import Image, ImageFilter
+
+    image = np.random.RandomState(137).randint(0, 256, (96, 96, 3), dtype=np.uint8)
+
+    pil_filter = getattr(ImageFilter, pil_filter_name)
+    pil_out = np.array(Image.fromarray(image).filter(pil_filter))
+
+    transform = A.Compose([A.Enhance(mode=mode, alpha_range=(alpha, alpha), p=1.0)])
+    ours = transform(image=image)["image"]
+
+    pil_interior = pil_out[1:-1, 1:-1]
+    ours_interior = ours[1:-1, 1:-1]
+
+    diff = np.abs(pil_interior.astype(np.int16) - ours_interior.astype(np.int16))
+    assert diff.max() <= 1, f"max abs diff {diff.max()} exceeds 1 LSB tolerance vs PIL {pil_filter_name}"
+    if pil_filter_name == "EDGE_ENHANCE_MORE":
+        np.testing.assert_array_equal(pil_interior, ours_interior)

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1743,6 +1743,31 @@ def test_enhance_invalid_alpha_range_raises(alpha_range):
         A.Enhance(mode="edge", alpha_range=alpha_range, p=1.0)
 
 
+def test_enhance_invalid_mode_in_functional_raises():
+    """generate_enhance_matrix must raise ValueError (not KeyError) on bad mode."""
+    with pytest.raises(ValueError, match="Unsupported enhance mode"):
+        fpixel.generate_enhance_matrix("not_a_mode", 0.5)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("mode", ["edge", "detail"])
+def test_enhance_applied_config_resolves_range_to_scalar(mode):
+    """applied_config must record the *sampled* alpha (a scalar in alpha_range), not the range itself.
+
+    This enforces the contract documented on BasicTransform.get_applied_config:
+    "all constructor params and range params resolved to sampled scalar values".
+    """
+    image = np.random.RandomState(137).randint(0, 256, (32, 32, 3), dtype=np.uint8)
+    alpha_range = (0.3, 0.9)
+    aug = A.Enhance(mode=mode, alpha_range=alpha_range, p=1.0)
+    aug(image=image)
+
+    sampled = aug.applied_config["alpha_range"]
+    assert isinstance(sampled, float), f"expected sampled scalar, got {type(sampled).__name__}: {sampled!r}"
+    assert alpha_range[0] <= sampled <= alpha_range[1]
+    # mode is already covered by the base init args; verify it's preserved
+    assert aug.applied_config["mode"] == mode
+
+
 @pytest.mark.parametrize(
     ("mode", "alpha", "pil_filter_name"),
     [

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1726,17 +1726,21 @@ def test_enhance_apply_to_images_matches_per_image(mode, dtype):
     np.testing.assert_array_equal(batched, per_image)
 
 
+def test_enhance_invalid_mode_raises():
+    with pytest.raises(ValueError):
+        A.Enhance(mode="invalid", alpha_range=(0.5, 1.0), p=1.0)
+
+
 @pytest.mark.parametrize(
-    ("mode", "alpha_range"),
+    "alpha_range",
     [
-        ("invalid", (0.5, 1.0)),
-        ("edge", (-0.1, 0.5)),
-        ("edge", (1.0, 0.5)),
+        (-0.1, 0.5),  # negative lower bound
+        (1.0, 0.5),  # decreasing
     ],
 )
-def test_enhance_invalid_params_raise(mode, alpha_range):
-    with pytest.raises(Exception):
-        A.Enhance(mode=mode, alpha_range=alpha_range, p=1.0)
+def test_enhance_invalid_alpha_range_raises(alpha_range):
+    with pytest.raises(ValueError):
+        A.Enhance(mode="edge", alpha_range=alpha_range, p=1.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Add a new Pillow-inspired Enhance pixel transform with configurable edge/detail modes and integrate it into the augmentations suite.

New Features:
- Introduce an Enhance image/volume transform that applies mild local edge or detail enhancement with controllable strength via alpha_range.
- Provide a functional helper to generate Pillow-compatible 3x3 enhancement kernels for edge and detail modes.

Enhancements:
- Cross-reference Enhance from existing Sharpen documentation and update README to list the new transform alongside other pixel-level operations.

Tests:
- Add comprehensive tests validating Enhance behavior, including parameter validation, kernel correctness against Pillow presets, batched vs per-image consistency, and dtype/shape preservation.
- Register Enhance in generic augmentation definition tests to ensure it participates in common test coverage.