### PR TITLE
perf(pixel): optimize LUT-heavy transforms

### DIFF
--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -249,6 +249,39 @@ def _equalize_cv(img: ImageType, mask: np.ndarray | None = None) -> ImageType:
     return sz_lut(img, lut, inplace=True)
 
 
+def _equalize_cv_multichannel_lut(img: ImageType) -> ImageType:
+    """Apply OpenCV-style equalization with one multichannel LUT pass for large
+    RGB images and multispectral inputs where per-channel assignment is slower.
+    """
+    luts = []
+    for channel_idx in range(get_num_channels(img)):
+        channel = img[..., channel_idx]
+        histogram = cv2.calcHist([channel], [0], None, [256], (0, 256)).ravel()
+        nonzero = np.flatnonzero(histogram)
+        if len(nonzero) == 0:
+            luts.append(np.arange(256, dtype=np.uint8))
+            continue
+
+        first_nonzero = nonzero[0]
+        total = reduce_sum(histogram)
+        denominator = total - histogram[first_nonzero]
+        if denominator == 0:
+            luts.append(np.arange(256, dtype=np.uint8))
+            continue
+
+        scale = 255.0 / denominator
+        cumsum_histogram = np.cumsum(histogram)
+        lut = np.clip(
+            ((cumsum_histogram - cumsum_histogram[first_nonzero]) * scale).round(),
+            0,
+            255,
+        ).astype(np.uint8)
+        luts.append(lut)
+
+    lut = np.stack(luts, axis=1).reshape(256, 1, get_num_channels(img))
+    return cv2.LUT(img, lut)
+
+
 def _check_preconditions(
     img: ImageType,
     mask: np.ndarray | None,
@@ -335,8 +368,13 @@ def equalize(
         return function(img, _handle_mask(mask))
 
     if mask is None and by_channels and mode == "cv" and is_rgb_image(img):
+        if img.shape[0] * img.shape[1] >= 1024 * 1024:
+            return _equalize_cv_multichannel_lut(img)
         channels = cv2.split(img)
         return cv2.merge([cv2.equalizeHist(channel) for channel in channels])
+
+    if mask is None and by_channels and mode == "cv" and get_num_channels(img) > NUM_RGB_CHANNELS:
+        return _equalize_cv_multichannel_lut(img)
 
     if not by_channels:
         result_img = cv2.cvtColor(img, cv2.COLOR_RGB2YCrCb)
@@ -344,7 +382,7 @@ def equalize(
         return cv2.cvtColor(result_img, cv2.COLOR_YCrCb2RGB)
 
     result_img = np.empty_like(img)
-    for i in range(NUM_RGB_CHANNELS):
+    for i in range(get_num_channels(img)):
         _mask = _handle_mask(mask, i)
         # Extract channel, process, and ensure we maintain 2D shape
         channel_result = function(img[..., i], _mask)
@@ -376,6 +414,17 @@ def evaluate_bez(
 
     one_minus_t = 1 - t
     return (3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3) * 255
+
+
+def _apply_multichannel_lut(img: ImageType, luts: np.ndarray, num_channels: int) -> ImageType:
+    """Apply channel-specific uint8 LUTs in one OpenCV pass for images,
+    batches, and volumes while preserving the original shape and channel order.
+    """
+    lut = np.ascontiguousarray(luts.T.reshape(256, 1, num_channels))
+    if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:
+        return cv2.LUT(img, lut)
+
+    return cv2.LUT(img.reshape(-1, 1, num_channels), lut).reshape(img.shape)
 
 
 @uint8_io
@@ -410,10 +459,7 @@ def move_tone_curve(
             np.uint8,
             inplace=False,
         )
-        result = np.empty_like(img)
-        for i in range(num_channels):
-            result[..., i] = sz_lut(img[..., i], np.ascontiguousarray(luts[i]), inplace=False)
-        return result
+        return _apply_multichannel_lut(img, luts, num_channels)
 
     raise TypeError(
         f"low_y and high_y must both be of type float or np.ndarray. Got {type(low_y)} and {type(high_y)}",

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -7,12 +7,14 @@ from typing import Any, Literal
 
 from ._functional_shared import (
     MAX_VALUES_BY_DTYPE,
+    MULTICHANNEL_LUT_LARGE_IMAGE_PIXELS,
     NUM_MULTI_CHANNEL_DIMENSIONS,
     NUM_RGB_CHANNELS,
     PCA,
     ImageType,
     add_array,
     add_constant,
+    apply_multichannel_lut,
     clip,
     clipped,
     cv2,
@@ -228,25 +230,27 @@ def _equalize_cv(img: ImageType, mask: np.ndarray | None = None) -> ImageType:
         return cv2.equalizeHist(img)
 
     histogram = cv2.calcHist([img], [0], mask, [256], (0, 256)).ravel()
-
-    # Find the first non-zero index with a numpy operation
-    i = np.flatnonzero(histogram)[0] if np.any(histogram) else 255
-
-    total = reduce_sum(histogram)
-
-    # Safe division for equalize: handle edge case of uniform histograms
-    # If histogram is uniform (denominator == 0), return image unchanged
-    denominator = total - histogram[i]
-    if denominator == 0:
-        # Uniform histogram - no equalization needed
+    lut = _create_equalize_cv_lut(histogram)
+    if lut is None:
         return img
 
-    scale = 255.0 / denominator
-    # Optimize cumulative sum and scale to generate LUT
-    cumsum_histogram = np.cumsum(histogram)
-    lut = np.clip(((cumsum_histogram - cumsum_histogram[i]) * scale).round(), 0, 255).astype(np.uint8)
-
     return sz_lut(img, lut, inplace=True)
+
+
+def _create_equalize_cv_lut(histogram: np.ndarray) -> np.ndarray | None:
+    nonzero = np.flatnonzero(histogram)
+    if len(nonzero) == 0:
+        return np.arange(256, dtype=np.uint8)
+
+    first_nonzero = nonzero[0]
+    total = reduce_sum(histogram)
+    denominator = total - histogram[first_nonzero]
+    if denominator == 0:
+        return None
+
+    scale = 255.0 / denominator
+    cumsum_histogram = np.cumsum(histogram)
+    return np.clip(((cumsum_histogram - cumsum_histogram[first_nonzero]) * scale).round(), 0, 255).astype(np.uint8)
 
 
 def _equalize_cv_multichannel_lut(img: ImageType) -> ImageType:
@@ -257,29 +261,10 @@ def _equalize_cv_multichannel_lut(img: ImageType) -> ImageType:
     for channel_idx in range(get_num_channels(img)):
         channel = img[..., channel_idx]
         histogram = cv2.calcHist([channel], [0], None, [256], (0, 256)).ravel()
-        nonzero = np.flatnonzero(histogram)
-        if len(nonzero) == 0:
-            luts.append(np.arange(256, dtype=np.uint8))
-            continue
+        lut = _create_equalize_cv_lut(histogram)
+        luts.append(np.arange(256, dtype=np.uint8) if lut is None else lut)
 
-        first_nonzero = nonzero[0]
-        total = reduce_sum(histogram)
-        denominator = total - histogram[first_nonzero]
-        if denominator == 0:
-            luts.append(np.arange(256, dtype=np.uint8))
-            continue
-
-        scale = 255.0 / denominator
-        cumsum_histogram = np.cumsum(histogram)
-        lut = np.clip(
-            ((cumsum_histogram - cumsum_histogram[first_nonzero]) * scale).round(),
-            0,
-            255,
-        ).astype(np.uint8)
-        luts.append(lut)
-
-    lut = np.stack(luts, axis=1).reshape(256, 1, get_num_channels(img))
-    return cv2.LUT(img, lut)
+    return apply_multichannel_lut(img, np.stack(luts), get_num_channels(img))
 
 
 def _check_preconditions(
@@ -368,7 +353,7 @@ def equalize(
         return function(img, _handle_mask(mask))
 
     if mask is None and by_channels and mode == "cv" and is_rgb_image(img):
-        if img.shape[0] * img.shape[1] >= 1024 * 1024:
+        if img.shape[0] * img.shape[1] >= MULTICHANNEL_LUT_LARGE_IMAGE_PIXELS:
             return _equalize_cv_multichannel_lut(img)
         channels = cv2.split(img)
         return cv2.merge([cv2.equalizeHist(channel) for channel in channels])
@@ -416,17 +401,6 @@ def evaluate_bez(
     return (3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3) * 255
 
 
-def _apply_multichannel_lut(img: ImageType, luts: np.ndarray, num_channels: int) -> ImageType:
-    """Apply channel-specific uint8 LUTs in one OpenCV pass for images,
-    batches, and volumes while preserving the original shape and channel order.
-    """
-    lut = np.ascontiguousarray(luts.T.reshape(256, 1, num_channels))
-    if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:
-        return cv2.LUT(img, lut)
-
-    return cv2.LUT(img.reshape(-1, 1, num_channels), lut).reshape(img.shape)
-
-
 @uint8_io
 def move_tone_curve(
     img: ImageType,
@@ -459,7 +433,7 @@ def move_tone_curve(
             np.uint8,
             inplace=False,
         )
-        return _apply_multichannel_lut(img, luts, num_channels)
+        return apply_multichannel_lut(img, luts, num_channels)
 
     raise TypeError(
         f"low_y and high_y must both be of type float or np.ndarray. Got {type(low_y)} and {type(high_y)}",

--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -197,15 +197,23 @@ def create_directional_gradient(height: int, width: int, angle: float) -> np.nda
     """
     # Fast path for horizontal gradients
     if angle == 0:
-        return np.linspace(0, 1, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
+        gradient = np.empty((height, width), dtype=np.float32)
+        gradient[:] = np.linspace(0, 1, width, dtype=np.float32)
+        return gradient
     if angle == 180:
-        return np.linspace(1, 0, width, dtype=np.float32)[None, :] * np.ones((height, 1), dtype=np.float32)
+        gradient = np.empty((height, width), dtype=np.float32)
+        gradient[:] = np.linspace(1, 0, width, dtype=np.float32)
+        return gradient
 
     # Fast path for vertical gradients
     if angle == 90:
-        return np.linspace(0, 1, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
+        gradient = np.empty((height, width), dtype=np.float32)
+        gradient[:] = np.linspace(0, 1, height, dtype=np.float32)[:, np.newaxis]
+        return gradient
     if angle == 270:
-        return np.linspace(1, 0, height, dtype=np.float32)[:, None] * np.ones((1, width), dtype=np.float32)
+        gradient = np.empty((height, width), dtype=np.float32)
+        gradient[:] = np.linspace(1, 0, height, dtype=np.float32)[:, np.newaxis]
+        return gradient
 
     # Fast path for diagonal gradients using broadcasting
     if angle in (45, 135, 225, 315):
@@ -344,6 +352,12 @@ def apply_linear_illumination(img: ImageType, intensity: float, angle: float) ->
 
     # Add channel dimension if needed
     if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:
+        num_channels = img.shape[2]
+        if num_channels > 1:
+            gradient = cv2.merge([gradient] * num_channels)
+            result = cv2.add(img, gradient)
+            np.clip(result, 0, 1, out=result)
+            return result
         gradient = gradient[..., np.newaxis]
 
     result = img + gradient
@@ -457,6 +471,91 @@ def _auto_contrast_single_channel(
     return sz_lut(img, lut, inplace=False)
 
 
+def _auto_contrast_pil_zero_cutoff(img: ImageUInt8, max_value: int) -> ImageUInt8:
+    """Apply Pillow-style autocontrast for single-channel images without building a
+    full histogram when no cutoff or ignored value is requested.
+    """
+    channel = img if img.ndim == MONO_CHANNEL_DIMENSIONS else img[..., 0]
+    min_intensity = int(np.min(channel))
+    max_intensity = int(np.max(channel))
+    if min_intensity >= max_intensity:
+        return img.copy()
+    lut = create_contrast_lut(np.empty(0), min_intensity, max_intensity, max_value, "pil")
+    result = sz_lut(channel, lut, inplace=False)
+    return result if img.ndim == MONO_CHANNEL_DIMENSIONS else result[..., np.newaxis]
+
+
+def _auto_contrast_multichannel_lut(
+    img: ImageUInt8,
+    cutoff: float,
+    method: Literal["cdf", "pil"],
+    max_value: int,
+) -> ImageUInt8:
+    """Apply per-channel autocontrast LUTs with one OpenCV pass for large RGB
+    images and multispectral inputs where split channel assignment is slower.
+    """
+    luts = []
+    for channel_idx in range(get_num_channels(img)):
+        channel = img[..., channel_idx]
+        hist = cv2.calcHist([channel], [0], None, [256], [0, max_value]).ravel()
+        lo, hi = get_histogram_bounds(hist, cutoff)
+        if hi <= lo:
+            luts.append(np.arange(256, dtype=np.uint8))
+            continue
+        luts.append(create_contrast_lut(hist, lo, hi, max_value, method))
+
+    lut = np.stack(luts, axis=1).reshape(256, 1, get_num_channels(img))
+    return cv2.LUT(img, lut)
+
+
+def _auto_contrast_multichannel_hist(
+    img: ImageUInt8,
+    cutoff: float,
+    ignore: int | None,
+    method: Literal["cdf", "pil"],
+    max_value: int,
+) -> ImageUInt8:
+    result = img.copy()
+    channels = cv2.split(img)
+    hists: list[np.ndarray | None] = []
+    for channel_idx, channel in enumerate(channels):
+        if ignore is not None and channel_idx == ignore:
+            hists.append(None)
+            continue
+        mask = None if ignore is None else (channel != ignore)
+        hist = cv2.calcHist([channel], [0], mask, [256], [0, max_value])
+        hists.append(hist.ravel())
+
+    for channel_idx, channel in enumerate(channels):
+        if ignore is not None and channel_idx == ignore:
+            continue
+
+        hist = hists[channel_idx]
+        if hist is None:
+            continue
+
+        lo, hi = get_histogram_bounds(hist, cutoff)
+        if hi <= lo:
+            continue
+
+        lut = create_contrast_lut(hist, lo, hi, max_value, method)
+        if ignore is not None:
+            lut[ignore] = ignore
+
+        result[..., channel_idx] = sz_lut(channel, lut)
+
+    return result
+
+
+def _should_use_auto_contrast_multichannel_lut(
+    img: ImageUInt8,
+    ignore: int | None,
+    method: Literal["cdf", "pil"],
+    num_channels: int,
+) -> bool:
+    return method == "cdf" and ignore is None and (num_channels > 3 or img.shape[0] * img.shape[1] >= 512 * 512)
+
+
 @uint8_io
 def auto_contrast(
     img: ImageType,
@@ -477,44 +576,19 @@ def auto_contrast(
         ImageType: Image with enhanced contrast
 
     """
-    result = img.copy()
     num_channels = get_num_channels(img)
     max_value = MAX_VALUES_BY_DTYPE[img.dtype]
+
+    if method == "pil" and cutoff == 0 and ignore is None and num_channels == 1:
+        return _auto_contrast_pil_zero_cutoff(img, max_value)
 
     if img.ndim == MONO_CHANNEL_DIMENSIONS:
         return _auto_contrast_single_channel(img, cutoff, ignore, method, max_value)
 
-    channels = cv2.split(img)
-    hists: list[np.ndarray | None] = []
-    for channel_idx, channel in enumerate(channels):
-        if ignore is not None and channel_idx == ignore:
-            hists.append(None)
-            continue
-        mask = None if ignore is None else (channel != ignore)
-        hist = cv2.calcHist([channel], [0], mask, [256], [0, max_value])
-        hists.append(hist.ravel())
+    if _should_use_auto_contrast_multichannel_lut(img, ignore, method, num_channels):
+        return _auto_contrast_multichannel_lut(img, cutoff, method, max_value)
 
-    for channel_idx in range(num_channels):
-        if ignore is not None and channel_idx == ignore:
-            continue
-
-        hist = hists[channel_idx]
-        if hist is None:
-            continue
-
-        channel = channels[channel_idx]
-
-        lo, hi = get_histogram_bounds(hist, cutoff)
-        if hi <= lo:
-            continue
-
-        lut = create_contrast_lut(hist, lo, hi, max_value, method)
-        if ignore is not None:
-            lut[ignore] = ignore
-
-        result[..., channel_idx] = sz_lut(channel, lut)
-
-    return result
+    return _auto_contrast_multichannel_hist(img, cutoff, ignore, method, max_value)
 
 
 def create_contrast_lut(

--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -12,12 +12,14 @@ from ._functional_noise import (
 from ._functional_shared import (
     MAX_VALUES_BY_DTYPE,
     MONO_CHANNEL_DIMENSIONS,
+    MULTICHANNEL_LUT_MEDIUM_IMAGE_PIXELS,
     NUM_MULTI_CHANNEL_DIMENSIONS,
     ImageType,
     ImageUInt8,
     add,
     add_array,
     add_weighted,
+    apply_multichannel_lut,
     clip,
     clipped,
     cv2,
@@ -461,13 +463,10 @@ def _auto_contrast_single_channel(
 ) -> ImageUInt8:
     mask = None if ignore is None else (img != ignore)
     hist = cv2.calcHist([img], [0], mask, [256], [0, max_value]).ravel()
-    lo, hi = get_histogram_bounds(hist, cutoff)
-    if hi <= lo:
+    lut = _create_auto_contrast_lut(hist, cutoff, ignore, method, max_value)
+    if lut is None:
         return img.copy()
 
-    lut = create_contrast_lut(hist, lo, hi, max_value, method)
-    if ignore is not None:
-        lut[ignore] = ignore
     return sz_lut(img, lut, inplace=False)
 
 
@@ -498,14 +497,10 @@ def _auto_contrast_multichannel_lut(
     for channel_idx in range(get_num_channels(img)):
         channel = img[..., channel_idx]
         hist = cv2.calcHist([channel], [0], None, [256], [0, max_value]).ravel()
-        lo, hi = get_histogram_bounds(hist, cutoff)
-        if hi <= lo:
-            luts.append(np.arange(256, dtype=np.uint8))
-            continue
-        luts.append(create_contrast_lut(hist, lo, hi, max_value, method))
+        lut = _create_auto_contrast_lut(hist, cutoff, None, method, max_value)
+        luts.append(np.arange(256, dtype=np.uint8) if lut is None else lut)
 
-    lut = np.stack(luts, axis=1).reshape(256, 1, get_num_channels(img))
-    return cv2.LUT(img, lut)
+    return apply_multichannel_lut(img, np.stack(luts), get_num_channels(img))
 
 
 def _auto_contrast_multichannel_hist(
@@ -534,17 +529,29 @@ def _auto_contrast_multichannel_hist(
         if hist is None:
             continue
 
-        lo, hi = get_histogram_bounds(hist, cutoff)
-        if hi <= lo:
+        lut = _create_auto_contrast_lut(hist, cutoff, ignore, method, max_value)
+        if lut is None:
             continue
-
-        lut = create_contrast_lut(hist, lo, hi, max_value, method)
-        if ignore is not None:
-            lut[ignore] = ignore
-
         result[..., channel_idx] = sz_lut(channel, lut)
 
     return result
+
+
+def _create_auto_contrast_lut(
+    hist: np.ndarray,
+    cutoff: float,
+    ignore: int | None,
+    method: Literal["cdf", "pil"],
+    max_value: int,
+) -> np.ndarray | None:
+    lo, hi = get_histogram_bounds(hist, cutoff)
+    if hi <= lo:
+        return None
+
+    lut = create_contrast_lut(hist, lo, hi, max_value, method)
+    if ignore is not None:
+        lut[ignore] = ignore
+    return lut
 
 
 def _should_use_auto_contrast_multichannel_lut(
@@ -553,7 +560,11 @@ def _should_use_auto_contrast_multichannel_lut(
     method: Literal["cdf", "pil"],
     num_channels: int,
 ) -> bool:
-    return method == "cdf" and ignore is None and (num_channels > 3 or img.shape[0] * img.shape[1] >= 512 * 512)
+    return (
+        method == "cdf"
+        and ignore is None
+        and (num_channels > 3 or img.shape[0] * img.shape[1] >= MULTICHANNEL_LUT_MEDIUM_IMAGE_PIXELS)
+    )
 
 
 @uint8_io

--- a/albumentations/augmentations/pixel/_functional_shared.py
+++ b/albumentations/augmentations/pixel/_functional_shared.py
@@ -58,9 +58,26 @@ from albumentations.core.type_definitions import (
     ImageUInt8,
 )
 
+MULTICHANNEL_LUT_MEDIUM_IMAGE_PIXELS = 512 * 512
+MULTICHANNEL_LUT_LARGE_IMAGE_PIXELS = 1024 * 1024
+
+
+def apply_multichannel_lut(img: ImageType, luts: np.ndarray, num_channels: int) -> ImageType:
+    """Apply channel-specific uint8 LUTs in one OpenCV pass for images, batches, and volumes while
+    preserving original shape and channel order.
+    """
+    lut = np.ascontiguousarray(luts.T.reshape(256, 1, num_channels))
+    if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:
+        return cv2.LUT(img, lut)
+
+    return cv2.LUT(img.reshape(-1, 1, num_channels), lut).reshape(img.shape)
+
+
 __all__ = [
     "MAX_VALUES_BY_DTYPE",
     "MONO_CHANNEL_DIMENSIONS",
+    "MULTICHANNEL_LUT_LARGE_IMAGE_PIXELS",
+    "MULTICHANNEL_LUT_MEDIUM_IMAGE_PIXELS",
     "NUM_MULTI_CHANNEL_DIMENSIONS",
     "NUM_RGB_CHANNELS",
     "PCA",
@@ -74,6 +91,7 @@ __all__ = [
     "add_constant",
     "add_vector",
     "add_weighted",
+    "apply_multichannel_lut",
     "clip",
     "clipped",
     "cv2",

--- a/albumentations/augmentations/pixel/dithering_functional.py
+++ b/albumentations/augmentations/pixel/dithering_functional.py
@@ -360,6 +360,42 @@ def random_dither(
     return quantized.astype(np.float32)
 
 
+def _floyd_steinberg_binary_uint8(img: ImageUInt8) -> ImageUInt8:
+    """Apply binary Floyd-Steinberg dithering to a single-channel uint8 image without
+    dtype-wrapper dispatch overhead in the default grayscale path.
+    """
+    channel = img[:, :, 0].astype(np.float32) * (1.0 / 255.0)
+    height, width = channel.shape
+
+    for row_idx in range(height):
+        next_row_idx = row_idx + 1
+        has_next_row = next_row_idx < height
+        for col_idx in range(width):
+            old_val = channel[row_idx, col_idx]
+            new_val = 1.0 if old_val >= 0.5 else 0.0
+            channel[row_idx, col_idx] = new_val
+            error = old_val - new_val
+
+            next_col_idx = col_idx + 1
+            if next_col_idx < width:
+                channel[row_idx, next_col_idx] += error * (7.0 / 16.0)
+
+            if has_next_row:
+                if col_idx > 0:
+                    channel[next_row_idx, col_idx - 1] += error * (3.0 / 16.0)
+                channel[next_row_idx, col_idx] += error * (5.0 / 16.0)
+                if next_col_idx < width:
+                    channel[next_row_idx, next_col_idx] += error * (1.0 / 16.0)
+
+    np.clip(channel, 0, 1, out=channel)
+    return (channel[:, :, np.newaxis] * 255).astype(np.uint8)
+
+
+def _should_vectorize_ordered_dither(height: int, width: int, num_channels: int) -> bool:
+    num_pixels = height * width
+    return (num_channels > 3 and num_pixels >= 512 * 512) or num_pixels >= 1024 * 1024
+
+
 def ordered_dither_uint8(
     img: ImageUInt8,
     n_colors: int,
@@ -393,6 +429,12 @@ def ordered_dither_uint8(
     levels = np.linspace(0, 255, n_colors).astype(np.uint8)
 
     lut = levels[np.minimum(np.arange(256) * n_colors // 256, n_colors - 1)]
+
+    if _should_vectorize_ordered_dither(height, width, img.shape[2]):
+        dithered = img.astype(np.int16)
+        dithered += ((tiled.astype(np.int16) - 128) // n_colors)[:, :, np.newaxis]
+        np.clip(dithered, 0, 255, out=dithered)
+        return sz_lut(dithered.astype(np.uint8), lut, inplace=False)
 
     for channel_idx in range(img.shape[2]):
         channel = img[:, :, channel_idx]
@@ -583,6 +625,15 @@ def _apply_single_dithering_method(
             kwargs.get("noise_range", (-0.5, 0.5)),
             random_generator,
         )
+    if (
+        img.dtype == np.uint8
+        and method == "error_diffusion"
+        and n_colors == 2
+        and kwargs.get("error_diffusion_algorithm", "floyd_steinberg") == "floyd_steinberg"
+        and not kwargs.get("serpentine", False)
+        and img.shape[2] == 1
+    ):
+        return _floyd_steinberg_binary_uint8(img)
 
     # Use float32 versions
     if method == "random":

--- a/albumentations/augmentations/pixel/dithering_functional.py
+++ b/albumentations/augmentations/pixel/dithering_functional.py
@@ -6,6 +6,10 @@ from typing import Any, cast
 import numpy as np
 from albucore import float32_io, sz_lut
 
+from albumentations.augmentations.pixel._functional_shared import (
+    MULTICHANNEL_LUT_LARGE_IMAGE_PIXELS,
+    MULTICHANNEL_LUT_MEDIUM_IMAGE_PIXELS,
+)
 from albumentations.augmentations.pixel.functional import to_gray_average, to_gray_weighted_average
 from albumentations.core.type_definitions import ImageFloat32, ImageType, ImageUInt8
 
@@ -393,7 +397,9 @@ def _floyd_steinberg_binary_uint8(img: ImageUInt8) -> ImageUInt8:
 
 def _should_vectorize_ordered_dither(height: int, width: int, num_channels: int) -> bool:
     num_pixels = height * width
-    return (num_channels > 3 and num_pixels >= 512 * 512) or num_pixels >= 1024 * 1024
+    return (
+        num_channels > 3 and num_pixels >= MULTICHANNEL_LUT_MEDIUM_IMAGE_PIXELS
+    ) or num_pixels >= MULTICHANNEL_LUT_LARGE_IMAGE_PIXELS
 
 
 def ordered_dither_uint8(
@@ -425,7 +431,6 @@ def ordered_dither_uint8(
     if n_colors == 2:
         return ((img > tiled[:, :, np.newaxis]) * 255).astype(np.uint8)
     # Multi-level: Create LUT once outside channel loop
-    result = np.zeros_like(img)
     levels = np.linspace(0, 255, n_colors).astype(np.uint8)
 
     lut = levels[np.minimum(np.arange(256) * n_colors // 256, n_colors - 1)]
@@ -436,6 +441,7 @@ def ordered_dither_uint8(
         np.clip(dithered, 0, 255, out=dithered)
         return sz_lut(dithered.astype(np.uint8), lut, inplace=False)
 
+    result = np.zeros_like(img)
     for channel_idx in range(img.shape[2]):
         channel = img[:, :, channel_idx]
         # Add dither pattern and quantize

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=4.13.0.92
-    - albucore==0.1.5
+    - albucore==0.1.6
 
 suggests:
   - pytorch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "albucore==0.1.5",
+  "albucore==0.1.6",
   "numpy>=1.24.4",
   "pydantic>=2.12.4",
   "pyyaml",

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -439,6 +439,15 @@ def test_equalize_rgb():
     assert np.all(img_cv == fpixel.equalize(img, mode="cv", by_channels=False))
 
 
+def test_equalize_multichannel():
+    rng = np.random.default_rng(137)
+    img = rng.integers(0, 256, (64, 64, 5), dtype=np.uint8)
+
+    expected = np.stack([cv2.equalizeHist(img[..., channel_idx]) for channel_idx in range(img.shape[2])], axis=-1)
+
+    np.testing.assert_array_equal(fpixel.equalize(img, mode="cv"), expected)
+
+
 def test_equalize_grayscale_mask():
     # Need fresh image for this test - equalize depends on histogram
     rng = np.random.default_rng(137)
@@ -1262,6 +1271,21 @@ def test_auto_contrast(img, expected):
         assert not np.all(
             result == img,
         ), "The output should change for non-constant input."
+
+
+def test_auto_contrast_multichannel_cdf_matches_per_channel():
+    rng = np.random.default_rng(137)
+    img = rng.integers(0, 256, (64, 64, 5), dtype=np.uint8)
+
+    expected = np.concatenate(
+        [
+            fpixel.auto_contrast(img[..., channel_idx : channel_idx + 1], cutoff=0, ignore=None, method="cdf")
+            for channel_idx in range(img.shape[2])
+        ],
+        axis=-1,
+    )
+
+    np.testing.assert_array_equal(fpixel.auto_contrast(img, cutoff=0, ignore=None, method="cdf"), expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -439,11 +439,15 @@ def test_equalize_rgb():
     assert np.all(img_cv == fpixel.equalize(img, mode="cv", by_channels=False))
 
 
-def test_equalize_multichannel():
+@pytest.mark.parametrize("shape", [(64, 64, 5), (1024, 1024, 3)])
+def test_equalize_multichannel(shape):
     rng = np.random.default_rng(137)
-    img = rng.integers(0, 256, (64, 64, 5), dtype=np.uint8)
+    img = rng.integers(0, 256, shape, dtype=np.uint8)
 
-    expected = np.stack([cv2.equalizeHist(img[..., channel_idx]) for channel_idx in range(img.shape[2])], axis=-1)
+    expected = np.stack(
+        [cv2.equalizeHist(img[..., channel_idx]) for channel_idx in range(img.shape[2])],
+        axis=-1,
+    )
 
     np.testing.assert_array_equal(fpixel.equalize(img, mode="cv"), expected)
 
@@ -1271,6 +1275,13 @@ def test_auto_contrast(img, expected):
         assert not np.all(
             result == img,
         ), "The output should change for non-constant input."
+
+
+def test_auto_contrast_pil_zero_cutoff_single_channel_fast_path():
+    img = np.array([[10, 20], [30, 40]], dtype=np.uint8)[..., np.newaxis]
+    expected = np.array([[0, 85], [170, 255]], dtype=np.uint8)[..., np.newaxis]
+
+    np.testing.assert_array_equal(fpixel.auto_contrast(img, cutoff=0, ignore=None, method="pil"), expected)
 
 
 def test_auto_contrast_multichannel_cdf_matches_per_channel():

--- a/tests/test_dithering.py
+++ b/tests/test_dithering.py
@@ -4,12 +4,12 @@ import numpy as np
 import pytest
 
 import albumentations as A
-import albumentations.augmentations.pixel.dithering_functional as dither_functional
 from albumentations.augmentations.pixel.dithering_functional import (
     apply_dithering,
     error_diffusion_dither,
     generate_bayer_matrix,
     ordered_dither,
+    ordered_dither_uint8,
     quantize_value,
     random_dither,
 )
@@ -111,11 +111,17 @@ class TestDitheringFunctional:
         rng = np.random.default_rng(137)
         img = rng.integers(0, 256, (17, 19, 5), dtype=np.uint8)
 
-        monkeypatch.setattr(dither_functional, "_should_vectorize_ordered_dither", lambda *_args: False)
-        expected = dither_functional.ordered_dither_uint8(img, n_colors=5, matrix_size=4)
+        monkeypatch.setattr(
+            "albumentations.augmentations.pixel.dithering_functional._should_vectorize_ordered_dither",
+            lambda *_args: False,
+        )
+        expected = ordered_dither_uint8(img, n_colors=5, matrix_size=4)
 
-        monkeypatch.setattr(dither_functional, "_should_vectorize_ordered_dither", lambda *_args: True)
-        result = dither_functional.ordered_dither_uint8(img, n_colors=5, matrix_size=4)
+        monkeypatch.setattr(
+            "albumentations.augmentations.pixel.dithering_functional._should_vectorize_ordered_dither",
+            lambda *_args: True,
+        )
+        result = ordered_dither_uint8(img, n_colors=5, matrix_size=4)
 
         np.testing.assert_array_equal(result, expected)
 

--- a/tests/test_dithering.py
+++ b/tests/test_dithering.py
@@ -116,6 +116,27 @@ class TestDitheringFunctional:
         with pytest.raises(ValueError):
             error_diffusion_dither(img, n_colors=2, algorithm="invalid")
 
+    def test_uint8_binary_floyd_steinberg_matches_float32_reference(self):
+        rng = np.random.default_rng(137)
+        img = rng.integers(0, 256, (16, 16, 1), dtype=np.uint8)
+
+        result = apply_dithering(
+            img,
+            method="error_diffusion",
+            n_colors=2,
+            color_mode="per_channel",
+            error_diffusion_algorithm="floyd_steinberg",
+            serpentine=False,
+        )
+        expected = error_diffusion_dither(
+            img.astype(np.float32) / 255.0,
+            n_colors=2,
+            algorithm="floyd_steinberg",
+            serpentine=False,
+        )
+
+        np.testing.assert_array_equal(result, (expected * 255).astype(np.uint8))
+
     def test_apply_dithering_grayscale_mode(self):
         """Test dithering with grayscale conversion."""
         rng = np.random.default_rng(137)

--- a/tests/test_dithering.py
+++ b/tests/test_dithering.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import albumentations as A
+import albumentations.augmentations.pixel.dithering_functional as dither_functional
 from albumentations.augmentations.pixel.dithering_functional import (
     apply_dithering,
     error_diffusion_dither,
@@ -16,6 +17,25 @@ from albumentations.augmentations.pixel.dithering_functional import (
 
 class TestDitheringFunctional:
     """Test dithering functional implementations."""
+
+    @staticmethod
+    def _assert_uint8_binary_floyd_steinberg_matches_reference(img: np.ndarray) -> None:
+        result = apply_dithering(
+            img,
+            method="error_diffusion",
+            n_colors=2,
+            color_mode="per_channel",
+            error_diffusion_algorithm="floyd_steinberg",
+            serpentine=False,
+        )
+        expected = error_diffusion_dither(
+            img.astype(np.float32) / 255.0,
+            n_colors=2,
+            algorithm="floyd_steinberg",
+            serpentine=False,
+        )
+
+        np.testing.assert_array_equal(result, (expected * 255).astype(np.uint8))
 
     def test_quantize_value(self):
         """Test value quantization."""
@@ -87,6 +107,18 @@ class TestDitheringFunctional:
             result = ordered_dither(img, n_colors=2, matrix_size=size)
             np.testing.assert_equal(result.shape, img.shape)
 
+    def test_ordered_dither_uint8_vectorized_path_matches_channel_loop(self, monkeypatch):
+        rng = np.random.default_rng(137)
+        img = rng.integers(0, 256, (17, 19, 5), dtype=np.uint8)
+
+        monkeypatch.setattr(dither_functional, "_should_vectorize_ordered_dither", lambda *_args: False)
+        expected = dither_functional.ordered_dither_uint8(img, n_colors=5, matrix_size=4)
+
+        monkeypatch.setattr(dither_functional, "_should_vectorize_ordered_dither", lambda *_args: True)
+        result = dither_functional.ordered_dither_uint8(img, n_colors=5, matrix_size=4)
+
+        np.testing.assert_array_equal(result, expected)
+
     def test_error_diffusion_dither(self):
         """Test error diffusion dithering."""
         # Create gradient image
@@ -120,22 +152,27 @@ class TestDitheringFunctional:
         rng = np.random.default_rng(137)
         img = rng.integers(0, 256, (16, 16, 1), dtype=np.uint8)
 
-        result = apply_dithering(
-            img,
-            method="error_diffusion",
-            n_colors=2,
-            color_mode="per_channel",
-            error_diffusion_algorithm="floyd_steinberg",
-            serpentine=False,
-        )
-        expected = error_diffusion_dither(
-            img.astype(np.float32) / 255.0,
-            n_colors=2,
-            algorithm="floyd_steinberg",
-            serpentine=False,
-        )
+        self._assert_uint8_binary_floyd_steinberg_matches_reference(img)
 
-        np.testing.assert_array_equal(result, (expected * 255).astype(np.uint8))
+    @pytest.mark.parametrize(
+        ("shape", "value"),
+        [
+            ((8, 8, 1), 0),
+            ((8, 8, 1), 255),
+            ((1, 16, 1), 0),
+            ((1, 16, 1), 255),
+            ((16, 1, 1), 0),
+            ((16, 1, 1), 255),
+        ],
+    )
+    def test_uint8_binary_floyd_steinberg_edge_cases_match_float32_reference(
+        self,
+        shape: tuple[int, int, int],
+        value: int,
+    ):
+        img = np.full(shape, value, dtype=np.uint8)
+
+        self._assert_uint8_binary_floyd_steinberg_matches_reference(img)
 
     def test_apply_dithering_grayscale_mode(self):
         """Test dithering with grayscale conversion."""

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "albucore"
-version = "0.1.5"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numkong" },
@@ -17,9 +17,9 @@ dependencies = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "stringzilla" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/23/d1eff908effdec4d6c79ef8566978f3cb55435ad19de0f090ebcd7794923/albucore-0.1.5.tar.gz", hash = "sha256:7f188c437405dbe132c168cb291f3b015f5f6c56d6c333277ab42ba635270ff4", size = 73106 }
+sdist = { url = "https://files.pythonhosted.org/packages/73/33/af2df301ecfd4f039acffa741d3266c1fa27d9f6ca6d60eafe83d8ba8267/albucore-0.1.6.tar.gz", hash = "sha256:0afdb9c4840bf060cab8c5b85ebf43c2df4de53c42013988a808aaba1ec0b5b1", size = 107185 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/0a/454d887ff1e19f7c7729f88acebfadc4b3e428d0172f1f385cd3d88dd6e1/albucore-0.1.5-py3-none-any.whl", hash = "sha256:13948e6bb80d55715ce2d17e47831f8f4e934d72e65bb2289ab69d5a2eda265a", size = 42044 },
+    { url = "https://files.pythonhosted.org/packages/e8/98/609eb10dfd2b6968eee5b01a3c9c2fc8caf79e40b86be2f5f4ec18d6a969/albucore-0.1.6-py3-none-any.whl", hash = "sha256:bd44b7af009e73d8906895c371d38aa210a9ea7e5fb06128c54875cc3ad4e3d4", size = 42578 },
 ]
 
 [[package]]
@@ -68,7 +68,7 @@ text = [
 
 [package.metadata]
 requires-dist = [
-    { name = "albucore", specifier = "==0.1.5" },
+    { name = "albucore", specifier = "==0.1.6" },
     { name = "huggingface-hub", marker = "extra == 'hub'" },
     { name = "numpy", specifier = ">=1.24.4" },
     { name = "opencv-contrib-python", marker = "extra == 'contrib'", specifier = ">=4.13.0.92" },


### PR DESCRIPTION
Use multichannel OpenCV LUT dispatch for per-channel tone curves, large equalize/autocontrast paths, and guarded ordered dithering cases to avoid Python channel loops. Bump Albucore to 0.1.6 and add regression coverage for the optimized histogram and dithering paths.

Made-with: Cursor

## Summary by Sourcery

Optimize pixel-level illumination, contrast, color equalization, and dithering operations for large and multi-channel images, and update dependencies accordingly.

Enhancements:
- Speed up linear illumination for multi-channel images by using OpenCV operations instead of per-channel NumPy broadcasting.
- Add fast paths for autocontrast, including Pillow-style single-channel zero-cutoff and multichannel LUT-based processing for large or high-channel-count images.
- Optimize OpenCV-style histogram equalization by adding a multichannel LUT path and generalized channel handling for large RGB and multispectral inputs.
- Introduce shared multichannel LUT application for tone curve transforms to reduce per-channel loops across images, batches, and volumes.
- Improve ordered dithering performance on large or high-channel-count images and add a specialized uint8 binary Floyd–Steinberg path for common grayscale error-diffusion cases.

Build:
- Bump albucore dependency to version 0.1.6 in project and conda recipe.

Tests:
- Add regression tests covering multichannel equalization, multichannel autocontrast CDF behavior, and the optimized uint8 Floyd–Steinberg dithering path.