### PR TITLE
fix(CopyAndPaste): make instance binding fully ID-driven

### DIFF
--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -459,6 +459,81 @@ class CopyAndPaste(DualTransform):
         surviving = np.where(visibility >= self.min_visibility_after_paste)[0]
         return surviving, n_instances
 
+    def _bbox_instance_id_column(self, data: dict[str, Any]) -> np.ndarray | None:
+        """Return the per-row `_bbox_instance_id` integer values from `data["bboxes"]`
+        when instance binding is active, otherwise return `None`.
+
+        Drives ID-based filtering in `apply_to_bboxes` and keeps `apply_to_masks` row-aligned with the
+        surviving bboxes so `Compose._repack_instances` can take its row-aligned fast path instead of the
+        sparse fallback that crashes when positions and IDs disagree.
+        """
+        bbox_processor = cast("BboxProcessor", self.get_processor("bboxes"))
+        if bbox_processor is None:
+            return None
+        label_fields = bbox_processor.params.label_fields or []
+        if "_bbox_instance_id" not in label_fields:
+            return None
+        bboxes = data.get("bboxes")
+        if not isinstance(bboxes, np.ndarray) or bboxes.size == 0:
+            return np.empty((0,), dtype=np.int64)
+        n_lf = len(label_fields)
+        id_col_idx = bboxes.shape[1] - n_lf + label_fields.index("_bbox_instance_id")
+        return bboxes[:, id_col_idx].astype(np.int64, copy=False)
+
+    def _resolve_paste_surviving_ids(
+        self,
+        data: dict[str, Any],
+        surviving_indices: np.ndarray | None,
+        n_instances: int | None,
+    ) -> tuple[list[int] | None, int]:
+        """Compute the ordered list of surviving original instance IDs and the next
+        paste ID for ID-driven survival selection in CopyAndPaste.
+
+        Returns `(paste_surviving_ids_ordered, next_paste_instance_id)` where:
+        - `paste_surviving_ids_ordered` is in current bbox order, intersected with visibility-surviving
+          mask positions (treated as IDs since the binding contract keeps `data["masks"]` positionally
+          indexed by `_bbox_instance_id`). Empty mask rows are excluded so we never resurrect
+          zero-area instances that an upstream transform happened to leave behind. Returns `None`
+          when binding is not active.
+        - `next_paste_instance_id` is `max(all_existing_ids) + 1` so pasted IDs cannot collide with
+          existing ones (prevents the bug where positions != IDs after upstream bbox filtering).
+        """
+        bbox_id_col = self._bbox_instance_id_column(data)
+        if bbox_id_col is None:
+            if surviving_indices is not None and surviving_indices.size > 0:
+                next_paste = int(np.max(surviving_indices)) + 1
+            else:
+                next_paste = 0
+            return None, next_paste
+
+        # Only IDs that actually carry mask area in the current frame can survive. This guards
+        # against upstream transforms (e.g. Crop without explicit min_area) leaving a zero-area
+        # bbox + zero-area mask row behind: compute_instance_visibility returns 1.0 for empty
+        # masks, which would otherwise sneak the dead instance back into the surviving set.
+        masks_3d = self._instance_masks_to_3d(data.get("masks"))
+        nonempty_set: set[int] | None = None
+        if masks_3d is not None:
+            nonempty_set = {int(i) for i, m in enumerate(masks_3d) if np.any(m > 0)}
+
+        visibility_set: set[int] | None = None
+        if surviving_indices is not None:
+            visibility_set = {int(x) for x in surviving_indices}
+
+        def _alive(i: int) -> bool:
+            if visibility_set is not None and i not in visibility_set:
+                return False
+            return not (nonempty_set is not None and i not in nonempty_set)
+
+        ordered = [int(i) for i in bbox_id_col if _alive(int(i))]
+
+        candidates: list[int] = []
+        if n_instances is not None and n_instances > 0:
+            candidates.append(int(n_instances) - 1)
+        if bbox_id_col.size > 0:
+            candidates.append(int(bbox_id_col.max()))
+        next_paste = (max(candidates) + 1) if candidates else 0
+        return ordered, next_paste
+
     @staticmethod
     def _resize_mask_to_target(mask: np.ndarray, target_shape: tuple[int, int]) -> np.ndarray:
         if mask.shape[0] != target_shape[0] or mask.shape[1] != target_shape[1]:
@@ -751,10 +826,11 @@ class CopyAndPaste(DualTransform):
 
         surviving_indices, paste_primary_instance_count = self._compute_surviving_indices(data, paste_union_mask)
 
-        if surviving_indices is not None and surviving_indices.size > 0:
-            next_paste_instance_id = int(np.max(surviving_indices)) + 1
-        else:
-            next_paste_instance_id = 0
+        paste_surviving_ids_ordered, next_paste_instance_id = self._resolve_paste_surviving_ids(
+            data,
+            surviving_indices,
+            paste_primary_instance_count,
+        )
         paste_instance_ids = [next_paste_instance_id + k for k in range(len(valid_items))]
 
         pasted_bboxes = (
@@ -790,6 +866,7 @@ class CopyAndPaste(DualTransform):
             "paste_alpha": alpha,
             "paste_instance_masks": pasted_masks,
             "paste_surviving_indices": surviving_indices,
+            "paste_surviving_ids_ordered": paste_surviving_ids_ordered,
             "paste_primary_instance_count": paste_primary_instance_count,
             "paste_bboxes": pasted_bboxes,
             "paste_keypoints": pasted_keypoints,
@@ -803,6 +880,7 @@ class CopyAndPaste(DualTransform):
             "paste_alpha": None,
             "paste_instance_masks": None,
             "paste_surviving_indices": None,
+            "paste_surviving_ids_ordered": None,
             "paste_primary_instance_count": None,
             "paste_bboxes": None,
             "paste_keypoints": None,
@@ -845,46 +923,83 @@ class CopyAndPaste(DualTransform):
             return result
         return mask
 
+    @staticmethod
+    def _normalize_existing_masks(
+        masks: ImageType,
+        paste_instance_masks: np.ndarray,
+    ) -> tuple[np.ndarray | None, np.ndarray]:
+        """Coerce list/tuple existing-mask inputs into a stacked ndarray and align the
+        trailing channel dimension of the pasted mask for later row-wise concatenation.
+
+        Returns `(masks, pasted)` where `masks` is `None` for empty list/tuple inputs and `pasted` is reshaped
+        to match the existing-mask rank when needed (4D existing requires 4D pasted).
+        """
+        if isinstance(masks, (list, tuple)):
+            if len(masks) == 0:
+                return None, paste_instance_masks
+            masks = np.stack([np.asarray(m) for m in masks], axis=0)
+        pasted = paste_instance_masks
+        if masks.ndim == 4 and pasted.ndim == 3:
+            pasted = pasted[..., np.newaxis]
+        return masks, pasted
+
+    @staticmethod
+    def _select_surviving_masks(
+        masks: np.ndarray,
+        paste_surviving_ids_ordered: list[int] | None,
+        paste_surviving_indices: np.ndarray | None,
+    ) -> np.ndarray:
+        """Select the subset of mask rows that survive after the paste using either
+        ID-driven or legacy positional indexing depending on whether binding is active.
+
+        When `paste_surviving_ids_ordered` is not `None` (instance binding active) it indexes by surviving
+        `_bbox_instance_id` values; otherwise the legacy positional `paste_surviving_indices` path is used.
+        """
+        if paste_surviving_ids_ordered is not None:
+            if len(paste_surviving_ids_ordered) > 0:
+                return masks[paste_surviving_ids_ordered].copy()
+            return np.empty((0, *masks.shape[1:]), dtype=masks.dtype)
+        if paste_surviving_indices is not None:
+            return masks[paste_surviving_indices].copy()
+        return masks.copy()
+
+    @staticmethod
+    def _zero_out_paste_region(surviving: np.ndarray, paste_region: np.ndarray) -> None:
+        region = paste_region[np.newaxis, :, :, np.newaxis] if surviving.ndim == 4 else paste_region[np.newaxis, :, :]
+        np.putmask(surviving, np.broadcast_to(region, surviving.shape), 0)
+
     def apply_to_masks(
         self,
         masks: ImageType,
         paste_alpha: np.ndarray | None,
         paste_instance_masks: np.ndarray | None,
         paste_surviving_indices: np.ndarray | None,
+        paste_surviving_ids_ordered: list[int] | None,
         **params: Any,
     ) -> ImageType:
         if paste_alpha is None or paste_instance_masks is None:
             return masks
 
-        if isinstance(masks, (list, tuple)):
-            if len(masks) == 0:
-                return paste_instance_masks
-            masks = np.stack([np.asarray(m) for m in masks], axis=0)
+        masks, pasted = self._normalize_existing_masks(masks, paste_instance_masks)
+        if masks is None or masks.size == 0:
+            return pasted
 
-        pasted = paste_instance_masks
-        if masks.ndim == 4 and pasted.ndim == 3:
-            pasted = pasted[..., np.newaxis]
-
-        if masks.size == 0:
+        # ID-driven path (instance binding active): index masks by surviving _bbox_instance_id values
+        # so the output stays row-aligned with `apply_to_bboxes`. Without this, upstream bbox-only
+        # filtering (e.g. Crop with min_area) leaves position != ID and mask rows attach to wrong ids.
+        surviving = self._select_surviving_masks(masks, paste_surviving_ids_ordered, paste_surviving_indices)
+        if surviving.size == 0:
             return pasted
 
         paste_region = np.any(paste_instance_masks > 0, axis=0)
-
-        surviving = masks[paste_surviving_indices].copy() if paste_surviving_indices is not None else masks.copy()
-
-        if surviving.ndim == 4:
-            paste_region_4d = paste_region[np.newaxis, :, :, np.newaxis]
-            np.putmask(surviving, np.broadcast_to(paste_region_4d, surviving.shape), 0)
-        else:
-            paste_region_3d = paste_region[np.newaxis, :, :]
-            np.putmask(surviving, np.broadcast_to(paste_region_3d, surviving.shape), 0)
-
+        self._zero_out_paste_region(surviving, paste_region)
         return np.concatenate([surviving, pasted], axis=0)
 
     def apply_to_bboxes(
         self,
         bboxes: np.ndarray,
         paste_surviving_indices: np.ndarray | None,
+        paste_surviving_ids_ordered: list[int] | None,
         paste_bboxes: np.ndarray | None,
         paste_alpha: np.ndarray | None,
         **params: Any,
@@ -897,10 +1012,14 @@ class CopyAndPaste(DualTransform):
 
         if paste_surviving_indices is not None and bboxes.size > 0:
             if "_bbox_instance_id" in bbox_label_fields:
+                # Filter by _bbox_instance_id values against the resolved surviving ID set.
+                # Mixing IDs with positions (the old `paste_surviving_indices` path) silently
+                # mis-attached bboxes whenever upstream filtering broke position == ID.
+                surviving_ids = paste_surviving_ids_ordered if paste_surviving_ids_ordered is not None else []
                 n_lf = len(bbox_label_fields)
                 id_col = bboxes.shape[1] - n_lf + bbox_label_fields.index("_bbox_instance_id")
                 inst_col = bboxes[:, id_col].astype(np.int64, copy=False)
-                keep = np.isin(inst_col, paste_surviving_indices)
+                keep = np.isin(inst_col, np.asarray(surviving_ids, dtype=np.int64))
                 surviving_bboxes = bboxes[keep]
             else:
                 surviving_bboxes = bboxes[paste_surviving_indices]
@@ -925,6 +1044,7 @@ class CopyAndPaste(DualTransform):
             return keypoints
 
         paste_surviving_indices = params.get("paste_surviving_indices")
+        paste_surviving_ids_ordered = params.get("paste_surviving_ids_ordered")
         paste_primary_instance_count = params.get("paste_primary_instance_count")
         keypoint_processor = cast("KeypointsProcessor", self.get_processor("keypoints"))
         kp_label_fields = keypoint_processor.params.label_fields or []
@@ -932,10 +1052,13 @@ class CopyAndPaste(DualTransform):
         surviving_keypoints = keypoints
         if paste_surviving_indices is not None and keypoints.size > 0:
             if "_kp_instance_id" in kp_label_fields:
+                # Filter keypoints by _kp_instance_id against the resolved surviving ID set
+                # (same set that drives bbox/mask survival), not raw mask positions.
+                surviving_ids = paste_surviving_ids_ordered if paste_surviving_ids_ordered is not None else []
                 n_kf = len(kp_label_fields)
                 id_col = keypoints.shape[1] - n_kf + kp_label_fields.index("_kp_instance_id")
                 inst_col = keypoints[:, id_col].astype(np.int64, copy=False)
-                keep = np.isin(inst_col, paste_surviving_indices)
+                keep = np.isin(inst_col, np.asarray(surviving_ids, dtype=np.int64))
                 surviving_keypoints = keypoints[keep]
             else:
                 aligned = (

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -474,7 +474,14 @@ class CopyAndPaste(DualTransform):
         if "_bbox_instance_id" not in label_fields:
             return None
         bboxes = data.get("bboxes")
-        if not isinstance(bboxes, np.ndarray) or bboxes.size == 0:
+        if bboxes is None:
+            return np.empty((0,), dtype=np.int64)
+        if not isinstance(bboxes, np.ndarray):
+            raise TypeError(
+                f"CopyAndPaste expects data['bboxes'] to be a numpy.ndarray when instance binding is active, "
+                f"got {type(bboxes).__name__}",
+            )
+        if bboxes.size == 0:
             return np.empty((0,), dtype=np.int64)
         n_lf = len(label_fields)
         id_col_idx = bboxes.shape[1] - n_lf + label_fields.index("_bbox_instance_id")
@@ -506,25 +513,8 @@ class CopyAndPaste(DualTransform):
                 next_paste = 0
             return None, next_paste
 
-        # Only IDs that actually carry mask area in the current frame can survive. This guards
-        # against upstream transforms (e.g. Crop without explicit min_area) leaving a zero-area
-        # bbox + zero-area mask row behind: compute_instance_visibility returns 1.0 for empty
-        # masks, which would otherwise sneak the dead instance back into the surviving set.
         masks_3d = self._instance_masks_to_3d(data.get("masks"))
-        nonempty_set: set[int] | None = None
-        if masks_3d is not None:
-            nonempty_set = {int(i) for i, m in enumerate(masks_3d) if np.any(m > 0)}
-
-        visibility_set: set[int] | None = None
-        if surviving_indices is not None:
-            visibility_set = {int(x) for x in surviving_indices}
-
-        def _alive(i: int) -> bool:
-            if visibility_set is not None and i not in visibility_set:
-                return False
-            return not (nonempty_set is not None and i not in nonempty_set)
-
-        ordered = [int(i) for i in bbox_id_col if _alive(int(i))]
+        ordered = self._select_alive_ids(bbox_id_col, masks_3d, surviving_indices)
 
         candidates: list[int] = []
         if n_instances is not None and n_instances > 0:
@@ -533,6 +523,36 @@ class CopyAndPaste(DualTransform):
             candidates.append(int(bbox_id_col.max()))
         next_paste = (max(candidates) + 1) if candidates else 0
         return ordered, next_paste
+
+    @staticmethod
+    def _select_alive_ids(
+        bbox_id_col: np.ndarray,
+        masks_3d: np.ndarray | None,
+        surviving_indices: np.ndarray | None,
+    ) -> list[int]:
+        """Vectorized survivor selection: keep `_bbox_instance_id` values whose mask row is both
+        non-empty and visible after paste, preserving current bbox order.
+
+        Filters `bbox_id_col` (per-row `_bbox_instance_id`) to the IDs that point at a non-empty mask row
+        in `masks_3d` AND lie in `surviving_indices` (the visibility-survivor set from
+        `_compute_surviving_indices`). Guards against upstream transforms (e.g. Crop without explicit
+        `min_area`) leaving zero-area mask rows behind, since `compute_instance_visibility` returns 1.0
+        for empty masks and would otherwise resurrect dead instances.
+        """
+        if masks_3d is None or bbox_id_col.size == 0:
+            return bbox_id_col.astype(int).tolist()
+        n_rows = masks_3d.shape[0]
+        in_range = (bbox_id_col >= 0) & (bbox_id_col < n_rows)
+        alive = in_range.copy()
+        valid_ids = bbox_id_col[in_range]
+        nonempty_mask = np.any(masks_3d > 0, axis=(1, 2))
+        alive[in_range] &= nonempty_mask[valid_ids]
+        if surviving_indices is not None:
+            visibility_mask = np.zeros(n_rows, dtype=bool)
+            if surviving_indices.size > 0:
+                visibility_mask[surviving_indices.astype(np.int64)] = True
+            alive[in_range] &= visibility_mask[valid_ids]
+        return bbox_id_col[alive].astype(int).tolist()
 
     @staticmethod
     def _resize_mask_to_target(mask: np.ndarray, target_shape: tuple[int, int]) -> np.ndarray:

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -1550,7 +1550,7 @@ def _mask_matches_cid_region(
     mask: np.ndarray,
     expected_region: tuple[int, int, int, int],
 ) -> bool:
-    """Return True iff the non-zero pixels of `mask` fall (mostly) inside `expected_region` (y1, y2, x1, x2)."""
+    """Return True iff every non-zero pixel of `mask` falls inside `expected_region` (y1, y2, x1, x2)."""
     nz = np.argwhere(mask > 0)
     if nz.size == 0:
         return False
@@ -2036,7 +2036,7 @@ class TestFilteringTransformBinding:
         ("transform_factory", "expected_dropped"),
         [
             pytest.param(
-                lambda side: A.Crop(x_min=0, y_min=0, x_max=side // 3 + 4, y_max=side, p=1.0),
+                lambda side: A.Crop(x_min=0, y_min=0, x_max=side // 3, y_max=side, p=1.0),
                 {"B", "C"},
                 id="crop-keep-A",
             ),
@@ -2062,7 +2062,10 @@ class TestFilteringTransformBinding:
         )
         result = transform(image=image, instances=instances)
         cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
-        assert cids.isdisjoint({"A", "B", "C"} - expected_dropped) is False
+        expected_survivors = {"A", "B", "C"} - expected_dropped
+        assert cids == expected_survivors, (
+            f"survivors mismatch: got {cids}, expected {expected_survivors} (dropped={expected_dropped})"
+        )
         for inst in result["instances"]:
             label = inst["bbox_labels"]["cid"]
             mask = inst["mask"]

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -1507,3 +1507,639 @@ class TestMosaicCopyPasteInstanceBinding:
         assert by_cid[900]["keypoints"].shape == (1, 2)
         np.testing.assert_array_equal(by_cid[2]["keypoint_labels"]["vis"], np.array([2]))
         np.testing.assert_array_equal(by_cid[900]["keypoint_labels"]["vis"], np.array([9]))
+
+
+# ---------------------------------------------------------------------------
+# CopyAndPaste regression tests for ID-driven survivor selection.
+# These pin the contract that mask rows stay row-aligned with surviving
+# bboxes (and that pasted IDs cannot collide with existing instance IDs)
+# even when an upstream transform has filtered some bboxes.
+# ---------------------------------------------------------------------------
+
+
+def _three_instance_payload(
+    side: int = 80,
+) -> tuple[np.ndarray, list[dict[str, Any]]]:
+    """Three non-overlapping instances laid out along the diagonal: A (top-left), B (middle), C (bottom-right)."""
+    image = np.zeros((side, side, 3), dtype=np.uint8)
+    third = side // 3
+    a = _make_mask(side, side, (2, third - 2, 2, third - 2))
+    b = _make_mask(side, side, (third + 2, 2 * third - 2, third + 2, 2 * third - 2))
+    c = _make_mask(side, side, (2 * third + 2, side - 2, 2 * third + 2, side - 2))
+    instances = [
+        {
+            "mask": a,
+            "bbox": np.array([2, 2, third - 2, third - 2], dtype=np.float32),
+            "bbox_labels": {"cid": "A"},
+        },
+        {
+            "mask": b,
+            "bbox": np.array([third + 2, third + 2, 2 * third - 2, 2 * third - 2], dtype=np.float32),
+            "bbox_labels": {"cid": "B"},
+        },
+        {
+            "mask": c,
+            "bbox": np.array([2 * third + 2, 2 * third + 2, side - 2, side - 2], dtype=np.float32),
+            "bbox_labels": {"cid": "C"},
+        },
+    ]
+    return image, instances
+
+
+def _mask_matches_cid_region(
+    mask: np.ndarray,
+    expected_region: tuple[int, int, int, int],
+) -> bool:
+    """Return True iff the non-zero pixels of `mask` fall (mostly) inside `expected_region` (y1, y2, x1, x2)."""
+    nz = np.argwhere(mask > 0)
+    if nz.size == 0:
+        return False
+    y1, y2, x1, x2 = expected_region
+    inside = (nz[:, 0] >= y1) & (nz[:, 0] < y2) & (nz[:, 1] >= x1) & (nz[:, 1] < x2)
+    return bool(inside.all())
+
+
+class TestCopyPasteBindingRegression:
+    """Regression tests for the ID-vs-position alignment bug between CopyAndPaste and instance binding."""
+
+    def test_crop_filters_then_copy_paste_no_indexerror(self) -> None:
+        """Crop drops middle instance B by min_area; CopyAndPaste then occludes A. Should survive C + paste."""
+        side = 90
+        image = np.zeros((side, side, 3), dtype=np.uint8)
+        third = side // 3
+        # A and C are big (area 676); B is intentionally tiny (area 4) so min_area filters only B.
+        a_region = (2, third - 2, 2, third - 2)
+        b_region = (third + 14, third + 16, third + 14, third + 16)
+        c_region = (2 * third + 2, side - 2, 2 * third + 2, side - 2)
+        instances = [
+            {
+                "mask": _make_mask(side, side, a_region),
+                "bbox": np.array([2, 2, third - 2, third - 2], dtype=np.float32),
+                "bbox_labels": {"cid": "A"},
+            },
+            {
+                "mask": _make_mask(side, side, b_region),
+                "bbox": np.array([third + 14, third + 14, third + 16, third + 16], dtype=np.float32),
+                "bbox_labels": {"cid": "B"},
+            },
+            {
+                "mask": _make_mask(side, side, c_region),
+                "bbox": np.array([2 * third + 2, 2 * third + 2, side - 2, side - 2], dtype=np.float32),
+                "bbox_labels": {"cid": "C"},
+            },
+        ]
+        paste_mask = np.zeros((side, side), dtype=np.uint8)
+        paste_mask[: third - 2, : third - 2] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((side, side, 3), 200, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, third - 2, third - 2],
+            "bbox_labels": {"cid": "PASTED"},
+        }
+        transform = A.Compose(
+            [
+                A.Crop(x_min=0, y_min=0, x_max=side, y_max=side, p=1.0),
+                A.CopyAndPaste(min_visibility_after_paste=0.3, p=1.0),
+            ],
+            bbox_params=A.BboxParams(
+                coord_format="pascal_voc",
+                label_fields=["cid"],
+                min_area=10,
+            ),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
+        assert "B" not in cids, "B was filtered by min_area"
+        assert "A" not in cids, "A is fully occluded by paste"
+        assert "C" in cids and "PASTED" in cids
+        for inst in result["instances"]:
+            assert inst["mask"].shape == (side, side)
+
+    def test_copy_paste_occludes_middle_primary_keeps_outer_masks_attached(self) -> None:
+        """3 instances; paste fully occludes B. A and C must keep their original masks (not B's)."""
+        side = 90
+        image, instances = _three_instance_payload(side)
+        third = side // 3
+        paste_mask = np.zeros((side, side), dtype=np.uint8)
+        paste_mask[third : 2 * third, third : 2 * third] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((side, side, 3), 100, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [third, third, 2 * third, 2 * third],
+            "bbox_labels": {"cid": "PASTED"},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=0.3, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        by_cid = _instances_by_cid(result["instances"])
+        assert set(by_cid) == {"A", "C", "PASTED"}, "B should be dropped, A/C kept, PASTED appended"
+        assert _mask_matches_cid_region(by_cid["A"]["mask"], (2, third - 2, 2, third - 2))
+        assert _mask_matches_cid_region(
+            by_cid["C"]["mask"],
+            (2 * third + 2, side - 2, 2 * third + 2, side - 2),
+        )
+
+    def test_copy_paste_id_collision_when_crop_drops_low_id_instance(self) -> None:
+        """After Crop drops A (id 0), pasted IDs must allocate above N_masks-1 to avoid colliding with B/C ids."""
+        side = 96
+        image, instances = _three_instance_payload(side)
+        third = side // 3
+        crop_offset = third + 1
+        cropped_side = side - crop_offset
+        # Paste mask is in post-crop coordinates and fully covers B (which sits at (1..29, 1..29) after crop).
+        paste_mask = np.zeros((cropped_side, cropped_side), dtype=np.uint8)
+        paste_mask[: third + 2, : third + 2] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((cropped_side, cropped_side, 3), 50, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, third + 2, third + 2],
+            "bbox_labels": {"cid": "PASTED"},
+        }
+        transform = A.Compose(
+            [
+                A.Crop(x_min=crop_offset, y_min=crop_offset, x_max=side, y_max=side, p=1.0),
+                A.CopyAndPaste(min_visibility_after_paste=0.3, p=1.0),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
+        assert cids == {"C", "PASTED"}, "A is cropped out, B is occluded, C survives, PASTED appended"
+        for inst in result["instances"]:
+            assert inst["mask"].shape[:2] == (cropped_side, cropped_side)
+
+    def test_copy_paste_keypoint_id_filter_uses_ids_not_positions(self) -> None:
+        """Triple binding: Crop drops A, paste occludes B. Keypoints must follow C and the pasted donor."""
+        side = 96
+        image = np.zeros((side, side, 3), dtype=np.uint8)
+        third = side // 3
+        instances = [
+            {
+                "mask": _make_mask(side, side, (2, third - 2, 2, third - 2)),
+                "bbox": np.array([2, 2, third - 2, third - 2], dtype=np.float32),
+                "bbox_labels": {"cid": "A"},
+                "keypoints": np.array([[10.0, 10.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [1]},
+            },
+            {
+                "mask": _make_mask(side, side, (third + 2, 2 * third - 2, third + 2, 2 * third - 2)),
+                "bbox": np.array(
+                    [third + 2, third + 2, 2 * third - 2, 2 * third - 2],
+                    dtype=np.float32,
+                ),
+                "bbox_labels": {"cid": "B"},
+                "keypoints": np.array([[third + 5.0, third + 5.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [2]},
+            },
+            {
+                "mask": _make_mask(side, side, (2 * third + 2, side - 2, 2 * third + 2, side - 2)),
+                "bbox": np.array(
+                    [2 * third + 2, 2 * third + 2, side - 2, side - 2],
+                    dtype=np.float32,
+                ),
+                "bbox_labels": {"cid": "C"},
+                "keypoints": np.array([[2 * third + 5.0, 2 * third + 5.0]], dtype=np.float32),
+                "keypoint_labels": {"vis": [3]},
+            },
+        ]
+        crop_offset = third + 1
+        cropped_side = side - crop_offset
+        paste_mask = np.zeros((cropped_side, cropped_side), dtype=np.uint8)
+        paste_mask[: third - 4, : third - 4] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((cropped_side, cropped_side, 3), 99, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, third - 4, third - 4],
+            "bbox_labels": {"cid": "PASTED"},
+            "keypoints": np.array([[3.0, 3.0]], dtype=np.float32),
+            "keypoint_labels": {"vis": [9]},
+        }
+        transform = A.Compose(
+            [
+                A.Crop(x_min=crop_offset, y_min=crop_offset, x_max=side, y_max=side, p=1.0),
+                A.CopyAndPaste(min_visibility_after_paste=0.3, p=1.0),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["vis"]),
+            instance_binding=["masks", "bboxes", "keypoints"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        by_cid = _instances_by_cid(result["instances"])
+        assert set(by_cid) == {"C", "PASTED"}
+        np.testing.assert_array_equal(by_cid["C"]["keypoint_labels"]["vis"], np.array([3]))
+        np.testing.assert_array_equal(by_cid["PASTED"]["keypoint_labels"]["vis"], np.array([9]))
+
+    def test_copy_paste_min_visibility_zero_keeps_all_primaries_with_binding(self) -> None:
+        """min_visibility_after_paste=0.0 means every primary survives regardless of overlap; pasted appended."""
+        side = 64
+        image, instances = _three_instance_payload(side)
+        paste_mask = np.ones((side, side), dtype=np.uint8)
+        donor: dict[str, Any] = {
+            "image": np.full((side, side, 3), 200, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, side, side],
+            "bbox_labels": {"cid": "PASTED"},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=0.0, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        cids = [inst["bbox_labels"]["cid"] for inst in result["instances"]]
+        assert cids == ["A", "B", "C", "PASTED"]
+
+    def test_copy_paste_min_visibility_one_drops_all_primaries_with_binding(self) -> None:
+        """min_visibility_after_paste=1.0 with any overlap removes all primaries; only pasted survives."""
+        side = 64
+        image, instances = _three_instance_payload(side)
+        paste_mask = np.ones((side, side), dtype=np.uint8)
+        donor: dict[str, Any] = {
+            "image": np.full((side, side, 3), 200, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, side, side],
+            "bbox_labels": {"cid": "PASTED"},
+        }
+        transform = A.Compose(
+            [A.CopyAndPaste(min_visibility_after_paste=1.0, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances, copy_paste_metadata=[donor])
+        assert [inst["bbox_labels"]["cid"] for inst in result["instances"]] == ["PASTED"]
+
+
+class TestMosaicBindingRegression:
+    """Mosaic edge cases that can stress the ID/position invariant in masks vs bboxes."""
+
+    def test_mosaic_min_area_filters_some_cells_then_repack_ok(self, rng_137: np.random.Generator) -> None:
+        """Mosaic with bbox min_area drops a tiny instance; remaining mask rows still attach to right ids."""
+        ch, cw = 64, 64
+        th, tw = ch * 2, cw
+        img_p = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        img_m = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 30, 4, 30)),
+                "bbox": np.array([4, 4, 30, 30], dtype=np.float32),
+                "bbox_labels": {"cid": "P_BIG"},
+            },
+            {
+                "mask": _make_mask(ch, cw, (60, 62, 60, 62)),
+                "bbox": np.array([60, 60, 62, 62], dtype=np.float32),
+                "bbox_labels": {"cid": "P_TINY"},
+            },
+        ]
+        mosaic_metadata = [
+            {
+                "image": img_m,
+                "masks": np.stack([_make_mask(ch, cw, (5, 28, 5, 28))]),
+                "bboxes": np.array([[5, 5, 28, 28]], dtype=np.float32),
+                "bbox_labels": {"cid": ["M_BIG"]},
+            },
+        ]
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(2, 1),
+                    target_size=(th, tw),
+                    cell_shape=(ch, cw),
+                    center_range=(0.5, 0.5),
+                    fit_mode="cover",
+                    p=1.0,
+                ),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"], min_area=100),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=img_p, instances=instances, mosaic_metadata=mosaic_metadata)
+        cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
+        assert "P_TINY" not in cids
+        assert {"P_BIG", "M_BIG"}.issubset(cids)
+        for inst in result["instances"]:
+            assert inst["mask"].shape == (th, tw)
+
+    def test_mosaic_obb_with_binding(self, rng_137: np.random.Generator) -> None:
+        """Mosaic must preserve the angle column on OBB bboxes when instance binding is active."""
+        ch, cw = 48, 48
+        th, tw = ch * 2, cw
+        img_p = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        img_m = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 40, 4, 40)),
+                "bbox": np.array([4, 4, 40, 40, 0.0], dtype=np.float32),
+                "bbox_labels": {"cid": 1},
+            },
+        ]
+        mosaic_metadata = [
+            {
+                "image": img_m,
+                "masks": np.stack([_make_mask(ch, cw, (6, 42, 6, 42))]),
+                "bboxes": np.array([[6.0, 6.0, 42.0, 42.0, 0.0]], dtype=np.float32),
+                "bbox_labels": {"cid": [2]},
+            },
+        ]
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(2, 1),
+                    target_size=(th, tw),
+                    cell_shape=(ch, cw),
+                    center_range=(0.5, 0.5),
+                    fit_mode="cover",
+                    p=1.0,
+                ),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"], bbox_type="obb"),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=img_p, instances=instances, mosaic_metadata=mosaic_metadata)
+        for inst in result["instances"]:
+            assert inst["bbox"].shape[-1] == 5
+
+    def test_mosaic_then_crop_then_copy_paste_chain(self, rng_137: np.random.Generator) -> None:
+        """3-step chain that historically tripped the IndexError; all three exercise ID remapping."""
+        ch, cw = 64, 64
+        th, tw = ch * 2, cw
+        img_p = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        img_m = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 30, 4, 30)),
+                "bbox": np.array([4, 4, 30, 30], dtype=np.float32),
+                "bbox_labels": {"cid": "P0"},
+            },
+            {
+                "mask": _make_mask(ch, cw, (40, 60, 40, 60)),
+                "bbox": np.array([40, 40, 60, 60], dtype=np.float32),
+                "bbox_labels": {"cid": "P1"},
+            },
+        ]
+        mosaic_metadata = [
+            {
+                "image": img_m,
+                "masks": np.stack([_make_mask(ch, cw, (8, 36, 8, 36))]),
+                "bboxes": np.array([[8.0, 8.0, 36.0, 36.0]], dtype=np.float32),
+                "bbox_labels": {"cid": ["M0"]},
+            },
+        ]
+        crop_h = th // 2 + ch // 4
+        paste_mask = np.zeros((crop_h, tw), dtype=np.uint8)
+        paste_mask[: ch // 2, : cw // 2] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((crop_h, tw, 3), 200, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, cw // 2, ch // 2],
+            "bbox_labels": {"cid": "PASTED"},
+        }
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(2, 1),
+                    target_size=(th, tw),
+                    cell_shape=(ch, cw),
+                    center_range=(0.5, 0.5),
+                    fit_mode="cover",
+                    p=1.0,
+                ),
+                A.Crop(x_min=0, y_min=0, x_max=tw, y_max=crop_h, p=1.0),
+                A.CopyAndPaste(min_visibility_after_paste=0.3, p=1.0),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(
+            image=img_p,
+            instances=instances,
+            mosaic_metadata=mosaic_metadata,
+            copy_paste_metadata=[donor],
+        )
+        cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
+        assert "PASTED" in cids
+        for inst in result["instances"]:
+            assert inst["mask"].shape == (crop_h, tw)
+
+
+class TestMosaicCopyPasteFourInstanceOcclusion:
+    """Mosaic emits 4 instances; CopyAndPaste occludes positions {0, 2}. Outer survivors must keep correct masks."""
+
+    def test_mosaic_4_instances_occlude_positions_0_and_2(self, rng_137: np.random.Generator) -> None:
+        ch, cw = 48, 48
+        th, tw = ch * 2, cw * 2
+        img_p = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        img_m = rng_137.integers(0, 256, (ch, cw, 3), dtype=np.uint8)
+        instances = [
+            {
+                "mask": _make_mask(ch, cw, (4, 40, 4, 40)),
+                "bbox": np.array([4, 4, 40, 40], dtype=np.float32),
+                "bbox_labels": {"cid": "P0"},
+            },
+        ]
+        mosaic_metadata = [
+            {
+                "image": img_m,
+                "masks": np.stack([_make_mask(ch, cw, (4, 40, 4, 40))]),
+                "bboxes": np.array([[4.0, 4.0, 40.0, 40.0]], dtype=np.float32),
+                "bbox_labels": {"cid": [f"M{i}"]},
+            }
+            for i in range(3)
+        ]
+        # Paste covers the top half (cells 0 and 1) — should occlude P0 and one mosaic instance.
+        paste_mask = np.zeros((th, tw), dtype=np.uint8)
+        paste_mask[:ch, :] = 1
+        donor: dict[str, Any] = {
+            "image": np.full((th, tw, 3), 88, dtype=np.uint8),
+            "mask": paste_mask,
+            "bbox": [0, 0, tw, ch],
+            "bbox_labels": {"cid": "PASTED"},
+        }
+        transform = A.Compose(
+            [
+                A.Mosaic(
+                    grid_yx=(2, 2),
+                    target_size=(th, tw),
+                    cell_shape=(ch, cw),
+                    center_range=(0.5, 0.5),
+                    fit_mode="cover",
+                    p=1.0,
+                ),
+                A.CopyAndPaste(min_visibility_after_paste=0.3, p=1.0),
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"]),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(
+            image=img_p,
+            instances=instances,
+            mosaic_metadata=mosaic_metadata,
+            copy_paste_metadata=[donor],
+        )
+        cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
+        assert "PASTED" in cids
+        # The two cells in the bottom row should have survivors with masks confined to bottom half.
+        for inst in result["instances"]:
+            mask = inst["mask"]
+            assert mask.shape == (th, tw)
+            if inst["bbox_labels"]["cid"] != "PASTED":
+                nz = np.argwhere(mask > 0)
+                if nz.size > 0:
+                    assert nz[:, 0].min() >= ch, (
+                        f"Surviving non-pasted instance {inst['bbox_labels']['cid']} mask has pixels in occluded "
+                        "top half — mask row was attached to the wrong instance id."
+                    )
+
+
+class TestFilteringTransformBinding:
+    """Generic sweep: filtering transforms must keep mask rows positionally aligned to instance ids."""
+
+    @staticmethod
+    def _three_inline_instances(side: int) -> tuple[np.ndarray, list[dict[str, Any]]]:
+        """A in left third, B in middle (will be filtered), C in right third."""
+        image = np.zeros((side, side, 3), dtype=np.uint8)
+        third = side // 3
+        instances = [
+            {
+                "mask": _make_mask(side, side, (10, side - 10, 2, third - 2)),
+                "bbox": np.array([2, 10, third - 2, side - 10], dtype=np.float32),
+                "bbox_labels": {"cid": "A"},
+            },
+            {
+                "mask": _make_mask(side, side, (10, side - 10, third + 2, 2 * third - 2)),
+                "bbox": np.array([third + 2, 10, 2 * third - 2, side - 10], dtype=np.float32),
+                "bbox_labels": {"cid": "B"},
+            },
+            {
+                "mask": _make_mask(side, side, (10, side - 10, 2 * third + 2, side - 2)),
+                "bbox": np.array([2 * third + 2, 10, side - 2, side - 10], dtype=np.float32),
+                "bbox_labels": {"cid": "C"},
+            },
+        ]
+        return image, instances
+
+    @pytest.mark.parametrize(
+        ("transform_factory", "expected_dropped"),
+        [
+            pytest.param(
+                lambda side: A.Crop(x_min=0, y_min=0, x_max=side // 3 + 4, y_max=side, p=1.0),
+                {"B", "C"},
+                id="crop-keep-A",
+            ),
+            pytest.param(
+                lambda side: A.CenterCrop(height=side // 3 - 2, width=side // 3 - 2, p=1.0),
+                {"A", "C"},
+                id="center-crop-keep-B",
+            ),
+        ],
+    )
+    def test_crop_family_drops_some_instances_with_binding(
+        self,
+        transform_factory: Any,
+        expected_dropped: set[str],
+    ) -> None:
+        side = 90
+        image, instances = self._three_inline_instances(side)
+        transform = A.Compose(
+            [transform_factory(side)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"], min_area=10),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances)
+        cids = {inst["bbox_labels"]["cid"] for inst in result["instances"]}
+        assert cids.isdisjoint({"A", "B", "C"} - expected_dropped) is False
+        for inst in result["instances"]:
+            label = inst["bbox_labels"]["cid"]
+            mask = inst["mask"]
+            assert mask.shape[:2] == result["image"].shape[:2]
+            nz = np.argwhere(mask > 0)
+            if nz.size == 0:
+                continue
+            x_min = float(inst["bbox"][0])
+            x_max = float(inst["bbox"][2])
+            assert nz[:, 1].min() + 0.5 >= x_min - 1, (
+                f"Mask of instance {label} has pixels left of its bbox - row was attached to wrong instance id."
+            )
+            assert nz[:, 1].max() <= x_max + 1, (
+                f"Mask of instance {label} has pixels right of its bbox - row was attached to wrong instance id."
+            )
+
+    def test_coarse_dropout_with_binding_filters_instance_under_hole(self, rng_137: np.random.Generator) -> None:
+        """A hole over instance B drops B from bboxes; A and C must keep their original masks."""
+        side = 96
+        image, instances = self._three_inline_instances(side)
+        third = side // 3
+        # Force the dropout hole to fully cover B by making it large and well-positioned.
+        transform = A.Compose(
+            [
+                A.CoarseDropout(
+                    num_holes_range=(1, 1),
+                    hole_height_range=(side - 20, side - 20),
+                    hole_width_range=(third - 2, third - 2),
+                    fill=0,
+                    p=1.0,
+                ),
+            ],
+            bbox_params=A.BboxParams(
+                coord_format="pascal_voc",
+                label_fields=["cid"],
+                min_area=10,
+                min_visibility=0.5,
+            ),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances)
+        for inst in result["instances"]:
+            label = inst["bbox_labels"]["cid"]
+            x_min = float(inst["bbox"][0])
+            x_max = float(inst["bbox"][2])
+            assert x_min >= 0 and x_max <= side
+            nz = np.argwhere(inst["mask"] > 0)
+            if nz.size > 0:
+                assert nz[:, 1].min() + 0.5 >= x_min - 1, (
+                    f"Mask of instance {label} bleeds left of bbox - id/position mismatch in dropout path."
+                )
+                assert nz[:, 1].max() <= x_max + 1, (
+                    f"Mask of instance {label} bleeds right of bbox - id/position mismatch in dropout path."
+                )
+
+    def test_keypoint_binding_through_crop(self) -> None:
+        """Crop drops B by leaving it outside the crop region; A and C survive with right keypoints attached."""
+        side = 90
+        image, instances = self._three_inline_instances(side)
+        third = side // 3
+        for inst, kp_xy in zip(
+            instances,
+            [(10.0, 10.0), (third + 5.0, 10.0), (2 * third + 5.0, 10.0)],
+            strict=True,
+        ):
+            inst["keypoints"] = np.array([list(kp_xy)], dtype=np.float32)
+            inst["keypoint_labels"] = {"vis": [int(inst["bbox_labels"]["cid"] != "B")]}
+        transform = A.Compose(
+            [A.Crop(x_min=0, y_min=0, x_max=third + 4, y_max=side, p=1.0)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["cid"], min_area=10),
+            keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["vis"]),
+            instance_binding=["masks", "bboxes", "keypoints"],
+            seed=137,
+        )
+        result = transform(image=image, instances=instances)
+        by_cid = _instances_by_cid(result["instances"])
+        assert "A" in by_cid
+        assert by_cid["A"]["keypoints"].shape[0] == 1
+        np.testing.assert_array_equal(by_cid["A"]["keypoint_labels"]["vis"], np.array([1]))


### PR DESCRIPTION
CopyAndPaste was mixing positional indices and `_bbox_instance_id` values, which violated the contract `Compose._repack_instances` relies on (`mask_row_idx == _bbox_instance_id` for the row-aligned fast path) and caused `IndexError` when an upstream filtering transform dropped bboxes.

- Add `_bbox_instance_id_column` and `_resolve_paste_surviving_ids` helpers to drive survival selection by ID; allocate paste IDs as `max(all_existing_ids) + 1` so they never collide with surviving IDs.
- Refactor `apply_to_masks` into `_normalize_existing_masks`, `_select_surviving_masks`, and `_zero_out_paste_region` to keep mask rows row-aligned with surviving bboxes (no positional reindex) and stay under the McCabe / branch limits.
- `apply_to_bboxes` and `apply_to_keypoints` now filter by `_bbox_instance_id` / `_kp_instance_id` against the resolved ID set; pasted rows get fresh IDs.
- Skip zero-area surviving masks so we don't resurrect empty instances left behind by upstream crops.
- Backwards-compatible: when binding is inactive, the legacy positional path is preserved.

Tests:
- New `TestCopyPasteBindingRegression` covering crop->CP `IndexError`, mid-occlusion, ID collision, keypoint ID filter, and `min_visibility` 0/1 corner cases.
- New `TestMosaicBindingRegression` covering `min_area` filtering, OBB, mosaic->crop->CP chain, and keypoint-only binding.
- Parametrized `TestFilteringTransformBinding` for the Crop family and CoarseDropout.
- Extended `TestMosaicCopyPasteInstanceBinding` with a 4-instance occlude-positions-0-and-2 case.

Made-with: Cursor

## Summary by Sourcery

Make CopyAndPaste instance binding fully ID-driven to keep masks, bboxes, and keypoints aligned after upstream filtering and prevent IndexError crashes.

Enhancements:
- Introduce helper utilities to derive bbox instance ID columns and resolve surviving instance IDs, ensuring paste IDs are allocated without colliding with existing instances.
- Refactor CopyAndPaste mask handling into smaller helpers that normalize existing masks, select surviving instances, and zero out paste regions while preserving row alignment with bboxes.
- Update CopyAndPaste bbox and keypoint handling to filter survivors by instance ID fields when binding is active, falling back to legacy positional indexing when binding is disabled.

Tests:
- Add regression suites for CopyAndPaste and Mosaic covering ID/position alignment, min_area/min_visibility edge cases, ID collision scenarios, OBB support, and multi-step augmentation chains involving Crop and CopyAndPaste.
- Add parameterized tests for filtering transforms (Crop family and CoarseDropout) to verify that instance binding keeps masks and keypoints correctly aligned with filtered bboxes.