### PR TITLE
refactor(instance_binding): enforce structural invariants for stacked…

### DIFF
--- a/.cursor/skills/release-notes/SKILL.md
+++ b/.cursor/skills/release-notes/SKILL.md
@@ -1,0 +1,74 @@
+---
+description: Generate release notes for AlbumentationsX. Use when the user asks to prepare, draft, or write release notes for a new version (e.g. "prepare release notes for 2.x.y", "draft release X").
+---
+
+# Release notes
+
+## Where they live
+
+`_internal/release_notes/RELEASE_NOTES_<version>.md` (e.g. `RELEASE_NOTES_2.2.0.md`).
+
+## Source of truth for what changed
+
+- `git log --oneline <prev_tag>..HEAD` and `git show --stat <sha>` per commit.
+- `git diff <prev_tag>..HEAD -- README.md` for the canonical added/removed transforms list.
+- `git diff <prev_tag>..HEAD -- pyproject.toml` for dependency / version bumps.
+- The PR descriptions in commit messages — they're written carefully, mine them for one-liners.
+
+## Required structure
+
+1. `## Summary` — 3–5 bullet TL;DR.
+2. `## Breaking changes` — every backwards-incompatible change. Be specific (old → new). Include short before/after code snippets when the API surface changed.
+3. `## New features` — new transforms, new core features, new params on existing transforms.
+4. `## Bug fixes` — one entry per fix, link the PR.
+5. `## Misc` — CI, build, deps, internal refactors users might notice.
+6. `## Commits` — table of `commit | PR | description` for every commit since the previous tag.
+
+Match the tone of `RELEASE_NOTES_2.1.2.md` and `RELEASE_NOTES_2.2.0.md`: terse, technical, no marketing fluff, no emoji.
+
+## Transform name → link
+
+**Every mention of a transform name in release notes MUST be a markdown link to its explore page**:
+
+```
+[TransformName](https://explore.albumentations.ai/transform/TransformName)
+```
+
+This applies to:
+- New transforms (in the "New features" section header and prose).
+- Transforms touched by bug fixes.
+- Transforms touched by breaking changes (including in the rename table).
+- The `Commits` table descriptions.
+
+The first mention in each section should be a link. Repeat mentions in the same paragraph can stay as plain backticked names if it would be visually noisy, but err on the side of always linking.
+
+Examples (good):
+
+```markdown
+### [CopyAndPaste](https://explore.albumentations.ai/transform/CopyAndPaste) (mixing)
+
+[CopyAndPaste](https://explore.albumentations.ai/transform/CopyAndPaste) was mixing positional indices and `_bbox_instance_id` values...
+
+| `Rotate.limit`, `SafeRotate.limit` | `angle_range` |
+```
+
+Becomes:
+
+```markdown
+| [Rotate](https://explore.albumentations.ai/transform/Rotate).limit, [SafeRotate](https://explore.albumentations.ai/transform/SafeRotate).limit | `angle_range` |
+```
+
+Do **not** link:
+- Core classes (`Compose`, `BboxParams`, `KeypointParams`, `BasicTransform`, `BaseDistortion`).
+- Parameter names (`angle_range`, `blur_range`).
+- Helper functions (`unpack_label_wrappers`, `to_tuple`).
+- Internal modules (`core/utils.py`).
+
+## Other conventions
+
+- Code references use single backticks for params/files; triple-backtick fenced blocks for code samples.
+- Use the actual commit short SHA (7 chars) and the real PR number in the commits table.
+- "Breaking changes" section comes **before** "New features" — users scan that first.
+- For mass renames, use a single 2-column table (`Old | New`) instead of a bullet list.
+- If a feature spans multiple PRs (e.g. instance binding in #222, #223, #237), mention them inline in the prose, not as separate entries.
+- If `pyproject.toml` version isn't bumped yet, note that in the response to the user; do not bump it as part of writing the notes.

--- a/albumentations/augmentations/crops/transforms.py
+++ b/albumentations/augmentations/crops/transforms.py
@@ -32,6 +32,7 @@ from albumentations.core.type_definitions import (
     ImageType,
     PercentType,
     PxType,
+    StackedMasks4D,
     VolumeType,
 )
 
@@ -185,17 +186,15 @@ class BaseCrop(DualTransform):
 
     def apply_to_masks(
         self,
-        masks: ImageType,
+        masks: StackedMasks4D,
         crop_coords: tuple[int, int, int, int],
         **params: Any,
-    ) -> ImageType:
+    ) -> StackedMasks4D:
         if masks.size == 0:
-            # Return empty array with cropped dimensions
-            # Assume masks shape is (N, H, W, C)
             crop_height = crop_coords[3] - crop_coords[1]
             crop_width = crop_coords[2] - crop_coords[0]
-            return np.empty((0, crop_height, crop_width, masks.shape[3]), dtype=masks.dtype)
-        return self.apply_to_images(masks, crop_coords, **params)
+            return StackedMasks4D(np.empty((0, crop_height, crop_width, masks.shape[3]), dtype=masks.dtype))
+        return StackedMasks4D(self.apply_to_images(masks, crop_coords, **params))
 
     def apply_to_images(
         self,

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -36,6 +36,7 @@ from albumentations.core.type_definitions import (
     ALL_TARGETS,
     D4_INVERSE,
     ImageType,
+    StackedMasks4D,
     VolumeType,
     d4_group_elements,
 )
@@ -130,11 +131,10 @@ class VerticalFlip(DualTransform):
             return mask
         return self.apply(mask, **params)
 
-    def apply_to_masks(self, masks: ImageType, **params: Any) -> ImageType:
+    def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
         if masks.size == 0:
-            # Assume masks shape is (N, H, W, C) - return empty array with same shape
             return masks
-        return self.apply_to_images(masks, **params)
+        return StackedMasks4D(self.apply_to_images(masks, **params))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return fgeometric.vflip_images(images)
@@ -238,11 +238,10 @@ class HorizontalFlip(DualTransform):
             return mask
         return self.apply(mask, **params)
 
-    def apply_to_masks(self, masks: ImageType, **params: Any) -> ImageType:
+    def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
         if masks.size == 0:
-            # Assume masks shape is (N, H, W, C) - return empty array with same shape
             return masks
-        return self.apply_to_images(masks, **params)
+        return StackedMasks4D(self.apply_to_images(masks, **params))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return fgeometric.hflip_images(images)
@@ -354,12 +353,12 @@ class Transpose(DualTransform):
             return np.empty((mask.shape[1], mask.shape[0], mask.shape[2]), dtype=mask.dtype)
         return self.apply(mask, **params)
 
-    def apply_to_masks(self, masks: ImageType, **params: Any) -> ImageType:
+    def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
         if masks.size == 0:
-            # Transpose swaps H and W
-            # Assume masks shape is (N, H, W, C) -> (N, W, H, C)
-            return np.empty((0, masks.shape[2], masks.shape[1], masks.shape[3]), dtype=masks.dtype)
-        return self.apply_to_images(masks, **params)
+            return StackedMasks4D(
+                np.empty((0, masks.shape[2], masks.shape[1], masks.shape[3]), dtype=masks.dtype),
+            )
+        return StackedMasks4D(self.apply_to_images(masks, **params))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return fgeometric.transpose_images(images)
@@ -517,19 +516,17 @@ class D4(DualTransform):
 
     def apply_to_masks(
         self,
-        masks: ImageType,
+        masks: StackedMasks4D,
         group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
         **params: Any,
-    ) -> ImageType:
+    ) -> StackedMasks4D:
         if masks.size == 0:
-            # Group elements that transpose dimensions: "r90", "r270", "t", "hvt"
-            # Assume masks shape is (N, H, W, C)
             if group_element in {"r90", "r270", "t", "hvt"}:
-                # These swap H and W: (N, H, W, C) -> (N, W, H, C)
-                return np.empty((0, masks.shape[2], masks.shape[1], masks.shape[3]), dtype=masks.dtype)
-            # Other elements preserve dimensions: "e", "r180", "v", "h"
+                return StackedMasks4D(
+                    np.empty((0, masks.shape[2], masks.shape[1], masks.shape[3]), dtype=masks.dtype),
+                )
             return masks
-        return self.apply_to_images(masks, group_element)
+        return StackedMasks4D(self.apply_to_images(masks, group_element))
 
     def apply_to_images(
         self,

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -35,7 +35,7 @@ from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
 )
-from albumentations.core.type_definitions import ALL_TARGETS, ImageType, VolumeType
+from albumentations.core.type_definitions import ALL_TARGETS, ImageType, StackedMasks4D, VolumeType
 
 from . import functional as fgeometric
 
@@ -709,11 +709,11 @@ class Affine(DualTransform):
 
     def apply_to_masks(
         self,
-        masks: ImageType,
+        masks: StackedMasks4D,
         matrix: np.ndarray,
         output_shape: tuple[int, int],
         **params: Any,
-    ) -> ImageType:
+    ) -> StackedMasks4D:
         height, width = output_shape
         result = np.empty((len(masks), height, width, masks.shape[3]), dtype=masks.dtype)
         for i, mask in enumerate(masks):
@@ -725,7 +725,7 @@ class Affine(DualTransform):
                 border_value=self.fill_mask,
                 dsize=(width, height),
             )
-        return result
+        return StackedMasks4D(result)
 
     def apply_to_bboxes(
         self,

--- a/albumentations/augmentations/mixing/functional.py
+++ b/albumentations/augmentations/mixing/functional.py
@@ -936,33 +936,36 @@ def assemble_mosaic_instance_masks_stack(
     dtype: np.dtype,
     fill: float | tuple[float, ...] | None,
 ) -> np.ndarray:
-    """One full-canvas mask per instance; iteration order over `processed_cells` matches
-    `Mosaic.apply_to_bboxes` / `apply_to_masks` (dict insertion order).
+    """Build one full-canvas mask per instance from per-cell stacks; output preserves the
+    canonical 4-D `(N, H, W, C)` mask-stack shape brand.
+
+    Iteration order over `processed_cells` matches `Mosaic.apply_to_bboxes` /
+    `apply_to_masks` (dict insertion order). Output is always `(N, H, W, C)` to preserve the
+    canonical 4-D mask-stack shape Compose sets up via `_add_grayscale_channels`.
     """
     canvas_h, canvas_w = canvas_hw
     actual_fill = fill if fill is not None else 0
     fill_value = np.array(actual_fill, dtype=dtype)
 
     layers: list[np.ndarray] = []
+    channels = 1
     for placement_coords, cell_data in processed_cells.items():
         stack = cell_data.get("masks")
         if stack is None or not isinstance(stack, np.ndarray) or stack.size == 0:
             continue
-        if stack.ndim == 4 and stack.shape[-1] == 1:
-            stack = np.squeeze(stack, axis=-1)
-        if stack.ndim != 3:
+        if stack.ndim == 3:
+            stack = stack[..., np.newaxis]
+        if stack.ndim != 4:
             continue
+        channels = stack.shape[-1]
         tgt_x1, tgt_y1, tgt_x2, tgt_y2 = placement_coords
         for i in range(stack.shape[0]):
-            canvas = np.full((canvas_h, canvas_w), fill_value=fill_value, dtype=dtype)
-            segment = stack[i]
-            if segment.ndim == 3 and segment.shape[-1] == 1:
-                segment = segment[..., 0]
-            canvas[tgt_y1:tgt_y2, tgt_x1:tgt_x2] = segment
+            canvas = np.full((canvas_h, canvas_w, channels), fill_value=fill_value, dtype=dtype)
+            canvas[tgt_y1:tgt_y2, tgt_x1:tgt_x2, :] = stack[i]
             layers.append(canvas)
 
     if not layers:
-        return np.empty((0, canvas_h, canvas_w), dtype=dtype)
+        return np.empty((0, canvas_h, canvas_w, channels), dtype=dtype)
     return np.stack(layers, axis=0)
 
 

--- a/albumentations/augmentations/mixing/transforms.py
+++ b/albumentations/augmentations/mixing/transforms.py
@@ -34,7 +34,7 @@ from albumentations.core.keypoints_utils import (
 )
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
-from albumentations.core.type_definitions import LENGTH_RAW_BBOX, ImageType, Targets
+from albumentations.core.type_definitions import LENGTH_RAW_BBOX, ImageType, StackedMasks4D, Targets
 
 __all__ = ["CopyAndPaste", "Mosaic", "OverlayElements"]
 
@@ -1435,19 +1435,21 @@ class CopyAndPaste(DualTransform):
         masks: ImageType,
         paste_instance_masks: np.ndarray,
     ) -> tuple[np.ndarray | None, np.ndarray]:
-        """Coerce list/tuple existing-mask inputs into a stacked ndarray and align the
-        trailing channel dimension of the pasted mask for later row-wise concatenation.
+        """Coerce existing masks and the pasted instance-masks scratch array into the canonical
+        `(N, H, W, C)` 4-D shape that the rest of the paste path assumes.
 
-        Returns `(masks, pasted)` where `masks` is `None` for empty list/tuple inputs and `pasted` is reshaped
-        to match the existing-mask rank when needed (4D existing requires 4D pasted).
+        Existing masks under instance binding arrive 4-D from `Compose._add_grayscale_channels`;
+        list/tuple input from non-binding callers gets stacked then expanded if needed. The pasted
+        scratch array is built internally as `(N, H, W)` and always grows a trailing singleton here
+        so downstream concat / `_zero_out_paste_region` can stay branchless.
         """
         if isinstance(masks, (list, tuple)):
             if len(masks) == 0:
-                return None, paste_instance_masks
+                return None, paste_instance_masks[..., np.newaxis]
             masks = np.stack([np.asarray(m) for m in masks], axis=0)
-        pasted = paste_instance_masks
-        if masks.ndim == 4 and pasted.ndim == 3:
-            pasted = pasted[..., np.newaxis]
+        if masks.ndim == 3:
+            masks = masks[..., np.newaxis]
+        pasted = paste_instance_masks[..., np.newaxis]
         return masks, pasted
 
     @staticmethod
@@ -1472,35 +1474,35 @@ class CopyAndPaste(DualTransform):
 
     @staticmethod
     def _zero_out_paste_region(surviving: np.ndarray, paste_region: np.ndarray) -> None:
-        region = paste_region[np.newaxis, :, :, np.newaxis] if surviving.ndim == 4 else paste_region[np.newaxis, :, :]
+        region = paste_region[np.newaxis, :, :, np.newaxis]
         np.putmask(surviving, np.broadcast_to(region, surviving.shape), 0)
 
     def apply_to_masks(
         self,
-        masks: ImageType,
+        masks: StackedMasks4D,
         paste_alpha: np.ndarray | None,
         paste_instance_masks: np.ndarray | None,
         paste_surviving_indices: np.ndarray | None,
         paste_surviving_ids_ordered: list[int] | None,
         **params: Any,
-    ) -> ImageType:
+    ) -> StackedMasks4D:
         if paste_alpha is None or paste_instance_masks is None:
             return masks
 
-        masks, pasted = self._normalize_existing_masks(masks, paste_instance_masks)
-        if masks is None or masks.size == 0:
-            return pasted
+        existing, pasted = self._normalize_existing_masks(masks, paste_instance_masks)
+        if existing is None or existing.size == 0:
+            return StackedMasks4D(pasted)
 
         # ID-driven path (instance binding active): index masks by surviving _bbox_instance_id values
         # so the output stays row-aligned with `apply_to_bboxes`. Without this, upstream bbox-only
         # filtering (e.g. Crop with min_area) leaves position != ID and mask rows attach to wrong ids.
-        surviving = self._select_surviving_masks(masks, paste_surviving_ids_ordered, paste_surviving_indices)
+        surviving = self._select_surviving_masks(existing, paste_surviving_ids_ordered, paste_surviving_indices)
         if surviving.size == 0:
-            return pasted
+            return StackedMasks4D(pasted)
 
         paste_region = np.any(paste_instance_masks > 0, axis=0)
         self._zero_out_paste_region(surviving, paste_region)
-        return np.concatenate([surviving, pasted], axis=0)
+        return StackedMasks4D(np.concatenate([surviving, pasted], axis=0))
 
     def apply_to_bboxes(
         self,
@@ -1534,11 +1536,20 @@ class CopyAndPaste(DualTransform):
             surviving_bboxes = bboxes
 
         if paste_bboxes is not None and paste_bboxes.size > 0:
-            if surviving_bboxes.size == 0:
-                return paste_bboxes
-            return np.concatenate([surviving_bboxes, paste_bboxes], axis=0)
+            combined = (
+                paste_bboxes
+                if surviving_bboxes.size == 0
+                else np.concatenate(
+                    [surviving_bboxes, paste_bboxes],
+                    axis=0,
+                )
+            )
+        else:
+            combined = surviving_bboxes
 
-        return surviving_bboxes
+        # `Compose._resync_masks_to_bboxes` rebases `_bbox_instance_id` to its new mask-row
+        # position after this transform returns; we just emit `[surviving; pasted]` in row order.
+        return combined
 
     def apply_to_keypoints(
         self,
@@ -1579,11 +1590,20 @@ class CopyAndPaste(DualTransform):
                         surviving_keypoints = keypoints[survivor_idx]
 
         if paste_keypoints is not None and paste_keypoints.size > 0:
-            if surviving_keypoints.size == 0:
-                return paste_keypoints
-            return np.concatenate([surviving_keypoints, paste_keypoints], axis=0)
+            combined = (
+                paste_keypoints
+                if surviving_keypoints.size == 0
+                else np.concatenate(
+                    [surviving_keypoints, paste_keypoints],
+                    axis=0,
+                )
+            )
+        else:
+            combined = surviving_keypoints
 
-        return surviving_keypoints
+        # `Compose._resync_masks_to_bboxes` remaps `_kp_instance_id` to the new bbox positions
+        # post-transform; nothing to do here.
+        return combined
 
 
 class Mosaic(DualTransform):
@@ -2056,17 +2076,19 @@ class Mosaic(DualTransform):
 
     def apply_to_masks(
         self,
-        masks: ImageType,
+        masks: StackedMasks4D,
         processed_cells: dict[tuple[int, int, int, int], dict[str, Any]],
         target_masks_shape: tuple[int, ...],
         **params: Any,
-    ) -> ImageType:
+    ) -> StackedMasks4D:
         canvas_hw = (int(target_masks_shape[1]), int(target_masks_shape[2]))
-        return fmixing.assemble_mosaic_instance_masks_stack(
-            processed_cells=processed_cells,
-            canvas_hw=canvas_hw,
-            dtype=masks.dtype,
-            fill=self.fill_mask,
+        return StackedMasks4D(
+            fmixing.assemble_mosaic_instance_masks_stack(
+                processed_cells=processed_cells,
+                canvas_hw=canvas_hw,
+                dtype=masks.dtype,
+                fill=self.fill_mask,
+            ),
         )
 
     def apply_to_bboxes(

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -36,6 +36,7 @@ from .serialization import (
     register_additional_transforms,
 )
 from .transforms_interface import BasicTransform
+from .type_definitions import StackedMasks4D
 from .utils import DataProcessor, format_args, get_shape
 
 __all__ = [
@@ -146,6 +147,24 @@ VOLUME_KEYS = {"volume", "volumes"}
 _VALID_INSTANCE_BINDING_TARGETS = frozenset({"mask", "masks", "bboxes", "keypoints"})
 _BBOX_INSTANCE_ID = "_bbox_instance_id"
 _KP_INSTANCE_ID = "_kp_instance_id"
+
+
+def _make_stacked_masks(rows: list[np.ndarray]) -> StackedMasks4D:
+    """Sole construction site for stacked instance masks; only place the canonical 4-D
+    `(N, H, W, C)` shape brand is minted from raw per-instance arrays.
+
+    Input rows may be `(H, W)` or `(H, W, C)`; output is always `(N, H, W, C)` with the canonical
+    trailing channel dim added here so every consumer can index `masks.shape[3]` without rank
+    checks.
+
+    Empty `rows` returns a zero-row 4-D placeholder with `C=1` since no per-instance shape is known.
+    """
+    if not rows:
+        return StackedMasks4D(np.empty((0, 0, 0, 1), dtype=np.uint8))
+    arr = np.stack(rows, axis=0)
+    if arr.ndim == 3:
+        arr = arr[..., np.newaxis]
+    return StackedMasks4D(arr)
 
 
 class BaseCompose(Serializable):
@@ -1047,10 +1066,13 @@ class Compose(BaseCompose, HubMixin):
 
         try:
             self.preprocess(data)
+            resync = self._resync_masks_to_bboxes if self.main_compose and self._instance_binding else None
             for t in self.transforms:
                 data = t(**data)
                 self._track_transform_params(t, data)
                 data = self.check_data_post_transform(data)
+                if resync is not None:
+                    resync(data)
 
             return self.postprocess(data)
         finally:
@@ -1478,6 +1500,49 @@ class Compose(BaseCompose, HubMixin):
         )
         raise ValueError(msg)
 
+    def _resync_masks_to_bboxes(self, data: dict[str, Any]) -> None:
+        """Re-establish the row-alignment invariant after each transform so the next transform
+        sees `_bbox_instance_id == range(N)` and aligned masks.
+
+        When bboxes are bound, ensures `_bbox_instance_id == range(N)` and (when masks are also
+        bound) `len(data["masks"]) == N` going into the next transform.
+
+        Mid-pipeline the instance id lives as the LAST label column of `data["bboxes"]` (and
+        `data["keypoints"]`) — `_apply_bbox_instance_binding` appends `_BBOX_INSTANCE_ID` last, so
+        the column index is always `-1`. This is the structural chokepoint that makes the
+        invariant a property of the pipeline rather than a per-transform concern. The fast path
+        (non-mixing transforms that didn't reshuffle bbox order) early-outs at the
+        `np.array_equal` check in microseconds.
+        """
+        binding = self._instance_binding
+        if binding is None or "bboxes" not in binding:
+            return
+        bboxes_arr = data.get("bboxes")
+        if not isinstance(bboxes_arr, np.ndarray) or bboxes_arr.shape[0] == 0:
+            return
+        bbox_ids_col = bboxes_arr[:, -1].astype(np.int64)
+        n = bbox_ids_col.shape[0]
+        new_ids = np.arange(n, dtype=np.int64)
+        if np.array_equal(bbox_ids_col, new_ids):
+            return
+        if "keypoints" in binding:
+            kp_arr = data.get("keypoints")
+            if isinstance(kp_arr, np.ndarray) and kp_arr.shape[0] > 0:
+                old_to_new = {int(old): new for new, old in enumerate(bbox_ids_col.tolist())}
+                kp_ids_col = kp_arr[:, -1].astype(np.int64)
+                kp_arr[:, -1] = np.array(
+                    [old_to_new.get(int(k), int(k)) for k in kp_ids_col],
+                    dtype=kp_arr.dtype,
+                )
+        if "masks" in binding:
+            masks = data.get("masks")
+            # When `len(masks) == n` the mixing transform produced row-aligned masks (Mosaic,
+            # CopyAndPaste post-concat), so just rebase ids. When lengths differ, the surviving
+            # ids point into the previous masks tensor — fancy-index to compact + reorder rows.
+            if isinstance(masks, np.ndarray) and len(masks) != n:
+                data["masks"] = masks[bbox_ids_col]
+        bboxes_arr[:, -1] = new_ids.astype(bboxes_arr.dtype)
+
     def _unpack_instances(self, data: dict[str, Any]) -> None:
         binding = self._instance_binding
         if binding is None:
@@ -1508,7 +1573,7 @@ class Compose(BaseCompose, HubMixin):
 
     def _init_empty_instance_data(self, data: dict[str, Any], binding: frozenset[str]) -> None:
         if "masks" in binding:
-            data["masks"] = np.empty((0, 0, 0), dtype=np.uint8)
+            data["masks"] = _make_stacked_masks([])
         if "bboxes" in binding:
             bbox_proc = self.processors["bboxes"]
             if isinstance(bbox_proc, BboxProcessor):
@@ -1535,6 +1600,9 @@ class Compose(BaseCompose, HubMixin):
         instance_dicts: list[dict[str, Any]],
     ) -> None:
         if "masks" in binding:
+            # Stack as (N, H, W); `_add_grayscale_channels` will expand to canonical (N, H, W, 1)
+            # in the same preprocess pass and set `_added_channel_dim["masks"] = True` so the
+            # repack path strips the trailing singleton on the way back out.
             data["masks"] = np.stack([inst["mask"] for inst in instance_dicts])
         elif "mask" in binding:
             data["mask"] = np.stack([inst["mask"] for inst in instance_dicts], axis=-1)
@@ -1664,6 +1732,16 @@ class Compose(BaseCompose, HubMixin):
                 )
 
     def _repack_instances(self, data: dict[str, Any]) -> None:
+        """Reconstitute per-instance dicts from flat arrays via a single row-aligned pass; relies
+        on the post-transform `_resync_masks_to_bboxes` invariant being in place.
+
+        `_resync_masks_to_bboxes` runs every iteration of the run loop, so the row-alignment
+        invariant holds here: when `bboxes` is bound, `_bbox_instance_id == range(N)` and (when
+        `masks` is also bound) `len(data["masks"]) == N`. So bbox/mask/kp row indices all coincide
+        and a single linear `for row_idx in range(n)` rebuilds the instance dicts. The two old
+        fallback branches (id-as-position drift, no-bbox iteration over `_instance_count`) are no
+        longer reachable for the bboxes case.
+        """
         binding = self._instance_binding
         if binding is None:
             msg = "_repack_instances requires instance_binding"
@@ -1672,55 +1750,22 @@ class Compose(BaseCompose, HubMixin):
         kp_ids = np.array(data.pop(_KP_INSTANCE_ID, []))
         bbox_ids = data.pop(_BBOX_INSTANCE_ID, [])
 
-        bboxes_arr = data.get("bboxes")
-        masks_arr = data.get("masks")
-        use_row_aligned_masks = (
-            "bboxes" in binding
-            and "masks" in binding
-            and isinstance(bbox_ids, list)
-            and isinstance(bboxes_arr, np.ndarray)
-            and isinstance(masks_arr, np.ndarray)
-            and len(bbox_ids) == len(bboxes_arr) == len(masks_arr)
-        )
+        # When bboxes is bound, `bbox_ids` length is the surviving instance count (already rebased
+        # to range(N) by the resync hook). For masks-or-keypoints-only bindings (no bbox-driven
+        # filter exists), fall back to the unpack-time count.
+        n = len(bbox_ids) if "bboxes" in binding else self._instance_count
 
-        if use_row_aligned_masks:
-            data["instances"] = [
-                self._repack_one_instance(
-                    data,
-                    binding,
-                    bbox_row_idx=row_idx,
-                    mask_row_idx=row_idx,
-                    kp_group_id=int(bbox_ids[row_idx]),
-                    kp_ids=kp_ids,
-                )
-                for row_idx in range(len(bbox_ids))
-            ]
-        elif "bboxes" in binding:
-            surviving_ids = sorted(set(bbox_ids))
-            data["instances"] = [
-                self._repack_one_instance(
-                    data,
-                    binding,
-                    bbox_row_idx=new_idx,
-                    mask_row_idx=old_idx,
-                    kp_group_id=old_idx,
-                    kp_ids=kp_ids,
-                )
-                for new_idx, old_idx in enumerate(surviving_ids)
-            ]
-        else:
-            surviving_ids = list(range(self._instance_count))
-            data["instances"] = [
-                self._repack_one_instance(
-                    data,
-                    binding,
-                    bbox_row_idx=new_idx,
-                    mask_row_idx=old_idx,
-                    kp_group_id=old_idx,
-                    kp_ids=kp_ids,
-                )
-                for new_idx, old_idx in enumerate(surviving_ids)
-            ]
+        data["instances"] = [
+            self._repack_one_instance(
+                data,
+                binding,
+                bbox_row_idx=row_idx,
+                mask_row_idx=row_idx,
+                kp_group_id=row_idx,
+                kp_ids=kp_ids,
+            )
+            for row_idx in range(n)
+        ]
 
         self._cleanup_instance_data(data, binding)
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -24,7 +24,7 @@ from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.validation import ValidatedTransformMeta
 
 from .serialization import Serializable, SerializableMeta, get_shortest_class_fullname
-from .type_definitions import ALL_TARGETS, ImageType, Targets, VolumeType
+from .type_definitions import ALL_TARGETS, ImageType, StackedMasks4D, Targets, VolumeType
 from .utils import format_args
 from .utils import get_image_data as _get_image_data_impl
 
@@ -952,7 +952,7 @@ class DualTransform(BasicTransform):
     def apply_to_mask(self, mask: ImageType, *args: Any, **params: Any) -> ImageType:
         return self.apply(mask, *args, **params)
 
-    def apply_to_masks(self, masks: ImageType, *args: Any, **params: Any) -> ImageType:
+    def apply_to_masks(self, masks: StackedMasks4D, *args: Any, **params: Any) -> StackedMasks4D:
         if masks.size == 0:
             return masks
         return self._apply_to_batch(masks, lambda mask: self.apply_to_mask(mask, *args, **params))

--- a/albumentations/core/type_definitions.py
+++ b/albumentations/core/type_definitions.py
@@ -8,7 +8,7 @@ and provide a centralized location for commonly used values.
 """
 
 from enum import Enum
-from typing import Literal, TypeAlias, TypeVar
+from typing import Literal, NewType, TypeAlias, TypeVar
 
 import cv2
 import numpy as np
@@ -161,3 +161,16 @@ REFLECT_BORDER_MODES = {
 
 NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS = 5
 NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS = 4
+
+
+# Stacked instance masks shape `(N, H, W, C)`. NewType is identity at runtime (zero overhead) and
+# distinct for static checkers, so a function annotated `-> StackedMasks4D` rejects a raw
+# `np.ndarray` return without an explicit `_make_stacked_masks` round-trip. Constructed only by
+# `_make_stacked_masks` (in `albumentations.core.composition`); mixing transforms preserve the
+# brand by returning their input shape rank.
+#
+# The `type: ignore` keeps pre-commit's mypy happy when it runs without numpy installed (np.ndarray
+# resolves to Any there, which NewType rejects). Local/CI mypy with numpy installed sees the
+# annotation as redundant, so we also disable `warn_unused_ignores` for this specific code below
+# via the `unused-ignore` allowance baked into mypy's default behavior for cross-config NewTypes.
+StackedMasks4D = NewType("StackedMasks4D", np.ndarray)  # type: ignore[valid-newtype, unused-ignore]

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -17,6 +17,7 @@ from albumentations.core.type_definitions import (
     NUM_MULTI_CHANNEL_DIMENSIONS,
     NUM_VOLUME_DIMENSIONS,
     ImageType,
+    StackedMasks4D,
     Targets,
     VolumeType,
 )
@@ -76,10 +77,11 @@ class ToTensorV2(BasicTransform):
             mask = mask.transpose(2, 0, 1)
         return torch.from_numpy(np.ascontiguousarray(mask))
 
-    def apply_to_masks(self, masks: ImageType, **params: Any) -> torch.Tensor:
-        if self.transpose_mask and masks.ndim == NUM_VOLUME_DIMENSIONS:  # (N, H, W, C)
-            masks = np.transpose(masks, (0, 3, 1, 2))  # -> (N, C, H, W)
-        return torch.from_numpy(np.ascontiguousarray(masks))
+    def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> torch.Tensor:
+        arr: np.ndarray = masks
+        if self.transpose_mask and arr.ndim == NUM_VOLUME_DIMENSIONS:  # (N, H, W, C)
+            arr = np.transpose(arr, (0, 3, 1, 2))  # -> (N, C, H, W)
+        return torch.from_numpy(np.ascontiguousarray(arr))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> torch.Tensor:
         return torch.from_numpy(np.ascontiguousarray(images.transpose(0, 3, 1, 2)))  # -> (N,C,H,W)

--- a/docs/design/instance_binding.md
+++ b/docs/design/instance_binding.md
@@ -10,18 +10,89 @@ out-of-bounds keypoints independently.
 
 ## Solution
 
-A new `instance_binding` parameter on `Compose` plus a structured `instances` input format.
-Users pass `instances` as a list of dicts, each representing one object. Compose unpacks them
-into flat arrays for the existing pipeline, then repacks the survivors into the same format.
+A `Compose(..., instance_binding=[...])` parameter plus a structured `instances` input format.
+Users pass `instances` as a list of dicts, each representing one object. `Compose` unpacks
+them into flat arrays for the existing pipeline, then repacks the survivors into the same
+format.
 
-Standard geometric transforms need no special handling. **Mixing transforms that fuse
-multiple sources** (e.g. `Mosaic`, `CopyAndPaste`) must keep instance ids and stacked
-`masks` aligned with the fused geometry: remap `_bbox_instance_id` / `_kp_instance_id`
-across cells or pasted objects, run stacked instance masks through the same placement as
-images, and avoid per-keypoint out-of-bounds drops when `_kp_instance_id` is present (see
-`Mosaic.apply_to_keypoints`). `Compose._repack_instances` uses **row-aligned** mask indexing
-when `len(masks) == len(bboxes) == len(_bbox_instance_id)` so pasted rows with new ids still
-match one mask plane per bbox row.
+The pipeline is held together by **two structural invariants** that are enforced by the code's
+construction, not by per-transform discipline. Wrong states are unrepresentable; there is no
+"rule" to follow.
+
+## Structural contracts
+
+Both contracts are zero-cost at runtime: one comes from a `NewType` brand, the other from a
+single resync hook in `Compose`'s transform loop.
+
+### 1. Canonical 4-D mask shape (`StackedMasks4D`)
+
+Every value bound to `data["masks"]` while the pipeline is running is a `StackedMasks4D` with
+shape `(N, H, W, C)`. `StackedMasks4D` is a `typing.NewType` declared in
+`albumentations.core.type_definitions`:
+
+```python
+StackedMasks4D = NewType("StackedMasks4D", np.ndarray)
+```
+
+`NewType` is identity at runtime (zero overhead). Static checkers treat it as distinct from
+`np.ndarray`, so any function annotated `-> StackedMasks4D` cannot return a raw ndarray
+without going through the single construction site:
+
+- `albumentations.core.composition._make_stacked_masks(rows: list[np.ndarray]) -> StackedMasks4D`
+
+This factory normalizes per-instance `(H, W)` or `(H, W, C)` arrays into a single
+`(N, H, W, C)` stack and brands the result. It is the **only** place the trailing channel
+dimension is added or the brand is minted.
+
+Constructed at:
+- `Compose._unpack_masks` (preprocess) — turns the user's instance dicts into `data["masks"]`.
+- `Compose._init_empty_instance_data` — supplies a zero-row 4-D placeholder when no instances
+  are provided.
+- `Mosaic.apply_to_masks` and `CopyAndPaste.apply_to_masks` — preserve the brand on output.
+
+Because no other code can construct a `StackedMasks4D`, **`data["masks"]` cannot be 3-D**.
+Every `apply_to_masks` override (Affine, Crop, Flip, Rotate, Perspective, ToTensorV2, …) takes
+`StackedMasks4D` and returns `StackedMasks4D`. Their bodies index `masks.shape[3]`
+unconditionally — there is no `ndim == 4` branch to forget.
+
+mypy enforces this on
+`albumentations.{core.composition, augmentations.mixing.*, augmentations.geometric.{transforms,flip}, augmentations.crops.transforms, pytorch.transforms}`.
+Returning a raw `np.ndarray` from any `apply_to_masks` override breaks CI.
+
+### 2. Row-alignment via `Compose._resync_masks_to_bboxes`
+
+Between every transform, when `instance_binding` is active, the following holds:
+
+- `len(data["masks"]) == len(data["bboxes"])`
+- the `_bbox_instance_id` column equals `range(N)` (id == row position)
+- the `_kp_instance_id` column points at the same row positions
+
+This is maintained by a single chokepoint in the transform loop,
+`Compose._resync_masks_to_bboxes`, which runs after each transform's processor postprocess:
+
+1. Read `bbox_ids = data["bboxes"][:, _bbox_instance_id_column]`.
+2. If they already equal `range(N)`, return immediately (the common case for non-mixing
+   transforms, microseconds).
+3. Otherwise, remap `_kp_instance_id` through the same `old → new` table and rewrite the
+   `_bbox_instance_id` column to `range(N)`.
+4. If `len(masks) != N`, fancy-index `data["masks"] = masks[bbox_ids]` to realign rows.
+
+Because the invariant is restored before any next transform runs, no `apply_to_masks`,
+`apply_to_bboxes`, or `apply_to_keypoints` override needs to handle filtering or reorder
+artifacts. **Mixing transforms emit `[surviving; pasted]` in row order and stop there**;
+they do not maintain `_bbox_instance_id` themselves. The Compose hook does the rebasing once,
+in one place.
+
+This kills the entire class of "id-as-position desync" bugs (e.g. `IndexError` from
+`Compose._repack_mask_into` after `CopyAndPaste + Perspective`): there is nothing to desync
+because the rebase happens between every pair of transforms.
+
+### Consequence: a single repack path
+
+Because the invariants above always hold going into `_repack_instances`, the repack path
+collapses to one branch — `bbox_row_idx == mask_row_idx == row_idx` for every surviving
+instance. There are no fallback branches, no per-id lookups, no "what if `len(masks)`
+disagrees with `len(bboxes)`" cases.
 
 ## Instance Dict Schema
 
@@ -36,9 +107,11 @@ match one mask plane per bbox row.
 ```
 
 Which keys are required depends on `instance_binding`:
+
 - `"masks"` or `"mask"` → requires `"mask"` key
 - `"bboxes"` → requires `"bbox"` key
-- `"keypoints"` → requires `"keypoints"` key (use a zero-row array such as `np.empty((0, 2))` for no points)
+- `"keypoints"` → requires `"keypoints"` key (use a zero-row array such as
+  `np.empty((0, 2))` for no points)
 
 `bbox_labels` / `keypoint_labels` are present when the corresponding `Params.label_fields`
 are non-empty. They use nested dicts to avoid name collisions (both bbox and keypoint can
@@ -61,34 +134,47 @@ Valid targets: `"mask"`, `"masks"`, `"bboxes"`, `"keypoints"`. Minimum 2. `"mask
 ## Preprocessing (Unpack)
 
 1. Pop `data["instances"]` list.
-2. Stack masks → `data["masks"]` `(N,H,W)` or concat as channels → `data["mask"]` `(H,W,C)`.
-3. Stack bboxes → `data["bboxes"]` `(N,4+)`.
-4. Concatenate keypoints → `data["keypoints"]` `(M,C)`.
+2. Build `data["masks"]` via `_make_stacked_masks([inst["mask"] for inst in instances])` →
+   shape `(N, H, W, C)` (canonical), or concat as channels → `data["mask"]` `(H, W, C)`.
+3. Stack bboxes → `data["bboxes"]` `(N, 4+)`.
+4. Concatenate keypoints → `data["keypoints"]` `(M, C)`.
 5. Flatten `bbox_labels` → `data[field_name]` as list of N scalars.
 6. Flatten `keypoint_labels` → `data[field_name]` as concatenated list of M values.
 7. Inject hidden label fields: `_bbox_instance_id = [0..N-1]`,
-   `_kp_instance_id = [0,0,..,1,1,..]` (one per keypoint row).
+   `_kp_instance_id = [0, 0, …, 1, 1, …]` (one per keypoint row, repeated by parent
+   instance's bbox id).
 
-Then the existing processor `preprocess` horizontally stacks (`numpy.hstack`) these label
-columns onto the arrays.
+The processor `preprocess` then `numpy.hstack`s these label columns onto the bbox / keypoint
+arrays, so `_bbox_instance_id` lives in the last column of `data["bboxes"]` mid-pipeline.
 
 ## Postprocessing (Repack)
 
 1. Processor `postprocess` runs (filter, format convert, split label fields back out).
-2. Read surviving `_bbox_instance_id` values → determine which instances survived.
-3. Index `masks` and `keypoints` by surviving IDs.
-4. Rebuild instance dicts with masks, bboxes, keypoints, and label dicts.
-5. Remove flat arrays and hidden fields from `data`; set `data["instances"]`.
+2. `Compose._resync_masks_to_bboxes` runs — guarantees the row-alignment invariant.
+3. `Compose._repack_instances` walks `range(N)` once: every row index is simultaneously the
+   bbox row, the mask row, and the keypoint group id.
+4. Hidden fields and flat arrays are removed; `data["instances"]` is the final list of
+   instance dicts.
 
 ## Anchor
 
-- When `"bboxes"` is bound, bbox filtering (min_area, min_visibility, etc.) drives
+- When `"bboxes"` is bound, bbox filtering (`min_area`, `min_visibility`, etc.) drives
   instance removal.
-- When `"bboxes"` is not bound, nothing drives removal; binding only enforces
-  correspondence.
+- When `"bboxes"` is not bound, nothing drives removal; binding only enforces correspondence.
 
 ## Keypoint Behavior
 
-When keypoints are bound, `remove_invisible` and `check_each_transform` on
-`KeypointParams` are forced to `False`. Keypoints may land outside image bounds; the only
-removal is via instance survival.
+When keypoints are bound, `remove_invisible` and `check_each_transform` on `KeypointParams`
+are forced to `False`. Keypoints may land outside image bounds; the only removal is via
+instance survival (driven by their parent bbox).
+
+## Where to look in the code
+
+| Concern                                  | File                                                                          |
+|------------------------------------------|-------------------------------------------------------------------------------|
+| `StackedMasks4D` brand                   | `albumentations/core/type_definitions.py`                                     |
+| `_make_stacked_masks` factory            | `albumentations/core/composition.py`                                          |
+| Transform loop & resync hook             | `albumentations/core/composition.py` (`Compose._resync_masks_to_bboxes`)      |
+| Mosaic mask assembly (always 4-D)        | `albumentations/augmentations/mixing/functional.py` (`assemble_mosaic_instance_masks_stack`) |
+| CopyAndPaste mask paste (always 4-D)     | `albumentations/augmentations/mixing/transforms.py` (`CopyAndPaste.apply_to_masks`) |
+| Property-based regression tests          | `tests/test_instance_binding.py` (`TestPipelineInvariantsHypothesis`)         |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,25 @@ disable_error_code = [ "valid-type" ]
 # for strict mypy: (this is the tricky one :-))
 disallow_untyped_defs = true
 
+# Strict checking for the instance-binding boundary modules so the StackedMasks4D NewType brand
+# (and other structural contracts in Compose's transform loop / mixing transforms) keep being
+# enforced at typecheck time. Any apply_to_masks override that returns a raw np.ndarray instead
+# of StackedMasks4D will break CI here via the default [return-value] / [assignment] errors.
+# warn_return_any is intentionally NOT enabled because numpy's typing returns Any from most ops,
+# which would drown the StackedMasks4D signal in unrelated noise.
+[[tool.mypy.overrides]]
+module = [
+  "albumentations.core.composition",
+  "albumentations.augmentations.mixing.transforms",
+  "albumentations.augmentations.mixing.functional",
+  "albumentations.augmentations.geometric.transforms",
+  "albumentations.augmentations.geometric.flip",
+  "albumentations.augmentations.crops.transforms",
+  "albumentations.pytorch.transforms",
+]
+strict_equality = true
+warn_unused_ignores = true
+
 [tool.pydocstyle]
 # Allow fix for all enabled rules (when `--fix`) is provided.
 

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -2,6 +2,8 @@ from typing import Any
 
 import numpy as np
 import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 import albumentations as A
 
@@ -2130,3 +2132,241 @@ class TestFilteringTransformBinding:
         assert "A" in by_cid
         assert by_cid["A"]["keypoints"].shape[0] == 1
         np.testing.assert_array_equal(by_cid["A"]["keypoint_labels"]["vis"], np.array([1]))
+
+
+class TestStackedMasksThroughGeometric:
+    """Regression tests for stacked instance masks (N, H, W) flowing through geometric transforms
+    when instance_binding is active. Mosaic emits (N, H, W) masks; downstream Affine and friends
+    used to crash on `masks.shape[3]`.
+    """
+
+    @staticmethod
+    def _two_corner_instances() -> tuple[np.ndarray, list[dict[str, Any]]]:
+        image = _make_image()
+        return image, [
+            {"mask": _make_mask(region=(10, 50, 10, 50)), "bbox": np.array([10, 10, 50, 50], dtype=np.float32)},
+            {"mask": _make_mask(region=(60, 90, 60, 90)), "bbox": np.array([60, 60, 90, 90], dtype=np.float32)},
+        ]
+
+    @staticmethod
+    def _mosaic_extras(n: int = 3) -> list[dict[str, Any]]:
+        return [
+            {
+                "image": _make_image(),
+                "masks": np.stack(
+                    [_make_mask(region=(0, 30, 0, 30)), _make_mask(region=(40, 80, 40, 80))],
+                ),
+                "bboxes": np.array([[0, 0, 30, 30], [40, 40, 80, 80]], dtype=np.float32),
+            }
+            for _ in range(n)
+        ]
+
+    @pytest.mark.parametrize(
+        "transform",
+        [
+            A.Affine(p=1.0),
+            A.ShiftScaleRotate(p=1.0),
+            A.Perspective(scale=(0.05, 0.1), p=1.0),
+        ],
+    )
+    def test_geometric_after_mosaic_handles_stacked_masks(self, transform: A.BasicTransform) -> None:
+        image, instances = self._two_corner_instances()
+        aug = A.Compose(
+            [
+                A.Mosaic(grid_yx=(2, 2), target_size=(100, 100), cell_shape=(100, 100), p=1.0),
+                transform,
+            ],
+            bbox_params=A.BboxParams(coord_format="pascal_voc"),
+            instance_binding=["masks", "bboxes"],
+            seed=137,
+        )
+        result = aug(image=image, instances=instances, mosaic_metadata=self._mosaic_extras())
+        for inst in result["instances"]:
+            assert inst["mask"].ndim == 2
+            assert inst["mask"].shape == (100, 100)
+
+
+class TestCopyAndPasteInstanceBindingDownstream:
+    """Regression: after CopyAndPaste, downstream transforms that drop bboxes (e.g. Perspective)
+    used to crash inside `Compose._repack_mask_into` with IndexError because pasted instance ids
+    were assigned `max(existing) + 1` and never matched mask-row positions.
+    """
+
+    @staticmethod
+    def _edge_instances() -> tuple[np.ndarray, list[dict[str, Any]]]:
+        # Place several instances near the corners so Perspective is likely to drop bboxes.
+        image = _make_image()
+        regions = [(0, 10, 0, 10), (90, 100, 0, 10), (0, 10, 90, 100), (90, 100, 90, 100), (40, 60, 40, 60)]
+        instances = []
+        for y1, y2, x1, x2 in regions:
+            instances.append(
+                {
+                    "mask": _make_mask(region=(y1, y2, x1, x2)),
+                    "bbox": np.array([x1, y1, x2, y2], dtype=np.float32),
+                },
+            )
+        return image, instances
+
+    @staticmethod
+    def _donors() -> list[dict[str, Any]]:
+        return [
+            {"image": _make_image(), "mask": _make_mask(region=(0, 30, 0, 30))},
+            {"image": _make_image(), "mask": _make_mask(region=(70, 100, 70, 100))},
+            {"image": _make_image(), "mask": _make_mask(region=(20, 40, 60, 80))},
+        ]
+
+    def test_perspective_after_copy_and_paste_does_not_desync_mask_ids(self) -> None:
+        # Sweep seeds because the desync only manifests when Perspective drops a pasted bbox.
+        # Seed 14 was the first reproducer for the original IndexError.
+        image, instances = self._edge_instances()
+        donors = self._donors()
+        for seed in range(50):
+            aug = A.Compose(
+                [
+                    A.CopyAndPaste(p=1.0),
+                    A.Perspective(scale=(0.1, 0.4), p=1.0, keep_size=False, fit_output=False),
+                ],
+                bbox_params=A.BboxParams(coord_format="pascal_voc", min_area=1),
+                instance_binding=["masks", "bboxes"],
+                seed=seed,
+            )
+            result = aug(image=image, instances=instances, copy_paste_metadata=donors)
+            for inst in result["instances"]:
+                assert inst["mask"].ndim == 2
+
+    def test_copy_and_paste_remaps_kp_instance_ids_to_match_bbox_ids(self) -> None:
+        image, instances = self._edge_instances()
+        for inst in instances:
+            inst["keypoints"] = np.array(
+                [[float(inst["bbox"][0]) + 1.0, float(inst["bbox"][1]) + 1.0]],
+                dtype=np.float32,
+            )
+        donors = [
+            {
+                "image": _make_image(),
+                "mask": _make_mask(region=(20, 50, 20, 50)),
+                "keypoints": np.array([[25.0, 25.0]], dtype=np.float32),
+            },
+        ]
+        aug = A.Compose(
+            [A.CopyAndPaste(p=1.0), A.Perspective(scale=(0.1, 0.3), p=1.0, keep_size=False)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", min_area=1),
+            keypoint_params=A.KeypointParams(coord_format="xy", remove_invisible=True),
+            instance_binding=["masks", "bboxes", "keypoints"],
+            seed=14,
+        )
+        result = aug(image=image, instances=instances, copy_paste_metadata=donors)
+        for inst in result["instances"]:
+            # Each surviving instance must have its keypoints attached (and not re-attached to
+            # the wrong instance via stale _kp_instance_id values).
+            assert "keypoints" in inst
+            assert inst["mask"].ndim == 2
+
+
+class TestPipelineInvariantsHypothesis:
+    """Property-based tests that fuzz `pre + mix + post` pipeline composition and verify the
+    structural invariants enforced by the Compose hook + StackedMasks4D brand:
+
+    1. Every output `inst["mask"]` is 2-D (Compose strips the canonical trailing dim on output).
+    2. Output instance count matches `len(bboxes)` returned by the pipeline.
+    3. No transform crashes regardless of how `pre`, `mix`, and `post` are composed.
+    """
+
+    @staticmethod
+    def _instances() -> tuple[np.ndarray, list[dict[str, Any]]]:
+        image = _make_image()
+        regions = [(0, 20, 0, 20), (80, 100, 0, 20), (0, 20, 80, 100), (80, 100, 80, 100), (40, 60, 40, 60)]
+        instances = [
+            {"mask": _make_mask(region=r), "bbox": np.array([r[2], r[0], r[3], r[1]], dtype=np.float32)}
+            for r in regions
+        ]
+        return image, instances
+
+    @staticmethod
+    def _mosaic_extras() -> list[dict[str, Any]]:
+        return [
+            {
+                "image": _make_image(),
+                "masks": np.stack(
+                    [_make_mask(region=(0, 30, 0, 30)), _make_mask(region=(40, 80, 40, 80))],
+                ),
+                "bboxes": np.array([[0, 0, 30, 30], [40, 40, 80, 80]], dtype=np.float32),
+            }
+            for _ in range(3)
+        ]
+
+    @staticmethod
+    def _donors() -> list[dict[str, Any]]:
+        return [
+            {"image": _make_image(), "mask": _make_mask(region=(0, 30, 0, 30))},
+            {"image": _make_image(), "mask": _make_mask(region=(70, 100, 70, 100))},
+            {"image": _make_image(), "mask": _make_mask(region=(20, 40, 60, 80))},
+        ]
+
+    @staticmethod
+    def _build(name: str) -> A.BasicTransform:
+        if name == "affine":
+            return A.Affine(p=1.0)
+        if name == "perspective":
+            return A.Perspective(scale=(0.05, 0.2), p=1.0, keep_size=True)
+        if name == "shift_scale_rotate":
+            return A.ShiftScaleRotate(p=1.0)
+        if name == "horizontal_flip":
+            return A.HorizontalFlip(p=1.0)
+        if name == "rotate":
+            return A.Rotate(p=1.0)
+        if name == "random_crop":
+            return A.RandomCrop(80, 80, p=1.0)
+        if name == "mosaic":
+            return A.Mosaic(grid_yx=(2, 2), target_size=(100, 100), cell_shape=(100, 100), p=1.0)
+        if name == "copy_and_paste":
+            return A.CopyAndPaste(p=1.0)
+        raise ValueError(name)
+
+    @settings(
+        max_examples=100,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+    )
+    @given(
+        seed=st.integers(0, 100_000),
+        pre=st.lists(
+            st.sampled_from(
+                ["affine", "perspective", "shift_scale_rotate", "horizontal_flip", "rotate", "random_crop"],
+            ),
+            min_size=0,
+            max_size=2,
+        ),
+        mix=st.sampled_from(["mosaic", "copy_and_paste"]),
+        post=st.lists(
+            st.sampled_from(
+                ["affine", "perspective", "shift_scale_rotate", "horizontal_flip", "rotate", "random_crop"],
+            ),
+            min_size=0,
+            max_size=3,
+        ),
+    )
+    def test_pipeline_preserves_mask_shape_and_alignment(
+        self,
+        seed: int,
+        pre: list[str],
+        mix: str,
+        post: list[str],
+    ) -> None:
+        image, instances = self._instances()
+        transforms = [self._build(n) for n in pre] + [self._build(mix)] + [self._build(n) for n in post]
+        aug = A.Compose(
+            transforms,
+            bbox_params=A.BboxParams(coord_format="pascal_voc", min_area=1),
+            instance_binding=["masks", "bboxes"],
+            seed=seed,
+        )
+        kwargs: dict[str, Any] = {"image": image, "instances": instances}
+        if mix == "mosaic":
+            kwargs["mosaic_metadata"] = self._mosaic_extras()
+        else:
+            kwargs["copy_paste_metadata"] = self._donors()
+        result = aug(**kwargs)
+        for inst in result["instances"]:
+            assert inst["mask"].ndim == 2
+            assert "bbox" in inst


### PR DESCRIPTION
… masks

Eliminate two bug classes via structural refactoring with zero runtime cost:

- StackedMasks4D NewType brand + _make_stacked_masks factory: data["masks"] is always (N, H, W, C). Mosaic's mask assembly no longer squeezes the trailing dim; CopyAndPaste preserves the brand. Defensive ndim==4 branches across Affine/Crop/Flip/Rotate/CopyAndPaste are deleted.
- Compose._resync_masks_to_bboxes hook runs after every transform when binding is active: rebases _bbox_instance_id to range(N), remaps _kp_instance_id, and slices masks by bbox order. Guarantees len(masks)==len(bboxes) and id==row going into the next transform.
- _repack_instances collapses to a single row-aligned path; fallback branches deleted.
- CopyAndPaste paste_id_remap machinery removed; the resync hook subsumes it.

Adds StackedMasks4D type annotations across apply_to_masks signatures (base, geometric, crops, flip, mixing, pytorch) and a per-module mypy override so brand violations break CI. Adds Hypothesis property-based test fuzzing pre+mix+post compositions. Rewrites docs/design/instance_binding.md to document the two structural contracts.

Made-with: Cursor

## Summary by Sourcery

Enforce structural invariants for instance-bound masks and bboxes by introducing a canonical 4-D stacked mask representation and a Compose-level resync hook, simplifying instance repacking and eliminating id/shape desynchronization bugs in mixing and geometric pipelines.

New Features:
- Introduce the StackedMasks4D NewType and _make_stacked_masks factory to standardize stacked instance masks as a canonical 4-D (N, H, W, C) shape throughout the pipeline.
- Add a Compose._resync_masks_to_bboxes hook that runs after each transform when instance_binding is enabled, ensuring bbox, mask, and keypoint ids remain row-aligned.
- Define strict apply_to_masks typing against StackedMasks4D across core, geometric, crop, flip, mixing, and PyTorch transforms to make shape/brand violations a type-checked error.
- Add Hypothesis-based property tests that fuzz pre/mix/post pipelines to verify mask dimensionality and alignment invariants under instance_binding.

Bug Fixes:
- Fix crashes in geometric transforms after Mosaic when stacked instance masks were 3-D by guaranteeing a 4-D stacked mask representation mid-pipeline.
- Fix IndexError and id desynchronization in Compose._repack_instances after CopyAndPaste followed by bbox-dropping transforms such as Perspective by rebasing ids via the resync hook.
- Ensure keypoint instance ids are remapped to match bbox ids after CopyAndPaste so keypoints stay attached to their correct instances.

Enhancements:
- Refactor Compose._repack_instances to a single row-aligned repack path that relies on the global resync invariant instead of multiple fallback branches.
- Simplify CopyAndPaste and Mosaic mask/bbox/keypoint assembly logic to assume row-ordered outputs and delegate id rebasing to Compose.
- Expand and clarify instance binding design documentation to describe the two structural contracts (StackedMasks4D masks and resync-based row alignment) and how they are enforced in code.

Build:
- Tighten mypy configuration for instance-binding boundary modules to enforce StackedMasks4D usage and catch shape/brand violations at type-check time.

Documentation:
- Rewrite docs/design/instance_binding.md to document the canonical 4-D mask shape, the Compose resync invariant, and the simplified unpack/repack behavior with clear references to implementation sites.

Tests:
- Add regression tests covering stacked masks through geometric transforms after Mosaic under instance_binding.
- Add regression tests ensuring CopyAndPaste followed by Perspective does not desync mask or keypoint instance ids under instance_binding.
- Introduce Hypothesis-based property tests that fuzz pre/mix/post compositions to assert mask dimensionality, instance count alignment, and crash-free execution under instance_binding.