### PR TITLE
perf: cache init args, bitwise posterize, faster corner illumination

### DIFF
--- a/.cursor/rules/albumentations-rules.mdc
+++ b/.cursor/rules/albumentations-rules.mdc
@@ -18,6 +18,9 @@ alwaysApply: true
   `(H, W, C)`, `(N, H, W, C)`, `(D, H, W, C)`, or `(N, D, H, W, C)`
 - Grayscale in Compose is `(H, W, 1)`, not `(H, W)`; do not add 2D grayscale compatibility branches to
   transform `apply_*` methods or functional kernels used by Compose
+- For performance work, benchmark before choosing `cv2`, `sz_lut`, or NumPy. Direct bitwise operations can beat
+  LUTs for true bit masks, scalar NumPy bitwise can beat OpenCV, and tiny transforms may be dominated by dispatch
+  overhead rather than pixel kernels.
 
 ## Complete Documentation
 

--- a/.cursor/skills/benchmark/SKILL.md
+++ b/.cursor/skills/benchmark/SKILL.md
@@ -26,6 +26,10 @@ Always benchmark all 9 combinations:
 Skip channel counts the transform explicitly doesn't support. Always include the channel axis: grayscale inputs are
 `(H, W, 1)`, not `(H, W)`.
 
+If the optimization changes dtype conversion or a `@uint8_io` / `@float32_io` wrapped function, benchmark the hot dtype
+and add correctness tests for the other supported dtype. For example, a uint8-only speedup in a `@uint8_io` function
+still needs a float32 regression test that verifies wrapper round-tripping.
+
 ## Template: Isolated Function
 
 ```python
@@ -154,9 +158,11 @@ for batch_size in BATCH_SIZES:
 
 - Run on the **same machine**, back-to-back, same conditions
 - Use at least **100 iterations** for fast functions; fewer for slow ones (aim for >1s total)
-- Test **both uint8 and float32** if the change affects dtype handling
+- Test **both uint8 and float32** if the change affects dtype handling. If benchmarking only the hot dtype, add
+  correctness tests for the other dtype.
 - A **>5% regression** on any combination requires justification or rework
 - If adding a new transform, benchmark against the equivalent naive numpy implementation
-- For batch optimizations, compare 1-channel vs 3-channel to verify speedup holds across channel counts
+- For batch optimizations, compare 1-channel, 3-channel RGB, and 5-channel multichannel inputs to verify speedup
+  holds across channel counts
 - Keep channel-last shapes throughout: images `(H,W,C)`, image batches `(N,H,W,C)`, volumes `(D,H,W,C)`,
   volume batches `(N,D,H,W,C)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,13 +100,30 @@ def __init__(self, brightness: float | tuple[float, float] = 0.2):
 
 ### Performance Requirements (Priority Order)
 
-1. **cv2.LUT for lookup operations** - fastest for pixel-wise transformations
-2. **cv2 operations over numpy** - generally faster for image processing
-3. **Vectorized numpy over loops** - eliminate Python loops where possible
-4. **In-place operations** - reduce memory allocations and unnecessary copies
-5. **Cache computations** in `get_params` or `get_params_dependent_on_data`
-6. **Remove dead code** - unused code impacts performance and maintainability
-7. Apply decorators `@uint8_io` or `@float32_io` for type consistency
+1. **cv2.LUT / sz_lut for true lookup operations** - fastest for most uint8 pixel-wise mappings
+2. **Direct bitwise operations for bit masks** - faster than LUTs for operations like posterization
+3. **cv2 operations over numpy when benchmarked faster** - generally faster for image processing, but not automatic
+4. **Vectorized numpy over loops** - eliminate Python loops where possible
+5. **In-place operations** - reduce memory allocations and unnecessary copies
+6. **Cache computations** in `get_params` or `get_params_dependent_on_data`
+7. **Remove dead code** - unused code impacts performance and maintainability
+8. Apply decorators `@uint8_io` or `@float32_io` for type consistency
+
+#### Performance Decision Rules
+
+- **Do not blindly replace NumPy with cv2**. Benchmark the exact shape/dtype/channel matrix.
+- **LUTs are not always best**. For operations that are literally bit masks, prefer direct bitwise operations
+  such as `img & np.uint8(mask)`.
+- **OpenCV bitwise is situational**. Use `cv2.bitwise_and` when both operands are dense contiguous arrays and
+  `dst=` can reuse output. Avoid allocating a full mask only to call OpenCV; scalar NumPy bitwise often wins.
+- **Per-channel broadcasting can be slow**. For multichannel bit masks, benchmark broadcasted `img & masks`
+  against a preallocated per-channel loop.
+- **Tiny transforms may be dispatch-bound**. For crop/flip/invert-style operations, profile Compose/transform
+  overhead before optimizing the pixel kernel.
+- **Avoid `cv2.distanceTransform` for single-source Euclidean distance fields**. Direct coordinate math with
+  `np.arange(..., dtype=np.float32)` and `cv2.sqrt(..., dst=...)` can be faster and simpler.
+- **Sparse multi-channel replacement can favor copy + assignment**. Benchmark threshold-dependent mask paths;
+  nested `np.where` is not automatically faster.
 
 ### Batch Optimization (`apply_to_images`)
 
@@ -258,7 +275,10 @@ Examples:
 ### Performance Anti-patterns
 
 - Not using cv2.LUT / `sz_lut` for lookup-based transformations
-- Using numpy when cv2 equivalent exists and is faster
+- Using numpy when cv2 equivalent exists and is benchmarked faster
+- Using `sz_lut` for simple bit-mask operations where direct bitwise is faster
+- Allocating full-size masks just to call `cv2.bitwise_*` when scalar NumPy bitwise would do
+- Using `cv2.distanceTransform` for a single-source Euclidean distance field
 - Using Python loops instead of vectorized numpy operations
 - Creating unnecessary array copies instead of in-place operations
 - Repeated array allocations in tight loops

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -162,7 +162,7 @@ def solarize(img: ImageType, threshold: float) -> ImageType:
 @clipped
 def posterize(img: ImageType, bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[1, 2, 3, 4, 5, 6, 7]]) -> ImageType:
     """Reduce bit depth by keeping only the highest N bits per channel. bits: 1-7 or list per
-    channel; LUT-based. uint8 I/O, clipped.
+    channel; implemented via bitwise masking on uint8. uint8 I/O, clipped.
 
     Args:
         img (ImageType): Input image. Can be single or multi-channel.

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -193,22 +193,16 @@ def posterize(img: ImageType, bits: Literal[1, 2, 3, 4, 5, 6, 7] | list[Literal[
         >>> result = posterize(image, bits=[3, 4, 5])  # RGB channels
 
     """
-    bits_array = np.uint8(bits)
+    bits_array = np.asarray(bits, dtype=np.uint8)
 
-    if not bits_array.shape or len(bits_array) == 1:
-        lut = np.arange(0, 256, dtype=np.uint8)
-        mask = ~np.uint8(2 ** (8 - bits_array) - 1)
-        lut &= mask
-
-        return sz_lut(img, lut, inplace=False)
+    if bits_array.ndim == 0 or bits_array.size == 1:
+        mask = ~np.uint8(2 ** (8 - int(bits_array.item())) - 1)
+        return img & mask
 
     result_img = np.empty_like(img)
     for i, channel_bits in enumerate(bits_array):
-        lut = np.arange(0, 256, dtype=np.uint8)
-        mask = ~np.uint8(2 ** (8 - channel_bits) - 1)
-        lut &= mask
-
-        result_img[..., i] = sz_lut(img[..., i], lut, inplace=True)
+        mask = ~np.uint8(2 ** (8 - int(channel_bits)) - 1)
+        np.bitwise_and(img[..., i], mask, out=result_img[..., i])
 
     return result_img
 

--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -235,6 +235,28 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
     return x + y
 
 
+def create_corner_illumination_gradient(
+    height: int,
+    width: int,
+    intensity: float,
+    corner: Literal[0, 1, 2, 3],
+) -> np.ndarray:
+    if intensity == 0:
+        return np.ones((height, width), dtype=np.float32)
+
+    corners = [(0, 0), (0, width - 1), (height - 1, width - 1), (height - 1, 0)]
+    corner_y, corner_x = corners[corner]
+
+    y = np.arange(height, dtype=np.float32)[:, np.newaxis] - corner_y
+    x = np.arange(width, dtype=np.float32)[np.newaxis, :] - corner_x
+
+    pattern = x * x + y * y
+    cv2.sqrt(pattern, dst=pattern)
+    cv2.multiply(pattern, -intensity / math.sqrt(height * height + width * width), dst=pattern)
+    cv2.add(pattern, 1, dst=pattern)
+    return pattern
+
+
 def create_illumination_gradient(
     height: int,
     width: int,
@@ -255,22 +277,7 @@ def create_illumination_gradient(
         return gradient
 
     if mode == "corner":
-        if intensity == 0:
-            return np.ones((height, width), dtype=np.float32)
-        corner = params["corner"]
-        diagonal_length = math.sqrt(height * height + width * width)
-        mask = np.full((height, width), 255, dtype=np.uint8)
-        corners = [(0, 0), (0, width - 1), (height - 1, width - 1), (height - 1, 0)]
-        mask[corners[corner]] = 0
-        pattern = cv2.distanceTransform(
-            mask,
-            distanceType=cv2.DIST_L2,
-            maskSize=cv2.DIST_MASK_PRECISE,
-            dstType=cv2.CV_32F,
-        )
-        cv2.multiply(pattern, -intensity / diagonal_length, dst=pattern)
-        cv2.add(pattern, 1, dst=pattern)
-        return pattern
+        return create_corner_illumination_gradient(height, width, intensity, params["corner"])
 
     # gaussian
     if intensity == 0:
@@ -345,28 +352,7 @@ def apply_corner_illumination(
 
     height, width = img.shape[:2]
 
-    # Pre-compute diagonal length once
-    diagonal_length = math.sqrt(height * height + width * width)
-
-    # Create inverted distance map mask directly
-    # Use uint8 for distanceTransform regardless of input dtype
-    mask = np.full((height, width), 255, dtype=np.uint8)
-
-    # Use array indexing instead of conditionals
-    corners = [(0, 0), (0, width - 1), (height - 1, width - 1), (height - 1, 0)]
-    mask[corners[corner]] = 0
-
-    # Calculate distance transform
-    pattern = cv2.distanceTransform(
-        mask,
-        distanceType=cv2.DIST_L2,
-        maskSize=cv2.DIST_MASK_PRECISE,
-        dstType=cv2.CV_32F,  # Specify float output directly
-    )
-
-    # Combine operations to reduce array copies
-    cv2.multiply(pattern, -intensity / diagonal_length, dst=pattern)
-    cv2.add(pattern, 1, dst=pattern)
+    pattern = create_corner_illumination_gradient(height, width, intensity, corner)
 
     if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:
         num_channels = img.shape[2]
@@ -1078,6 +1064,7 @@ __all__ = [
     "apply_vignette",
     "auto_contrast",
     "create_contrast_lut",
+    "create_corner_illumination_gradient",
     "create_directional_gradient",
     "create_illumination_gradient",
     "generate_plasma_pattern",

--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -241,6 +241,28 @@ def create_corner_illumination_gradient(
     intensity: float,
     corner: Literal[0, 1, 2, 3],
 ) -> np.ndarray:
+    """Create float32 (H, W) corner illumination map for multiply_by_array
+    using Euclidean distance from a selected corner with diagonal scaling.
+
+    The map follows `1 + scale * distance`, where `distance` is the Euclidean distance from each pixel
+    to the selected image corner and `scale` combines `intensity` with a diagonal-based normalization
+    (numerically aligned with the previous `cv2.distanceTransform` implementation).
+
+    Args:
+        height (int): Output height `H`.
+        width (int): Output width `W`.
+        intensity (float): Signed strength. `0` returns an all-ones map (no effect). Positive values
+            increase multipliers with distance from the selected corner (typical vignette-style corner
+            darkening when applied via `multiply_by_array`). Negative values invert the radial scaling
+            (relative brightening toward the corner vs. the image edges), matching the prior corner
+            illumination behavior.
+        corner (Literal[0, 1, 2, 3]): Corner that anchors the distance field: `0` top-left, `1`
+            top-right, `2` bottom-right, `3` bottom-left.
+
+    Returns:
+        np.ndarray: Float32 array with shape `(height, width)`.
+
+    """
     if intensity == 0:
         return np.ones((height, width), dtype=np.float32)
 

--- a/albumentations/augmentations/pixel/_functional_noise.py
+++ b/albumentations/augmentations/pixel/_functional_noise.py
@@ -554,7 +554,7 @@ def generate_enhance_matrix(mode: Literal["edge", "detail"], alpha: float) -> np
     return kernel.astype(np.float32, copy=False)
 
 
-SPARSE_SALT_AND_PEPPER_THRESHOLD = 0.08
+SPARSE_SALT_AND_PEPPER_THRESHOLD = 0.16
 
 
 def apply_salt_and_pepper(

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -82,6 +82,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         str,
         Callable[..., Any],
     ]  # mapping for targets (plus additional targets) and methods for which they depend
+    _transform_init_args_names_cache: ClassVar[tuple[str, ...] | None] = None
     call_backup = None
     interpolation: int
     fill: tuple[float, ...] | float
@@ -198,7 +199,10 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         to collect all possible parameters, excluding 'self' and 'strict'
         which are handled separately.
         """
-        import inspect
+        transform_cls = type(self)
+        cache = transform_cls.__dict__.get("_transform_init_args_names_cache")
+        if cache is not None:
+            return cache
 
         all_param_names = set()
 
@@ -218,7 +222,9 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
                 continue
 
         # Exclude 'self' and 'strict'
-        return tuple(sorted(all_param_names - {"self", "strict"}))
+        result = tuple(sorted(all_param_names - {"self", "strict"}))
+        type.__setattr__(transform_cls, "_transform_init_args_names_cache", result)
+        return result
 
     def set_processors(self, processors: dict[str, BboxProcessor | KeypointsProcessor]) -> None:
         """Set the processors dictionary used for processing bbox and keypoint transformations.

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -754,6 +754,17 @@ Python `for y in range(h): for x in range(w):` loops are ~100x slower than vecto
 
 Any function `f(pixel) -> pixel` on uint8 data should build a 256-entry LUT and apply it via `sz_lut(img, lut, inplace=...)`. This is orders of magnitude faster than per-pixel numpy.
 
+Exception: if the operation is literally a bit mask, direct bitwise operations can be faster than LUTs.
+
+```python
+# Fast for posterization-style bit masks
+mask = ~np.uint8(2 ** (8 - num_bits) - 1)
+result = img & mask
+```
+
+For multichannel bit masks, benchmark broadcasted `img & masks` against a preallocated per-channel loop. Broadcasting
+small per-channel masks can create slow strided operations.
+
 ### 3. Vectorize LUT and Array Construction
 
 Replace Python list comprehensions with numpy vectorized equivalents:
@@ -801,7 +812,20 @@ result = img + alpha * (img - blurred)
 result = add_weighted(img, 1.0 + alpha, blurred, -alpha)
 ```
 
-### 7. Preallocate Outside Loops
+### 7. Choose OpenCV vs NumPy by Benchmark
+
+OpenCV is often faster for image-sized dense operations, but not automatically. Benchmark the exact dtype, shape, and
+channel matrix before switching.
+
+- Use scalar NumPy bitwise, for example `img & np.uint8(mask)`, when the operation has a scalar mask.
+- Use `cv2.bitwise_*` only when both operands are dense contiguous arrays and `dst=` can reuse output.
+- Do not allocate a full image-sized mask only to call OpenCV; that allocation often loses.
+- Avoid `cv2.distanceTransform` for a single-source Euclidean distance field. Direct coordinate math with
+  `np.arange(..., dtype=np.float32)` and `cv2.sqrt(..., dst=...)` is simpler and can be faster.
+- For sparse multi-channel replacement, copy plus masked assignment can beat nested `np.where`; benchmark the
+  density threshold.
+
+### 8. Preallocate Outside Loops
 
 Move `np.zeros` / `np.empty` calls outside loops and reset with `arr[:] = 0`:
 
@@ -818,14 +842,14 @@ for item in items:
     cv2.fillPoly(mask, ...)
 ```
 
-### 8. Skip Redundant Work in Hot Paths
+### 9. Skip Redundant Work in Hot Paths
 
 - Guard `np.ascontiguousarray` with `if not arr.flags["C_CONTIGUOUS"]`
 - Use `first_result[np.newaxis]` instead of `np.array([first_result])` for batch-of-one
 - Precompute loop-invariant expressions (e.g., `inv_sq = 1.0 / (step * step)`)
 - Use `np.where(mask)` instead of `np.argwhere(mask)` — returns tuple of 1D arrays instead of 2D index array
 
-### 9. Vectorize Random Number Generation
+### 10. Vectorize Random Number Generation
 
 Replace per-element Python RNG loops with single numpy calls:
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -2153,6 +2153,20 @@ def test_create_corner_illumination_gradient_matches_distance_transform(corner, 
     np.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-6)
 
 
+def test_create_corner_illumination_gradient_zero_intensity_returns_ones():
+    height, width = 13, 17
+    expected = np.ones((height, width), dtype=np.float32)
+
+    results = [fpixel.create_corner_illumination_gradient(height, width, 0.0, corner) for corner in range(4)]
+
+    for result in results:
+        assert result.shape == (height, width)
+        assert result.dtype == np.float32
+        np.testing.assert_array_equal(result, expected)
+    for result in results[1:]:
+        np.testing.assert_array_equal(result, results[0])
+
+
 @pytest.mark.parametrize(
     ["corner", "intensity", "expected_corner"],
     [

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -2132,6 +2132,27 @@ def test_gradient_range():
         assert gradient.max() <= 1 + 1e-7
 
 
+@pytest.mark.parametrize("corner", [0, 1, 2, 3])
+@pytest.mark.parametrize("intensity", [-0.2, 0.2])
+def test_create_corner_illumination_gradient_matches_distance_transform(corner, intensity):
+    height, width = 13, 17
+    corners = [(0, 0), (0, width - 1), (height - 1, width - 1), (height - 1, 0)]
+    mask = np.full((height, width), 255, dtype=np.uint8)
+    mask[corners[corner]] = 0
+    expected = cv2.distanceTransform(
+        mask,
+        distanceType=cv2.DIST_L2,
+        maskSize=cv2.DIST_MASK_PRECISE,
+        dstType=cv2.CV_32F,
+    )
+    cv2.multiply(expected, -intensity / np.sqrt(height * height + width * width), dst=expected)
+    cv2.add(expected, 1, dst=expected)
+
+    result = fpixel.create_corner_illumination_gradient(height, width, intensity, corner)
+
+    np.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-6)
+
+
 @pytest.mark.parametrize(
     ["corner", "intensity", "expected_corner"],
     [
@@ -3556,6 +3577,51 @@ class TestSolarizeLutVectorized:
         result = fpixel.solarize(img, threshold)
         assert result.shape == img.shape
         assert result.dtype == np.uint8
+
+
+class TestPosterizeBitwise:
+    @pytest.mark.parametrize("bits", [1, 3, 4, 7])
+    def test_scalar_bits_uint8(self, bits):
+        rng = np.random.default_rng(137)
+        img = rng.integers(0, 256, (16, 16, 3), dtype=np.uint8)
+        mask = ~np.uint8(2 ** (8 - bits) - 1)
+
+        result = fpixel.posterize(img, bits)
+
+        np.testing.assert_array_equal(result, img & mask)
+
+    def test_scalar_bits_float32(self):
+        rng = np.random.default_rng(137)
+        img_uint8 = rng.integers(0, 256, (16, 16, 3), dtype=np.uint8)
+        img_float32 = to_float(img_uint8)
+        mask = ~np.uint8(2 ** (8 - 4) - 1)
+
+        result = fpixel.posterize(img_float32, 4)
+
+        np.testing.assert_allclose(result, to_float(img_uint8 & mask), atol=1 / 255)
+
+    def test_per_channel_bits_uint8(self):
+        rng = np.random.default_rng(137)
+        img = rng.integers(0, 256, (16, 16, 3), dtype=np.uint8)
+        bits = [3, 4, 5]
+        masks = np.array([~np.uint8(2 ** (8 - channel_bits) - 1) for channel_bits in bits], dtype=np.uint8)
+
+        result = fpixel.posterize(img, bits)
+
+        np.testing.assert_array_equal(result, img & masks)
+
+    def test_per_channel_bits_batch_uint8(self):
+        rng = np.random.default_rng(137)
+        images = rng.integers(0, 256, (2, 16, 16, 3), dtype=np.uint8)
+        bits = [3, 4, 5]
+        expected = np.empty_like(images)
+        for channel_idx, channel_bits in enumerate(bits):
+            mask = ~np.uint8(2 ** (8 - channel_bits) - 1)
+            np.bitwise_and(images[..., channel_idx], mask, out=expected[..., channel_idx])
+
+        result = fpixel.posterize(images, bits)
+
+        np.testing.assert_array_equal(result, expected)
 
 
 class TestToGrayDesaturationUint8FastPath:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2991,6 +2991,27 @@ def test_applied_config_invalid_key_raises():
         aug(image=_make_test_image())
 
 
+def test_transform_init_args_names_are_cached():
+    """Repeated applied_config builds should not re-run signature introspection."""
+
+    class CacheProbeTransform(ImageOnlyTransform):
+        def __init__(self, alpha: int = 137, p: float = 1.0):
+            super().__init__(p=p)
+            self.alpha = alpha
+
+        def apply(self, img: np.ndarray, **params: Any) -> np.ndarray:
+            return img
+
+    CacheProbeTransform._transform_init_args_names_cache = None
+    aug = CacheProbeTransform(alpha=138)
+
+    assert "alpha" in aug.get_transform_init_args_names()
+
+    with mock.patch("inspect.signature", side_effect=AssertionError("signature should be cached")):
+        assert "alpha" in aug.get_transform_init_args_names()
+        assert aug.get_transform_init_args()["alpha"] == 138
+
+
 def test_from_applied_transforms_reproduces_output():
     """Compose.from_applied_transforms() produces identical output to the original run."""
     image = _make_test_image()


### PR DESCRIPTION
- Cache get_transform_init_args_names per class to cut Compose overhead
- Posterize: scalar and per-channel via bitwise ops vs LUT
- Corner illumination: Euclidean distance instead of distanceTransform
- SaltAndPepper: raise sparse threshold for copy-assign path
- Tests for posterize, corner gradient parity, init-args cache

Made-with: Cursor

## Summary by Sourcery

Optimize several pixel-level operations and transform initialization to reduce overhead while clarifying performance guidelines and expanding tests.

Enhancements:
- Cache per-class transform init-arg names to avoid repeated signature introspection during Compose usage.
- Replace distanceTransform-based corner illumination gradients with a direct Euclidean distance implementation reused by both creation and application paths.
- Speed up posterize by using direct bitwise masking for scalar and per-channel bit depths instead of LUTs.
- Adjust the salt-and-pepper noise sparse threshold to favor a faster copy-and-assign path.

Documentation:
- Expand performance and coding guidelines to cover when to favor bitwise operations over LUTs, when to choose OpenCV vs NumPy, and how to benchmark dtype- and channel-dependent optimizations.

Tests:
- Add regression tests for corner illumination gradient parity with distanceTransform and for posterize bitwise behavior across dtypes, channels, and batched inputs.
- Add a test ensuring transform init-arg names are cached and not recomputed on repeated access.

Chores:
- Update internal benchmarking skill documentation with dtype coverage expectations and channel-count benchmarking guidance.