### PR TITLE
feat(erasing): add grayscale fill mode

### DIFF
--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -231,7 +231,7 @@ class Erasing(BaseDropout):
     Note:
         - If sampled parameters are invalid for the current image geometry, no erasing is performed.
         - The actual erased area and aspect ratio are randomly sampled within the specified ranges for each
-            application.
+          application.
         - When using inpainting methods, only grayscale or RGB images are supported.
         - When using `fill="grayscale"`, `fill_mask` must be None.
 
@@ -328,7 +328,10 @@ class Erasing(BaseDropout):
         max_valid_area = min(max_area, max_area_h, max_area_w)
 
         if max_valid_area < min_area:
-            return {"holes": np.empty((0, 4), dtype=np.int32)}
+            return {
+                "holes": np.empty((0, 4), dtype=np.int32),
+                "seed": self.random_generator.integers(0, 2**32 - 1),
+            }
 
         erase_area = self.py_random.uniform(min_area, max_valid_area)
 
@@ -336,7 +339,10 @@ class Erasing(BaseDropout):
         min_r = max(r_min, erase_area / (height * height))
 
         if min_r > max_r:
-            return {"holes": np.empty((0, 4), dtype=np.int32)}
+            return {
+                "holes": np.empty((0, 4), dtype=np.int32),
+                "seed": self.random_generator.integers(0, 2**32 - 1),
+            }
 
         aspect_ratio = self.py_random.uniform(min_r, max_r)
 

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -1,10 +1,8 @@
-"""Implementation of coarse dropout and random erasing augmentations.
+"""Implementation of coarse dropout and erasing augmentations.
 
-This module provides several variations of coarse dropout augmentations, which drop out
-rectangular regions from images. It includes CoarseDropout for randomly placed dropouts,
-ConstrainedCoarseDropout for dropping out regions based on masks or bounding boxes,
-and Erasing for random erasing augmentation. These techniques help models become more
-robust to occlusions and varying object completeness.
+This module provides several coarse region corruption transforms, including random rectangular dropout,
+object-constrained dropout, and random erasing. These augmentations help models become more robust to
+occlusion, missing evidence, and over-reliance on local color cues.
 """
 
 from typing import Annotated, Any, Literal
@@ -205,7 +203,7 @@ class Erasing(BaseDropout):
         ratio (tuple[float, float]): Range for the aspect ratio (width/height) of the erased region.
             The actual ratio will be randomly sampled from (ratio[0], ratio[1]).
             Default: (0.3, 3.3)
-        fill (tuple[float, float] | float | Literal['random', 'random_uniform', 'inpaint_telea', 'inpaint_ns']):
+        fill (float | tuple[float, ...] | str):
             Value used to fill the erased regions. Can be:
             - int or float: fills all channels with this value
             - tuple: fills each channel with corresponding value
@@ -213,6 +211,7 @@ class Erasing(BaseDropout):
             - "random_uniform": fills entire erased region with a single random color
             - "inpaint_telea": uses OpenCV Telea inpainting method
             - "inpaint_ns": uses OpenCV Navier-Stokes inpainting method
+            - "grayscale": converts erased regions to grayscale while preserving structure
             Default: 0
         fill_mask (tuple[float, float] | float | None): Value used to fill erased regions in the mask.
             If None, mask regions are not modified. Default: None
@@ -228,11 +227,11 @@ class Erasing(BaseDropout):
         hbb
 
     Note:
-        - The transform attempts to find valid erasing parameters up to 10 times.
-          If unsuccessful, no erasing is performed.
-        - The actual erased area and aspect ratio are randomly sampled within
-          the specified ranges for each application.
+        - If sampled parameters are invalid for the current image geometry, no erasing is performed.
+        - The actual erased area and aspect ratio are randomly sampled within the specified ranges for each
+            application.
         - When using inpainting methods, only grayscale or RGB images are supported.
+        - When using `fill="grayscale"`, `fill_mask` must be None.
 
     Examples:
         >>> import numpy as np
@@ -245,7 +244,7 @@ class Erasing(BaseDropout):
         >>> transform = A.Erasing(
         ...     scale=(0.1, 0.4),
         ...     ratio=(0.5, 2.0),
-        ...     fill_value="random_uniform",
+        ...     fill="random_uniform",
         ...     p=1.0
         ... )
         >>> transformed = transform(image=image)
@@ -273,7 +272,9 @@ class Erasing(BaseDropout):
         self,
         scale: tuple[float, float] = (0.02, 0.33),
         ratio: tuple[float, float] = (0.3, 3.3),
-        fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"] = 0,
+        fill: tuple[float, ...]
+        | float
+        | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns", "grayscale"] = 0,
         fill_mask: tuple[float, ...] | float | None = None,
         p: float = 0.5,
     ):
@@ -283,67 +284,31 @@ class Erasing(BaseDropout):
         self.ratio = ratio
 
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
-        """Calculate erasing parameters (box position and size) from image shape and ratio ranges.
-        Direct derivation; used by Erasing get_params_dependent_on_data.
-
-        Given:
-        - Image dimensions (H, W)
-        - Target area (A)
-        - Aspect ratio (r = w/h)
-
-        We know:
-        - h * w = A (area equation)
-        - w = r * h (aspect ratio equation)
-
-        Therefore:
-        - h * (r * h) = A
-        - h² = A/r
-        - h = sqrt(A/r)
-        - w = r * sqrt(A/r) = sqrt(A*r)
-        """
         height, width = params["shape"][:2]
         total_area = height * width
 
-        # Calculate maximum valid area based on dimensions and aspect ratio
         max_area = total_area * self.scale[1]
         min_area = total_area * self.scale[0]
 
-        # For each aspect ratio r, the maximum area is constrained by:
-        # h = sqrt(A/r) ≤ H and w = sqrt(A*r) ≤ W
-        # Therefore: A ≤ min(r*H², W²/r)
         r_min, r_max = self.ratio
-
-        def area_constraint_h(r: float) -> float:
-            return r * height * height
-
-        def area_constraint_w(r: float) -> float:
-            return width * width / r
-
-        # Find maximum valid area considering aspect ratio constraints
-        max_area_h = min(area_constraint_h(r_min), area_constraint_h(r_max))
-        max_area_w = min(area_constraint_w(r_min), area_constraint_w(r_max))
-        max_valid_area = min(max_area, max_area_h, max_area_w)
+        max_valid_area = min(max_area, r_min * height * height, width * width / r_max)
 
         if max_valid_area < min_area:
-            return {"holes": np.array([], dtype=np.int32).reshape((0, 4))}
+            return {"holes": np.empty((0, 4), dtype=np.int32)}
 
-        # Sample valid area and aspect ratio
         erase_area = self.py_random.uniform(min_area, max_valid_area)
 
-        # Calculate valid aspect ratio range for this area
         max_r = min(r_max, width * width / erase_area)
         min_r = max(r_min, erase_area / (height * height))
 
         if min_r > max_r:
-            return {"holes": np.array([], dtype=np.int32).reshape((0, 4))}
+            return {"holes": np.empty((0, 4), dtype=np.int32)}
 
         aspect_ratio = self.py_random.uniform(min_r, max_r)
 
-        # Calculate dimensions
         h = round(np.sqrt(erase_area / aspect_ratio))
         w = round(np.sqrt(erase_area * aspect_ratio))
 
-        # Sample position
         top = self.py_random.randint(0, height - h)
         left = self.py_random.randint(0, width - w)
 
@@ -353,7 +318,6 @@ class Erasing(BaseDropout):
             "scale": erase_area / total_area,
             "ratio": aspect_ratio,
         }
-
         return {"holes": holes, "seed": self.random_generator.integers(0, 2**32 - 1)}
 
 

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -286,6 +286,24 @@ class Erasing(BaseDropout):
         self.ratio = ratio
 
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+        """Calculate erasing parameters (box position and size) from image shape and ratio ranges.
+        Direct derivation; used by Erasing get_params_dependent_on_data.
+
+        Given:
+        - Image dimensions (H, W)
+        - Target area (A)
+        - Aspect ratio (r = w/h)
+
+        We know:
+        - h * w = A (area equation)
+        - w = r * h (aspect ratio equation)
+
+        Therefore:
+        - h * (r * h) = A
+        - h² = A/r
+        - h = sqrt(A/r)
+        - w = r * sqrt(A/r) = sqrt(A*r)
+        """
         height, width = params["shape"][:2]
         total_area = height * width
 

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -1,8 +1,10 @@
-"""Implementation of coarse dropout and erasing augmentations.
+"""Implementation of coarse dropout and random erasing augmentations.
 
-This module provides several coarse region corruption transforms, including random rectangular dropout,
-object-constrained dropout, and random erasing. These augmentations help models become more robust to
-occlusion, missing evidence, and over-reliance on local color cues.
+This module provides several variations of coarse dropout augmentations, which drop out
+rectangular regions from images. It includes CoarseDropout for randomly placed dropouts,
+ConstrainedCoarseDropout for dropping out regions based on masks or bounding boxes,
+and Erasing for random erasing augmentation. These techniques help models become more
+robust to occlusions and varying object completeness.
 """
 
 from typing import Annotated, Any, Literal
@@ -287,11 +289,25 @@ class Erasing(BaseDropout):
         height, width = params["shape"][:2]
         total_area = height * width
 
+        # Calculate maximum valid area based on dimensions and aspect ratio
         max_area = total_area * self.scale[1]
         min_area = total_area * self.scale[0]
 
+        # For each aspect ratio r, the maximum area is constrained by:
+        # h = sqrt(A/r) ≤ H and w = sqrt(A*r) ≤ W
+        # Therefore: A ≤ min(r*H², W²/r)
         r_min, r_max = self.ratio
-        max_valid_area = min(max_area, r_min * height * height, width * width / r_max)
+
+        def area_constraint_h(r: float) -> float:
+            return r * height * height
+
+        def area_constraint_w(r: float) -> float:
+            return width * width / r
+
+        # Find maximum valid area considering aspect ratio constraints
+        max_area_h = min(area_constraint_h(r_min), area_constraint_h(r_max))
+        max_area_w = min(area_constraint_w(r_min), area_constraint_w(r_max))
+        max_valid_area = min(max_area, max_area_h, max_area_w)
 
         if max_valid_area < min_area:
             return {"holes": np.empty((0, 4), dtype=np.int32)}

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -21,7 +21,7 @@ from albucore import (
 )
 
 from albumentations.augmentations.geometric.functional import split_uniform_grid
-from albumentations.augmentations.pixel._functional_color import grayscale_to_multichannel, to_gray_weighted_average
+from albumentations.augmentations.pixel.functional import grayscale_to_multichannel, to_gray_weighted_average
 from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.type_definitions import ImageType
 
@@ -31,6 +31,7 @@ __all__ = [
     "calculate_grid_dimensions",
     "channel_dropout",
     "cutout",
+    "fill_holes_with_grayscale",
     "fill_volume_holes_with_grayscale",
     "fill_volumes_holes_with_grayscale",
     "filter_bboxes_by_holes",
@@ -38,7 +39,6 @@ __all__ = [
     "generate_grid_holes",
     "generate_grid_mask_holes",
     "generate_random_fill",
-    "grayscale_holes",
     "mask_to_rects",
 ]
 
@@ -164,7 +164,7 @@ def fill_holes_with_value(img: ImageType, holes: np.ndarray, fill: np.ndarray) -
     return img
 
 
-def grayscale_holes(img: ImageType, holes: np.ndarray) -> ImageType:
+def fill_holes_with_grayscale(img: ImageType, holes: np.ndarray) -> ImageType:
     """Convert selected rectangular holes to grayscale while preserving the input array shape,
     dtype, and channel layout expected by dropout transforms.
 
@@ -176,26 +176,25 @@ def grayscale_holes(img: ImageType, holes: np.ndarray) -> ImageType:
         ImageType: Image with grayscale-converted holes.
 
     Raises:
-        TypeError: If image has channels other than 1 or 3.
+        ValueError: If image has channels other than 1 or 3.
 
     """
-    result = img.copy()
-    num_channels = get_num_channels(result)
+    num_channels = get_num_channels(img)
 
     if holes.size == 0:
-        return result
+        return img
 
     if num_channels not in {1, 3}:
-        raise TypeError("Grayscale hole dropout expects 1 or 3 channel images.")
+        raise ValueError("Grayscale fill works only for 1 or 3 channel images")
 
     if num_channels == 1:
-        return result
+        return img
 
     for x_min, y_min, x_max, y_max in holes:
-        patch = result[y_min:y_max, x_min:x_max]
-        result[y_min:y_max, x_min:x_max] = grayscale_to_multichannel(to_gray_weighted_average(patch), 3)
+        patch = img[y_min:y_max, x_min:x_max]
+        img[y_min:y_max, x_min:x_max] = grayscale_to_multichannel(to_gray_weighted_average(patch), 3)
 
-    return result
+    return img
 
 
 def fill_volume_holes_with_grayscale(volume: ImageType, holes: np.ndarray) -> ImageType:
@@ -210,7 +209,7 @@ def fill_volume_holes_with_grayscale(volume: ImageType, holes: np.ndarray) -> Im
         ImageType: Volume with grayscale-converted holes.
 
     Raises:
-        TypeError: If volume has channels other than 1 or 3.
+        ValueError: If volume has channels other than 1 or 3.
 
     """
     if volume.ndim == 3 or holes.size == 0:
@@ -218,22 +217,21 @@ def fill_volume_holes_with_grayscale(volume: ImageType, holes: np.ndarray) -> Im
 
     num_channels = volume.shape[3]
     if num_channels not in {1, 3}:
-        raise TypeError("Grayscale hole dropout expects 1 or 3 channel images.")
+        raise ValueError("Grayscale fill works only for 1 or 3 channel images")
 
     if num_channels == 1:
         return volume
 
-    result = volume.copy()
     for x_min, y_min, x_max, y_max in holes:
-        patch_batch = result[:, y_min:y_max, x_min:x_max]
-        result[:, y_min:y_max, x_min:x_max] = grayscale_to_multichannel(
+        patch_batch = volume[:, y_min:y_max, x_min:x_max]
+        volume[:, y_min:y_max, x_min:x_max] = grayscale_to_multichannel(
             to_gray_weighted_average(patch_batch),
             3,
         )
-    return result
+    return volume
 
 
-def fill_volumes_holes_with_grayscale(images: ImageType, holes: np.ndarray) -> ImageType:
+def fill_volumes_holes_with_grayscale(volumes: ImageType, holes: np.ndarray) -> ImageType:
     """Convert shared rectangular holes to grayscale across an image batch while preserving
     batch shape, per-image dtype, and channel layout used by Compose.
 
@@ -241,40 +239,39 @@ def fill_volumes_holes_with_grayscale(images: ImageType, holes: np.ndarray) -> I
     4-D slice rather than image-by-image, avoiding repeated Python-loop overhead.
 
     Args:
-        images (ImageType): Batch of images with shape (N, H, W, C) or
-            batch of volumes with shape (N, D, H, W, C).
+        volumes (ImageType): Batch of volumes with shape (N, D, H, W, C) or
+            batch of images with shape (N, H, W, C).
         holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates.
 
     Returns:
         ImageType: Batch with grayscale-converted holes.
 
     Raises:
-        TypeError: If images have channels other than 1 or 3.
+        ValueError: If images have channels other than 1 or 3.
 
     """
-    num_channels = get_num_channels(images)
+    num_channels = get_num_channels(volumes)
     if holes.size == 0:
-        return images
+        return volumes
 
     if num_channels not in {1, 3}:
-        raise TypeError("Grayscale hole dropout expects 1 or 3 channel images.")
+        raise ValueError("Grayscale fill works only for 1 or 3 channel images")
 
     if num_channels == 1:
-        return images
+        return volumes
 
-    if images.ndim == 5:
-        flattened = images.reshape(-1, *images.shape[2:])
+    if volumes.ndim == 5:
+        flattened = volumes.reshape(-1, *volumes.shape[2:])
         result = fill_volumes_holes_with_grayscale(flattened, holes)
-        return result.reshape(images.shape)
+        return result.reshape(volumes.shape)
 
-    result = images.copy()
     for x_min, y_min, x_max, y_max in holes:
-        patch_batch = result[:, y_min:y_max, x_min:x_max]
-        result[:, y_min:y_max, x_min:x_max] = grayscale_to_multichannel(
+        patch_batch = volumes[:, y_min:y_max, x_min:x_max]
+        volumes[:, y_min:y_max, x_min:x_max] = grayscale_to_multichannel(
             to_gray_weighted_average(patch_batch),
             3,
         )
-    return result
+    return volumes
 
 
 def fill_volume_holes_with_value(volume: ImageType, holes: np.ndarray, fill: np.ndarray) -> ImageType:
@@ -427,7 +424,7 @@ def cutout(
         if fill == "random_uniform":
             return fill_holes_with_random(img, holes, random_generator, uniform=True)
         if fill == "grayscale":
-            return grayscale_holes(img, holes)
+            return fill_holes_with_grayscale(img, holes)
         raise ValueError(f"Unsupported string fill: {fill}")
 
     # Convert numeric fill values to numpy array

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -209,11 +209,11 @@ def fill_volume_holes_with_grayscale(volume: ImageType, holes: np.ndarray) -> Im
 
     """
     if volume.ndim == 3 or holes.size == 0:
-        return volume.copy()
+        return volume
 
     num_channels = volume.shape[3]
     if num_channels == 1:
-        return volume.copy()
+        return volume
 
     if num_channels != 3:
         raise TypeError("Grayscale hole dropout expects 1- or 3-channel images.")
@@ -249,7 +249,7 @@ def fill_volumes_holes_with_grayscale(images: ImageType, holes: np.ndarray) -> I
     """
     num_channels = get_num_channels(images)
     if holes.size == 0 or num_channels == 1:
-        return images.copy()
+        return images
 
     if num_channels != 3:
         raise TypeError("Grayscale hole dropout expects 1- or 3-channel images.")

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -25,6 +25,8 @@ from albumentations.augmentations.pixel._functional_color import grayscale_to_mu
 from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.type_definitions import ImageType
 
+FillValueLiteral = Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns", "grayscale"]
+
 __all__ = [
     "calculate_grid_dimensions",
     "channel_dropout",
@@ -180,11 +182,14 @@ def grayscale_holes(img: ImageType, holes: np.ndarray) -> ImageType:
     result = img.copy()
     num_channels = get_num_channels(result)
 
-    if holes.size == 0 or num_channels == 1:
+    if holes.size == 0:
         return result
 
-    if num_channels != 3:
-        raise TypeError("Grayscale hole dropout expects 1- or 3-channel images.")
+    if num_channels not in {1, 3}:
+        raise TypeError("Grayscale hole dropout expects 1 or 3 channel images.")
+
+    if num_channels == 1:
+        return result
 
     for x_min, y_min, x_max, y_max in holes:
         patch = result[y_min:y_max, x_min:x_max]
@@ -212,11 +217,11 @@ def fill_volume_holes_with_grayscale(volume: ImageType, holes: np.ndarray) -> Im
         return volume
 
     num_channels = volume.shape[3]
+    if num_channels not in {1, 3}:
+        raise TypeError("Grayscale hole dropout expects 1 or 3 channel images.")
+
     if num_channels == 1:
         return volume
-
-    if num_channels != 3:
-        raise TypeError("Grayscale hole dropout expects 1- or 3-channel images.")
 
     result = volume.copy()
     for x_min, y_min, x_max, y_max in holes:
@@ -248,11 +253,14 @@ def fill_volumes_holes_with_grayscale(images: ImageType, holes: np.ndarray) -> I
 
     """
     num_channels = get_num_channels(images)
-    if holes.size == 0 or num_channels == 1:
+    if holes.size == 0:
         return images
 
-    if num_channels != 3:
-        raise TypeError("Grayscale hole dropout expects 1- or 3-channel images.")
+    if num_channels not in {1, 3}:
+        raise TypeError("Grayscale hole dropout expects 1 or 3 channel images.")
+
+    if num_channels == 1:
+        return images
 
     if images.ndim == 5:
         flattened = images.reshape(-1, *images.shape[2:])
@@ -385,7 +393,7 @@ def fill_volumes_holes_with_random(
 def cutout(
     img: ImageType,
     holes: np.ndarray,
-    fill: float | tuple[float, ...] | str,
+    fill: float | tuple[float, ...] | FillValueLiteral,
     random_generator: np.random.Generator,
 ) -> ImageType:
     """Apply cutout: cut rectangular holes and fill. holes: [x1,y1,x2,y2]; fill: constant, 'random',
@@ -394,7 +402,7 @@ def cutout(
     Args:
         img (ImageType): The image to augment
         holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates
-        fill (float | tuple[float, ...] | str):
+        fill (float | tuple[float, ...] | FillValueLiteral):
             Value to fill holes with. Can be:
             - number (int/float): Will be broadcast to all channels
             - sequence (tuple/list/ndarray): Must match number of channels
@@ -443,7 +451,7 @@ def cutout(
 def cutout_on_volume(
     volume: ImageType,
     holes: np.ndarray,
-    fill: float | tuple[float, ...] | str,
+    fill: float | tuple[float, ...] | FillValueLiteral,
     random_generator: np.random.Generator,
 ) -> ImageType:
     """Apply cutout to volume (D,H,W,C): cut holes and fill. fill: constant, 'random', 'random_uniform',
@@ -452,7 +460,7 @@ def cutout_on_volume(
     Args:
         volume (ImageType): The volume to augment
         holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates
-        fill (float | tuple[float, ...] | str):
+        fill (float | tuple[float, ...] | FillValueLiteral):
             Value to fill holes with. Can be:
             - number (int/float): Will be broadcast to all channels
             - sequence (tuple/list/ndarray): Must match number of channels
@@ -508,7 +516,7 @@ def cutout_on_volume(
 def cutout_on_volumes(
     volumes: np.ndarray,
     holes: np.ndarray,
-    fill: float | tuple[float, ...] | str,
+    fill: float | tuple[float, ...] | FillValueLiteral,
     random_generator: np.random.Generator,
 ) -> np.ndarray:
     """Apply cutout to batch of volumes (N,D,H,W,C): cut holes and fill. fill: constant, 'random',
@@ -517,7 +525,7 @@ def cutout_on_volumes(
     Args:
         volumes (np.ndarray): The image to augment
         holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates
-        fill (float | tuple[float, ...] | str):
+        fill (float | tuple[float, ...] | FillValueLiteral):
             Value to fill holes with. Can be:
             - number (int/float): Will be broadcast to all channels
             - sequence (tuple/list/ndarray): Must match number of channels

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -21,7 +21,7 @@ from albucore import (
 )
 
 from albumentations.augmentations.geometric.functional import split_uniform_grid
-from albumentations.augmentations.pixel.functional import grayscale_to_multichannel, to_gray_weighted_average
+from albumentations.augmentations.pixel.functional import grayscale_to_multichannel, to_gray_average
 from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.type_definitions import ImageType
 
@@ -175,24 +175,18 @@ def fill_holes_with_grayscale(img: ImageType, holes: np.ndarray) -> ImageType:
     Returns:
         ImageType: Image with grayscale-converted holes.
 
-    Raises:
-        ValueError: If image has channels other than 1 or 3.
-
     """
     num_channels = get_num_channels(img)
 
     if holes.size == 0:
         return img
 
-    if num_channels not in {1, 3}:
-        raise ValueError("Grayscale fill works only for 1 or 3 channel images")
-
     if num_channels == 1:
         return img
 
     for x_min, y_min, x_max, y_max in holes:
         patch = img[y_min:y_max, x_min:x_max]
-        img[y_min:y_max, x_min:x_max] = grayscale_to_multichannel(to_gray_weighted_average(patch), 3)
+        img[y_min:y_max, x_min:x_max] = grayscale_to_multichannel(to_gray_average(patch), num_channels)
 
     return img
 
@@ -208,25 +202,19 @@ def fill_volume_holes_with_grayscale(volume: ImageType, holes: np.ndarray) -> Im
     Returns:
         ImageType: Volume with grayscale-converted holes.
 
-    Raises:
-        ValueError: If volume has channels other than 1 or 3.
-
     """
     if volume.ndim == 3 or holes.size == 0:
         return volume
 
     num_channels = volume.shape[3]
-    if num_channels not in {1, 3}:
-        raise ValueError("Grayscale fill works only for 1 or 3 channel images")
-
     if num_channels == 1:
         return volume
 
     for x_min, y_min, x_max, y_max in holes:
         patch_batch = volume[:, y_min:y_max, x_min:x_max]
         volume[:, y_min:y_max, x_min:x_max] = grayscale_to_multichannel(
-            to_gray_weighted_average(patch_batch),
-            3,
+            to_gray_average(patch_batch),
+            num_channels,
         )
     return volume
 
@@ -246,16 +234,10 @@ def fill_volumes_holes_with_grayscale(volumes: ImageType, holes: np.ndarray) -> 
     Returns:
         ImageType: Batch with grayscale-converted holes.
 
-    Raises:
-        ValueError: If images have channels other than 1 or 3.
-
     """
     num_channels = get_num_channels(volumes)
     if holes.size == 0:
         return volumes
-
-    if num_channels not in {1, 3}:
-        raise ValueError("Grayscale fill works only for 1 or 3 channel images")
 
     if num_channels == 1:
         return volumes
@@ -268,8 +250,8 @@ def fill_volumes_holes_with_grayscale(volumes: ImageType, holes: np.ndarray) -> 
     for x_min, y_min, x_max, y_max in holes:
         patch_batch = volumes[:, y_min:y_max, x_min:x_max]
         volumes[:, y_min:y_max, x_min:x_max] = grayscale_to_multichannel(
-            to_gray_weighted_average(patch_batch),
-            3,
+            to_gray_average(patch_batch),
+            num_channels,
         )
     return volumes
 

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -21,6 +21,7 @@ from albucore import (
 )
 
 from albumentations.augmentations.geometric.functional import split_uniform_grid
+from albumentations.augmentations.pixel._functional_color import grayscale_to_multichannel, to_gray_weighted_average
 from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.type_definitions import ImageType
 
@@ -28,11 +29,14 @@ __all__ = [
     "calculate_grid_dimensions",
     "channel_dropout",
     "cutout",
+    "fill_volume_holes_with_grayscale",
+    "fill_volumes_holes_with_grayscale",
     "filter_bboxes_by_holes",
     "filter_keypoints_in_holes",
     "generate_grid_holes",
     "generate_grid_mask_holes",
     "generate_random_fill",
+    "grayscale_holes",
     "mask_to_rects",
 ]
 
@@ -158,6 +162,113 @@ def fill_holes_with_value(img: ImageType, holes: np.ndarray, fill: np.ndarray) -
     return img
 
 
+def grayscale_holes(img: ImageType, holes: np.ndarray) -> ImageType:
+    """Convert selected rectangular holes to grayscale while preserving the input array shape,
+    dtype, and channel layout expected by dropout transforms.
+
+    Args:
+        img (ImageType): Input image.
+        holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates.
+
+    Returns:
+        ImageType: Image with grayscale-converted holes.
+
+    Raises:
+        TypeError: If image has channels other than 1 or 3.
+
+    """
+    result = img.copy()
+    num_channels = get_num_channels(result)
+
+    if holes.size == 0 or num_channels == 1:
+        return result
+
+    if num_channels != 3:
+        raise TypeError("Grayscale hole dropout expects 1- or 3-channel images.")
+
+    for x_min, y_min, x_max, y_max in holes:
+        patch = result[y_min:y_max, x_min:x_max]
+        result[y_min:y_max, x_min:x_max] = grayscale_to_multichannel(to_gray_weighted_average(patch), 3)
+
+    return result
+
+
+def fill_volume_holes_with_grayscale(volume: ImageType, holes: np.ndarray) -> ImageType:
+    """Convert shared rectangular holes to grayscale across a single volume while preserving
+    volume shape, dtype, and channel layout.
+
+    Args:
+        volume (ImageType): Volume with shape (D, H, W, C) or (D, H, W).
+        holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates.
+
+    Returns:
+        ImageType: Volume with grayscale-converted holes.
+
+    Raises:
+        TypeError: If volume has channels other than 1 or 3.
+
+    """
+    if volume.ndim == 3 or holes.size == 0:
+        return volume.copy()
+
+    num_channels = volume.shape[3]
+    if num_channels == 1:
+        return volume.copy()
+
+    if num_channels != 3:
+        raise TypeError("Grayscale hole dropout expects 1- or 3-channel images.")
+
+    result = volume.copy()
+    for x_min, y_min, x_max, y_max in holes:
+        patch_batch = result[:, y_min:y_max, x_min:x_max]
+        result[:, y_min:y_max, x_min:x_max] = grayscale_to_multichannel(
+            to_gray_weighted_average(patch_batch),
+            3,
+        )
+    return result
+
+
+def fill_volumes_holes_with_grayscale(images: ImageType, holes: np.ndarray) -> ImageType:
+    """Convert shared rectangular holes to grayscale across an image batch while preserving
+    batch shape, per-image dtype, and channel layout used by Compose.
+
+    All images share the same holes, so each hole's patch is processed as a single
+    4-D slice rather than image-by-image, avoiding repeated Python-loop overhead.
+
+    Args:
+        images (ImageType): Batch of images with shape (N, H, W, C) or
+            batch of volumes with shape (N, D, H, W, C).
+        holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates.
+
+    Returns:
+        ImageType: Batch with grayscale-converted holes.
+
+    Raises:
+        TypeError: If images have channels other than 1 or 3.
+
+    """
+    num_channels = get_num_channels(images)
+    if holes.size == 0 or num_channels == 1:
+        return images.copy()
+
+    if num_channels != 3:
+        raise TypeError("Grayscale hole dropout expects 1- or 3-channel images.")
+
+    if images.ndim == 5:
+        flattened = images.reshape(-1, *images.shape[2:])
+        result = fill_volumes_holes_with_grayscale(flattened, holes)
+        return result.reshape(images.shape)
+
+    result = images.copy()
+    for x_min, y_min, x_max, y_max in holes:
+        patch_batch = result[:, y_min:y_max, x_min:x_max]
+        result[:, y_min:y_max, x_min:x_max] = grayscale_to_multichannel(
+            to_gray_weighted_average(patch_batch),
+            3,
+        )
+    return result
+
+
 def fill_volume_holes_with_value(volume: ImageType, holes: np.ndarray, fill: np.ndarray) -> ImageType:
     """Fill rectangular holes in a volume (D,H,W,C) with constant value. holes: [x1,y1,x2,y2]; fill
     broadcast. Used by cutout_on_volume for numeric fill.
@@ -274,22 +385,23 @@ def fill_volumes_holes_with_random(
 def cutout(
     img: ImageType,
     holes: np.ndarray,
-    fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"],
+    fill: float | tuple[float, ...] | str,
     random_generator: np.random.Generator,
 ) -> ImageType:
     """Apply cutout: cut rectangular holes and fill. holes: [x1,y1,x2,y2]; fill: constant, 'random',
-    'random_uniform', or inpaint_telea/inpaint_ns.
+    'random_uniform', inpaint_telea/inpaint_ns, or grayscale.
 
     Args:
         img (ImageType): The image to augment
         holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates
-        fill (tuple[float, ...] | float | Literal['random', 'random_uniform', 'inpaint_telea', 'inpaint_ns']):
+        fill (float | tuple[float, ...] | str):
             Value to fill holes with. Can be:
             - number (int/float): Will be broadcast to all channels
             - sequence (tuple/list/ndarray): Must match number of channels
             - "random": Different random values for each pixel
             - "random_uniform": Same random value for entire hole
             - "inpaint_telea"/"inpaint_ns": OpenCV inpainting methods
+            - "grayscale": Convert holes to grayscale while preserving image shape and dtype
         random_generator (np.random.Generator): Random number generator for random fills
 
     Raises:
@@ -306,6 +418,8 @@ def cutout(
             return fill_holes_with_random(img, holes, random_generator, uniform=False)
         if fill == "random_uniform":
             return fill_holes_with_random(img, holes, random_generator, uniform=True)
+        if fill == "grayscale":
+            return grayscale_holes(img, holes)
         raise ValueError(f"Unsupported string fill: {fill}")
 
     # Convert numeric fill values to numpy array
@@ -329,22 +443,23 @@ def cutout(
 def cutout_on_volume(
     volume: ImageType,
     holes: np.ndarray,
-    fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"],
+    fill: float | tuple[float, ...] | str,
     random_generator: np.random.Generator,
 ) -> ImageType:
     """Apply cutout to volume (D,H,W,C): cut holes and fill. fill: constant, 'random', 'random_uniform',
-    or inpaint. holes: [x1,y1,x2,y2].
+    inpaint, or grayscale. holes: [x1,y1,x2,y2].
 
     Args:
         volume (ImageType): The volume to augment
         holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates
-        fill (tuple[float, ...] | float | Literal['random', 'random_uniform', 'inpaint_telea', 'inpaint_ns']):
+        fill (float | tuple[float, ...] | str):
             Value to fill holes with. Can be:
             - number (int/float): Will be broadcast to all channels
             - sequence (tuple/list/ndarray): Must match number of channels
             - "random": Different random values for each pixel
             - "random_uniform": Same random value for entire hole, different values across images
             - "inpaint_telea"/"inpaint_ns": OpenCV inpainting methods
+            - "grayscale": Convert holes to grayscale while preserving image shape and dtype
         random_generator (np.random.Generator): Random number generator for random fills
 
     Raises:
@@ -366,6 +481,8 @@ def cutout_on_volume(
             return fill_volume_holes_with_random(volume, holes, random_generator, uniform=False)
         if fill == "random_uniform":
             return fill_volume_holes_with_random(volume, holes, random_generator, uniform=True)
+        if fill == "grayscale":
+            return fill_volume_holes_with_grayscale(volume, holes)
         raise ValueError(f"Unsupported string fill: {fill}")
 
     # Convert numeric fill values to numpy array
@@ -391,22 +508,23 @@ def cutout_on_volume(
 def cutout_on_volumes(
     volumes: np.ndarray,
     holes: np.ndarray,
-    fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"],
+    fill: float | tuple[float, ...] | str,
     random_generator: np.random.Generator,
 ) -> np.ndarray:
     """Apply cutout to batch of volumes (N,D,H,W,C): cut holes and fill. fill: constant, 'random',
-    'random_uniform', or inpaint. holes: [x1,y1,x2,y2].
+    'random_uniform', inpaint, or grayscale. holes: [x1,y1,x2,y2].
 
     Args:
         volumes (np.ndarray): The image to augment
         holes (np.ndarray): Array of [x1, y1, x2, y2] coordinates
-        fill (tuple[float, ...] | float | Literal['random', 'random_uniform', 'inpaint_telea', 'inpaint_ns']):
+        fill (float | tuple[float, ...] | str):
             Value to fill holes with. Can be:
             - number (int/float): Will be broadcast to all channels
             - sequence (tuple/list/ndarray): Must match number of channels
             - "random": Different random values for each pixel
             - "random_uniform": Same random value for entire hole, different values across images
             - "inpaint_telea"/"inpaint_ns": OpenCV inpainting methods
+            - "grayscale": Convert holes to grayscale while preserving image shape and dtype
         random_generator (np.random.Generator): Random number generator for random fills
 
     Raises:
@@ -430,6 +548,8 @@ def cutout_on_volumes(
             return fill_volumes_holes_with_random(volumes, holes, random_generator, uniform=False)
         if fill == "random_uniform":
             return fill_volumes_holes_with_random(volumes, holes, random_generator, uniform=True)
+        if fill == "grayscale":
+            return fill_volumes_holes_with_grayscale(volumes, holes)
         raise ValueError(f"Unsupported string fill: {fill}")
 
     # Convert numeric fill values to numpy array

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -9,7 +9,6 @@ in images, which can help models become more robust to occlusions and missing in
 from typing import Any, Literal, cast
 
 import numpy as np
-from albucore import get_num_channels
 from pydantic import Field
 
 from albumentations.augmentations.dropout import functional as fdropout
@@ -131,30 +130,25 @@ class BaseDropout(DualTransform):
         self.fill = fill  # type: ignore[assignment]
         self.fill_mask = fill_mask
 
+    def _validate_fill_channel_count(self, data: ImageType | VolumeType, channel_ndims: set[int]) -> None:
+        num_channels = data.shape[-1] if data.ndim in channel_ndims else 1
+
+        if self.fill in {"inpaint_telea", "inpaint_ns"} and num_channels not in {1, 3}:
+            raise ValueError("Inpainting works only for 1 or 3 channel images")
+
+        if self.fill == "grayscale" and num_channels not in {1, 3}:
+            raise ValueError("Grayscale fill works only for 1 or 3 channel images")
+
     def apply(self, img: ImageType, holes: np.ndarray, seed: int, **params: Any) -> ImageType:
         if holes.size == 0:
             return img
-        if self.fill in {"inpaint_telea", "inpaint_ns"}:
-            num_channels = get_num_channels(img)
-            if num_channels not in {1, 3}:
-                raise ValueError("Inpainting works only for 1 or 3 channel images")
-        if self.fill == "grayscale":
-            num_channels = get_num_channels(img)
-            if num_channels not in {1, 3}:
-                raise ValueError("Grayscale fill works only for 1 or 3 channel images")
+        self._validate_fill_channel_count(img, {2, 3})
         return cutout(img, holes, self.fill, np.random.default_rng(seed))
 
     def apply_to_images(self, images: ImageType, holes: np.ndarray, seed: int, **params: Any) -> ImageType:
         if holes.size == 0:
             return images
-        if self.fill in {"inpaint_telea", "inpaint_ns"}:
-            num_channels = images.shape[3] if images.ndim == 4 else 1
-            if num_channels not in {1, 3}:
-                raise ValueError("Inpainting works only for 1 or 3 channel images")
-        if self.fill == "grayscale":
-            num_channels = images.shape[3] if images.ndim == 4 else 1
-            if num_channels not in {1, 3}:
-                raise ValueError("Grayscale fill works only for 1 or 3 channel images")
+        self._validate_fill_channel_count(images, {4})
         # Images (N, H, W, C) have the same structure as volumes (D, H, W, C)
         return cutout_on_volume(images, holes, self.fill, np.random.default_rng(seed))
 
@@ -166,14 +160,7 @@ class BaseDropout(DualTransform):
     def apply_to_volumes(self, volumes: VolumeType, holes: np.ndarray, seed: int, **params: Any) -> VolumeType:
         if holes.size == 0:
             return volumes
-        if self.fill in {"inpaint_telea", "inpaint_ns"}:
-            num_channels = volumes.shape[4] if volumes.ndim == 5 else 1
-            if num_channels not in {1, 3}:
-                raise ValueError("Inpainting works only for 1 or 3 channel images")
-        if self.fill == "grayscale":
-            num_channels = volumes.shape[4] if volumes.ndim == 5 else 1
-            if num_channels not in {1, 3}:
-                raise ValueError("Grayscale fill works only for 1 or 3 channel images")
+        self._validate_fill_channel_count(volumes, {5})
         return cutout_on_volumes(volumes, holes, self.fill, np.random.default_rng(seed))
 
     def apply_to_mask3d(self, mask: VolumeType, holes: np.ndarray, seed: int, **params: Any) -> VolumeType:

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -37,7 +37,7 @@ class BaseDropout(DualTransform):
     including applying cutouts to images and masks.
 
     Args:
-        fill (tuple[float, ...] | float | Literal['random', 'random_uniform', 'inpaint_telea', 'inpaint_ns']):
+        fill (float | tuple[float, ...] | str):
             Value to fill dropped regions.
         fill_mask (tuple[float, ...] | float | None): Value to fill
             dropped regions in the mask. If None, the mask is not modified.
@@ -112,16 +112,22 @@ class BaseDropout(DualTransform):
     _targets: tuple[Targets, ...] | Targets = ALL_TARGETS
 
     class InitSchema(BaseTransformInitSchema):
-        fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"]
+        fill: (
+            tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns", "grayscale"]
+        )
         fill_mask: tuple[float, ...] | float | None
 
     def __init__(
         self,
-        fill: tuple[float, ...] | float | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns"],
+        fill: tuple[float, ...]
+        | float
+        | Literal["random", "random_uniform", "inpaint_telea", "inpaint_ns", "grayscale"],
         fill_mask: tuple[float, ...] | float | None,
         p: float,
     ):
         super().__init__(p=p)
+        if fill == "grayscale" and fill_mask is not None:
+            raise ValueError("fill_mask must be None when fill='grayscale'")
         self.fill = fill  # type: ignore[assignment]
         self.fill_mask = fill_mask
 
@@ -132,6 +138,10 @@ class BaseDropout(DualTransform):
             num_channels = get_num_channels(img)
             if num_channels not in {1, 3}:
                 raise ValueError("Inpainting works only for 1 or 3 channel images")
+        if self.fill == "grayscale":
+            num_channels = get_num_channels(img)
+            if num_channels not in {1, 3}:
+                raise ValueError("Grayscale fill works only for 1 or 3 channel images")
         return cutout(img, holes, self.fill, np.random.default_rng(seed))
 
     def apply_to_images(self, images: ImageType, holes: np.ndarray, seed: int, **params: Any) -> ImageType:
@@ -141,6 +151,10 @@ class BaseDropout(DualTransform):
             num_channels = images.shape[3] if images.ndim == 4 else 1
             if num_channels not in {1, 3}:
                 raise ValueError("Inpainting works only for 1 or 3 channel images")
+        if self.fill == "grayscale":
+            num_channels = images.shape[3] if images.ndim == 4 else 1
+            if num_channels not in {1, 3}:
+                raise ValueError("Grayscale fill works only for 1 or 3 channel images")
         # Images (N, H, W, C) have the same structure as volumes (D, H, W, C)
         return cutout_on_volume(images, holes, self.fill, np.random.default_rng(seed))
 
@@ -156,6 +170,10 @@ class BaseDropout(DualTransform):
             num_channels = volumes.shape[4] if volumes.ndim == 5 else 1
             if num_channels not in {1, 3}:
                 raise ValueError("Inpainting works only for 1 or 3 channel images")
+        if self.fill == "grayscale":
+            num_channels = volumes.shape[4] if volumes.ndim == 5 else 1
+            if num_channels not in {1, 3}:
+                raise ValueError("Grayscale fill works only for 1 or 3 channel images")
         return cutout_on_volumes(volumes, holes, self.fill, np.random.default_rng(seed))
 
     def apply_to_mask3d(self, mask: VolumeType, holes: np.ndarray, seed: int, **params: Any) -> VolumeType:

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -13,7 +13,7 @@ from tests.conftest import (
     SQUARE_MULTI_UINT8_IMAGE,
     SQUARE_UINT8_IMAGE,
 )
-from tests.helpers import TransformTestHelper
+from tests.helpers import TestDataFactory, TransformTestHelper
 
 from .aug_definitions import transforms2metadata_key
 from .utils import get_2d_transforms, get_dual_transforms, get_image_only_transforms, set_seed
@@ -1284,6 +1284,122 @@ def test_pixel_dropout_mismatched_tuple_dimensions(drop_value, channels, expecte
         # Multi-channel - check each channel
         for channel_idx in range(channels):
             assert np.all(result[:, :, channel_idx] == expected_values[channel_idx])
+
+
+def test_erasing_grayscale_fill_converts_only_sampled_patch():
+    image = TestDataFactory.create_image((64, 64, 3), dtype=np.uint8, seed=137)
+
+    transform = A.Erasing(
+        scale=(0.2, 0.2),
+        ratio=(1.0, 1.0),
+        fill="grayscale",
+        p=1.0,
+    )
+    transform.set_random_seed(137)
+
+    result = transform(image=image)["image"]
+    holes = transform.params["holes"]
+
+    assert holes.shape == (1, 4)
+    x_min, y_min, x_max, y_max = holes[0]
+
+    outside_mask = np.ones(image.shape[:2], dtype=bool)
+    outside_mask[y_min:y_max, x_min:x_max] = False
+
+    np.testing.assert_array_equal(result[outside_mask], image[outside_mask])
+
+    hole_patch = result[y_min:y_max, x_min:x_max]
+    np.testing.assert_array_equal(hole_patch[..., 0], hole_patch[..., 1])
+    np.testing.assert_array_equal(hole_patch[..., 1], hole_patch[..., 2])
+
+
+def test_erasing_grayscale_fill_rejects_non_rgb_multichannel():
+    image = TestDataFactory.create_image((32, 32, 4), dtype=np.uint8, seed=137)
+
+    transform = A.Erasing(
+        scale=(0.2, 0.2),
+        ratio=(1.0, 1.0),
+        fill="grayscale",
+        p=1.0,
+    )
+
+    with pytest.raises(ValueError, match="1 or 3 channel"):
+        transform(image=image)
+
+
+def test_erasing_grayscale_fill_requires_fill_mask_none():
+    with pytest.raises(ValueError, match="fill_mask must be None"):
+        A.Erasing(
+            scale=(0.2, 0.2),
+            ratio=(1.0, 1.0),
+            fill="grayscale",
+            fill_mask=0,
+            p=1.0,
+        )
+
+
+def test_erasing_grayscale_fill_on_volume():
+    volume = TestDataFactory.create_volume((4, 64, 64, 3), dtype=np.uint8, seed=137)
+
+    transform = A.Erasing(
+        scale=(0.2, 0.2),
+        ratio=(1.0, 1.0),
+        fill="grayscale",
+        p=1.0,
+    )
+    transform.set_random_seed(137)
+
+    result = transform(volume=volume)["volume"]
+    holes = transform.params["holes"]
+
+    assert holes.shape == (1, 4)
+    x_min, y_min, x_max, y_max = holes[0]
+
+    result_outside = result.copy()
+    volume_outside = volume.copy()
+    result_outside[:, y_min:y_max, x_min:x_max, :] = 0
+    volume_outside[:, y_min:y_max, x_min:x_max, :] = 0
+
+    np.testing.assert_array_equal(result_outside, volume_outside)
+
+    hole_patch = result[:, y_min:y_max, x_min:x_max, :]
+    np.testing.assert_array_equal(hole_patch[..., 0], hole_patch[..., 1])
+    np.testing.assert_array_equal(hole_patch[..., 1], hole_patch[..., 2])
+
+
+def test_erasing_grayscale_fill_on_volumes():
+    volumes = np.stack(
+        [
+            TestDataFactory.create_volume((4, 64, 64, 3), dtype=np.uint8, seed=137),
+            TestDataFactory.create_volume((4, 64, 64, 3), dtype=np.uint8, seed=138),
+        ],
+        axis=0,
+    )
+
+    transform = A.Erasing(
+        scale=(0.2, 0.2),
+        ratio=(1.0, 1.0),
+        fill="grayscale",
+        p=1.0,
+    )
+    transform.set_random_seed(137)
+
+    result = transform(volumes=volumes)["volumes"]
+    holes = transform.params["holes"]
+
+    assert holes.shape == (1, 4)
+    x_min, y_min, x_max, y_max = holes[0]
+
+    result_outside = result.copy()
+    volumes_outside = volumes.copy()
+    result_outside[:, :, y_min:y_max, x_min:x_max, :] = 0
+    volumes_outside[:, :, y_min:y_max, x_min:x_max, :] = 0
+
+    np.testing.assert_array_equal(result_outside, volumes_outside)
+
+    hole_patch = result[:, :, y_min:y_max, x_min:x_max, :]
+    np.testing.assert_array_equal(hole_patch[..., 0], hole_patch[..., 1])
+    np.testing.assert_array_equal(hole_patch[..., 1], hole_patch[..., 2])
 
 
 def test_salt_and_pepper_noise():


### PR DESCRIPTION
## Summary by Sourcery

Add a grayscale fill mode to erasing/cutout dropout transforms for images, volumes, and volume batches, with appropriate validation and support across the dropout pipeline.

New Features:
- Support using fill="grayscale" in Erasing and underlying cutout functions to convert erased regions to grayscale while preserving image shape and dtype for images, volumes, and batches.

Enhancements:
- Broaden BaseDropout and Erasing fill parameter types to accept a generic string mode and document the new grayscale behavior.
- Introduce helper functions to apply grayscale conversion to cutout holes for single images, single volumes, and batches of volumes, reusing common dropout infrastructure.
- Improve erasing parameter generation by returning an empty holes array directly when no valid region can be found.

Tests:
- Add tests covering grayscale fill behavior for single images, single volumes, and batches of volumes, including that only sampled regions are modified and that channels are equalized.
- Add validation tests ensuring grayscale fill is restricted to 1- or 3-channel inputs and that fill_mask must be None when using fill="grayscale".