### PR TITLE
Codex restore map resolution range

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -151,7 +151,7 @@ repos:
       - id: codespell
         additional_dependencies: ["tomli"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.2
+    rev: v2.0.0
     hooks:
       - id: mypy
         files: ^albumentations/

--- a/albumentations/augmentations/geometric/_functional_distortion.py
+++ b/albumentations/augmentations/geometric/_functional_distortion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Literal
 
 from ._functional_shared import (
+    albucore_resize,
     cv2,
     math,
     np,
@@ -72,6 +73,44 @@ def generate_inverse_distortion_map(
             best_dist[ny_upd, nx_upd] = dist_upd
 
     return inv_map_x, inv_map_y
+
+
+def upscale_distortion_maps(
+    map_x: np.ndarray,
+    map_y: np.ndarray,
+    target_shape: tuple[int, int],
+    interpolation: int = cv2.INTER_LINEAR,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Upscale coarse distortion coordinate maps to full image size and rescale coordinates,
+    enabling faster map generation while preserving full-resolution remapping.
+
+    Distortion transforms can generate coordinate maps at reduced resolution, then upscale
+    them before remapping full-resolution targets to trade geometric precision for speed.
+
+    Args:
+        map_x (np.ndarray): X-coordinate map generated at the lower resolution.
+        map_y (np.ndarray): Y-coordinate map generated at the lower resolution.
+        target_shape (tuple[int, int]): Target image shape as `(height, width)`.
+        interpolation (int): OpenCV interpolation flag used for resizing the maps.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: Upscaled `map_x` and `map_y` with coordinates
+            adjusted for the target shape.
+
+    """
+    height, width = target_shape
+    map_height, map_width = map_x.shape[:2]
+
+    if (map_height, map_width) == (height, width):
+        return map_x, map_y
+
+    scale_y = map_height / height
+    scale_x = map_width / width
+
+    map_x = albucore_resize(map_x[:, :, np.newaxis], (width, height), interpolation=interpolation)[:, :, 0]
+    map_y = albucore_resize(map_y[:, :, np.newaxis], (width, height), interpolation=interpolation)[:, :, 0]
+
+    return map_x / scale_x, map_y / scale_y
 
 
 def generate_displacement_fields(
@@ -562,4 +601,5 @@ __all__ = [
     "get_camera_matrix_distortion_maps",
     "get_fisheye_distortion_maps",
     "tps_transform",
+    "upscale_distortion_maps",
 ]

--- a/albumentations/augmentations/geometric/_functional_distortion.py
+++ b/albumentations/augmentations/geometric/_functional_distortion.py
@@ -103,13 +103,25 @@ def upscale_distortion_maps(
     if (map_height, map_width) == (height, width):
         return map_x, map_y
 
-    scale_y = map_height / height
-    scale_x = map_width / width
+    y_coords, x_coords = np.meshgrid(
+        np.arange(map_height, dtype=np.float32),
+        np.arange(map_width, dtype=np.float32),
+        indexing="ij",
+    )
+    dx = map_x - x_coords
+    dy = map_y - y_coords
 
-    map_x = cv2.resize(map_x, (width, height), interpolation=interpolation)
-    map_y = cv2.resize(map_y, (width, height), interpolation=interpolation)
+    scale_y = 1 if height == 1 or map_height == 1 else (map_height - 1) / (height - 1)
+    scale_x = 1 if width == 1 or map_width == 1 else (map_width - 1) / (width - 1)
+    dx = cv2.resize(dx, (width, height), interpolation=interpolation) / scale_x
+    dy = cv2.resize(dy, (width, height), interpolation=interpolation) / scale_y
 
-    return map_x / scale_x, map_y / scale_y
+    y_coords, x_coords = np.meshgrid(
+        np.arange(height, dtype=np.float32),
+        np.arange(width, dtype=np.float32),
+        indexing="ij",
+    )
+    return x_coords + dx, y_coords + dy
 
 
 def generate_displacement_fields(

--- a/albumentations/augmentations/geometric/_functional_distortion.py
+++ b/albumentations/augmentations/geometric/_functional_distortion.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Literal
 
 from ._functional_shared import (
-    albucore_resize,
     cv2,
     math,
     np,
@@ -107,8 +106,8 @@ def upscale_distortion_maps(
     scale_y = map_height / height
     scale_x = map_width / width
 
-    map_x = albucore_resize(map_x[:, :, np.newaxis], (width, height), interpolation=interpolation)[:, :, 0]
-    map_y = albucore_resize(map_y[:, :, np.newaxis], (width, height), interpolation=interpolation)[:, :, 0]
+    map_x = cv2.resize(map_x, (width, height), interpolation=interpolation)
+    map_y = cv2.resize(map_y, (width, height), interpolation=interpolation)
 
     return map_x / scale_x, map_y / scale_y
 

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -89,6 +89,10 @@ class BaseDistortion(DualTransform):
               less accurate for large distortions. Recommended for large images or many keypoints.
             - "direct": Uses inverse mapping. More accurate for large distortions but slower.
             Default: "mask"
+        map_resolution_range (tuple[float, float]): Range for sampling the distortion map resolution
+            relative to the target size. Values must be in (0, 1], where 1.0 uses full-resolution
+            maps and lower values generate smaller maps that are upscaled before remapping.
+            Default: (1.0, 1.0).
         p (float): Probability of applying the transform.
 
     Targets:
@@ -199,6 +203,11 @@ class BaseDistortion(DualTransform):
         ]
         fill: tuple[float, ...] | float
         fill_mask: tuple[float, ...] | float
+        map_resolution_range: Annotated[
+            tuple[float, float],
+            AfterValidator(check_range_bounds(0, 1, min_inclusive=False)),
+            AfterValidator(nondecreasing),
+        ]
 
     def __init__(
         self,
@@ -227,6 +236,7 @@ class BaseDistortion(DualTransform):
         ] = cv2.BORDER_CONSTANT,
         fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
+        map_resolution_range: tuple[float, float] = (1.0, 1.0),
     ):
         super().__init__(p=p)
         self.interpolation = interpolation
@@ -235,6 +245,31 @@ class BaseDistortion(DualTransform):
         self.border_mode = border_mode
         self.fill = fill
         self.fill_mask = fill_mask
+        self.map_resolution_range = map_resolution_range
+
+    def _get_map_resolution_and_shape(self, image_shape: tuple[int, int]) -> tuple[float, tuple[int, int]]:
+        min_resolution, max_resolution = self.map_resolution_range
+        map_resolution = (
+            min_resolution
+            if min_resolution == max_resolution
+            else self.py_random.uniform(min_resolution, max_resolution)
+        )
+        self.applied_config["map_resolution_range"] = map_resolution
+
+        height, width = image_shape
+        scaled_shape = (
+            max(1, int(height * map_resolution)),
+            max(1, int(width * map_resolution)),
+        )
+        return map_resolution, scaled_shape
+
+    def _maybe_upscale_maps(
+        self,
+        map_x: np.ndarray,
+        map_y: np.ndarray,
+        image_shape: tuple[int, int],
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return fgeometric.upscale_distortion_maps(map_x, map_y, image_shape, self.interpolation)
 
     def apply(
         self,
@@ -347,7 +382,9 @@ class ElasticTransform(BaseDistortion):
               less accurate for large distortions. Recommended for large images or many keypoints.
             - "direct": Uses inverse mapping. More accurate for large distortions but slower.
             Default: "mask"
-
+        map_resolution_range (tuple[float, float]): Range for sampling the displacement map resolution
+            relative to the target size. Values below 1.0 generate lower-resolution maps and upscale
+            them, trading precision for speed. Default: (1.0, 1.0).
         p (float): Probability of applying the transform. Default: 0.5
 
     Targets:
@@ -417,6 +454,7 @@ class ElasticTransform(BaseDistortion):
         ] = cv2.BORDER_CONSTANT,
         fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
+        map_resolution_range: tuple[float, float] = (1.0, 1.0),
         p: float = 0.5,
     ):
         super().__init__(
@@ -427,6 +465,7 @@ class ElasticTransform(BaseDistortion):
             border_mode=border_mode,
             fill=fill,
             fill_mask=fill_mask,
+            map_resolution_range=map_resolution_range,
         )
         self.alpha = alpha
         self.sigma = sigma
@@ -439,13 +478,15 @@ class ElasticTransform(BaseDistortion):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        height, width = params["shape"][:2]
+        image_shape = params["shape"][:2]
+        map_resolution, scaled_shape = self._get_map_resolution_and_shape(image_shape)
+        scaled_height, scaled_width = scaled_shape
         kernel_size = (17, 17) if self.approximate else (0, 0)
 
         dx, dy = fgeometric.generate_displacement_fields(
-            (height, width),
-            self.alpha,
-            self.sigma,
+            scaled_shape,
+            self.alpha * map_resolution,
+            self.sigma * map_resolution,
             same_dxdy=self.same_dxdy,
             kernel_size=kernel_size,
             random_generator=self.random_generator,
@@ -453,12 +494,13 @@ class ElasticTransform(BaseDistortion):
         )
 
         y_coords, x_coords = np.meshgrid(
-            np.arange(height, dtype=np.float32),
-            np.arange(width, dtype=np.float32),
+            np.arange(scaled_height, dtype=np.float32),
+            np.arange(scaled_width, dtype=np.float32),
             indexing="ij",
         )
         map_x = (x_coords + dx).astype(np.float32)
         map_y = (y_coords + dy).astype(np.float32)
+        map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
         return {
             "map_x": map_x,
@@ -498,6 +540,9 @@ class PiecewiseAffine(BaseDistortion):
               less accurate for large distortions. Recommended for large images or many keypoints.
             - "direct": Uses inverse mapping. More accurate for large distortions but slower.
             Default: "mask"
+        map_resolution_range (tuple[float, float]): Range for sampling the displacement map resolution
+            relative to the target size. Values below 1.0 generate lower-resolution maps and upscale
+            them, trading precision for speed. Default: (1.0, 1.0).
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -573,6 +618,7 @@ class PiecewiseAffine(BaseDistortion):
         ] = cv2.BORDER_CONSTANT,
         fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
+        map_resolution_range: tuple[float, float] = (1.0, 1.0),
     ):
         super().__init__(
             p=p,
@@ -582,6 +628,7 @@ class PiecewiseAffine(BaseDistortion):
             border_mode=border_mode,
             fill=fill,
             fill_mask=fill_mask,
+            map_resolution_range=map_resolution_range,
         )
 
         self.scale_range = scale_range
@@ -595,24 +642,24 @@ class PiecewiseAffine(BaseDistortion):
         data: dict[str, Any],
     ) -> dict[str, Any]:
         image_shape = params["shape"][:2]
+        _, scaled_shape = self._get_map_resolution_and_shape(image_shape)
 
         nb_rows = np.clip(self.py_random.randint(*self.nb_rows_range), 2, None)
         nb_cols = np.clip(self.py_random.randint(*self.nb_cols_range), 2, None)
         scale = self.py_random.uniform(*self.scale_range)
 
-        self.applied_config = {
-            "scale_range": scale,
-            "nb_rows_range": int(nb_rows),
-            "nb_cols_range": int(nb_cols),
-        }
+        self.applied_config["scale_range"] = scale
+        self.applied_config["nb_rows_range"] = int(nb_rows)
+        self.applied_config["nb_cols_range"] = int(nb_cols)
 
         map_x, map_y = fgeometric.create_piecewise_affine_maps(
-            image_shape=image_shape,
+            image_shape=scaled_shape,
             grid=(nb_rows, nb_cols),
             scale=scale,
             absolute_scale=self.absolute_scale,
             random_generator=self.random_generator,
         )
+        map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
         return {"map_x": map_x, "map_y": map_y}
 
@@ -652,6 +699,9 @@ class OpticalDistortion(BaseDistortion):
               less accurate for large distortions. Recommended for large images or many keypoints.
             - "direct": Uses inverse mapping. More accurate for large distortions but slower.
             Default: "mask"
+        map_resolution_range (tuple[float, float]): Range for sampling the displacement map resolution
+            relative to the target size. Values below 1.0 generate lower-resolution maps and upscale
+            them, trading precision for speed. Default: (1.0, 1.0).
 
         p (float): Probability of applying the transform. Default: 0.5.
 
@@ -717,6 +767,7 @@ class OpticalDistortion(BaseDistortion):
         ] = cv2.BORDER_CONSTANT,
         fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
+        map_resolution_range: tuple[float, float] = (1.0, 1.0),
     ):
         super().__init__(
             interpolation=interpolation,
@@ -726,6 +777,7 @@ class OpticalDistortion(BaseDistortion):
             border_mode=border_mode,
             fill=fill,
             fill_mask=fill_mask,
+            map_resolution_range=map_resolution_range,
         )
         self.distort_range = distort_range
         self.mode = mode
@@ -736,21 +788,23 @@ class OpticalDistortion(BaseDistortion):
         data: dict[str, Any],
     ) -> dict[str, Any]:
         image_shape = params["shape"][:2]
+        _, scaled_shape = self._get_map_resolution_and_shape(image_shape)
 
         k = self.py_random.uniform(*self.distort_range)
 
-        self.applied_config = {"distort_range": k}
+        self.applied_config["distort_range"] = k
 
         if self.mode == "camera":
             map_x, map_y = fgeometric.get_camera_matrix_distortion_maps(
-                image_shape,
+                scaled_shape,
                 k,
             )
         else:
             map_x, map_y = fgeometric.get_fisheye_distortion_maps(
-                image_shape,
+                scaled_shape,
                 k,
             )
+        map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
         return {"map_x": map_x, "map_y": map_y}
 
@@ -783,6 +837,9 @@ class GridDistortion(BaseDistortion):
               less accurate for large distortions. Recommended for large images or many keypoints.
             - "direct": Uses inverse mapping. More accurate for large distortions but slower.
             Default: "mask"
+        map_resolution_range (tuple[float, float]): Range for sampling the displacement map resolution
+            relative to the target size. Values below 1.0 generate lower-resolution maps and upscale
+            them, trading precision for speed. Default: (1.0, 1.0).
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -859,6 +916,7 @@ class GridDistortion(BaseDistortion):
         ] = cv2.BORDER_CONSTANT,
         fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
+        map_resolution_range: tuple[float, float] = (1.0, 1.0),
     ):
         super().__init__(
             interpolation=interpolation,
@@ -868,6 +926,7 @@ class GridDistortion(BaseDistortion):
             border_mode=border_mode,
             fill=fill,
             fill_mask=fill_mask,
+            map_resolution_range=map_resolution_range,
         )
         self.num_steps = num_steps
         self.distort_range = distort_range
@@ -879,6 +938,7 @@ class GridDistortion(BaseDistortion):
         data: dict[str, Any],
     ) -> dict[str, Any]:
         image_shape = params["shape"][:2]
+        _, scaled_shape = self._get_map_resolution_and_shape(image_shape)
 
         steps_x = (1 + self.random_generator.uniform(*self.distort_range, size=self.num_steps + 1)).tolist()
         steps_y = (1 + self.random_generator.uniform(*self.distort_range, size=self.num_steps + 1)).tolist()
@@ -890,7 +950,7 @@ class GridDistortion(BaseDistortion):
 
         if self.normalized:
             normalized_params = fgeometric.normalize_grid_distortion_steps(
-                image_shape,
+                scaled_shape,
                 self.num_steps,
                 steps_x,
                 steps_y,
@@ -901,11 +961,12 @@ class GridDistortion(BaseDistortion):
             )
 
         map_x, map_y = fgeometric.generate_grid(
-            image_shape,
+            scaled_shape,
             steps_x,
             steps_y,
             self.num_steps,
         )
+        map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
         return {"map_x": map_x, "map_y": map_y}
 
@@ -956,6 +1017,9 @@ class ThinPlateSpline(BaseDistortion):
               less accurate for large distortions. Recommended for large images or many keypoints.
             - "direct": Uses inverse mapping. More accurate for large distortions but slower.
             Default: "mask"
+        map_resolution_range (tuple[float, float]): Range for sampling the displacement map resolution
+            relative to the target size. Values below 1.0 generate lower-resolution maps and upscale
+            them, trading precision for speed. Default: (1.0, 1.0).
 
         p (float): Probability of applying the transform. Default: 0.5
 
@@ -1064,6 +1128,7 @@ class ThinPlateSpline(BaseDistortion):
         ] = cv2.BORDER_CONSTANT,
         fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
+        map_resolution_range: tuple[float, float] = (1.0, 1.0),
     ):
         super().__init__(
             interpolation=interpolation,
@@ -1073,6 +1138,7 @@ class ThinPlateSpline(BaseDistortion):
             border_mode=border_mode,
             fill=fill,
             fill_mask=fill_mask,
+            map_resolution_range=map_resolution_range,
         )
         self.scale_range = scale_range
         self.num_control_points = num_control_points
@@ -1083,12 +1149,15 @@ class ThinPlateSpline(BaseDistortion):
         data: dict[str, Any],
     ) -> dict[str, Any]:
         height, width = params["shape"][:2]
+        image_shape = (height, width)
+        _, scaled_shape = self._get_map_resolution_and_shape(image_shape)
+        scaled_height, scaled_width = scaled_shape
 
         src_points = fgeometric.generate_control_points(self.num_control_points)
 
         scale = self.py_random.uniform(*self.scale_range) / 10
 
-        self.applied_config = {"scale_range": scale * 10}
+        self.applied_config["scale_range"] = scale * 10
         dst_points = src_points + self.random_generator.normal(
             0,
             scale,
@@ -1097,9 +1166,9 @@ class ThinPlateSpline(BaseDistortion):
 
         weights, affine = fgeometric.compute_tps_weights(src_points, dst_points)
 
-        points = np.empty((height * width, 2), dtype=np.float32)
-        points[:, 0] = np.tile(np.arange(width, dtype=np.float32) / width, height)
-        points[:, 1] = np.repeat(np.arange(height, dtype=np.float32) / height, width)
+        points = np.empty((scaled_height * scaled_width, 2), dtype=np.float32)
+        points[:, 0] = np.tile(np.arange(scaled_width, dtype=np.float32) / scaled_width, scaled_height)
+        points[:, 1] = np.repeat(np.arange(scaled_height, dtype=np.float32) / scaled_height, scaled_width)
 
         transformed = fgeometric.tps_transform(
             points,
@@ -1107,11 +1176,12 @@ class ThinPlateSpline(BaseDistortion):
             weights,
             affine,
         )
-        transformed[:, 0] *= width
-        transformed[:, 1] *= height
+        transformed[:, 0] *= scaled_width
+        transformed[:, 1] *= scaled_height
 
-        map_x = transformed[:, 0].reshape(height, width).astype(np.float32)
-        map_y = transformed[:, 1].reshape(height, width).astype(np.float32)
+        map_x = transformed[:, 0].reshape(scaled_height, scaled_width).astype(np.float32)
+        map_y = transformed[:, 1].reshape(scaled_height, scaled_width).astype(np.float32)
+        map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
         return {
             "map_x": map_x,
@@ -1138,6 +1208,9 @@ class WaterRefraction(BaseDistortion):
         border_mode (int): OpenCV border mode. Default: cv2.BORDER_REFLECT_101.
         fill (float | tuple): Fill value for constant border. Default: 0.
         fill_mask (float | tuple): Fill value for mask borders. Default: 0.
+        map_resolution_range (tuple[float, float]): Range for sampling the displacement map resolution
+            relative to the target size. Values below 1.0 generate lower-resolution maps and upscale
+            them, trading precision for speed. Default: (1.0, 1.0).
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -1211,6 +1284,7 @@ class WaterRefraction(BaseDistortion):
         ] = cv2.BORDER_REFLECT_101,
         fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
+        map_resolution_range: tuple[float, float] = (1.0, 1.0),
         p: float = 0.5,
     ):
         super().__init__(
@@ -1220,6 +1294,7 @@ class WaterRefraction(BaseDistortion):
             border_mode=border_mode,
             fill=fill,
             fill_mask=fill_mask,
+            map_resolution_range=map_resolution_range,
             p=p,
         )
         self.amplitude_range = amplitude_range
@@ -1232,29 +1307,29 @@ class WaterRefraction(BaseDistortion):
         data: dict[str, Any],
     ) -> dict[str, Any]:
         image_shape = params["shape"][:2]
-        height, width = image_shape
+        _, scaled_shape = self._get_map_resolution_and_shape(image_shape)
+        scaled_height, scaled_width = scaled_shape
 
-        img_size = min(height, width)
+        img_size = min(scaled_height, scaled_width)
         amplitude_frac = self.py_random.uniform(*self.amplitude_range)
         wavelength_frac = self.py_random.uniform(*self.wavelength_range)
         num_waves = self.py_random.randint(*self.num_waves_range)
 
-        self.applied_config = {
-            "amplitude_range": amplitude_frac,
-            "wavelength_range": wavelength_frac,
-            "num_waves_range": num_waves,
-        }
+        self.applied_config["amplitude_range"] = amplitude_frac
+        self.applied_config["wavelength_range"] = wavelength_frac
+        self.applied_config["num_waves_range"] = num_waves
 
         amplitude = amplitude_frac * img_size
         wavelength = wavelength_frac * img_size
 
         map_x, map_y = fpixel.generate_water_displacement_maps(
-            image_shape,
+            scaled_shape,
             amplitude,
             wavelength,
             num_waves,
             self.random_generator,
         )
+        map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
         return {
             "map_x": map_x,
@@ -1294,6 +1369,9 @@ class PixelSpread(BaseDistortion):
             `cv2.BORDER_CONSTANT`. Default: 0.
         fill_mask (float | tuple[float, ...]): Fill value for masks under constant border.
             Default: 0.
+        map_resolution_range (tuple[float, float]): Range for sampling the displacement map resolution
+            relative to the target size. Values below 1.0 generate lower-resolution maps and upscale
+            them, trading precision for speed. Default: (1.0, 1.0).
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -1366,6 +1444,7 @@ class PixelSpread(BaseDistortion):
         ] = cv2.BORDER_REFLECT_101,
         fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
+        map_resolution_range: tuple[float, float] = (1.0, 1.0),
         p: float = 0.5,
     ):
         super().__init__(
@@ -1375,6 +1454,7 @@ class PixelSpread(BaseDistortion):
             border_mode=border_mode,
             fill=fill,
             fill_mask=fill_mask,
+            map_resolution_range=map_resolution_range,
             p=p,
         )
         self.radius = radius
@@ -1384,20 +1464,24 @@ class PixelSpread(BaseDistortion):
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, Any]:
-        height, width = params["shape"][:2]
+        image_shape = params["shape"][:2]
+        map_resolution, scaled_shape = self._get_map_resolution_and_shape(image_shape)
+        scaled_height, scaled_width = scaled_shape
 
         row_coords, col_coords = np.meshgrid(
-            np.arange(height, dtype=np.float32),
-            np.arange(width, dtype=np.float32),
+            np.arange(scaled_height, dtype=np.float32),
+            np.arange(scaled_width, dtype=np.float32),
             indexing="ij",
         )
+        scaled_radius = round(self.radius * map_resolution)
         offsets = self.random_generator.integers(
-            -self.radius,
-            self.radius + 1,
-            size=(height, width, 2),
+            -scaled_radius,
+            scaled_radius + 1,
+            size=(scaled_height, scaled_width, 2),
             dtype=np.int32,
         )
         map_y = (row_coords + offsets[..., 0]).astype(np.float32)
         map_x = (col_coords + offsets[..., 1]).astype(np.float32)
+        map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
         return {"map_x": map_x, "map_y": map_y}

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -939,9 +939,10 @@ class GridDistortion(BaseDistortion):
     ) -> dict[str, Any]:
         image_shape = params["shape"][:2]
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape)
+        num_steps = min(self.num_steps, *scaled_shape)
 
-        steps_x = (1 + self.random_generator.uniform(*self.distort_range, size=self.num_steps + 1)).tolist()
-        steps_y = (1 + self.random_generator.uniform(*self.distort_range, size=self.num_steps + 1)).tolist()
+        steps_x = (1 + self.random_generator.uniform(*self.distort_range, size=num_steps + 1)).tolist()
+        steps_y = (1 + self.random_generator.uniform(*self.distort_range, size=num_steps + 1)).tolist()
 
         # distort_range is per-cell uniform bounds; record realized (min, max) of sampled distortions
         # (steps are stored as 1+sample, so subtract 1 to get the raw distortion values).
@@ -951,7 +952,7 @@ class GridDistortion(BaseDistortion):
         if self.normalized:
             normalized_params = fgeometric.normalize_grid_distortion_steps(
                 scaled_shape,
-                self.num_steps,
+                num_steps,
                 steps_x,
                 steps_y,
             )
@@ -964,7 +965,7 @@ class GridDistortion(BaseDistortion):
             scaled_shape,
             steps_x,
             steps_y,
-            self.num_steps,
+            num_steps,
         )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
@@ -1473,7 +1474,7 @@ class PixelSpread(BaseDistortion):
             np.arange(scaled_width, dtype=np.float32),
             indexing="ij",
         )
-        scaled_radius = round(self.radius * map_resolution)
+        scaled_radius = max(1, round(self.radius * map_resolution))
         offsets = self.random_generator.integers(
             -scaled_radius,
             scaled_radius + 1,

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -257,9 +257,11 @@ class BaseDistortion(DualTransform):
         self.applied_config["map_resolution_range"] = map_resolution
 
         height, width = image_shape
+        min_height = min(2, height)
+        min_width = min(2, width)
         scaled_shape = (
-            max(1, int(height * map_resolution)),
-            max(1, int(width * map_resolution)),
+            max(min_height, int(height * map_resolution)),
+            max(min_width, int(width * map_resolution)),
         )
         return map_resolution, scaled_shape
 
@@ -794,6 +796,15 @@ class OpticalDistortion(BaseDistortion):
 
         self.applied_config["distort_range"] = k
 
+        if k == 0:
+            height, width = image_shape
+            map_y, map_x = np.meshgrid(
+                np.arange(height, dtype=np.float32),
+                np.arange(width, dtype=np.float32),
+                indexing="ij",
+            )
+            return {"map_x": map_x, "map_y": map_y}
+
         if self.mode == "camera":
             map_x, map_y = fgeometric.get_camera_matrix_distortion_maps(
                 scaled_shape,
@@ -948,6 +959,15 @@ class GridDistortion(BaseDistortion):
         # (steps are stored as 1+sample, so subtract 1 to get the raw distortion values).
         all_steps = np.array(steps_x + steps_y) - 1.0
         self.applied_config["distort_range"] = (float(all_steps.min()), float(all_steps.max()))
+
+        if np.all(all_steps == 0):
+            height, width = image_shape
+            map_y, map_x = np.meshgrid(
+                np.arange(height, dtype=np.float32),
+                np.arange(width, dtype=np.float32),
+                indexing="ij",
+            )
+            return {"map_x": map_x, "map_y": map_y}
 
         if self.normalized:
             normalized_params = fgeometric.normalize_grid_distortion_steps(

--- a/tests/test_distortion_map_resolution.py
+++ b/tests/test_distortion_map_resolution.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import albumentations as A
+from albumentations.augmentations.geometric import functional as fgeometric
 
 DISTORTION_TRANSFORMS = [
     pytest.param(A.ElasticTransform, {"alpha": 2, "sigma": 20}, id="ElasticTransform"),
@@ -17,6 +18,13 @@ DISTORTION_TRANSFORMS = [
         id="WaterRefraction",
     ),
     pytest.param(A.PixelSpread, {"radius": 3}, id="PixelSpread"),
+]
+
+NOOP_DISTORTION_TRANSFORMS = [
+    pytest.param(A.ElasticTransform, {"alpha": 0, "sigma": 20}, id="ElasticTransform"),
+    pytest.param(A.GridDistortion, {"num_steps": 5, "distort_range": (0, 0)}, id="GridDistortion"),
+    pytest.param(A.OpticalDistortion, {"distort_range": (0, 0)}, id="OpticalDistortion"),
+    pytest.param(A.WaterRefraction, {"amplitude_range": (0, 0)}, id="WaterRefraction"),
 ]
 
 
@@ -72,6 +80,40 @@ def test_low_map_resolution_returns_full_size_maps_for_tiny_images(transform_cls
     assert result["map_y"].shape == image.shape[:2]
     assert result["map_x"].dtype == np.float32
     assert result["map_y"].dtype == np.float32
+
+
+def test_upscale_distortion_maps_preserves_identity_map():
+    height, width = 13, 17
+    map_height, map_width = 4, 5
+    y_coords, x_coords = np.meshgrid(
+        np.arange(map_height, dtype=np.float32),
+        np.arange(map_width, dtype=np.float32),
+        indexing="ij",
+    )
+
+    map_x, map_y = fgeometric.upscale_distortion_maps(x_coords, y_coords, (height, width))
+
+    expected_y, expected_x = np.meshgrid(
+        np.arange(height, dtype=np.float32),
+        np.arange(width, dtype=np.float32),
+        indexing="ij",
+    )
+    np.testing.assert_array_equal(map_x, expected_x)
+    np.testing.assert_array_equal(map_y, expected_y)
+
+
+@pytest.mark.parametrize(("transform_cls", "params"), NOOP_DISTORTION_TRANSFORMS)
+def test_noop_distortion_stays_noop_with_low_map_resolution(transform_cls, params):
+    image = _make_image()
+    transform = A.Compose(
+        [transform_cls(**params, map_resolution_range=(0.25, 0.25), p=1.0)],
+        seed=137,
+        strict=True,
+    )
+
+    result = transform(image=image)
+
+    np.testing.assert_array_equal(result["image"], image)
 
 
 @pytest.mark.parametrize(("transform_cls", "params"), DISTORTION_TRANSFORMS)

--- a/tests/test_distortion_map_resolution.py
+++ b/tests/test_distortion_map_resolution.py
@@ -1,0 +1,115 @@
+"""Tests for reduced-resolution distortion map generation."""
+
+import numpy as np
+import pytest
+
+import albumentations as A
+
+DISTORTION_TRANSFORMS = [
+    pytest.param(A.ElasticTransform, {"alpha": 2, "sigma": 20}, id="ElasticTransform"),
+    pytest.param(A.GridDistortion, {"num_steps": 5, "distort_range": (-0.2, 0.2)}, id="GridDistortion"),
+    pytest.param(A.OpticalDistortion, {"distort_range": (-0.05, 0.05)}, id="OpticalDistortion"),
+    pytest.param(A.PiecewiseAffine, {"scale_range": (0.03, 0.05)}, id="PiecewiseAffine"),
+    pytest.param(A.ThinPlateSpline, {"scale_range": (0.2, 0.4)}, id="ThinPlateSpline"),
+    pytest.param(
+        A.WaterRefraction,
+        {"amplitude_range": (0.02, 0.04), "wavelength_range": (0.1, 0.2)},
+        id="WaterRefraction",
+    ),
+    pytest.param(A.PixelSpread, {"radius": 3}, id="PixelSpread"),
+]
+
+
+def _make_image(shape: tuple[int, int, int] = (64, 48, 3)) -> np.ndarray:
+    return np.random.default_rng(137).integers(0, 256, shape, dtype=np.uint8)
+
+
+@pytest.mark.parametrize(("transform_cls", "params"), DISTORTION_TRANSFORMS)
+def test_map_resolution_range_accepts_valid_tuple(transform_cls, params):
+    transform = transform_cls(**params, map_resolution_range=(0.25, 1.0), p=1.0)
+
+    assert transform.map_resolution_range == (0.25, 1.0)
+
+
+@pytest.mark.parametrize(
+    "map_resolution_range",
+    [
+        (0.0, 1.0),
+        (-0.1, 1.0),
+        (0.25, 1.1),
+        (0.75, 0.25),
+    ],
+)
+def test_map_resolution_range_rejects_invalid_values(map_resolution_range):
+    with pytest.raises(ValueError):
+        A.ElasticTransform(map_resolution_range=map_resolution_range)
+
+
+@pytest.mark.parametrize(("transform_cls", "params"), DISTORTION_TRANSFORMS)
+def test_low_map_resolution_returns_full_size_maps(transform_cls, params):
+    image = _make_image()
+    transform = transform_cls(**params, map_resolution_range=(0.25, 0.25), p=1.0)
+    transform.set_random_seed(137)
+
+    result = transform.get_params_dependent_on_data({"shape": image.shape}, {"image": image})
+
+    assert result["map_x"].shape == image.shape[:2]
+    assert result["map_y"].shape == image.shape[:2]
+    assert result["map_x"].dtype == np.float32
+    assert result["map_y"].dtype == np.float32
+
+
+@pytest.mark.parametrize(("transform_cls", "params"), DISTORTION_TRANSFORMS)
+def test_map_resolution_range_records_sampled_scalar(transform_cls, params):
+    image = _make_image()
+    transform = transform_cls(**params, map_resolution_range=(0.25, 0.75), p=1.0)
+    transform(image=image)
+
+    sampled = transform.applied_config["map_resolution_range"]
+    assert isinstance(sampled, float)
+    assert 0.25 <= sampled <= 0.75
+
+
+@pytest.mark.parametrize(("transform_cls", "params"), DISTORTION_TRANSFORMS)
+def test_default_map_resolution_matches_explicit_full_resolution(transform_cls, params):
+    image = _make_image()
+    default_transform = transform_cls(**params, p=1.0)
+    explicit_transform = transform_cls(**params, map_resolution_range=(1.0, 1.0), p=1.0)
+    default_transform.set_random_seed(137)
+    explicit_transform.set_random_seed(137)
+
+    default_result = default_transform(image=image)
+    explicit_result = explicit_transform(image=image)
+
+    np.testing.assert_array_equal(default_result["image"], explicit_result["image"])
+
+
+@pytest.mark.parametrize(("transform_cls", "params"), DISTORTION_TRANSFORMS)
+def test_low_map_resolution_applies_consistently_to_targets(transform_cls, params):
+    image = _make_image()
+    mask = np.zeros(image.shape[:2], dtype=np.uint8)
+    mask[16:48, 12:36] = 1
+    bboxes = np.array([[12, 16, 36, 48]], dtype=np.float32)
+    keypoints = np.array([[24, 32]], dtype=np.float32)
+
+    transform = A.Compose(
+        [transform_cls(**params, map_resolution_range=(0.25, 0.25), p=1.0)],
+        bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["bbox_labels"]),
+        keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["keypoint_labels"]),
+        seed=137,
+        strict=True,
+    )
+
+    result = transform(
+        image=image,
+        mask=mask,
+        bboxes=bboxes,
+        bbox_labels=[1],
+        keypoints=keypoints,
+        keypoint_labels=[2],
+    )
+
+    assert result["image"].shape == image.shape
+    assert result["mask"].shape == mask.shape
+    assert len(result["bboxes"]) == len(result["bbox_labels"])
+    assert len(result["keypoints"]) == len(result["keypoint_labels"])

--- a/tests/test_distortion_map_resolution.py
+++ b/tests/test_distortion_map_resolution.py
@@ -60,6 +60,21 @@ def test_low_map_resolution_returns_full_size_maps(transform_cls, params):
 
 
 @pytest.mark.parametrize(("transform_cls", "params"), DISTORTION_TRANSFORMS)
+@pytest.mark.parametrize("shape", [(2, 3, 3), (1, 1, 3)])
+def test_low_map_resolution_returns_full_size_maps_for_tiny_images(transform_cls, params, shape):
+    image = _make_image(shape)
+    transform = transform_cls(**params, map_resolution_range=(0.25, 0.25), p=1.0)
+    transform.set_random_seed(137)
+
+    result = transform.get_params_dependent_on_data({"shape": image.shape}, {"image": image})
+
+    assert result["map_x"].shape == image.shape[:2]
+    assert result["map_y"].shape == image.shape[:2]
+    assert result["map_x"].dtype == np.float32
+    assert result["map_y"].dtype == np.float32
+
+
+@pytest.mark.parametrize(("transform_cls", "params"), DISTORTION_TRANSFORMS)
 def test_map_resolution_range_records_sampled_scalar(transform_cls, params):
     image = _make_image()
     transform = transform_cls(**params, map_resolution_range=(0.25, 0.75), p=1.0)

--- a/tools/check_cv2_geometric_forbidden.py
+++ b/tools/check_cv2_geometric_forbidden.py
@@ -9,6 +9,7 @@ Use albucore equivalents for multi-channel support:
 
 Allowlist:
 - cv2.remap in geometric/functional.py and pixel/functional.py: 2D data only.
+- cv2.resize for 2D float32 distortion maps where adding a synthetic channel is unnecessary.
 """
 
 from __future__ import annotations
@@ -33,6 +34,7 @@ ALLOWLIST: list[tuple[str, str]] = [
     ("albumentations/augmentations/pixel/functional.py", "remap"),
     # 2D resize: `resize()` falls back to cv2 for ndim==2 inputs (albucore.resize requires 3D).
     ("albumentations/augmentations/geometric/functional.py", "resize"),
+    ("albumentations/augmentations/geometric/_functional_distortion.py", "resize"),
 ]
 
 


### PR DESCRIPTION
## Summary by Sourcery

Add configurable reduced-resolution distortion map generation to geometric distortion transforms while preserving full-resolution remapping and update type validation and tooling accordingly.

New Features:
- Introduce a map_resolution_range parameter on distortion transforms to control the resolution of generated displacement maps relative to the target image size.

Enhancements:
- Refactor distortion map generation through shared helpers to support sampling of map resolution and optional upscaling of coarse maps to full image size.
- Extend BaseDistortion init schema with validation for map_resolution_range values to ensure they are within (0, 1] and non-decreasing.

Build:
- Update the mypy pre-commit hook to version v2.0.0.

Documentation:
- Document the new map_resolution_range parameter and its behavior across geometric distortion transforms.

Tests:
- Add tests covering valid and invalid map_resolution_range values, map size and dtype for low-resolution maps, determinism with default vs explicit full resolution, and consistency of low-resolution maps across images, masks, bboxes, and keypoints.

Chores:
- Allow cv2.resize usage in the geometric distortion functional module for internal map upscaling.