### PR TITLE
perf: cv2 hot paths for sharpness, color, geometry, mixing

### DIFF
--- a/albumentations/augmentations/crops/special.py
+++ b/albumentations/augmentations/crops/special.py
@@ -12,6 +12,7 @@ from ._transforms_shared import (
     Field,
     ImageType,
     check_range_bounds,
+    cv2,
     fcrops,
     model_validator,
     nondecreasing,
@@ -197,7 +198,8 @@ class CropNonEmptyMaskIfExists(BaseCrop):
         if mask.any():
             # Find non-zero regions in mask
             mask_sum = reduce_sum(mask, axis=-1) if mask.ndim == NUM_MULTI_CHANNEL_DIMENSIONS else mask
-            non_zero_yx = np.argwhere(mask_sum)
+            non_zero_xy = cv2.findNonZero((mask_sum > 0).astype(np.uint8))
+            non_zero_yx = non_zero_xy[:, 0, ::-1]
             y, x = self.py_random.choice(non_zero_yx)
 
             # Calculate crop coordinates centered around chosen point

--- a/albumentations/augmentations/geometric/_functional_distortion.py
+++ b/albumentations/augmentations/geometric/_functional_distortion.py
@@ -112,7 +112,7 @@ def generate_displacement_fields(
             dtype=np.float32,
         )
         # Normalize inplace
-        max_abs = np.abs(fields, out=np.empty_like(fields)).max()
+        max_abs = cv2.norm(fields.reshape(-1, fields.shape[-1]), cv2.NORM_INF)
         if max_abs > 1e-6:
             fields /= max_abs
     else:  # uniform is already normalized to [-1, 1]

--- a/albumentations/augmentations/geometric/_functional_keypoints.py
+++ b/albumentations/augmentations/geometric/_functional_keypoints.py
@@ -293,18 +293,26 @@ def to_distance_maps(
 
     # Create coordinate grids
     yy, xx = np.mgrid[:height, :width]
+    xx = xx.astype(np.float32)
+    yy = yy.astype(np.float32)
 
     # Convert keypoints to numpy array
     keypoints_array = np.array(keypoints)
 
-    # Compute distances for all keypoints at once
-    distances = np.sqrt(
-        (xx[..., np.newaxis] - keypoints_array[:, 0]) ** 2 + (yy[..., np.newaxis] - keypoints_array[:, 1]) ** 2,
-    )
+    # Compute distances for all keypoints with OpenCV's fused sqrt(dx^2 + dy^2).
+    distances = np.empty((height, width, len(keypoints_array)), dtype=np.float32)
+    dx = np.empty((height, width), dtype=np.float32)
+    dy = np.empty_like(dx)
+    magnitude = np.empty_like(dx)
+    for keypoint_idx, (x, y, *_) in enumerate(keypoints_array):
+        cv2.subtract(xx, float(x), dst=dx)
+        cv2.subtract(yy, float(y), dst=dy)
+        cv2.magnitude(dx, dy, magnitude)
+        distances[..., keypoint_idx] = magnitude
 
     if inverted:
         return (1 / (distances + 1)).astype(np.float32)
-    return distances.astype(np.float32)
+    return distances
 
 
 def validate_if_not_found_coords(

--- a/albumentations/augmentations/geometric/_functional_keypoints.py
+++ b/albumentations/augmentations/geometric/_functional_keypoints.py
@@ -31,6 +31,8 @@ from ._functional_shared import (
     warn,
 )
 
+CV2_DISTANCE_MAP_MAX_KEYPOINTS = 32
+
 
 @handle_empty_array("keypoints")
 @angle_2pi_range
@@ -291,13 +293,22 @@ def to_distance_maps(
     if len(keypoints) == 0:
         return np.zeros((height, width, 0), dtype=np.float32)
 
+    # Convert keypoints to numpy array
+    keypoints_array = np.array(keypoints)
+    if len(keypoints_array) > CV2_DISTANCE_MAP_MAX_KEYPOINTS:
+        yy, xx = np.mgrid[:height, :width]
+        distances = np.sqrt(
+            (xx[..., np.newaxis] - keypoints_array[:, 0]) ** 2 + (yy[..., np.newaxis] - keypoints_array[:, 1]) ** 2,
+        )
+
+        if inverted:
+            return (1 / (distances + 1)).astype(np.float32)
+        return distances.astype(np.float32)
+
     # Create coordinate grids
     yy, xx = np.mgrid[:height, :width]
     xx = xx.astype(np.float32)
     yy = yy.astype(np.float32)
-
-    # Convert keypoints to numpy array
-    keypoints_array = np.array(keypoints)
 
     # Compute distances for all keypoints with OpenCV's fused sqrt(dx^2 + dy^2).
     distances = np.empty((height, width, len(keypoints_array)), dtype=np.float32)

--- a/albumentations/augmentations/mixing/functional.py
+++ b/albumentations/augmentations/mixing/functional.py
@@ -160,15 +160,22 @@ def compute_instance_visibility(
         np.ndarray: (N,) array of visibility ratios in [0, 1]. 1.0 = fully visible, 0.0 = fully occluded.
 
     """
-    opaque_region = paste_mask > 0
+    opaque_region = (paste_mask > 0).astype(np.uint8)
+    overlap = np.empty_like(opaque_region)
+    visibility = np.empty(existing_masks.shape[0], dtype=np.float64)
 
-    original_areas = np.sum(existing_masks > 0, axis=(1, 2)).astype(np.float64)
-    occluded_areas = np.sum((existing_masks > 0) & opaque_region[np.newaxis], axis=(1, 2)).astype(np.float64)
+    for mask_idx, mask in enumerate(existing_masks):
+        instance_mask = (mask > 0).astype(np.uint8)
+        original_area = cv2.countNonZero(instance_mask)
+        if original_area == 0:
+            visibility[mask_idx] = 1.0
+            continue
 
-    remaining_areas = original_areas - occluded_areas
+        cv2.bitwise_and(instance_mask, opaque_region, dst=overlap)
+        occluded_area = cv2.countNonZero(overlap)
+        visibility[mask_idx] = (original_area - occluded_area) / original_area
 
-    safe_areas = np.where(original_areas > 0, original_areas, 1.0)
-    return np.where(original_areas > 0, remaining_areas / safe_areas, 1.0)
+    return visibility
 
 
 def calculate_mosaic_center_point(

--- a/albumentations/augmentations/mixing/functional.py
+++ b/albumentations/augmentations/mixing/functional.py
@@ -160,12 +160,12 @@ def compute_instance_visibility(
         np.ndarray: (N,) array of visibility ratios in [0, 1]. 1.0 = fully visible, 0.0 = fully occluded.
 
     """
-    opaque_region = (paste_mask > 0).astype(np.uint8)
+    binary_masks = np.ascontiguousarray(existing_masks > 0, dtype=np.uint8)
+    opaque_region = np.ascontiguousarray(paste_mask > 0, dtype=np.uint8)
     overlap = np.empty_like(opaque_region)
     visibility = np.empty(existing_masks.shape[0], dtype=np.float64)
 
-    for mask_idx, mask in enumerate(existing_masks):
-        instance_mask = (mask > 0).astype(np.uint8)
+    for mask_idx, instance_mask in enumerate(binary_masks):
         original_area = cv2.countNonZero(instance_mask)
         if original_area == 0:
             visibility[mask_idx] = 1.0

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -924,9 +924,16 @@ def to_gray_desaturation(img: ImageType) -> ImageType:
 
     """
     if img.dtype == np.uint8:
-        ch_max = np.max(img, axis=-1).astype(np.uint16)
-        ch_min = np.min(img, axis=-1).astype(np.uint16)
-        return ((ch_max + ch_min) >> 1).astype(np.uint8)
+        if img.shape[-1] == 1:
+            return img[..., 0]
+        channels = cv2.split(img)
+        ch_max = channels[0]
+        ch_min = channels[0]
+        for channel in channels[1:]:
+            ch_max = cv2.max(ch_max, channel)
+            ch_min = cv2.min(ch_min, channel)
+        channel_sum = cv2.add(ch_max, ch_min, dtype=cv2.CV_16U)
+        return (channel_sum >> 1).astype(np.uint8)
     float_image = img.astype(np.float32)
     return (np.max(float_image, axis=-1) + np.min(float_image, axis=-1)) * 0.5
 

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 from ._functional_shared import (
     MAX_VALUES_BY_DTYPE,
+    NUM_MULTI_CHANNEL_DIMENSIONS,
     NUM_RGB_CHANNELS,
     PCA,
     ImageType,
@@ -926,6 +927,10 @@ def to_gray_desaturation(img: ImageType) -> ImageType:
     if img.dtype == np.uint8:
         if img.shape[-1] == 1:
             return img[..., 0]
+        if img.ndim > NUM_MULTI_CHANNEL_DIMENSIONS:
+            ch_max = np.max(img, axis=-1).astype(np.uint16)
+            ch_min = np.min(img, axis=-1).astype(np.uint16)
+            return ((ch_max + ch_min) >> 1).astype(np.uint8)
         channels = cv2.split(img)
         ch_max = channels[0]
         ch_min = channels[0]

--- a/albumentations/augmentations/pixel/_functional_histology.py
+++ b/albumentations/augmentations/pixel/_functional_histology.py
@@ -30,9 +30,12 @@ def rgb_to_optical_density(img: ImageType, eps: float = 1e-6) -> np.ndarray:
 
     """
     max_value = MAX_VALUES_BY_DTYPE[img.dtype]
-    pixel_matrix = img.reshape(-1, 3).astype(np.float32)
-    pixel_matrix = np.maximum(pixel_matrix / max_value, eps)
-    return -np.log(pixel_matrix)
+    pixel_matrix = np.ascontiguousarray(img.reshape(-1, 3)).astype(np.float32, copy=True)
+    cv2.multiply(pixel_matrix, 1.0 / max_value, dst=pixel_matrix)
+    cv2.max(pixel_matrix, eps, dst=pixel_matrix)
+    cv2.log(pixel_matrix, dst=pixel_matrix)
+    cv2.multiply(pixel_matrix, -1.0, dst=pixel_matrix)
+    return pixel_matrix
 
 
 def normalize_vectors(vectors: np.ndarray) -> np.ndarray:

--- a/albumentations/augmentations/pixel/_functional_sharpness.py
+++ b/albumentations/augmentations/pixel/_functional_sharpness.py
@@ -125,9 +125,11 @@ def pixel_dropout(
             fill_values[...] = drop_values
         else:
             fill_values = drop_values
+        fill_values = np.ascontiguousarray(fill_values)
         cv_mask = drop_mask[..., 0] if drop_mask.ndim == image.ndim and drop_mask.shape[-1] == 1 else drop_mask
+        cv_mask = np.ascontiguousarray(cv_mask.astype(np.uint8) * 255)
         result = image.copy()
-        cv2.copyTo(fill_values, cv_mask.astype(np.uint8) * 255, result)
+        cv2.copyTo(fill_values, cv_mask, result)
         return result
     return np.where(drop_mask, drop_values, image)
 

--- a/albumentations/augmentations/pixel/_functional_sharpness.py
+++ b/albumentations/augmentations/pixel/_functional_sharpness.py
@@ -84,9 +84,14 @@ def unsharp_mask(
 
     diff = cv2.absdiff(image, blurred)
     threshold_value = threshold / 255.0 if image.dtype == np.float32 else threshold
-    mask = diff > threshold_value
+    if image.ndim == NUM_MULTI_CHANNEL_DIMENSIONS and image.shape[2] not in {1, 3, 4}:
+        mask = diff > threshold_value
+        return np.where(mask, sharpened, image).astype(image.dtype, copy=False)
 
-    return np.where(mask, sharpened, image).astype(image.dtype, copy=False)
+    mask = cv2.compare(diff, threshold_value, cv2.CMP_GT)
+    result = image.copy()
+    cv2.copyTo(sharpened, mask, result)
+    return result
 
 
 @preserve_channel_dim
@@ -114,6 +119,16 @@ def pixel_dropout(
             drop_mask = drop_mask[None, ...]
     elif drop_mask.ndim == image.ndim - 1:
         drop_mask = drop_mask[..., None]
+    if image.ndim <= NUM_MULTI_CHANNEL_DIMENSIONS:
+        if drop_values.shape != image.shape:
+            fill_values = np.empty_like(image)
+            fill_values[...] = drop_values
+        else:
+            fill_values = drop_values
+        cv_mask = drop_mask[..., 0] if drop_mask.ndim == image.ndim and drop_mask.shape[-1] == 1 else drop_mask
+        result = image.copy()
+        cv2.copyTo(fill_values, cv_mask.astype(np.uint8) * 255, result)
+        return result
     return np.where(drop_mask, drop_values, image)
 
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -3578,6 +3578,18 @@ class TestToGrayDesaturationUint8FastPath:
         expected = (255 + 0) // 2
         assert result[0, 0] == expected
 
+    @pytest.mark.parametrize("shape", [(2, 16, 16, 3), (2, 4, 16, 16, 3)])
+    def test_uint8_batch_and_volume_match_reference(self, shape):
+        rng = np.random.default_rng(137)
+        img = rng.integers(0, 256, shape, dtype=np.uint8)
+
+        ch_max = np.max(img, axis=-1).astype(np.uint16)
+        ch_min = np.min(img, axis=-1).astype(np.uint16)
+        expected = ((ch_max + ch_min) >> 1).astype(np.uint8)
+
+        result = fpixel.to_gray_desaturation(img)
+        np.testing.assert_array_equal(result, expected)
+
 
 class TestToGrayDesaturationNonUint8:
     """Verify non-uint8 desaturation paths remain correct."""


### PR DESCRIPTION
Made-with: Cursor

## Summary by Sourcery

Optimize image augmentation hot paths using OpenCV operations for sharper performance across mixing, pixel, geometric, and crop transforms.

Bug Fixes:
- Handle zero-area instance masks in visibility computation by treating them as fully visible.
- Preserve grayscale single-channel images when converting to gray via desaturation.

Enhancements:
- Replace NumPy-based visibility computation in mixing with OpenCV bitwise operations to reduce per-mask overhead.
- Accelerate unsharp masking and pixel dropout by using OpenCV thresholding and masked copy operations when channel layouts allow.
- Speed up keypoint distance map generation via OpenCV fused magnitude computations on preallocated buffers.
- Optimize uint8 desaturation to grayscale using OpenCV per-channel max/min and 16-bit-safe addition.
- Rewrite RGB-to-optical-density conversion to use OpenCV arithmetic and log operations on contiguous matrices.
- Use OpenCV to find non-zero crop locations from masks and to normalize displacement fields via fast infinity-norm computation.