### PR TITLE
fix(applied_config): resolve range params to sampled scalars in CopyA…

### DIFF
--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -1557,7 +1557,7 @@ class PixelSpread(BaseDistortion):
         height, width = params["shape"][:2]
         map_resolution = self.py_random.uniform(*self.map_resolution_range)
 
-        self.applied_config = {"map_resolution_range": map_resolution}
+        self.applied_config["map_resolution_range"] = map_resolution
 
         scaled_height = max(1, int(height * map_resolution))
         scaled_width = max(1, int(width * map_resolution))

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -1557,6 +1557,8 @@ class PixelSpread(BaseDistortion):
         height, width = params["shape"][:2]
         map_resolution = self.py_random.uniform(*self.map_resolution_range)
 
+        self.applied_config = {"map_resolution_range": map_resolution}
+
         scaled_height = max(1, int(height * map_resolution))
         scaled_width = max(1, int(width * map_resolution))
 

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -743,6 +743,7 @@ class CopyAndPaste(DualTransform):
         paste_union_mask = np.any(pasted_masks > 0, axis=0)
 
         blend_sigma = self.py_random.uniform(*self.blend_sigma_range)
+        self.applied_config = {"blend_sigma_range": blend_sigma}
         alpha = fmixing.create_copy_paste_alpha(pasted_masks, self.blend_mode, blend_sigma)
 
         surviving_indices, paste_primary_instance_count = self._compute_surviving_indices(data, paste_union_mask)

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -743,7 +743,7 @@ class CopyAndPaste(DualTransform):
         paste_union_mask = np.any(pasted_masks > 0, axis=0)
 
         blend_sigma = self.py_random.uniform(*self.blend_sigma_range)
-        self.applied_config = {"blend_sigma_range": blend_sigma}
+        self.applied_config["blend_sigma_range"] = blend_sigma
         alpha = fmixing.create_copy_paste_alpha(pasted_masks, self.blend_mode, blend_sigma)
 
         surviving_indices, paste_primary_instance_count = self._compute_surviving_indices(data, paste_union_mask)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3203,6 +3203,37 @@ def test_applied_config_resolves_range_param_to_scalar(aug_cls, range_param, ini
     )
 
 
+@pytest.mark.parametrize(("aug_cls", "range_param", "init_kwargs"), SINGLE_SAMPLE_RANGE_RESOLUTIONS)
+def test_applied_config_range_param_refreshes_each_call(aug_cls, range_param, init_kwargs):
+    """applied_config[range_param] must reflect the *most recent* sample, not stale state.
+
+    Guards against a "sample once, reuse forever" regression where a transform instance
+    caches the first sampled value across subsequent calls. Runs the transform 8 times
+    with a wide range and asserts (a) every call produces a scalar in-range, and
+    (b) at least two distinct values appear (probabilistic; range is wide enough that
+    the false-positive rate is negligible).
+    """
+    image = _make_test_image()
+    aug = aug_cls(**init_kwargs, p=1.0)
+    low, high = init_kwargs[range_param]
+
+    samples = []
+    for _ in range(8):
+        data = TransformTestHelper.prepare_test_data(aug_cls, image)
+        aug(**data)
+        sampled = aug.applied_config.get(range_param)
+        assert isinstance(sampled, (int, float, np.integer, np.floating)), (
+            f"{aug_cls.__name__}.applied_config[{range_param!r}] not a scalar on repeat call: {sampled!r}"
+        )
+        assert low <= sampled <= high
+        samples.append(float(sampled))
+
+    assert len(set(samples)) > 1, (
+        f"{aug_cls.__name__}.applied_config[{range_param!r}] returned the same value across 8 calls: {samples!r}; "
+        f"likely cached/stale state instead of per-call resampling"
+    )
+
+
 def test_applied_config_resolves_copy_and_paste_blend_sigma_range():
     """CopyAndPaste.blend_sigma_range must resolve to a sampled scalar (special case: needs metadata)."""
     image = _make_test_image()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3142,3 +3142,81 @@ def test_applied_config_pixel_distribution_adaptation():
     aug = A.PixelDistributionAdaptation(blend_ratio=(0.5, 1.0), p=1.0)
     aug(image=image, pda_metadata=[reference])
     _assert_applied_config_valid(aug)
+
+
+# ── applied_config: range params must resolve to sampled scalars ─────────────
+#
+# These transforms unconditionally sample exactly one scalar from a `_range`
+# constructor parameter on every apply (e.g., `self.py_random.uniform(*self.foo_range)`).
+# Per the get_applied_config contract, the sampled scalar must be recorded in
+# `applied_config[range_param_name]` so that replay/debug shows the concrete
+# value, not the original input range.
+#
+# Format: (transform_class, range_param_name, init_kwargs)
+# init_kwargs MUST set the range parameter to a non-degenerate range
+# (low != high) so we can distinguish "scalar sample" from "original tuple".
+SINGLE_SAMPLE_RANGE_RESOLUTIONS: list[tuple[type, str, dict[str, Any]]] = [
+    (A.Blur, "blur_limit", {"blur_limit": (3, 9)}),
+    (A.GaussianBlur, "blur_limit", {"blur_limit": (3, 9)}),
+    (A.MedianBlur, "blur_limit", {"blur_limit": (3, 9)}),
+    (A.MotionBlur, "blur_limit", {"blur_limit": (3, 9)}),
+    (A.Enhance, "alpha_range", {"alpha_range": (0.3, 0.9)}),
+    (A.PlasmaShadow, "shadow_intensity_range", {"shadow_intensity_range": (0.2, 0.8)}),
+    (A.PixelSpread, "map_resolution_range", {"radius": 2, "map_resolution_range": (0.3, 0.7)}),
+    (A.ElasticTransform, "map_resolution_range", {"map_resolution_range": (0.3, 0.7)}),
+    (A.GridDistortion, "map_resolution_range", {"map_resolution_range": (0.3, 0.7)}),
+    (A.OpticalDistortion, "map_resolution_range", {"map_resolution_range": (0.3, 0.7)}),
+    (A.PiecewiseAffine, "map_resolution_range", {"map_resolution_range": (0.3, 0.7)}),
+    (A.ThinPlateSpline, "map_resolution_range", {"map_resolution_range": (0.3, 0.7)}),
+]
+
+
+@pytest.mark.parametrize(("aug_cls", "range_param", "init_kwargs"), SINGLE_SAMPLE_RANGE_RESOLUTIONS)
+def test_applied_config_resolves_range_param_to_scalar(aug_cls, range_param, init_kwargs):
+    """Single-sample `_range` params must be recorded as the sampled scalar in applied_config.
+
+    Catches the bug pattern where get_params samples from a range but forgets to record the
+    scalar — leaving `applied_config[range]` as the original input tuple, which silently
+    breaks replay/debug consumers of get_applied_config().
+    """
+    image = _make_test_image()
+    aug = aug_cls(**init_kwargs, p=1.0)
+    original_range = init_kwargs[range_param]
+    low, high = original_range
+    assert low != high, "test setup error: pick a non-degenerate range to distinguish scalar from tuple"
+
+    data = TransformTestHelper.prepare_test_data(aug_cls, image)
+    aug(**data)
+
+    sampled = aug.applied_config.get(range_param)
+    assert sampled is not None, f"{aug_cls.__name__}.applied_config missing key {range_param!r}"
+    assert not isinstance(sampled, (tuple, list)), (
+        f"{aug_cls.__name__}.applied_config[{range_param!r}] is still a tuple {sampled!r}; "
+        f"get_params likely sampled but forgot to record the scalar via "
+        f"`self.applied_config = {{{range_param!r}: sampled_value, ...}}`"
+    )
+    assert isinstance(sampled, (int, float, np.integer, np.floating)), (
+        f"{aug_cls.__name__}.applied_config[{range_param!r}] should be a scalar, got {type(sampled).__name__}"
+    )
+    assert low <= sampled <= high, (
+        f"{aug_cls.__name__}.applied_config[{range_param!r}]={sampled} outside input range [{low}, {high}]"
+    )
+
+
+def test_applied_config_resolves_copy_and_paste_blend_sigma_range():
+    """CopyAndPaste.blend_sigma_range must resolve to a sampled scalar (special case: needs metadata)."""
+    image = _make_test_image()
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    overlay = {
+        "image": np.full((40, 40, 3), 200, dtype=np.uint8),
+        "mask": np.ones((40, 40), dtype=np.uint8),
+    }
+
+    aug = A.CopyAndPaste(blend_mode="gaussian", blend_sigma_range=(0.5, 2.0), p=1.0)
+    aug(image=image, mask=mask, copy_paste_metadata=[overlay])
+
+    sampled = aug.applied_config.get("blend_sigma_range")
+    assert isinstance(sampled, float), (
+        f"CopyAndPaste.applied_config['blend_sigma_range'] should be a float scalar, got {sampled!r}"
+    )
+    assert 0.5 <= sampled <= 2.0


### PR DESCRIPTION
…ndPaste, PixelSpread

Both transforms unconditionally sample one scalar from a `_range` constructor parameter (`blend_sigma_range` and `map_resolution_range` respectively) but never recorded the sampled value in `applied_config`, leaving consumers of `get_applied_config()` looking at the original input range tuple instead of the concrete value used for that call. This silently broke replay/debug.

Audit of all `_range` constructor params confirmed these are the only true violators on main. The other transforms flagged by a naive scan (Illumination, PhotoMetricDistort, RandomShadow, TextImage, Dithering) are either conditionally sampled (already correct) or sample arrays/per-element values where keeping the range tuple is the right semantics.

WaterRefraction accepts `map_resolution_range` via `BaseDistortion` but never reads it — that is a separate dead-parameter issue, not in scope here, and adding a sample call would change RNG behavior for existing seeded users.

Adds `tests/test_core.py::test_applied_config_resolves_range_param_to_scalar` parametrized over the known single-sample range params to catch future regressions, plus a dedicated test for `CopyAndPaste` (which needs metadata).

Made-with: Cursor

## Summary by Sourcery

Ensure single-sample range parameters are recorded as concrete scalar values in applied_config for accurate replay and debugging.

Bug Fixes:
- Record the sampled map_resolution_range scalar in PixelSpread applied_config instead of leaving the original range tuple.
- Record the sampled blend_sigma_range scalar in CopyAndPaste applied_config instead of leaving the original range tuple.

Tests:
- Add a parametrized test suite to verify that all known single-sample _range parameters are stored as scalars within their configured ranges in applied_config.
- Add a dedicated CopyAndPaste test to assert blend_sigma_range is resolved to a float scalar in applied_config when using gaussian blending.