### PR TITLE
docs(geometric): remove PiecewiseAffine slow warning

### DIFF
--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -26,7 +26,6 @@ target types.
 """
 
 from typing import Annotated, Any, Literal
-from warnings import warn
 
 import cv2
 import numpy as np
@@ -511,7 +510,6 @@ class PiecewiseAffine(BaseDistortion):
         hbb, obb
 
     Note:
-        - This augmentation is very slow. Consider using `ElasticTransform` instead, which is at least 10x faster.
         - The augmentation may not always produce visible effects, especially with small scale values.
         - For keypoints and bounding boxes, the transformation might move them outside the image boundaries.
           In such cases, the keypoints will be set to (-1, -1) and the bounding boxes will be removed.
@@ -584,11 +582,6 @@ class PiecewiseAffine(BaseDistortion):
             border_mode=border_mode,
             fill=fill,
             fill_mask=fill_mask,
-        )
-
-        warn(
-            "This augmenter is very slow. Try to use `ElasticTransform` instead, which is at least 10x faster.",
-            stacklevel=2,
         )
 
         self.scale_range = scale_range


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Remove the explicit performance warning from the PiecewiseAffine augmentation.

Documentation:
- Remove the note in PiecewiseAffine documentation that labels the augmentation as very slow compared to ElasticTransform.

Chores:
- Remove the runtime warning emitted by PiecewiseAffine that discouraged its use for performance reasons.