### PR TITLE
fix(compose): refresh unseeded worker RNG from PyTorch DataLoader

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -55,6 +55,7 @@ __all__ = [
 ]
 
 NUM_ONEOF_TRANSFORMS = 2
+_UINT32_MODULUS = 1 << 32
 
 _RANGE_PARAMS_CACHE: dict[type, frozenset[str]] = {}
 
@@ -862,8 +863,8 @@ class BaseCompose(Serializable):
             if worker_info is not None:
                 # We're in a DataLoader worker process
                 # Use torch.initial_seed() which is unique per worker and changes on respawn
-                torch_seed = torch.initial_seed() % (2**32)
-                return (base_seed + torch_seed) % (2**32)
+                torch_seed = torch.initial_seed() % _UINT32_MODULUS
+                return (base_seed + torch_seed) % _UINT32_MODULUS
         except (ImportError, AttributeError):
             # PyTorch not available or not in worker context
             pass
@@ -1316,7 +1317,7 @@ class Compose(BaseCompose, HubMixin):
                     effective_seed = self._get_effective_seed(self._base_seed)
                 else:
                     # No explicit seed: follow the worker seed so new epochs stay random.
-                    effective_seed = current_torch_seed % (2**32)
+                    effective_seed = current_torch_seed % _UINT32_MODULUS
 
                 # Update our own random state
                 self.random_generator = np.random.default_rng(effective_seed)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1296,9 +1296,6 @@ class Compose(BaseCompose, HubMixin):
         """Check and update random seed in worker context. Recalculates effective seed and
         propagates to all transforms for reproducibility.
         """
-        if not hasattr(self, "_base_seed") or self._base_seed is None:
-            return
-
         # Check if we're in a worker and need to update the seed
         try:
             import torch
@@ -1310,12 +1307,16 @@ class Compose(BaseCompose, HubMixin):
                 current_torch_seed = torch.initial_seed()
 
                 # Check if we've already synchronized for this seed
-                if hasattr(self, "_last_torch_seed") and self._last_torch_seed == current_torch_seed:
+                if self._last_torch_seed == current_torch_seed:
                     return
 
                 # Update the seed and mark as synchronized
                 self._last_torch_seed = current_torch_seed
-                effective_seed = self._get_effective_seed(self._base_seed)
+                if self._base_seed is not None:
+                    effective_seed = self._get_effective_seed(self._base_seed)
+                else:
+                    # No explicit seed: follow the worker seed so new epochs stay random.
+                    effective_seed = current_torch_seed % (2**32)
 
                 # Update our own random state
                 self.random_generator = np.random.default_rng(effective_seed)


### PR DESCRIPTION
Before the fix, worker reseeding exited early when `self._base_seed` was `None`. That meant pipelines created without an explicit `seed=` did not synchronize their random state from the PyTorch worker seed inside worker processes. As a result, the _Compose_ instance kept using the same internal RNG state pattern for a given worker/process position, which is why the same batch position could receive the same augmentation pattern across epochs.

Closes: #266 