### PR TITLE
perf: cv2 rot transpose, faster dropout masks, salt/pepper, cached de…

### DIFF
--- a/.cursor/rules/albumentations-rules.mdc
+++ b/.cursor/rules/albumentations-rules.mdc
@@ -14,6 +14,10 @@ alwaysApply: true
 - Use `pytest.mark.parametrize` for parameterized tests
 - Default test values should be 137, not 42
 - NEVER create temporary tests - add permanent tests to test suite
+- Within `Compose`, images and volumes always have an explicit channel dimension:
+  `(H, W, C)`, `(N, H, W, C)`, `(D, H, W, C)`, or `(N, D, H, W, C)`
+- Grayscale in Compose is `(H, W, 1)`, not `(H, W)`; do not add 2D grayscale compatibility branches to
+  transform `apply_*` methods or functional kernels used by Compose
 
 ## Complete Documentation
 

--- a/.cursor/skills/add-transform/SKILL.md
+++ b/.cursor/skills/add-transform/SKILL.md
@@ -111,7 +111,11 @@ class MyTransform(DualTransform):  # or ImageOnlyTransform / NoOp
 - Prefer **relative parameters** (fractions of image size) over fixed pixel values
 - Use **`ImageType`** for image/mask/volume type hints, `np.ndarray` only for bboxes/keypoints
 - **Use descriptive variable names** — avoid single-letter or generic names like `x`, `y`, `dx`, `dy`, `cx`, `cy`. Prefer `pixel_cols`, `norm_x`, `center_col`, `run_starts`, `col_x`, etc. Names should read like documentation.
-- **Images under Compose are always `(H, W, C)`** — `num_channels = img.shape[-1]` always. Never write `img.shape[-1] if img.ndim >= 3 else 1` or guard with `if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS`.
+- **Images and volumes under Compose always have channels** — images are `(H, W, C)`, image batches are
+  `(N, H, W, C)`, volumes are `(D, H, W, C)`, and volume batches are `(N, D, H, W, C)`.
+- **Grayscale under Compose is `(H, W, 1)`**, not `(H, W)`. Do not add functional-layer compatibility branches for
+  2D grayscale images in code reached through `Compose`.
+- Branch on `ndim` to distinguish image vs batch vs volume paths when needed, not to infer whether channels exist.
 - **Helper functions belong in `functional.py`**, never in the transform class file.
 
 ## 4. Add batch optimization (`apply_to_images`)

--- a/.cursor/skills/benchmark/SKILL.md
+++ b/.cursor/skills/benchmark/SKILL.md
@@ -23,7 +23,8 @@ Always benchmark all 9 combinations:
 | 1024×1024  | 3        | High-res segmentation                 |
 | 1024×1024  | 5        | Satellite imagery                     |
 
-Skip channel counts the transform explicitly doesn't support.
+Skip channel counts the transform explicitly doesn't support. Always include the channel axis: grayscale inputs are
+`(H, W, 1)`, not `(H, W)`.
 
 ## Template: Isolated Function
 
@@ -37,7 +38,7 @@ N = 100
 
 for size_name, (h, w) in SIZES.items():
     for ch in CHANNELS:
-        shape = (h, w) if ch == 1 else (h, w, ch)
+        shape = (h, w, ch)
         img = np.random.randint(0, 256, shape, dtype=np.uint8)
 
         old_t = timeit.timeit(lambda img=img: old_func(img, **params), number=N)
@@ -59,7 +60,7 @@ transform = A.Compose([A.YourTransform(p=1.0)])
 
 for size_name, (h, w) in SIZES.items():
     for ch in CHANNELS:
-        shape = (h, w) if ch == 1 else (h, w, ch)
+        shape = (h, w, ch)
         img = np.random.randint(0, 256, shape, dtype=np.uint8)
 
         t = timeit.timeit(lambda img=img: transform(image=img), number=100)
@@ -157,3 +158,5 @@ for batch_size in BATCH_SIZES:
 - A **>5% regression** on any combination requires justification or rework
 - If adding a new transform, benchmark against the equivalent naive numpy implementation
 - For batch optimizations, compare 1-channel vs 3-channel to verify speedup holds across channel counts
+- Keep channel-last shapes throughout: images `(H,W,C)`, image batches `(N,H,W,C)`, volumes `(D,H,W,C)`,
+  volume batches `(N,D,H,W,C)`

--- a/.cursor/skills/review-transform/SKILL.md
+++ b/.cursor/skills/review-transform/SKILL.md
@@ -19,6 +19,8 @@ Run these checks in order. Report issues with severity: 🔴 Critical, 🟡 Impo
 - Off-by-one errors in coordinate handling
 - Incorrect dtype preservation (uint8 in → uint8 out, float32 in → float32 out)
 - BBox/keypoint coordinate correctness after spatial transforms
+- Do not request 2D grayscale compatibility for Compose paths: images and volumes are channel-last with explicit channels
+  (`(H,W,C)`, `(N,H,W,C)`, `(D,H,W,C)`, `(N,D,H,W,C)`), and grayscale is `(H,W,1)`.
 - **Never auto-detect bbox type from column count** — type comes from `BboxParams.bbox_type`
 - For OBB: never use raw `cv2.minAreaRect` output; use `cv2.boxPoints` then `polygons_to_obb`
 
@@ -62,6 +64,7 @@ Priority order to check:
 
 - [ ] **Custom `apply_to_images`** if expensive setup (kernels, LUTs, gradient maps) can be computed once per batch
 - [ ] **No redundant `ndim == 4` checks** on images — they're always 4D in batch context
+- [ ] **No 2D grayscale branches** in Compose functional paths — grayscale images are `(H,W,1)`
 - [ ] **No reshape trick**: Do NOT reshape `(N,H,W,1)` to `(H,W,N)` for cv2 — 2–4× slower due to non-contiguous copy + sequential channel processing
 
 Flag any violations with a concrete speedup suggestion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,14 @@ AlbumentationsX is a high-performance computer vision augmentation library. We p
 - Default test values should be 137, not 42
 - Prefer relative parameters (fractions of image size) over fixed pixel values
 
+### Image and Volume Shape Invariants
+
+- Within `Compose`, images and volumes are always channel-last with an explicit channel dimension.
+- Single images are `(H, W, C)`; grayscale is `(H, W, 1)`, not `(H, W)`.
+- Image batches are `(N, H, W, C)`, volumes are `(D, H, W, C)`, and volume batches are `(N, D, H, W, C)`.
+- Do not add functional-layer compatibility branches for 2D grayscale images when code is used through `Compose`.
+- Branching on `ndim` is appropriate to distinguish image, batch, volume, and volume batch paths, not to infer channels.
+
 ### Validation Principles
 
 - **Compose-level checks**: All validation of transform compatibility (bbox_type, target support) happens at `Compose.__init__()` time

--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -132,7 +132,7 @@ def defocus(img: ImageType, radius: int, alias_blur: float) -> ImageType:
     """Blur with aliased disk kernel to simulate out-of-focus. radius, alias_blur set size and
     softness. Use for depth-of-field or bokeh-style effects.
     """
-    return convolve(img, kernel=_create_defocus_kernel_cached(radius, alias_blur))
+    return convolve(img, kernel=create_defocus_kernel(radius, alias_blur))
 
 
 def central_zoom(img: ImageType, zoom_factor: int) -> ImageType:

--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -7,6 +7,7 @@ These functions form the foundation for the corresponding transform classes.
 
 import random
 from collections.abc import Sequence
+from functools import lru_cache
 from itertools import product
 from math import ceil
 from typing import Literal
@@ -108,25 +109,30 @@ def glass_blur(
     return cv2.GaussianBlur(x, sigmaX=sigma, ksize=(0, 0))
 
 
+@lru_cache(maxsize=128)
+def _create_defocus_kernel_cached(radius: int, alias_blur: float) -> np.ndarray:
+    length = np.arange(-max(8, radius), max(8, radius) + 1, dtype=np.float32)
+    ksize = 3 if radius <= EIGHT else 5
+
+    x, y = np.meshgrid(length, length)
+    aliased_disk = (x**2 + y**2 <= radius**2).astype(np.float32)
+    aliased_disk /= reduce_sum(aliased_disk)
+
+    return cv2.GaussianBlur(aliased_disk, (ksize, ksize), sigmaX=alias_blur)
+
+
 def create_defocus_kernel(radius: int, alias_blur: float) -> np.ndarray:
     """Create defocus (aliased disk) convolution kernel. radius, alias_blur control disk
     shape and smoothing. Returns kernel for convolve.
     """
-    length = np.arange(-max(8, radius), max(8, radius) + 1)
-    ksize = 3 if radius <= EIGHT else 5
-
-    x, y = np.meshgrid(length, length)
-    aliased_disk = np.array((x**2 + y**2) <= radius**2, dtype=np.float32)
-    aliased_disk /= reduce_sum(aliased_disk)
-
-    return cv2.GaussianBlur(aliased_disk, (ksize, ksize), sigmaX=alias_blur)
+    return _create_defocus_kernel_cached(radius, alias_blur).copy()
 
 
 def defocus(img: ImageType, radius: int, alias_blur: float) -> ImageType:
     """Blur with aliased disk kernel to simulate out-of-focus. radius, alias_blur set size and
     softness. Use for depth-of-field or bokeh-style effects.
     """
-    return convolve(img, kernel=create_defocus_kernel(radius, alias_blur))
+    return convolve(img, kernel=_create_defocus_kernel_cached(radius, alias_blur))
 
 
 def central_zoom(img: ImageType, zoom_factor: int) -> ImageType:

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1570,7 +1570,7 @@ def transpose(img: ImageType) -> ImageType:
 
     """
     num_channels = img.shape[-1]
-    if num_channels in {1, 3, 4}:
+    if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS and num_channels in {1, 3, 4}:
         result = cv2.transpose(img if num_channels != 1 else img[..., 0])
         return result[..., None] if num_channels == 1 else result
 
@@ -1661,7 +1661,7 @@ def rot90(img: ImageType, group_element: Literal["e", "r90", "r180", "r270"]) ->
         return img
 
     num_channels = img.shape[-1]
-    if num_channels in {1, 3, 4}:
+    if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS and num_channels in {1, 3, 4}:
         if rot90_count == 1:
             rotate_code = cv2.ROTATE_90_COUNTERCLOCKWISE
         elif rot90_count == 2:

--- a/albumentations/augmentations/geometric/functional.py
+++ b/albumentations/augmentations/geometric/functional.py
@@ -1569,6 +1569,11 @@ def transpose(img: ImageType) -> ImageType:
         ImageType: Transposed array.
 
     """
+    num_channels = img.shape[-1]
+    if num_channels in {1, 3, 4}:
+        result = cv2.transpose(img if num_channels != 1 else img[..., 0])
+        return result[..., None] if num_channels == 1 else result
+
     # Generate the new axes order
     new_axes = list(range(img.ndim))
     new_axes[0], new_axes[1] = 1, 0  # Swap the first two dimensions
@@ -1652,6 +1657,22 @@ def rot90(img: ImageType, group_element: Literal["e", "r90", "r180", "r270"]) ->
 
     """
     rot90_count = C4_GROUP_ELEMENT_TO_K[group_element]
+    if rot90_count == 0:
+        return img
+
+    num_channels = img.shape[-1]
+    if num_channels in {1, 3, 4}:
+        if rot90_count == 1:
+            rotate_code = cv2.ROTATE_90_COUNTERCLOCKWISE
+        elif rot90_count == 2:
+            rotate_code = cv2.ROTATE_180
+        else:
+            rotate_code = cv2.ROTATE_90_CLOCKWISE
+
+        cv2_input = img if num_channels != 1 else img[..., 0]
+        result = cv2.rotate(cv2_input, rotate_code)
+        return result[..., None] if num_channels == 1 else result
+
     return np.rot90(img, rot90_count)
 
 

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -2406,6 +2406,13 @@ def pixel_dropout(
         np.ndarray: Image with dropped pixels
 
     """
+    if image.ndim == 4:
+        if drop_mask.ndim == 2:
+            drop_mask = drop_mask[None, :, :, None]
+        elif drop_mask.ndim == 3:
+            drop_mask = drop_mask[None, ...]
+    elif drop_mask.ndim == image.ndim - 1:
+        drop_mask = drop_mask[..., None]
     return np.where(drop_mask, drop_values, image)
 
 
@@ -3281,7 +3288,6 @@ def apply_salt_and_pepper(
 
     Args:
         img (ImageType): Input image of any dtype and dimensions:
-            - 2D: (H, W) - grayscale
             - 3D: (H, W, C) - RGB/multi-channel
             - 4D: (D, H, W, C) - volume with depth
         salt_mask (np.ndarray): Boolean mask indicating salt pixels (H, W)
@@ -3292,6 +3298,22 @@ def apply_salt_and_pepper(
 
     """
     max_value = MAX_VALUES_BY_DTYPE[img.dtype]
+    num_channels = img.shape[-1]
+    if num_channels > 1:
+        result = img.copy()
+        if img.ndim == 3:
+            result[salt_mask] = max_value
+            result[pepper_mask] = 0
+        elif img.ndim == 4:
+            result[:, salt_mask] = max_value
+            result[:, pepper_mask] = 0
+        elif img.ndim == 5:
+            result[:, :, salt_mask] = max_value
+            result[:, :, pepper_mask] = 0
+        else:
+            return np.where(salt_mask[..., None], max_value, np.where(pepper_mask[..., None], 0, img))
+        return result
+
     return np.where(salt_mask[..., None], max_value, np.where(pepper_mask[..., None], 0, img))
 
 
@@ -3911,24 +3933,9 @@ def get_drop_mask(
 
     """
     if per_channel or len(shape) == 2:
-        return random_generator.choice(
-            [True, False],
-            shape,
-            p=[dropout_prob, 1 - dropout_prob],
-        )
+        return random_generator.random(shape) < dropout_prob
 
-    # Generate 2D mask and expand to match channels
-    mask_2d = random_generator.choice(
-        [True, False],
-        shape[:2],
-        p=[dropout_prob, 1 - dropout_prob],
-    )
-
-    # If input is 2D, return 2D mask
-    if len(shape) == 2:
-        return mask_2d
-
-    # For 3D input, expand and repeat across channels
+    mask_2d = random_generator.random(shape[:2]) < dropout_prob
     return np.repeat(mask_2d[..., None], shape[2], axis=2)
 
 

--- a/albumentations/augmentations/pixel/functional.py
+++ b/albumentations/augmentations/pixel/functional.py
@@ -3275,6 +3275,9 @@ def generate_enhance_matrix(mode: Literal["edge", "detail"], alpha: float) -> np
     return kernel.astype(np.float32, copy=False)
 
 
+SPARSE_SALT_AND_PEPPER_THRESHOLD = 0.08
+
+
 def apply_salt_and_pepper(
     img: ImageType,
     salt_mask: np.ndarray,
@@ -3298,23 +3301,17 @@ def apply_salt_and_pepper(
 
     """
     max_value = MAX_VALUES_BY_DTYPE[img.dtype]
-    num_channels = img.shape[-1]
-    if num_channels > 1:
-        result = img.copy()
-        if img.ndim == 3:
-            result[salt_mask] = max_value
-            result[pepper_mask] = 0
-        elif img.ndim == 4:
-            result[:, salt_mask] = max_value
-            result[:, pepper_mask] = 0
-        elif img.ndim == 5:
-            result[:, :, salt_mask] = max_value
-            result[:, :, pepper_mask] = 0
-        else:
-            return np.where(salt_mask[..., None], max_value, np.where(pepper_mask[..., None], 0, img))
-        return result
+    if img.shape[-1] > 1:
+        noisy_fraction = (np.count_nonzero(salt_mask) + np.count_nonzero(pepper_mask)) / salt_mask.size
+        if noisy_fraction <= SPARSE_SALT_AND_PEPPER_THRESHOLD:
+            result = img.copy()
+            result[..., salt_mask, :] = max_value
+            result[..., pepper_mask, :] = 0
+            return result
 
-    return np.where(salt_mask[..., None], max_value, np.where(pepper_mask[..., None], 0, img))
+    salt_mask = salt_mask[..., None]
+    pepper_mask = pepper_mask[..., None]
+    return np.where(salt_mask, max_value, np.where(pepper_mask, 0, img))
 
 
 # Pre-compute constant kernels

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -211,6 +211,18 @@ def apply(self, img: np.ndarray, **params) -> np.ndarray:
       return rgb_to_hsv(img)  # RGB-specific processing
   ```
 
+### Image and Volume Shape Invariants
+
+- Within `Compose`, images and volumes are always channel-last with an explicit channel dimension:
+  - Single image: `(H, W, C)`, including grayscale as `(H, W, 1)`
+  - Image batch: `(N, H, W, C)`
+  - Single volume: `(D, H, W, C)`
+  - Volume batch: `(N, D, H, W, C)`
+- Do not add compatibility branches for grayscale images shaped as `(H, W)` in transform `apply_*` methods or functional
+  kernels used by `Compose`; normalize inputs before they reach transform logic.
+- It is fine to branch on `img.ndim` when selecting between image, image batch, volume, and volume batch logic. Do not
+  use `img.ndim` to infer whether a Compose image has channels.
+
 ### Handling Auxiliary Data via Metadata
 
 When a transform requires complex or variable auxiliary data beyond simple configuration parameters (e.g., additional images and labels for `Mosaic`, extra images for domain adaptation transforms like `FDA` or `HistogramMatching`), **do not pass this data directly through the `__init__` constructor**.

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -46,6 +46,14 @@ def test_transpose_float(input_shape, expected_shape):
     assert transposed.shape == expected_shape
 
 
+def test_transpose_volume_matches_numpy():
+    volume = np.arange(2 * 3 * 4 * 3, dtype=np.uint8).reshape(2, 3, 4, 3)
+
+    result = fgeometric.transpose(volume)
+
+    np.testing.assert_array_equal(result, volume.transpose(1, 0, 2, 3))
+
+
 @pytest.mark.parametrize("target", ["image", "mask"])
 def test_rot90(target):
     img = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 1]], dtype=np.uint8)
@@ -68,6 +76,14 @@ def test_rot90_float(target):
     img, expected = convert_2d_to_target_format([img, expected], target=target)
     rotated = fgeometric.rot90(img, "r90")
     np.testing.assert_array_almost_equal_nulp(rotated, expected)
+
+
+def test_rot90_volume_matches_numpy():
+    volume = np.arange(2 * 3 * 4 * 3, dtype=np.uint8).reshape(2, 3, 4, 3)
+
+    result = fgeometric.rot90(volume, "r90")
+
+    np.testing.assert_array_equal(result, np.rot90(volume, 1))
 
 
 @pytest.mark.parametrize("target", ["image", "mask"])
@@ -1582,12 +1598,42 @@ def test_apply_salt_and_pepper_preserves_shape_and_values(channels):
     np.testing.assert_array_equal(result[1, 1], image[1, 1])
 
 
+@pytest.mark.parametrize("shape", [(2, 3, 4, 3), (2, 2, 3, 4, 3)])
+def test_apply_salt_and_pepper_broadcasts_masks_to_batches_and_volumes(shape):
+    image = np.full(shape, 137, dtype=np.uint8)
+    salt_mask = np.zeros((3, 4), dtype=bool)
+    pepper_mask = np.zeros((3, 4), dtype=bool)
+    salt_mask[0, 1] = True
+    pepper_mask[2, 3] = True
+
+    result = fpixel.apply_salt_and_pepper(image, salt_mask, pepper_mask)
+
+    assert result.shape == image.shape
+    np.testing.assert_array_equal(result[..., 0, 1, :], np.full(shape[:-3] + (3,), 255, dtype=np.uint8))
+    np.testing.assert_array_equal(result[..., 2, 3, :], np.zeros(shape[:-3] + (3,), dtype=np.uint8))
+    np.testing.assert_array_equal(result[..., 1, 1, :], image[..., 1, 1, :])
+
+
 def test_create_defocus_kernel_returns_independent_arrays():
     kernel = fblur.create_defocus_kernel(5, 0.3)
     kernel[0, 0] = 137
 
     fresh_kernel = fblur.create_defocus_kernel(5, 0.3)
 
+    assert fresh_kernel[0, 0] != 137
+
+
+def test_defocus_does_not_expose_cached_kernel_to_convolve_mutation(monkeypatch):
+    def mutating_convolve(img, kernel):
+        kernel[0, 0] = 137
+        return img
+
+    monkeypatch.setattr(fblur, "convolve", mutating_convolve)
+    image = np.zeros((3, 3, 1), dtype=np.uint8)
+
+    fblur.defocus(image, 5, 0.3)
+
+    fresh_kernel = fblur.create_defocus_kernel(5, 0.3)
     assert fresh_kernel[0, 0] != 137
 
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -12,6 +12,7 @@ from albucore import (
 )
 from sklearn.decomposition import NMF
 
+import albumentations.augmentations.blur.functional as fblur
 import albumentations.augmentations.geometric.functional as fgeometric
 import albumentations.augmentations.pixel.functional as fpixel
 from albumentations.core.type_definitions import d4_group_elements
@@ -1531,6 +1532,63 @@ def test_pixel_dropout_sequence_per_channel():
         assert np.all(result[:, :, channel_idx] == expected_value), (
             f"Channel {channel_idx} should be filled with value {expected_value}"
         )
+
+
+def test_pixel_dropout_shared_2d_mask_applies_to_all_channels():
+    image = np.arange(3 * 4 * 3, dtype=np.uint8).reshape(3, 4, 3)
+    drop_mask = np.array(
+        [
+            [True, False, False, True],
+            [False, True, False, False],
+            [False, False, True, False],
+        ],
+    )
+
+    result = fpixel.pixel_dropout(image, drop_mask, np.array(137, dtype=np.uint8))
+
+    np.testing.assert_array_equal(result[drop_mask], np.full((4, 3), 137, dtype=np.uint8))
+    np.testing.assert_array_equal(result[~drop_mask], image[~drop_mask])
+
+
+def test_pixel_dropout_shared_2d_mask_broadcasts_to_image_batch():
+    images = np.arange(2 * 3 * 4 * 3, dtype=np.uint8).reshape(2, 3, 4, 3)
+    drop_mask = np.array(
+        [
+            [True, False, False, True],
+            [False, True, False, False],
+            [False, False, True, False],
+        ],
+    )
+
+    result = fpixel.pixel_dropout(images, drop_mask, np.array(137, dtype=np.uint8))
+
+    np.testing.assert_array_equal(result[:, drop_mask], np.full((2, 4, 3), 137, dtype=np.uint8))
+    np.testing.assert_array_equal(result[:, ~drop_mask], images[:, ~drop_mask])
+
+
+@pytest.mark.parametrize("channels", [1, 3, 5])
+def test_apply_salt_and_pepper_preserves_shape_and_values(channels):
+    image = np.full((3, 4, channels), 100, dtype=np.uint8)
+    salt_mask = np.zeros((3, 4), dtype=bool)
+    pepper_mask = np.zeros((3, 4), dtype=bool)
+    salt_mask[0, 1] = True
+    pepper_mask[2, 3] = True
+
+    result = fpixel.apply_salt_and_pepper(image, salt_mask, pepper_mask)
+
+    assert result.shape == image.shape
+    np.testing.assert_array_equal(result[0, 1], np.full(channels, 255, dtype=np.uint8))
+    np.testing.assert_array_equal(result[2, 3], np.zeros(channels, dtype=np.uint8))
+    np.testing.assert_array_equal(result[1, 1], image[1, 1])
+
+
+def test_create_defocus_kernel_returns_independent_arrays():
+    kernel = fblur.create_defocus_kernel(5, 0.3)
+    kernel[0, 0] = 137
+
+    fresh_kernel = fblur.create_defocus_kernel(5, 0.3)
+
+    assert fresh_kernel[0, 0] != 137
 
 
 def test_prepare_drop_values_random_two_channels():


### PR DESCRIPTION
…focus kernels

Made-with: Cursor

## Summary by Sourcery

Optimize image pixel and geometric augmentations for performance while improving mask broadcasting behavior and kernel reuse.

New Features:
- Support broadcasting 2D and 3D dropout masks across channels and image batches in pixel dropout.

Bug Fixes:
- Ensure salt-and-pepper noise application correctly handles multi-channel images while preserving unaffected pixels.
- Return independent defocus kernels from the public factory function despite internal caching.

Enhancements:
- Add OpenCV-based fast paths for transpose and 90-degree rotations on common channel layouts (1, 3, 4) to speed up geometric transforms.
- Vectorize dropout mask generation using uniform random sampling for improved performance and simpler logic.
- Introduce an LRU-cached defocus kernel generator reused by the defocus blur operation to avoid recomputing identical kernels.

Tests:
- Add tests covering shared 2D pixel dropout masks across channels and batches.
- Add tests validating salt-and-pepper noise shape preservation and per-pixel values across different channel counts.
- Add a regression test ensuring defocus kernel creation returns fresh, independent arrays.