### PR TITLE
fix(core): resolve additional_targets for shape and image metadata

### DIFF
--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -8,7 +8,6 @@ channels rather than relying on a subset.
 
 from typing import Annotated, Any
 
-from albucore import get_image_data
 from pydantic import AfterValidator
 
 from albumentations.core.pydantic import check_range_bounds
@@ -102,7 +101,7 @@ class ChannelDropout(ImageOnlyTransform):
         return result
 
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, list[int]]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         num_channels = metadata["num_channels"]
         if num_channels == 1:
             msg = "Images has one channel. ChannelDropout is not defined."

--- a/albumentations/augmentations/pixel/color.py
+++ b/albumentations/augmentations/pixel/color.py
@@ -14,7 +14,6 @@ import numpy as np
 from albucore import (
     MAX_VALUES_BY_DTYPE,
     batch_transform,
-    get_image_data,
     get_num_channels,
     is_grayscale_image,
     is_rgb_image,
@@ -186,7 +185,7 @@ class RandomToneCurve(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        num_channels = get_image_data(data)["num_channels"]
+        num_channels = self.get_image_data(data)["num_channels"]
         result = {
             "num_channels": num_channels,
         }

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -11,7 +11,6 @@ import cv2
 import numpy as np
 from albucore import (
     MAX_VALUES_BY_DTYPE,
-    get_image_data,
     multiply,
 )
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -132,7 +131,7 @@ class GaussNoise(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, float]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         max_value = MAX_VALUES_BY_DTYPE[metadata["dtype"]]
         shape = (metadata["height"], metadata["width"], metadata["num_channels"])
 
@@ -364,7 +363,7 @@ class MultiplicativeNoise(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         image_shape = (metadata["height"], metadata["width"], metadata["num_channels"])
         num_channels = image_shape[-1]
 
@@ -708,7 +707,7 @@ class AdditiveNoise(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         max_value = MAX_VALUES_BY_DTYPE[metadata["dtype"]]
         shape = (metadata["height"], metadata["width"], metadata["num_channels"])
 
@@ -833,7 +832,7 @@ class SaltAndPepper(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         height, width = (metadata["height"], metadata["width"])
 
         total_amount = self.py_random.uniform(*self.amount_range)

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -11,7 +11,6 @@ from typing import Annotated, Any, Literal, cast
 import albucore
 import cv2
 import numpy as np
-from albucore import get_image_data
 from pydantic import Field, model_validator
 from pydantic.functional_validators import AfterValidator
 from typing_extensions import Self
@@ -321,7 +320,7 @@ class RandomGravel(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, np.ndarray]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         height, width = (metadata["height"], metadata["width"])
 
         # Calculate ROI in pixels
@@ -507,7 +506,7 @@ class RandomRain(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         height, width = (metadata["height"], metadata["width"])
 
         # Simpler calculations, directly following Kornia
@@ -937,7 +936,7 @@ class RandomSunFlare(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         height, width = (metadata["height"], metadata["width"])
         diagonal = math.sqrt(height**2 + width**2)
 
@@ -1125,7 +1124,7 @@ class RandomShadow(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, list[np.ndarray]]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         height, width = (metadata["height"], metadata["width"])
 
         num_shadows = self.py_random.randint(*self.num_shadows_range)
@@ -1358,7 +1357,7 @@ class Spatter(ImageOnlyTransform):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        metadata = get_image_data(data)
+        metadata = self.get_image_data(data)
         height, width = (metadata["height"], metadata["width"])
 
         mean = self.py_random.uniform(*self.mean_range)
@@ -1529,7 +1528,7 @@ class AtmosphericFog(ImageOnlyTransform):
             depth_map = (dist / max_dist).astype(np.float32)
 
         max_val = float(albucore.MAX_VALUES_BY_DTYPE[np.uint8])
-        image_data = albucore.get_image_data(data)
+        image_data = self.get_image_data(data)
         img_dtype = image_data["dtype"]
         actual_max = float(albucore.MAX_VALUES_BY_DTYPE[img_dtype])
         fog_color_scaled = tuple(c / max_val * actual_max for c in self.fog_color)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -14,7 +14,7 @@ import types
 import warnings
 from collections import defaultdict
 from collections.abc import Iterator, Sequence
-from typing import Any, Union, cast, get_args, get_origin
+from typing import Any, ClassVar, Union, cast, get_args, get_origin
 
 import cv2
 import numpy as np
@@ -498,7 +498,7 @@ class BaseCompose(Serializable):
 
         """
         if self.check_each_transform:
-            shape = get_shape(data)
+            shape = get_shape(data, self._additional_targets)
 
             for proc in self.check_each_transform:
                 for data_name, data_value in data.items():
@@ -1221,8 +1221,10 @@ class Compose(BaseCompose, HubMixin):
         shape_check_targets = {"image", "mask", "images", "volume", "volumes", "mask3d", "masks", "masks3d"}
 
         for data_name, data_value in data.items():
-            # Skip if not in our check list
-            if data_name not in shape_check_targets:
+            # Resolve aliases via additional_targets so e.g. {'custom_image_key': 'image'}
+            # gets the same shape-consistency check as the canonical 'image' key.
+            canonical = self._additional_targets.get(data_name, data_name)
+            if canonical not in shape_check_targets:
                 continue
 
             # Skip empty data
@@ -1233,7 +1235,7 @@ class Compose(BaseCompose, HubMixin):
             if data_value.size == 0:
                 continue
 
-            self._process_data_shape(data_name, data_value, shapes, volume_shapes)
+            self._process_data_shape(canonical, data_value, shapes, volume_shapes)
 
         return shapes, volume_shapes
 
@@ -1318,32 +1320,42 @@ class Compose(BaseCompose, HubMixin):
             if isinstance(value, np.ndarray) and not value.flags["C_CONTIGUOUS"]:
                 data[key] = np.ascontiguousarray(value)
 
+    # Maps canonical grayscale-bearing target -> expected ndim *without* the channel dim.
+    _GRAYSCALE_KEYS: ClassVar[dict[str, int]] = {
+        "image": 2,  # (H, W) => (H, W, 1)
+        "images": 3,  # (N, H, W) => (N, H, W, 1)
+        "mask": 2,  # (H, W) => (H, W, 1)
+        "masks": 3,  # (N, H, W) => (N, H, W, 1)
+        "volume": 3,  # (D, H, W) => (D, H, W, 1)
+        "volumes": 4,  # (N, D, H, W) => (N, D, H, W, 1)
+        "mask3d": 3,  # (D, H, W) => (D, H, W, 1)
+        "masks3d": 4,  # (N, D, H, W) => (N, D, H, W, 1)
+    }
+
     def _add_grayscale_channels(self, data: dict[str, Any]) -> None:
-        """Add channel dimension to grayscale data if missing. (H,W) -> (H,W,1) etc. for
-        image, mask, images, volume, etc. Tracks in _added_channel_dim for postprocess.
+        """Add a trailing channel dimension to grayscale image/mask/volume entries,
+        resolving `_additional_targets` so aliased keys are handled like canonical ones.
+
+        Expands `(H, W)` to `(H, W, 1)` (and the equivalent for batches/volumes). Tracks
+        expansion in `_added_channel_dim` (keyed by user key) and `_added_channel_canonical`
+        (user_key -> canonical name) so postprocess can strip only what we added.
         """
-        # Track which data had channel dimensions added
         self._added_channel_dim = {}
+        self._added_channel_canonical = {}
 
-        # Keys that should have channel dimension added when grayscale
-        grayscale_keys = {
-            "image": 2,  # (H, W) => (H, W, 1)
-            "images": 3,  # (N, H, W) => (N, H, W, 1)
-            "mask": 2,  # (H, W) => (H, W, 1)
-            "masks": 3,  # (N, H, W) => (N, H, W, 1)
-            "volume": 3,  # (D, H, W) => (D, H, W, 1)
-            "volumes": 4,  # (N, D, H, W) => (N, D, H, W, 1)
-            "mask3d": 3,  # (D, H, W) => (D, H, W, 1)
-            "masks3d": 4,  # (N, D, H, W) => (N, D, H, W, 1)
-        }
-
-        for key, expected_ndim in grayscale_keys.items():
-            if key in data and isinstance(data[key], np.ndarray):
-                if data[key].ndim == expected_ndim:
-                    data[key] = np.expand_dims(data[key], axis=-1)
-                    self._added_channel_dim[key] = True
-                else:
-                    self._added_channel_dim[key] = False
+        for key, value in data.items():
+            canonical = self._additional_targets.get(key, key)
+            expected_ndim = self._GRAYSCALE_KEYS.get(canonical)
+            if expected_ndim is None:
+                continue
+            if not isinstance(value, np.ndarray):
+                continue
+            self._added_channel_canonical[key] = canonical
+            if value.ndim == expected_ndim:
+                data[key] = np.expand_dims(value, axis=-1)
+                self._added_channel_dim[key] = True
+            else:
+                self._added_channel_dim[key] = False
 
     def postprocess(self, data: dict[str, Any]) -> dict[str, Any]:
         """Apply post-processing after all transforms. Runs processor postprocess and
@@ -1374,15 +1386,22 @@ class Compose(BaseCompose, HubMixin):
         return data
 
     def _remove_grayscale_channels(self, data: dict[str, Any]) -> None:
-        """Remove channel dimensions that were added during preprocessing. Uses
-        _added_channel_dim to squeeze only where we added; supports numpy and torch.
+        """Strip the trailing channel dimension that `_add_grayscale_channels` added,
+        for both numpy arrays and torch tensors, using the bookkeeping from preprocess.
+
+        Uses `_added_channel_dim` to squeeze only where we added a dim, and
+        `_added_channel_canonical` to dispatch torch logic by canonical role so aliased
+        keys are handled the same as their canonical counterparts.
         """
         if not hasattr(self, "_added_channel_dim"):
             return
 
+        canonical_map = getattr(self, "_added_channel_canonical", {})
+
         for key, was_added in self._added_channel_dim.items():
             if was_added and key in data:
                 value = data[key]
+                canonical = canonical_map.get(key, key)
 
                 # Handle numpy arrays
                 if isinstance(value, np.ndarray):
@@ -1397,10 +1416,10 @@ class Compose(BaseCompose, HubMixin):
                     if isinstance(value, torch.Tensor):
                         # For torch tensors, we need to handle different cases
                         # ToTensorV2 transposes image tensors but not mask tensors
-                        if key in {"image", "images"} and len(value.shape) >= 3 and value.shape[0] == 1:
+                        if canonical in {"image", "images"} and len(value.shape) >= 3 and value.shape[0] == 1:
                             # Image tensor with shape (1, H, W) -> (H, W) is not typical, skip
                             pass
-                        elif key in {"mask", "masks", "mask3d", "masks3d"} and value.shape[-1] == 1:
+                        elif canonical in {"mask", "masks", "mask3d", "masks3d"} and value.shape[-1] == 1:
                             # Mask tensor with shape (..., H, W, 1) -> (..., H, W)
                             data[key] = torch.squeeze(value, dim=-1)
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -26,6 +26,7 @@ from albumentations.core.validation import ValidatedTransformMeta
 from .serialization import Serializable, SerializableMeta, get_shortest_class_fullname
 from .type_definitions import ALL_TARGETS, ImageType, Targets, VolumeType
 from .utils import format_args
+from .utils import get_image_data as _get_image_data_impl
 
 __all__ = ["BasicTransform", "CustomTransformsApplyMixin", "DualTransform", "ImageOnlyTransform", "NoOp", "Transform3D"]
 
@@ -580,32 +581,56 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
         return params
 
+    # Maps canonical shape-bearing target name -> callable extracting the raw shape tuple
+    # used by get_params_dependent_on_data implementations. Order encodes lookup priority.
+    _SHAPE_TARGETS_TUPLE: ClassVar[tuple[tuple[str, Callable[[Any], tuple[int, ...]]], ...]] = (
+        ("image", lambda v: v.shape),
+        ("images", lambda v: v[0].shape),
+        ("volume", lambda v: v[0].shape),  # first slice handles DHW or DHWC
+        ("volumes", lambda v: v[0][0].shape),  # first slice of first volume
+        ("mask", lambda v: v.shape),
+        ("masks", lambda v: v[0].shape),
+        ("mask3d", lambda v: v[0].shape),
+        ("masks3d", lambda v: v[0][0].shape),
+    )
+
     def _extract_shape_from_data(self, data: dict[str, Any]) -> tuple[int, ...] | None:
-        """Extract shape information from various data types (image, images, volume, mask, etc.).
-        Used for params that need H, W. Returns tuple or None.
+        """Return the raw .shape tuple of the first image/mask/volume entry in `data`,
+        resolving aliases via `_additional_targets` (priority from `_SHAPE_TARGETS_TUPLE`).
+
+        Returns None if nothing matches. Aliased keys like
+        `{'custom_image_key': 'image'}` resolve to their canonical role.
         """
-        # Check images/volumes first (most common)
-        if "image" in data:
-            return data["image"].shape
-        if "images" in data:
-            return data["images"][0].shape
-        if "volume" in data:
-            # For volumes, take a slice to get 2D shape
-            return data["volume"][0].shape  # Take first slice (works for both DHWC and DHW)
-        if "volumes" in data:
-            # For batch of volumes
-            return data["volumes"][0][0].shape  # Take first slice of first volume (works for both NDHWC and NDHW)
-        if "mask" in data:
-            return data["mask"].shape
-        if "masks" in data:
-            return data["masks"][0].shape
-        if "mask3d" in data:
-            # For 3D masks, take a slice to get 2D shape
-            return data["mask3d"][0].shape  # Take first slice (works for both DHWC and DHW)
-        if "masks3d" in data:
-            # For batch of 3D masks
-            return data["masks3d"][0][0].shape  # Take first slice of first mask (works for both NDHWC and NDHW)
+        # Resolve canonical target -> user key, picking canonical when both present
+        # and otherwise the first alias seen.
+        resolved: dict[str, str] = {}
+        target_set = {name for name, _ in self._SHAPE_TARGETS_TUPLE}
+        for data_key, value in data.items():
+            target = self._additional_targets.get(data_key, data_key)
+            if target not in target_set or value is None:
+                continue
+            if target not in resolved or data_key == target:
+                resolved[target] = data_key
+
+        for target, extractor in self._SHAPE_TARGETS_TUPLE:
+            chosen = resolved.get(target)
+            if chosen is None:
+                continue
+            return extractor(data[chosen])
         return None
+
+    def get_image_data(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Return image metadata (dtype, height, width, num_channels) for the first match,
+        resolving aliases via `self._additional_targets` (drop-in for albucore helper).
+
+        Mirrors the contract of the previous `albucore.get_image_data` helper but
+        resolves aliased keys (e.g. `add_targets({'custom_image_key': 'image'})`) first.
+
+        Raises:
+            ValueError: If no valid image/volume data is present in `data`.
+
+        """
+        return _get_image_data_impl(data, self._additional_targets)
 
     def _add_transform_specific_params(self, params: dict[str, Any]) -> None:
         """Add transform-specific parameters to params dict (interpolation, fill, fill_mask).

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -134,15 +134,21 @@ def get_image_data(
 
 
 def _resolve_volume_key(data: dict[str, Any], aliases: dict[str, str], canonical: str) -> str | None:
-    """Find the user key in `data` whose canonical role matches `canonical`
-    ('volume' or 'volumes'); canonical wins over any alias. Helper for `get_volume_shape`.
+    """Resolve which user key holds volume or volumes data, skipping `None` values
+    and preferring the canonical key name over aliases (same rules as image resolution).
+
+    Returns None if no non-`None` entry matches `canonical`.
     """
-    if canonical in data:
-        return canonical
-    for key in data:
-        if aliases.get(key) == canonical:
-            return key
-    return None
+    chosen: str | None = None
+    for key, value in data.items():
+        if value is None:
+            continue
+        target = aliases.get(key, key)
+        if target != canonical:
+            continue
+        if chosen is None or key == canonical:
+            chosen = key
+    return chosen
 
 
 def _volume_shape_from_array(vol: Any) -> tuple[int, int, int]:

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -17,8 +17,38 @@ from albumentations.core.label_manager import LabelManager
 
 from .serialization import Serializable
 
+_IMAGE_DATA_PRIORITY: tuple[str, ...] = ("image", "images", "volume", "volumes")
 
-def get_shape(data: dict[str, Any]) -> tuple[int, int]:
+
+def _resolve_image_data_keys(
+    data: dict[str, Any],
+    additional_targets: dict[str, str] | None,
+) -> dict[str, str]:
+    """Map canonical image targets (image, images, volume, volumes) to the user key
+    holding that data, honoring `additional_targets` aliases (private shape helper).
+
+    The canonical key wins over any alias (so passing both `image=...` and `image2=...`
+    where `image2` aliases `image` keeps `image` as the source). Among aliases that map
+    to the same canonical target, the first one encountered in `data` wins.
+    """
+    aliases = additional_targets or {}
+    resolved: dict[str, str] = {}
+    for key, value in data.items():
+        target = aliases.get(key, key)
+        if target not in _IMAGE_DATA_PRIORITY:
+            continue
+        if value is None:
+            continue
+        # Canonical key always wins; otherwise, first alias seen wins.
+        if target not in resolved or key == target:
+            resolved[target] = key
+    return resolved
+
+
+def get_shape(
+    data: dict[str, Any],
+    additional_targets: dict[str, str] | None = None,
+) -> tuple[int, int]:
     """Extract (height, width) from data dict. Keys: image, images, volume, volumes.
     Raises if no image/volume present. Call for spatial checks during pipeline.
 
@@ -30,56 +60,143 @@ def get_shape(data: dict[str, Any]) -> tuple[int, int]:
             - 'volumes': Batch of 3D arrays of shape (N, D, H, W, C)
             - 'image': 2D array of shape (H, W, C)
             - 'images': Batch of arrays of shape (N, H, W, C)
+        additional_targets (dict[str, str] | None): Mapping of alias key -> canonical
+            target name (e.g. {'custom_image_key': 'image'}). When provided, aliased
+            keys are resolved to their canonical role.
 
     Returns:
         tuple[int, int]: (height, width) dimensions
 
     """
-    # After preprocessing, all data has channel dimension at the end
-    if "image" in data:
-        return _get_shape_from_image(data["image"])
-    if "images" in data:
-        return _get_shape_from_images(data["images"])
-    if "volume" in data:
-        return _get_shape_from_volume(data["volume"])
-    if "volumes" in data:
-        return _get_shape_from_volumes(data["volumes"])
+    resolved = _resolve_image_data_keys(data, additional_targets)
+    if "image" in resolved:
+        return _get_shape_from_image(data[resolved["image"]])
+    if "images" in resolved:
+        return _get_shape_from_images(data[resolved["images"]])
+    if "volume" in resolved:
+        return _get_shape_from_volume(data[resolved["volume"]])
+    if "volumes" in resolved:
+        return _get_shape_from_volumes(data[resolved["volumes"]])
 
     raise ValueError("No image or volume found in data", data.keys())
 
 
-def get_volume_shape(data: dict[str, Any]) -> tuple[int, int, int] | None:
-    """Extract (depth, height, width) from data containing 'volume' or 'volumes'.
-    Returns None if no volume data. Handles PyTorch tensor layouts (CDHW, NCDHW).
+def get_image_data(
+    data: dict[str, Any],
+    additional_targets: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Extract image metadata (dtype, height, width, num_channels) from a data dict,
+    resolving `additional_targets` aliases (priority: image, images, volume, volumes).
+
+    Checks for image data under canonical keys in priority order:
+    `'image'` > `'images'` > `'volume'` > `'volumes'`. When `additional_targets`
+    is provided, keys aliased to one of those canonical targets are also resolved (e.g.
+    `{'custom_image_key': 'image'}` makes `data['custom_image_key']` count as `'image'`).
+
+    Height and width skip batch/depth dimensions according to the canonical role:
+        - 'image':   H, W from shape[0], shape[1]
+        - 'images':  H, W from shape[1], shape[2]   (skip batch dim)
+        - 'volume':  H, W from shape[1], shape[2]   (skip depth dim)
+        - 'volumes': H, W from shape[2], shape[3]   (skip batch + depth dims)
+
+    Args:
+        data (dict[str, Any]): Dictionary potentially containing image/volume arrays.
+        additional_targets (dict[str, str] | None): Mapping of alias key -> canonical
+            target name. When None, only canonical keys are checked.
+
+    Returns:
+        dict[str, Any]: Dictionary with 'dtype', 'height', 'width', 'num_channels' keys.
+
+    Raises:
+        ValueError: If no valid image/volume data keys are found in the dictionary.
+
+    """
+    resolved = _resolve_image_data_keys(data, additional_targets)
+    for target in _IMAGE_DATA_PRIORITY:
+        key = resolved.get(target)
+        if key is None:
+            continue
+        arr = data[key]
+        shape = arr.shape
+        if target == "image":
+            height, width = shape[0], shape[1]
+        elif target in {"images", "volume"}:
+            height, width = shape[1], shape[2]
+        else:  # "volumes"
+            height, width = shape[2], shape[3]
+        return {
+            "dtype": arr.dtype,
+            "height": height,
+            "width": width,
+            "num_channels": shape[-1],
+        }
+    raise ValueError("No valid image/volume data found in data dict")
+
+
+def _resolve_volume_key(data: dict[str, Any], aliases: dict[str, str], canonical: str) -> str | None:
+    """Find the user key in `data` whose canonical role matches `canonical`
+    ('volume' or 'volumes'); canonical wins over any alias. Helper for `get_volume_shape`.
+    """
+    if canonical in data:
+        return canonical
+    for key in data:
+        if aliases.get(key) == canonical:
+            return key
+    return None
+
+
+def _volume_shape_from_array(vol: Any) -> tuple[int, int, int]:
+    """Return (D, H, W) from a single volume array, handling both torch CDHW/DHW layouts
+    and numpy DHWC/DHW layouts. Private helper for `get_volume_shape`.
+    """
+    if _is_torch_tensor(vol):
+        if len(vol.shape) == 4:  # (C, D, H, W)
+            return int(vol.shape[1]), int(vol.shape[2]), int(vol.shape[3])
+        if len(vol.shape) == 3:  # (D, H, W)
+            return int(vol.shape[0]), int(vol.shape[1]), int(vol.shape[2])
+    return vol.shape[0], vol.shape[1], vol.shape[2]
+
+
+def _volumes_shape_from_array(vols: Any) -> tuple[int, int, int]:
+    """Return (D, H, W) from a batch-of-volumes array, handling both torch NCDHW/NDHW
+    layouts and numpy NDHWC/NDHW layouts. Private helper for `get_volume_shape`.
+    """
+    if _is_torch_tensor(vols):
+        if len(vols.shape) == 5:  # (N, C, D, H, W)
+            return int(vols.shape[2]), int(vols.shape[3]), int(vols.shape[4])
+        if len(vols.shape) == 4:  # (N, D, H, W)
+            return int(vols.shape[1]), int(vols.shape[2]), int(vols.shape[3])
+    return vols[0].shape[0], vols[0].shape[1], vols[0].shape[2]
+
+
+def get_volume_shape(
+    data: dict[str, Any],
+    additional_targets: dict[str, str] | None = None,
+) -> tuple[int, int, int] | None:
+    """Extract (depth, height, width) from data containing 'volume' or 'volumes',
+    honoring `additional_targets` aliases; returns None when no volume data is present.
+
+    Handles PyTorch tensor layouts (CDHW, NCDHW) and numpy layouts (DHWC, NDHWC).
+    Aliased volume keys resolve to their canonical role.
 
     Args:
         data (dict[str, Any]): Dictionary containing volume data
+        additional_targets (dict[str, str] | None): Mapping of alias key -> canonical
+            target name. When None, only canonical keys are checked.
 
     Returns:
         tuple[int, int, int] | None: (depth, height, width) dimensions if volume data exists, None otherwise
 
     """
-    if "volume" in data:
-        vol = data["volume"]
-        # Handle PyTorch tensors
-        if _is_torch_tensor(vol):
-            if len(vol.shape) == 4:  # (C, D, H, W)
-                return int(vol.shape[1]), int(vol.shape[2]), int(vol.shape[3])
-            if len(vol.shape) == 3:  # (D, H, W)
-                return int(vol.shape[0]), int(vol.shape[1]), int(vol.shape[2])
-        # Regular numpy array
-        return vol.shape[0], vol.shape[1], vol.shape[2]
+    aliases = additional_targets or {}
 
-    if "volumes" in data:
-        vols = data["volumes"]
-        # Handle PyTorch tensors
-        if _is_torch_tensor(vols):
-            if len(vols.shape) == 5:  # (N, C, D, H, W)
-                return int(vols.shape[2]), int(vols.shape[3]), int(vols.shape[4])
-            if len(vols.shape) == 4:  # (N, D, H, W)
-                return int(vols.shape[1]), int(vols.shape[2]), int(vols.shape[3])
-        # Regular numpy array - take first volume
-        return vols[0].shape[0], vols[0].shape[1], vols[0].shape[2]
+    volume_key = _resolve_volume_key(data, aliases, "volume")
+    if volume_key is not None:
+        return _volume_shape_from_array(data[volume_key])
+
+    volumes_key = _resolve_volume_key(data, aliases, "volumes")
+    if volumes_key is not None:
+        return _volumes_shape_from_array(data[volumes_key])
 
     return None
 
@@ -211,6 +328,9 @@ class DataProcessor(ABC):
         self.params = params
         self.data_fields = [self.default_data_name]
         self.label_manager = LabelManager()
+        # Cached so get_shape lookups can resolve aliased image/mask/volume keys
+        # (e.g. {'custom_image_key': 'image'}). Updated by add_targets.
+        self._additional_targets: dict[str, str] = {}
 
         if additional_targets is not None:
             self.add_targets(additional_targets)
@@ -228,9 +348,14 @@ class DataProcessor(ABC):
         raise NotImplementedError
 
     def add_targets(self, additional_targets: dict[str, str]) -> None:
-        """Register additional target keys processed like default_data_name. Maps name to
-        type; type must match default_data_name. Compose calls when building pipeline.
+        """Register additional target keys processed like `default_data_name`, and cache
+        the full alias map so shape-helper lookups resolve aliased image/mask/volume keys.
+
+        Maps name to type; type must match `default_data_name`. Caching the full alias
+        map lets `get_shape`/`get_volume_shape` resolve aliased image/mask/volume keys.
+        Compose calls this when building the pipeline.
         """
+        self._additional_targets.update(additional_targets)
         for k, v in additional_targets.items():
             if v == self.default_data_name and k not in self.data_fields:
                 self.data_fields.append(k)
@@ -264,11 +389,11 @@ class DataProcessor(ABC):
             dict[str, Any]: Processed data dictionary.
 
         """
-        shape: tuple[int, int] | tuple[int, int, int] = get_shape(data)
+        shape: tuple[int, int] | tuple[int, int, int] = get_shape(data, self._additional_targets)
 
         # For xyz keypoints, get full 3D shape if available
         if hasattr(self.params, "coord_format") and self.params.coord_format == "xyz":
-            volume_shape = get_volume_shape(data)
+            volume_shape = get_volume_shape(data, self._additional_targets)
             if volume_shape is not None:
                 shape = volume_shape
 
@@ -308,7 +433,7 @@ class DataProcessor(ABC):
             data (dict[str, Any]): Data dictionary to preprocess.
 
         """
-        shape = get_shape(data)
+        shape = get_shape(data, self._additional_targets)
 
         # Convert all sequences (including empty lists) to numpy arrays with proper shape
         for data_name in set(self.data_fields) & set(data.keys()):

--- a/tests/test_additional_targets.py
+++ b/tests/test_additional_targets.py
@@ -1,0 +1,564 @@
+"""Tests for additional_targets alias resolution across shape/metadata helpers and
+end-to-end transform pipelines.
+
+Covers the family of helpers that historically read data by hardcoded keys
+(`image`, `images`, `mask`, ...) and ignored `_additional_targets`:
+
+- `albumentations.core.utils.get_image_data`
+- `albumentations.core.utils.get_shape`
+- `albumentations.core.utils.get_volume_shape`
+- `BasicTransform._extract_shape_from_data`
+- `BasicTransform.get_image_data`
+- `Compose._gather_shapes_from_data`
+- `Compose._add_grayscale_channels` / `_remove_grayscale_channels`
+- `check_data_post_transform` (via `get_shape`)
+
+Plus integration tests reproducing the user-reported bug (KeyError 'shape',
+"No valid image/volume data found in data dict") for every transform that needs
+shape metadata at param-sampling time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import albumentations as A
+from albumentations.core.transforms_interface import BasicTransform
+from albumentations.core.utils import get_image_data, get_shape, get_volume_shape
+
+# ---------------------------------------------------------------------------
+# get_image_data
+# ---------------------------------------------------------------------------
+
+
+class TestGetImageData:
+    def test_canonical_image(self) -> None:
+        data = {"image": np.zeros((10, 20, 3), dtype=np.uint8)}
+        meta = get_image_data(data)
+        assert meta == {"dtype": np.uint8, "height": 10, "width": 20, "num_channels": 3}
+
+    def test_canonical_images(self) -> None:
+        data = {"images": np.zeros((4, 10, 20, 3), dtype=np.float32)}
+        meta = get_image_data(data)
+        assert meta["height"] == 10
+        assert meta["width"] == 20
+        assert meta["num_channels"] == 3
+        assert meta["dtype"] == np.float32
+
+    def test_canonical_volume(self) -> None:
+        data = {"volume": np.zeros((5, 10, 20, 3), dtype=np.uint16)}
+        meta = get_image_data(data)
+        assert meta["height"] == 10
+        assert meta["width"] == 20
+        assert meta["num_channels"] == 3
+        assert meta["dtype"] == np.uint16
+
+    def test_canonical_volumes(self) -> None:
+        data = {"volumes": np.zeros((2, 5, 10, 20, 3), dtype=np.uint8)}
+        meta = get_image_data(data)
+        assert meta["height"] == 10
+        assert meta["width"] == 20
+        assert meta["num_channels"] == 3
+
+    def test_aliased_image(self) -> None:
+        data = {"custom_image_key": np.zeros((10, 20, 3), dtype=np.uint8)}
+        meta = get_image_data(data, {"custom_image_key": "image"})
+        assert meta == {"dtype": np.uint8, "height": 10, "width": 20, "num_channels": 3}
+
+    def test_aliased_images(self) -> None:
+        data = {"my_imgs": np.zeros((4, 10, 20, 3), dtype=np.uint8)}
+        meta = get_image_data(data, {"my_imgs": "images"})
+        assert meta["height"] == 10 and meta["width"] == 20
+
+    def test_aliased_volume(self) -> None:
+        data = {"my_vol": np.zeros((5, 10, 20, 3), dtype=np.uint8)}
+        meta = get_image_data(data, {"my_vol": "volume"})
+        assert meta["height"] == 10 and meta["width"] == 20
+
+    def test_aliased_volumes(self) -> None:
+        data = {"my_vols": np.zeros((2, 5, 10, 20, 3), dtype=np.uint8)}
+        meta = get_image_data(data, {"my_vols": "volumes"})
+        assert meta["height"] == 10 and meta["width"] == 20
+
+    def test_priority_canonical_wins_over_alias(self) -> None:
+        """When both canonical and alias resolve to 'image', the canonical key is used."""
+        canonical = np.zeros((10, 20, 3), dtype=np.uint8)
+        aliased = np.zeros((50, 60, 1), dtype=np.uint8)
+        data = {"image": canonical, "custom_image_key": aliased}
+        meta = get_image_data(data, {"custom_image_key": "image"})
+        assert meta["height"] == 10 and meta["width"] == 20
+
+    def test_priority_image_over_images(self) -> None:
+        data = {
+            "images": np.zeros((4, 50, 60, 3), dtype=np.uint8),
+            "image": np.zeros((10, 20, 3), dtype=np.uint8),
+        }
+        meta = get_image_data(data)
+        assert meta["height"] == 10 and meta["width"] == 20
+
+    def test_aliased_image_when_canonical_missing(self) -> None:
+        data = {
+            "custom_img": np.zeros((10, 20, 3), dtype=np.uint8),
+            "bboxes": np.array([[0, 0, 1, 1]]),
+            "labels": [1],
+        }
+        meta = get_image_data(data, {"custom_img": "image"})
+        assert meta["height"] == 10
+
+    def test_ignores_non_image_keys(self) -> None:
+        data = {
+            "bboxes": np.array([[0, 0, 1, 1]]),
+            "keypoints": np.array([[0, 0]]),
+            "labels": [1],
+        }
+        with pytest.raises(ValueError, match="No valid image/volume data"):
+            get_image_data(data)
+
+    def test_empty_dict_raises(self) -> None:
+        with pytest.raises(ValueError, match="No valid image/volume data"):
+            get_image_data({})
+
+    def test_none_value_skipped(self) -> None:
+        data = {"image": None, "custom_img": np.zeros((10, 20, 3), dtype=np.uint8)}
+        meta = get_image_data(data, {"custom_img": "image"})
+        assert meta["height"] == 10
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.float32, np.float64])
+    def test_dtype_preserved(self, dtype: type) -> None:
+        data = {"image": np.zeros((4, 5, 3), dtype=dtype)}
+        assert get_image_data(data)["dtype"] == np.dtype(dtype)
+
+    def test_grayscale_after_expand(self) -> None:
+        data = {"image": np.zeros((10, 20, 1), dtype=np.uint8)}
+        meta = get_image_data(data)
+        assert meta["num_channels"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_shape
+# ---------------------------------------------------------------------------
+
+
+class TestGetShape:
+    @pytest.mark.parametrize(
+        ("data", "expected"),
+        [
+            ({"image": np.zeros((10, 20, 3), dtype=np.uint8)}, (10, 20)),
+            ({"images": np.zeros((4, 10, 20, 3), dtype=np.uint8)}, (10, 20)),
+            ({"volume": np.zeros((5, 10, 20, 3), dtype=np.uint8)}, (10, 20)),
+            ({"volumes": np.zeros((2, 5, 10, 20, 3), dtype=np.uint8)}, (10, 20)),
+        ],
+    )
+    def test_canonical_keys(self, data: dict[str, Any], expected: tuple[int, int]) -> None:
+        assert get_shape(data) == expected
+
+    @pytest.mark.parametrize(
+        ("data", "aliases", "expected"),
+        [
+            ({"x_img": np.zeros((10, 20, 3), dtype=np.uint8)}, {"x_img": "image"}, (10, 20)),
+            ({"x_imgs": np.zeros((4, 10, 20, 3), dtype=np.uint8)}, {"x_imgs": "images"}, (10, 20)),
+            ({"x_vol": np.zeros((5, 10, 20, 3), dtype=np.uint8)}, {"x_vol": "volume"}, (10, 20)),
+            ({"x_vols": np.zeros((2, 5, 10, 20, 3), dtype=np.uint8)}, {"x_vols": "volumes"}, (10, 20)),
+        ],
+    )
+    def test_aliased_keys(
+        self,
+        data: dict[str, Any],
+        aliases: dict[str, str],
+        expected: tuple[int, int],
+    ) -> None:
+        assert get_shape(data, aliases) == expected
+
+    def test_canonical_wins_over_alias(self) -> None:
+        data = {
+            "image": np.zeros((10, 20, 3), dtype=np.uint8),
+            "x_img": np.zeros((50, 60, 3), dtype=np.uint8),
+        }
+        assert get_shape(data, {"x_img": "image"}) == (10, 20)
+
+    def test_no_image_raises(self) -> None:
+        with pytest.raises(ValueError, match="No image or volume found"):
+            get_shape({"bboxes": np.array([[0, 0, 1, 1]])})
+
+    def test_torch_chw_under_alias(self) -> None:
+        torch = pytest.importorskip("torch")
+        data = {"x_img": torch.zeros(3, 10, 20)}
+        assert get_shape(data, {"x_img": "image"}) == (10, 20)
+
+
+# ---------------------------------------------------------------------------
+# get_volume_shape
+# ---------------------------------------------------------------------------
+
+
+class TestGetVolumeShape:
+    def test_canonical_volume(self) -> None:
+        data = {"volume": np.zeros((5, 10, 20, 3), dtype=np.uint8)}
+        assert get_volume_shape(data) == (5, 10, 20)
+
+    def test_canonical_volumes(self) -> None:
+        data = {"volumes": np.zeros((2, 5, 10, 20, 3), dtype=np.uint8)}
+        assert get_volume_shape(data) == (5, 10, 20)
+
+    def test_aliased_volume(self) -> None:
+        data = {"my_vol": np.zeros((5, 10, 20, 3), dtype=np.uint8)}
+        assert get_volume_shape(data, {"my_vol": "volume"}) == (5, 10, 20)
+
+    def test_returns_none_when_no_volume(self) -> None:
+        data = {"image": np.zeros((10, 20, 3), dtype=np.uint8)}
+        assert get_volume_shape(data) is None
+
+
+# ---------------------------------------------------------------------------
+# BasicTransform._extract_shape_from_data + .get_image_data
+# ---------------------------------------------------------------------------
+
+
+class _DummyDual(A.DualTransform):
+    """Minimal dual transform exposing _extract_shape_from_data for tests."""
+
+    def apply(self, img, **params):
+        return img
+
+    def apply_to_mask(self, mask, **params):
+        return mask
+
+
+@pytest.mark.parametrize(
+    ("data_key", "shape_in", "expected"),
+    [
+        ("image", (10, 20, 3), (10, 20, 3)),
+        ("mask", (10, 20), (10, 20)),
+        ("images", (4, 10, 20, 3), (10, 20, 3)),
+        ("masks", (4, 10, 20), (10, 20)),
+        ("volume", (5, 10, 20, 3), (10, 20, 3)),
+        ("mask3d", (5, 10, 20), (10, 20)),
+        ("volumes", (2, 5, 10, 20, 3), (10, 20, 3)),
+        ("masks3d", (2, 5, 10, 20), (10, 20)),
+    ],
+)
+def test_extract_shape_aliased(
+    data_key: str,
+    shape_in: tuple[int, ...],
+    expected: tuple[int, ...],
+) -> None:
+    """Each canonical target keyed under an alias still resolves to the right .shape."""
+    transform = _DummyDual(p=1.0)
+    alias = f"my_{data_key}"
+    transform.add_targets({alias: data_key})
+    data = {alias: np.zeros(shape_in, dtype=np.uint8)}
+    assert transform._extract_shape_from_data(data) == expected
+
+
+def test_extract_shape_no_data_returns_none() -> None:
+    transform = _DummyDual(p=1.0)
+    assert transform._extract_shape_from_data({"bboxes": np.zeros((0, 4))}) is None
+
+
+def test_extract_shape_canonical_wins_over_alias() -> None:
+    transform = _DummyDual(p=1.0)
+    transform.add_targets({"img2": "image"})
+    data = {
+        "image": np.zeros((10, 20, 3), dtype=np.uint8),
+        "img2": np.zeros((50, 60, 3), dtype=np.uint8),
+    }
+    assert transform._extract_shape_from_data(data) == (10, 20, 3)
+
+
+def test_basictransform_get_image_data_uses_aliases() -> None:
+    transform = _DummyDual(p=1.0)
+    transform.add_targets({"my_img": "image"})
+    data = {"my_img": np.zeros((10, 20, 3), dtype=np.uint8)}
+    meta = transform.get_image_data(data)
+    assert meta["height"] == 10
+    assert meta["width"] == 20
+    assert meta["num_channels"] == 3
+
+
+def test_basictransform_get_image_data_raises_without_image() -> None:
+    transform = _DummyDual(p=1.0)
+    with pytest.raises(ValueError, match="No valid image/volume data"):
+        transform.get_image_data({"bboxes": np.zeros((0, 4))})
+
+
+# ---------------------------------------------------------------------------
+# Compose._gather_shapes_from_data
+# ---------------------------------------------------------------------------
+
+
+def test_gather_shapes_aliased_consistent() -> None:
+    compose = A.Compose([A.NoOp()])
+    compose.add_targets({"img2": "image", "msk2": "mask"})
+    data = {
+        "img2": np.zeros((10, 20, 3), dtype=np.uint8),
+        "msk2": np.zeros((10, 20), dtype=np.uint8),
+    }
+    shapes, volume_shapes = compose._gather_shapes_from_data(data)
+    assert shapes == [(10, 20), (10, 20)]
+    assert volume_shapes == []
+
+
+def test_gather_shapes_aliased_inconsistent_raises() -> None:
+    compose = A.Compose([A.NoOp()], is_check_shapes=True)
+    compose.add_targets({"img2": "image", "msk2": "mask"})
+    with pytest.raises(ValueError):
+        compose(
+            img2=np.zeros((10, 20, 3), dtype=np.uint8),
+            msk2=np.zeros((50, 60), dtype=np.uint8),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Compose grayscale channel handling
+# ---------------------------------------------------------------------------
+
+
+def test_grayscale_aliased_image_expanded_and_stripped() -> None:
+    compose = A.Compose([A.HorizontalFlip(p=1.0)])
+    compose.add_targets({"img2": "image"})
+    out = compose(img2=np.zeros((10, 20), dtype=np.uint8))
+    assert out["img2"].shape == (10, 20)
+
+
+def test_grayscale_aliased_mask_expanded_and_stripped() -> None:
+    compose = A.Compose([A.HorizontalFlip(p=1.0)])
+    compose.add_targets({"msk2": "mask"})
+    out = compose(
+        image=np.zeros((10, 20, 3), dtype=np.uint8),
+        msk2=np.zeros((10, 20), dtype=np.uint8),
+    )
+    assert out["msk2"].shape == (10, 20)
+
+
+def test_grayscale_aliased_image_with_channel_no_strip() -> None:
+    """If user already passes (H,W,C), preprocessor must not strip on output."""
+    compose = A.Compose([A.HorizontalFlip(p=1.0)])
+    compose.add_targets({"img2": "image"})
+    out = compose(img2=np.zeros((10, 20, 3), dtype=np.uint8))
+    assert out["img2"].shape == (10, 20, 3)
+
+
+def test_grayscale_aliased_added_channel_dim_tracking() -> None:
+    """Internal bookkeeping keys the alias under the user key with canonical map."""
+    compose = A.Compose([A.HorizontalFlip(p=1.0)])
+    compose.add_targets({"img2": "image"})
+    # Run preprocessing only, then inspect bookkeeping
+    data = {"img2": np.zeros((10, 20), dtype=np.uint8)}
+    compose._preprocess_arrays(data)
+    assert compose._added_channel_dim == {"img2": True}
+    assert compose._added_channel_canonical == {"img2": "image"}
+    assert data["img2"].shape == (10, 20, 1)
+
+
+# ---------------------------------------------------------------------------
+# Integration: user-reported bug pipeline
+# ---------------------------------------------------------------------------
+
+
+def _make_user_pipeline() -> A.Compose:
+    """Replicates the pipeline from the GitHub issue."""
+    return A.Compose(
+        [
+            A.Resize(p=1.0, height=64, width=64, interpolation=1, mask_interpolation=0),
+            A.HorizontalFlip(p=1.0),
+            A.Affine(
+                p=1.0,
+                border_mode=1,
+                fill=0.0,
+                fit_output=False,
+                interpolation=1,
+                keep_ratio=True,
+                mask_interpolation=0,
+                rotate=(-15.0, 15.0),
+                rotate_method="largest_box",
+            ),
+            A.ColorJitter(p=1.0),
+            A.OneOf(
+                [
+                    A.GaussNoise(p=1.0),
+                    A.ISONoise(p=1.0),
+                    A.MultiplicativeNoise(p=1.0),
+                ],
+                p=1.0,
+            ),
+            A.Normalize(p=1.0),
+        ],
+        p=1.0,
+        seed=43,
+    )
+
+
+def test_user_issue_pipeline_runs_with_aliased_keys() -> None:
+    pipeline = _make_user_pipeline()
+    pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    out = pipeline(custom_image_key=img, custom_mask_key=mask)
+    assert set(out.keys()) == {"custom_image_key", "custom_mask_key"}
+    assert out["custom_image_key"].shape == (64, 64, 3)
+    assert out["custom_mask_key"].shape == (64, 64)
+
+
+def test_user_issue_pipeline_many_seeds() -> None:
+    """OneOf with all branches at p=1.0 hits each noise transform across seeds; with the bug, this
+    used to KeyError 'shape' from Affine and ValueError from GaussNoise/ISONoise/MultiplicativeNoise.
+    """
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    mask = np.zeros((100, 100), dtype=np.uint8)
+    for seed in range(20):
+        pipeline = A.Compose(
+            [
+                A.Affine(p=1.0),
+                A.ColorJitter(p=1.0),
+                A.OneOf(
+                    [A.GaussNoise(p=1.0), A.ISONoise(p=1.0), A.MultiplicativeNoise(p=1.0)],
+                    p=1.0,
+                ),
+            ],
+            seed=seed,
+        )
+        pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
+        pipeline(custom_image_key=img, custom_mask_key=mask)
+
+
+# ---------------------------------------------------------------------------
+# Integration: every shape-dependent transform under aliased keys
+# ---------------------------------------------------------------------------
+
+
+# Each entry is a transform constructor that forces p=1.0 and exercises a
+# get_params_dependent_on_data path that needs `params["shape"]` or get_image_data.
+_SHAPE_DEPENDENT_TRANSFORMS: list[tuple[str, A.BasicTransform]] = [
+    ("Affine", A.Affine(p=1.0)),
+    ("ColorJitter", A.ColorJitter(p=1.0)),
+    ("ChannelShuffle", A.ChannelShuffle(p=1.0)),
+    ("FancyPCA", A.FancyPCA(p=1.0)),
+    ("GaussNoise", A.GaussNoise(p=1.0)),
+    ("MultiplicativeNoise", A.MultiplicativeNoise(p=1.0)),
+    ("ISONoise", A.ISONoise(p=1.0)),
+    ("SaltAndPepper", A.SaltAndPepper(p=1.0)),
+    ("RandomFog", A.RandomFog(p=1.0)),
+    ("RandomRain", A.RandomRain(p=1.0)),
+    ("RandomGravel", A.RandomGravel(p=1.0)),
+    ("RandomShadow", A.RandomShadow(p=1.0)),
+    ("RandomSunFlare", A.RandomSunFlare(p=1.0)),
+    ("ChannelDropout", A.ChannelDropout(p=1.0)),
+    ("PlasmaShadow", A.PlasmaShadow(p=1.0)),
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "transform"),
+    _SHAPE_DEPENDENT_TRANSFORMS,
+    ids=[name for name, _ in _SHAPE_DEPENDENT_TRANSFORMS],
+)
+def test_shape_dependent_transforms_under_aliased_keys(
+    name: str,
+    transform: BasicTransform,
+) -> None:
+    """Every transform that consults shape/image metadata at param time must work
+    when the user only passes aliased keys (the original GitHub issue).
+    """
+    img = np.full((40, 50, 3), 128, dtype=np.uint8)
+    mask = np.zeros((40, 50), dtype=np.uint8)
+    pipeline = A.Compose([transform], seed=0)
+    pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
+    out = pipeline(custom_image_key=img, custom_mask_key=mask)
+    assert "custom_image_key" in out
+    assert out["custom_image_key"].shape == img.shape
+    assert "custom_mask_key" in out
+    assert out["custom_mask_key"].shape == mask.shape
+
+
+# ---------------------------------------------------------------------------
+# Integration: bbox postprocess path (get_shape used by check_data_post_transform)
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_postprocess_with_aliased_image() -> None:
+    pipeline = A.Compose(
+        [A.HorizontalFlip(p=1.0), A.Affine(p=1.0)],
+        bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["lab"]),
+        seed=0,
+    )
+    pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
+    out = pipeline(
+        custom_image_key=np.zeros((100, 100, 3), dtype=np.uint8),
+        custom_mask_key=np.zeros((100, 100), dtype=np.uint8),
+        bboxes=[[0, 0, 10, 10]],
+        lab=[1],
+    )
+    assert "bboxes" in out
+    assert len(out["bboxes"]) == 1
+
+
+def test_keypoint_postprocess_with_aliased_image() -> None:
+    pipeline = A.Compose(
+        [A.HorizontalFlip(p=1.0), A.Affine(p=1.0)],
+        keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["lab"]),
+        seed=0,
+    )
+    pipeline.add_targets({"custom_image_key": "image"})
+    out = pipeline(
+        custom_image_key=np.zeros((100, 100, 3), dtype=np.uint8),
+        keypoints=[[10, 20]],
+        lab=[1],
+    )
+    assert "keypoints" in out
+    assert len(out["keypoints"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: mixed default + alias
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_default_and_alias_image() -> None:
+    """Both `image` and an aliased `image2` must be transformed identically."""
+    img1 = np.full((40, 50, 3), 10, dtype=np.uint8)
+    img2 = np.full((40, 50, 3), 200, dtype=np.uint8)
+    pipeline = A.Compose([A.HorizontalFlip(p=1.0)], seed=0)
+    pipeline.add_targets({"image2": "image"})
+    out = pipeline(image=img1, image2=img2)
+    np.testing.assert_array_equal(out["image"], img1[:, ::-1])
+    np.testing.assert_array_equal(out["image2"], img2[:, ::-1])
+
+
+def test_mixed_default_and_alias_mask() -> None:
+    img = np.zeros((40, 50, 3), dtype=np.uint8)
+    mask1 = np.zeros((40, 50), dtype=np.uint8)
+    mask1[:, :10] = 1
+    mask2 = np.zeros((40, 50), dtype=np.uint8)
+    mask2[:, -10:] = 5
+    pipeline = A.Compose([A.HorizontalFlip(p=1.0)], seed=0)
+    pipeline.add_targets({"mask2": "mask"})
+    out = pipeline(image=img, mask=mask1, mask2=mask2)
+    np.testing.assert_array_equal(out["mask"], mask1[:, ::-1])
+    np.testing.assert_array_equal(out["mask2"], mask2[:, ::-1])
+
+
+# ---------------------------------------------------------------------------
+# Regression: the exact errors reported in the GitHub issue
+# ---------------------------------------------------------------------------
+
+
+def test_regression_keyerror_shape_no_longer_raised() -> None:
+    """Affine used to raise `KeyError: 'shape'` when only aliased keys were present."""
+    pipeline = A.Compose([A.Affine(p=1.0)], seed=0)
+    pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
+    pipeline(
+        custom_image_key=np.zeros((40, 50, 3), dtype=np.uint8),
+        custom_mask_key=np.zeros((40, 50), dtype=np.uint8),
+    )
+
+
+def test_regression_no_valid_image_data_no_longer_raised() -> None:
+    """GaussNoise/ISONoise/MultiplicativeNoise used to raise
+    'No valid image/volume data found in data dict'.
+    """
+    pipeline = A.Compose([A.GaussNoise(p=1.0)], seed=0)
+    pipeline.add_targets({"custom_image_key": "image"})
+    pipeline(custom_image_key=np.zeros((40, 50, 3), dtype=np.uint8))

--- a/tests/test_additional_targets.py
+++ b/tests/test_additional_targets.py
@@ -211,6 +211,20 @@ class TestGetVolumeShape:
         data = {"image": np.zeros((10, 20, 3), dtype=np.uint8)}
         assert get_volume_shape(data) is None
 
+    def test_canonical_volume_none_uses_aliased_key(self) -> None:
+        """`volume: None` must not shadow a non-`None` value under an alias (regression: PR review)."""
+        data = {
+            "volume": None,
+            "my_vol": np.zeros((5, 10, 20, 3), dtype=np.uint8),
+        }
+        assert get_volume_shape(data, {"my_vol": "volume"}) == (5, 10, 20)
+
+    def test_canonical_volume_wins_over_alias_when_both_set(self) -> None:
+        vol = np.zeros((5, 10, 20, 3), dtype=np.uint8)
+        other = np.zeros((2, 3, 4, 3), dtype=np.uint8)
+        data = {"my_vol": other, "volume": vol}
+        assert get_volume_shape(data, {"my_vol": "volume"}) == (5, 10, 20)
+
 
 # ---------------------------------------------------------------------------
 # BasicTransform._extract_shape_from_data + .get_image_data


### PR DESCRIPTION
Add alias-aware get_image_data/get_shape in core utils, BasicTransform helpers, and Compose preprocessing/post checks. Route pixel transforms through self.get_image_data. Add tests for additional_targets.

Made-with: Cursor

Fixes: https://github.com/albumentations-team/AlbumentationsX/issues/238

## Summary by Sourcery

Honor `additional_targets` aliases when deriving image/volume shapes and metadata across core utilities, transforms, and Compose pipelines to fix failures when only aliased keys are provided.

Bug Fixes:
- Fix shape and metadata resolution for transforms and Compose checks when images, masks, and volumes are passed only via `additional_targets` aliases instead of canonical keys.
- Resolve previous errors such as missing `shape` and "No valid image/volume data found" when sampling params for shape-dependent transforms under aliased keys.

Enhancements:
- Introduce alias-aware helpers for extracting image metadata and shapes in core utils and BasicTransform, and route pixel transforms through a unified image-data accessor.
- Extend Compose preprocessing, grayscale channel handling, and shape consistency checks to work via canonical roles resolved from `additional_targets`.

Tests:
- Add comprehensive unit and integration tests covering alias resolution for image/volume shape helpers, BasicTransform and Compose behaviors, and all shape-dependent transforms under aliased keys, including regressions for the reported issue.