### PR TITLE
fix(mixing): raise TypeError on non-dict bbox_labels/keypoint_labels …

### DIFF
--- a/albumentations/augmentations/mixing/functional.py
+++ b/albumentations/augmentations/mixing/functional.py
@@ -540,14 +540,34 @@ def unpack_label_wrappers(item: dict[str, Any]) -> dict[str, Any]:
     Both Mosaic and CopyAndPaste store per-item label values under `bbox_labels` and
     `keypoint_labels` (dicts mapping label-field-name → value). This helper flattens
     them so that `_preprocess_item_annotations` can find the fields at the top level.
+
+    Raises:
+        TypeError: If `bbox_labels` or `keypoint_labels` is present but is not a dict
+            (e.g. a bare list of labels). Both wrapper keys are reserved by the
+            Mosaic/CopyAndPaste metadata format and must map label-field name to its
+            list of values, e.g. `{"class_id": [3, 7]}` — not `[3, 7]` directly.
+
     """
     if "bbox_labels" not in item and "keypoint_labels" not in item:
         return item
     unpacked = {k: v for k, v in item.items() if k not in ("bbox_labels", "keypoint_labels")}
     for wrapper_key in ("bbox_labels", "keypoint_labels"):
-        labels = item.get(wrapper_key)
-        if isinstance(labels, dict):
-            unpacked.update(labels)
+        if wrapper_key not in item:
+            continue
+        labels = item[wrapper_key]
+        if labels is None:
+            continue
+        if not isinstance(labels, dict):
+            raise TypeError(
+                f"Mosaic/CopyAndPaste metadata: `{wrapper_key}` must be a dict mapping "
+                f"label-field name to its values (e.g. `{{'class_id': [3, 7]}}`), got "
+                f"{type(labels).__name__}. The keys `bbox_labels` and `keypoint_labels` "
+                "are reserved wrapper keys in per-item metadata; if you intended to pass "
+                f"a bare list of labels, wrap it in a dict keyed by the label_field name "
+                f"declared in BboxParams/KeypointParams.label_fields, e.g. "
+                f"`{wrapper_key}={{'<your_label_field>': <values>}}`.",
+            )
+        unpacked.update(labels)
     return unpacked
 
 

--- a/tests/test_mixing.py
+++ b/tests/test_mixing.py
@@ -648,3 +648,43 @@ class TestCopyAndPasteEdgeCases:
         )
         assert len(result["bboxes"]) == 2
         assert np.any(result["image"] > 0)
+
+
+class TestUnpackLabelWrappers:
+    """Tests for `unpack_label_wrappers` reserved-key handling."""
+
+    def test_no_wrapper_keys_returns_input_unchanged(self):
+        item = {"image": np.zeros((4, 4, 3), dtype=np.uint8), "class_labels": [1, 2]}
+        result = fmixing.unpack_label_wrappers(item)
+        assert result is item
+
+    def test_wrapper_dict_is_flattened(self):
+        item = {
+            "image": np.zeros((4, 4, 3), dtype=np.uint8),
+            "bbox_labels": {"class_labels": [1, 2]},
+            "keypoint_labels": {"kp_classes": ["eye"]},
+        }
+        result = fmixing.unpack_label_wrappers(item)
+        assert "bbox_labels" not in result
+        assert "keypoint_labels" not in result
+        assert result["class_labels"] == [1, 2]
+        assert result["kp_classes"] == ["eye"]
+
+    def test_none_wrapper_value_is_skipped(self):
+        item = {"image": np.zeros((4, 4, 3), dtype=np.uint8), "bbox_labels": None}
+        result = fmixing.unpack_label_wrappers(item)
+        assert "bbox_labels" not in result
+
+    @pytest.mark.parametrize(
+        ("wrapper_key", "bad_value"),
+        [
+            ("bbox_labels", [1, 2, 3]),
+            ("bbox_labels", (1, 2)),
+            ("keypoint_labels", ["eye", "nose"]),
+            ("keypoint_labels", np.array([1, 2])),
+        ],
+    )
+    def test_non_dict_wrapper_raises_typeerror(self, wrapper_key, bad_value):
+        item = {"image": np.zeros((4, 4, 3), dtype=np.uint8), wrapper_key: bad_value}
+        with pytest.raises(TypeError, match=f"`{wrapper_key}` must be a dict"):
+            fmixing.unpack_label_wrappers(item)


### PR DESCRIPTION
…wrappers

`unpack_label_wrappers` previously silently dropped `bbox_labels` / `keypoint_labels` when the value wasn't a dict (e.g. a bare list of labels in the legacy shape). Downstream Mosaic/CopyAndPaste validators then complained about missing label fields with no hint that the real cause was the reserved wrapper key being used with the wrong shape.

Now raise a clear `TypeError` naming the offending key and the expected `{<label_field>: [...]}` shape. `None` values are still skipped.

Adds `TestUnpackLabelWrappers` covering: no-op path, dict flattening, `None` skip, and `TypeError` for list/tuple/np.ndarray values on both wrapper keys.

Made-with: Cursor

## Summary by Sourcery

Validate and clarify handling of reserved bbox/keypoint label wrapper keys in mixing metadata to avoid silent misconfiguration.

Bug Fixes:
- Raise a descriptive TypeError when `bbox_labels` or `keypoint_labels` is present with a non-dict value instead of silently dropping the labels.

Enhancements:
- Document the expected dict shape for `bbox_labels` and `keypoint_labels` in `unpack_label_wrappers` and allow `None` values to be ignored.

Tests:
- Add `TestUnpackLabelWrappers` test cases covering pass-through behavior, dict flattening, skipping `None` values, and TypeError on non-dict wrapper values.