### PR TITLE
chore: bump version to 2.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.2.2"
+version = "2.2.3"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volumes, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0 (open source); commercial licenses are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.2.2"
+version = "2.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
Patch release version bump: `pyproject.toml` and synced `uv.lock`.

Prepare for tagging `v2.2.3` / PyPI publish when ready.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Build:
- Update the package version in pyproject.toml from 2.2.2 to 2.2.3 and refresh the corresponding uv.lock metadata.