### PR TITLE
fix(compose): sync RNG state in DataLoader workers

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -28,7 +28,13 @@ from .analytics.telemetry import get_telemetry_client
 from .bbox_utils import BboxParams, BboxProcessor
 from .hub_mixin import HubMixin
 from .keypoints_utils import KeypointParams, KeypointsProcessor
-from .random_utils import _derive_effective_seed, _get_runtime_rng_context, _RuntimeRngContext
+from .random_utils import (
+    _derive_effective_seed,
+    _get_runtime_rng_context,
+    _restore_runtime_rng_state,
+    _RuntimeRngContext,
+    _should_sync_runtime_rng,
+)
 from .serialization import (
     SERIALIZABLE_REGISTRY,
     Serializable,
@@ -360,11 +366,12 @@ class BaseCompose(Serializable):
         """Refresh copied RNG state inside PyTorch DataLoader workers unless the user explicitly
         installed exact RNG objects through set_random_state.
         """
-        if self._manual_random_state:
-            return
-
         runtime_context = _get_runtime_rng_context(self._base_seed)
-        if runtime_context is None or runtime_context == self._rng_context:
+        if runtime_context is None or not _should_sync_runtime_rng(
+            manual=self._manual_random_state,
+            current_context=self._rng_context,
+            runtime_context=runtime_context,
+        ):
             return
 
         self._set_random_state(
@@ -902,11 +909,7 @@ class BaseCompose(Serializable):
         call can resynchronize against the active DataLoader seed.
         """
         self.__dict__.update(state)
-        if not hasattr(self, "_base_seed"):
-            self._base_seed = getattr(self, "seed", None)
-        if not hasattr(self, "_manual_random_state"):
-            self._manual_random_state = False
-        self._rng_context = None
+        _restore_runtime_rng_state(self)
 
     def _get_effective_seed(self, base_seed: int | None) -> int | None:
         """Get effective seed considering worker context. In PyTorch DataLoader workers,

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -28,6 +28,7 @@ from .analytics.telemetry import get_telemetry_client
 from .bbox_utils import BboxParams, BboxProcessor
 from .hub_mixin import HubMixin
 from .keypoints_utils import KeypointParams, KeypointsProcessor
+from .random_utils import _derive_effective_seed, _get_runtime_rng_context, _RuntimeRngContext
 from .serialization import (
     SERIALIZABLE_REGISTRY,
     Serializable,
@@ -55,7 +56,6 @@ __all__ = [
 ]
 
 NUM_ONEOF_TRANSFORMS = 2
-_UINT32_MODULUS = 1 << 32
 
 _RANGE_PARAMS_CACHE: dict[type, frozenset[str]] = {}
 
@@ -270,6 +270,9 @@ class BaseCompose(Serializable):
         self.processors: dict[str, BboxProcessor | KeypointsProcessor] = {}
         self._set_keys()
         self.set_mask_interpolation(mask_interpolation)
+        self._base_seed: int | None = None
+        self._manual_random_state = False
+        self._rng_context: _RuntimeRngContext | None = None
         self.set_random_seed(seed)
         self.save_applied_params = save_applied_params
 
@@ -286,6 +289,9 @@ class BaseCompose(Serializable):
         self,
         random_generator: np.random.Generator,
         py_random: random.Random,
+        *,
+        runtime_context: _RuntimeRngContext | None = None,
+        manual: bool = True,
     ) -> None:
         """Set random state directly from numpy and Python random generators. Propagates to all
         child transforms. Used for reproducibility.
@@ -293,15 +299,43 @@ class BaseCompose(Serializable):
         Args:
             random_generator (np.random.Generator): numpy random generator to use
             py_random (random.Random): python random generator to use
+            runtime_context (_RuntimeRngContext | None): DataLoader worker context for internal propagation.
+                User calls should leave this as None.
+            manual (bool): Whether this state came from explicit user control. Internal callers
+                set False so automatic worker synchronization can still refresh copied RNG state.
 
+        """
+        self._set_random_state(
+            random_generator,
+            py_random,
+            runtime_context=runtime_context,
+            manual=manual,
+        )
+
+    def _set_random_state(
+        self,
+        random_generator: np.random.Generator,
+        py_random: random.Random,
+        *,
+        runtime_context: _RuntimeRngContext | None,
+        manual: bool,
+    ) -> None:
+        """Set RNG objects and propagate the same runtime context to children so nested pipelines
+        share the parent RNG stream instead of reseeding independently.
         """
         self.random_generator = random_generator
         self.py_random = py_random
+        self._rng_context = runtime_context
+        self._manual_random_state = manual
 
-        # Propagate both random states to all transforms
         for transform in self.transforms:
             if isinstance(transform, (BasicTransform, BaseCompose)):
-                transform.set_random_state(random_generator, py_random)
+                transform.set_random_state(
+                    random_generator,
+                    py_random,
+                    runtime_context=runtime_context,
+                    manual=manual,
+                )
 
     def set_random_seed(self, seed: int | None) -> None:
         """Set random state from a single integer seed. Propagates to all child transforms.
@@ -311,17 +345,34 @@ class BaseCompose(Serializable):
             seed (int | None): Random seed to use
 
         """
-        # Store the original seed
         self.seed = seed
+        self._base_seed = seed
+        runtime_context = _get_runtime_rng_context(seed)
+        effective_seed = runtime_context.effective_seed if runtime_context else seed
+        self._set_random_state(
+            np.random.default_rng(effective_seed),
+            random.Random(effective_seed),
+            runtime_context=runtime_context,
+            manual=False,
+        )
 
-        # Use base seed directly (subclasses like Compose can override this)
-        self.random_generator = np.random.default_rng(seed)
-        self.py_random = random.Random(seed)
+    def _sync_runtime_random_state(self) -> None:
+        """Refresh copied RNG state inside PyTorch DataLoader workers unless the user explicitly
+        installed exact RNG objects through set_random_state.
+        """
+        if self._manual_random_state:
+            return
 
-        # Propagate seed to all transforms
-        for transform in self.transforms:
-            if isinstance(transform, (BasicTransform, BaseCompose)):
-                transform.set_random_seed(seed)
+        runtime_context = _get_runtime_rng_context(self._base_seed)
+        if runtime_context is None or runtime_context == self._rng_context:
+            return
+
+        self._set_random_state(
+            np.random.default_rng(runtime_context.effective_seed),
+            random.Random(runtime_context.effective_seed),
+            runtime_context=runtime_context,
+            manual=False,
+        )
 
     def set_mask_interpolation(self, mask_interpolation: int | None) -> None:
         """Set interpolation mode for mask resizing operations. Propagates recursively to all
@@ -820,7 +871,12 @@ class BaseCompose(Serializable):
 
         # Copy random state from original instance to new instance
         if hasattr(self, "random_generator") and hasattr(self, "py_random"):
-            new_instance.set_random_state(self.random_generator, self.py_random)
+            new_instance.set_random_state(
+                self.random_generator,
+                self.py_random,
+                runtime_context=self._rng_context,
+                manual=self._manual_random_state,
+            )
 
         return new_instance
 
@@ -841,6 +897,17 @@ class BaseCompose(Serializable):
             "p": self.p,
         }
 
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore pickled compose objects and clear runtime worker context so the first worker
+        call can resynchronize against the active DataLoader seed.
+        """
+        self.__dict__.update(state)
+        if not hasattr(self, "_base_seed"):
+            self._base_seed = getattr(self, "seed", None)
+        if not hasattr(self, "_manual_random_state"):
+            self._manual_random_state = False
+        self._rng_context = None
+
     def _get_effective_seed(self, base_seed: int | None) -> int | None:
         """Get effective seed considering worker context. In PyTorch DataLoader workers,
         combines base_seed with torch.initial_seed() for per-worker reproducibility.
@@ -852,24 +919,10 @@ class BaseCompose(Serializable):
             int | None: Effective seed after considering worker context
 
         """
-        if base_seed is None:
-            return base_seed
-
-        try:
-            import torch
-            import torch.utils.data
-
-            worker_info = torch.utils.data.get_worker_info()
-            if worker_info is not None:
-                # We're in a DataLoader worker process
-                # Use torch.initial_seed() which is unique per worker and changes on respawn
-                torch_seed = torch.initial_seed() % _UINT32_MODULUS
-                return (base_seed + torch_seed) % _UINT32_MODULUS
-        except (ImportError, AttributeError):
-            # PyTorch not available or not in worker context
-            pass
-
-        return base_seed
+        runtime_context = _get_runtime_rng_context(base_seed)
+        if runtime_context is None:
+            return _derive_effective_seed(base_seed, None)
+        return runtime_context.effective_seed
 
 
 class Compose(BaseCompose, HubMixin):
@@ -990,12 +1043,11 @@ class Compose(BaseCompose, HubMixin):
         # warning and falls back to legacy permissive behavior — kept for one minor version
         # so users with custom transforms that drop mask rows can opt out while migrating.
         self._strict_instance_invariant = strict_instance_invariant
-        self._base_seed = seed
         super().__init__(
             transforms=transforms,
             p=p,
             mask_interpolation=mask_interpolation,
-            seed=self._get_effective_seed(seed),
+            seed=seed,
             save_applied_params=save_applied_params,
         )
 
@@ -1025,7 +1077,6 @@ class Compose(BaseCompose, HubMixin):
         self.save_applied_params = save_applied_params
         self._images_was_list = False
         self._masks_was_list = False
-        self._last_torch_seed: int | None = None
 
         # Telemetry runs after nested composes so main_compose=False is already set on them.
         self._maybe_send_telemetry(telemetry)
@@ -1222,8 +1273,7 @@ class Compose(BaseCompose, HubMixin):
             KeyError: If positional arguments are provided.
 
         """
-        # Check and sync worker seed if needed
-        self._check_worker_seed()
+        self._sync_runtime_random_state()
 
         if args:
             msg = "You have to pass data to augmentations as named arguments, for example: aug(image=image)"
@@ -1294,88 +1344,10 @@ class Compose(BaseCompose, HubMixin):
         return Compose(transforms, p=1.0)
 
     def _check_worker_seed(self) -> None:
-        """Check and update random seed in worker context. Recalculates effective seed and
-        propagates to all transforms for reproducibility.
+        """Backward-compatible alias for runtime worker RNG synchronization kept for private
+        callers that still reach the old worker-seed method name.
         """
-        # Check if we're in a worker and need to update the seed
-        try:
-            import torch
-            import torch.utils.data
-
-            worker_info = torch.utils.data.get_worker_info()
-            if worker_info is not None:
-                # Get the current torch initial seed
-                current_torch_seed = torch.initial_seed()
-
-                # Check if we've already synchronized for this seed
-                if self._last_torch_seed == current_torch_seed:
-                    return
-
-                # Update the seed and mark as synchronized
-                self._last_torch_seed = current_torch_seed
-                if self._base_seed is not None:
-                    effective_seed = self._get_effective_seed(self._base_seed)
-                else:
-                    # No explicit seed: follow the worker seed so new epochs stay random.
-                    effective_seed = current_torch_seed % _UINT32_MODULUS
-
-                # Update our own random state
-                self.random_generator = np.random.default_rng(effective_seed)
-                self.py_random = random.Random(effective_seed)
-
-                # Propagate to all transforms
-                for transform in self.transforms:
-                    if hasattr(transform, "set_random_state"):
-                        transform.set_random_state(self.random_generator, self.py_random)
-                    elif hasattr(transform, "set_random_seed"):
-                        # For transforms that don't have set_random_state, use set_random_seed
-                        transform.set_random_seed(effective_seed)
-        except (ImportError, AttributeError):
-            pass
-
-    def __setstate__(self, state: dict[str, Any]) -> None:
-        """Set state from unpickling and handle worker seed. Resets _last_torch_seed and
-        recalculates effective seed so worker sync runs again after unpickling.
-        """
-        self.__dict__.update(state)
-        # If we have a base seed, recalculate effective seed in worker context
-        if hasattr(self, "_base_seed") and self._base_seed is not None:
-            # Reset _last_torch_seed to ensure worker-seed sync runs after unpickling
-            self._last_torch_seed = None
-            # Recalculate effective seed in worker context
-            self.set_random_seed(self._base_seed)
-        elif hasattr(self, "seed") and self.seed is not None:
-            # For backward compatibility, if no base seed but seed exists
-            self._base_seed = self.seed
-            self._last_torch_seed = None
-            self.set_random_seed(self.seed)
-
-    def set_random_seed(self, seed: int | None) -> None:
-        """Override for worker-aware seed. Stores _base_seed, computes effective seed via
-        _get_effective_seed and propagates to all transforms.
-
-        Args:
-            seed (int | None): Random seed to use
-
-        """
-        # Store the original base seed
-        self._base_seed = seed
-        self.seed = seed
-
-        # Get effective seed considering worker context
-        effective_seed = self._get_effective_seed(seed)
-
-        # Initialize random generators with effective seed
-        self.random_generator = np.random.default_rng(effective_seed)
-        self.py_random = random.Random(effective_seed)
-
-        # Propagate to all transforms
-        for transform in self.transforms:
-            if hasattr(transform, "set_random_state"):
-                transform.set_random_state(self.random_generator, self.py_random)
-            elif hasattr(transform, "set_random_seed"):
-                # For transforms that don't have set_random_state, use set_random_seed
-                transform.set_random_seed(effective_seed)
+        self._sync_runtime_random_state()
 
     def preprocess(self, data: Any) -> None:
         """Preprocess input data before applying transforms. Validates shapes (if
@@ -2374,6 +2346,8 @@ class OneOf(BaseCompose):
             KeyError: If positional arguments are provided.
 
         """
+        self._sync_runtime_random_state()
+
         if self.replay_mode:
             for t in self.transforms:
                 data = t(**data)
@@ -2469,6 +2443,8 @@ class SomeOf(BaseCompose):
             dict[str, Any]: Dictionary with transformed data.
 
         """
+        self._sync_runtime_random_state()
+
         if self.replay_mode:
             for t in self.transforms:
                 data = t(**data)
@@ -2592,6 +2568,8 @@ class OneOrOther(BaseCompose):
             dict[str, Any]: Dictionary with transformed data.
 
         """
+        self._sync_runtime_random_state()
+
         if self.replay_mode:
             for t in self.transforms:
                 data = t(**data)
@@ -2651,6 +2629,8 @@ class SelectiveChannelTransform(BaseCompose):
             dict[str, Any]: Dictionary with transformed data.
 
         """
+        self._sync_runtime_random_state()
+
         if force_apply or self.py_random.random() < self.p:
             image = data["image"]
 
@@ -2908,6 +2888,8 @@ class Sequential(BaseCompose):
             dict[str, Any]: Dictionary with transformed data.
 
         """
+        self._sync_runtime_random_state()
+
         if self.replay_mode or force_apply or self.py_random.random() < self.p:
             for t in self.transforms:
                 data = t(**data)

--- a/albumentations/core/random_utils.py
+++ b/albumentations/core/random_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Final
+from typing import Any, Final
 
 _UINT32_MODULUS: Final = 1 << 32
 
@@ -60,3 +60,29 @@ def _get_runtime_rng_context(base_seed: int | None) -> _RuntimeRngContext | None
         return None
 
     return _RuntimeRngContext(worker_seed=worker_seed, effective_seed=effective_seed)
+
+
+def _should_sync_runtime_rng(
+    *,
+    manual: bool,
+    current_context: _RuntimeRngContext | None,
+    runtime_context: _RuntimeRngContext | None,
+) -> bool:
+    """Return whether RNG state should be rebuilt for the active runtime context while preserving
+    parent-propagated effective seeds for children in the same worker.
+    """
+    if manual or runtime_context is None:
+        return False
+    if current_context is None:
+        return True
+    return current_context.worker_seed != runtime_context.worker_seed
+
+
+def _restore_runtime_rng_state(target: Any) -> None:
+    """Restore runtime RNG bookkeeping after unpickling so objects resynchronize against the
+    active DataLoader worker seed on their first post-unpickle call.
+    """
+    target_state = target.__dict__
+    target_state.setdefault("_base_seed", getattr(target, "seed", None))
+    target_state.setdefault("_manual_random_state", False)
+    target_state["_rng_context"] = None

--- a/albumentations/core/random_utils.py
+++ b/albumentations/core/random_utils.py
@@ -1,0 +1,62 @@
+"""Private helpers for runtime random seed synchronization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+_UINT32_MODULUS: Final = 1 << 32
+
+
+@dataclass(frozen=True, slots=True)
+class _RuntimeRngContext:
+    """Runtime-only RNG context derived from the current DataLoader worker and effective seed used
+    to rebuild copied RNG state in worker processes.
+    """
+
+    worker_seed: int
+    effective_seed: int
+
+
+def _get_torch_worker_seed() -> int | None:
+    """Return PyTorch's current DataLoader worker seed inside worker processes, or None when
+    PyTorch is unavailable or the call happens outside DataLoader workers.
+    """
+    try:
+        import torch
+        import torch.utils.data
+    except ImportError:
+        return None
+
+    try:
+        if torch.utils.data.get_worker_info() is None:
+            return None
+        return torch.initial_seed() % _UINT32_MODULUS
+    except AttributeError:
+        return None
+
+
+def _derive_effective_seed(base_seed: int | None, worker_seed: int | None) -> int | None:
+    """Derive the runtime seed from the user-provided base seed and optional DataLoader worker
+    seed while preserving None as unseeded outside worker processes.
+    """
+    if worker_seed is None:
+        return base_seed
+    if base_seed is None:
+        return worker_seed
+    return (base_seed + worker_seed) % _UINT32_MODULUS
+
+
+def _get_runtime_rng_context(base_seed: int | None) -> _RuntimeRngContext | None:
+    """Build a runtime RNG context for the current PyTorch DataLoader worker so copied pipeline
+    RNG state can be replaced exactly once per worker seed.
+    """
+    worker_seed = _get_torch_worker_seed()
+    if worker_seed is None:
+        return None
+
+    effective_seed = _derive_effective_seed(base_seed, worker_seed)
+    if effective_seed is None:
+        return None
+
+    return _RuntimeRngContext(worker_seed=worker_seed, effective_seed=effective_seed)

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -23,7 +23,13 @@ from albumentations.core.bbox_utils import BboxProcessor
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.validation import ValidatedTransformMeta
 
-from .random_utils import _derive_effective_seed, _get_runtime_rng_context, _RuntimeRngContext
+from .random_utils import (
+    _derive_effective_seed,
+    _get_runtime_rng_context,
+    _restore_runtime_rng_state,
+    _RuntimeRngContext,
+    _should_sync_runtime_rng,
+)
 from .serialization import Serializable, SerializableMeta, get_shortest_class_fullname
 from .type_definitions import ALL_TARGETS, ImageType, StackedMasks4D, Targets, VolumeType
 from .utils import format_args
@@ -222,11 +228,12 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         """Refresh copied RNG state inside PyTorch DataLoader workers unless the user explicitly
         installed exact RNG objects through set_random_state.
         """
-        if self._manual_random_state:
-            return
-
         runtime_context = _get_runtime_rng_context(self._base_seed)
-        if runtime_context is None or runtime_context == self._rng_context:
+        if runtime_context is None or not _should_sync_runtime_rng(
+            manual=self._manual_random_state,
+            current_context=self._rng_context,
+            runtime_context=runtime_context,
+        ):
             return
 
         self._set_random_state(
@@ -250,11 +257,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         can resynchronize against the active DataLoader seed.
         """
         self.__dict__.update(state)
-        if not hasattr(self, "_base_seed"):
-            self._base_seed = getattr(self, "seed", None)
-        if not hasattr(self, "_manual_random_state"):
-            self._manual_random_state = False
-        self._rng_context = None
+        _restore_runtime_rng_state(self)
 
     def get_dict_with_id(self) -> dict[str, Any]:
         """Return a dictionary representation of the transform with its ID. Used for replay and

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -23,6 +23,7 @@ from albumentations.core.bbox_utils import BboxProcessor
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.validation import ValidatedTransformMeta
 
+from .random_utils import _derive_effective_seed, _get_runtime_rng_context, _RuntimeRngContext
 from .serialization import Serializable, SerializableMeta, get_shortest_class_fullname
 from .type_definitions import ALL_TARGETS, ImageType, StackedMasks4D, Targets, VolumeType
 from .utils import format_args
@@ -109,6 +110,9 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         self._set_keys()
         self.processors: dict[str, BboxProcessor | KeypointsProcessor] = {}
         self.seed: int | None = None
+        self._base_seed: int | None = None
+        self._manual_random_state = False
+        self._rng_context: _RuntimeRngContext | None = None
         self.set_random_seed(self.seed)
         self._strict = False  # Use private attribute
         self.invalid_args: list[str] = []  # Store invalid args found during init
@@ -156,6 +160,9 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         self,
         random_generator: np.random.Generator,
         py_random: random.Random,
+        *,
+        runtime_context: _RuntimeRngContext | None = None,
+        manual: bool = True,
     ) -> None:
         """Set random state directly from numpy and Python random generators. Used for
         reproducibility and replay. Called by Compose.
@@ -163,10 +170,34 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         Args:
             random_generator (np.random.Generator): numpy random generator to use
             py_random (random.Random): python random generator to use
+            runtime_context (_RuntimeRngContext | None): DataLoader worker context for internal propagation.
+                User calls should leave this as None.
+            manual (bool): Whether this state came from explicit user control. Internal callers
+                set False so automatic worker synchronization can still refresh copied RNG state.
 
+        """
+        self._set_random_state(
+            random_generator,
+            py_random,
+            runtime_context=runtime_context,
+            manual=manual,
+        )
+
+    def _set_random_state(
+        self,
+        random_generator: np.random.Generator,
+        py_random: random.Random,
+        *,
+        runtime_context: _RuntimeRngContext | None,
+        manual: bool,
+    ) -> None:
+        """Set RNG objects and record whether automatic worker synchronization may replace them
+        after DataLoader process boundaries copy parent RNG state.
         """
         self.random_generator = random_generator
         self.py_random = py_random
+        self._rng_context = runtime_context
+        self._manual_random_state = manual
 
     def set_random_seed(self, seed: int | None) -> None:
         """Set random state from a single integer seed. Initializes both numpy and Python random
@@ -177,8 +208,53 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
         """
         self.seed = seed
-        self.random_generator = np.random.default_rng(seed)
-        self.py_random = random.Random(seed)
+        self._base_seed = seed
+        runtime_context = _get_runtime_rng_context(seed)
+        effective_seed = runtime_context.effective_seed if runtime_context else seed
+        self._set_random_state(
+            np.random.default_rng(effective_seed),
+            random.Random(effective_seed),
+            runtime_context=runtime_context,
+            manual=False,
+        )
+
+    def _sync_runtime_random_state(self) -> None:
+        """Refresh copied RNG state inside PyTorch DataLoader workers unless the user explicitly
+        installed exact RNG objects through set_random_state.
+        """
+        if self._manual_random_state:
+            return
+
+        runtime_context = _get_runtime_rng_context(self._base_seed)
+        if runtime_context is None or runtime_context == self._rng_context:
+            return
+
+        self._set_random_state(
+            np.random.default_rng(runtime_context.effective_seed),
+            random.Random(runtime_context.effective_seed),
+            runtime_context=runtime_context,
+            manual=False,
+        )
+
+    def _get_effective_seed(self, base_seed: int | None) -> int | None:
+        """Return the seed that would be used in the current runtime context while preserving
+        None outside DataLoader workers for unseeded transforms.
+        """
+        runtime_context = _get_runtime_rng_context(base_seed)
+        if runtime_context is None:
+            return _derive_effective_seed(base_seed, None)
+        return runtime_context.effective_seed
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore pickled transforms and clear runtime worker context so the first worker call
+        can resynchronize against the active DataLoader seed.
+        """
+        self.__dict__.update(state)
+        if not hasattr(self, "_base_seed"):
+            self._base_seed = getattr(self, "seed", None)
+        if not hasattr(self, "_manual_random_state"):
+            self._manual_random_state = False
+        self._rng_context = None
 
     def get_dict_with_id(self) -> dict[str, Any]:
         """Return a dictionary representation of the transform with its ID. Used for replay and
@@ -275,6 +351,8 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             if self.applied_in_replay:
                 return self.apply_with_params(self.params, **kwargs)
             return kwargs
+
+        self._sync_runtime_random_state()
 
         self.params = {}
         self.applied_config = {}

--- a/tests/test_per_worker_seed.py
+++ b/tests/test_per_worker_seed.py
@@ -300,6 +300,23 @@ def test_seeded_compose_dataloader_reproducible_with_same_torch_generator_seed()
 
 
 @pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+def test_seeded_compose_dataloader_seed_changes_child_random_params():
+    """Changing Compose seed should change child transform params under the same worker seeds."""
+    seed_137_batch = _first_batches_across_epochs(
+        DropoutPositionDataset(use_compose=True, seed=137),
+        generator_seed=140,
+        epochs=1,
+    )[0]
+    seed_138_batch = _first_batches_across_epochs(
+        DropoutPositionDataset(use_compose=True, seed=138),
+        generator_seed=140,
+        epochs=1,
+    )[0]
+
+    assert seed_137_batch != seed_138_batch
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
 def test_persistent_workers_advance_rng_across_epochs():
     """Persistent workers should keep advancing RNG instead of resetting to worker seed every call."""
     first_batches = _first_batches_across_epochs(
@@ -386,6 +403,32 @@ def test_manual_compose_random_state_disables_worker_sync(monkeypatch):
     transform._sync_runtime_random_state()
 
     assert transform.random_generator is original_random_generator
+
+
+def test_child_transform_preserves_parent_seeded_runtime_context(monkeypatch):
+    """Child transforms should keep the parent Compose effective seed in the same worker."""
+
+    def runtime_context(base_seed: int | None) -> _RuntimeRngContext:
+        effective_seed = _derive_effective_seed(base_seed, 140)
+        assert effective_seed is not None
+        return _RuntimeRngContext(
+            worker_seed=140,
+            effective_seed=effective_seed,
+        )
+
+    monkeypatch.setattr("albumentations.core.composition._get_runtime_rng_context", runtime_context)
+    monkeypatch.setattr("albumentations.core.transforms_interface._get_runtime_rng_context", runtime_context)
+    transform = A.Compose([A.HorizontalFlip(p=1.0)], seed=137)
+    expected_context = _RuntimeRngContext(worker_seed=140, effective_seed=277)
+
+    transform._sync_runtime_random_state()
+    child_transform = transform.transforms[0]
+
+    assert child_transform._rng_context == expected_context
+
+    child_transform._sync_runtime_random_state()
+
+    assert child_transform._rng_context == expected_context
 
 
 def test_manual_basic_transform_random_state_disables_worker_sync(monkeypatch):

--- a/tests/test_per_worker_seed.py
+++ b/tests/test_per_worker_seed.py
@@ -107,6 +107,8 @@ def _fork_worker_context() -> str:
         pytest.skip("PyTorch not available")
     if sys.platform == "win32":
         pytest.skip("fork multiprocessing context is not available on Windows")
+    if sys.platform == "darwin":
+        pytest.skip("fork multiprocessing context is not supported for these tests on macOS")
     if "fork" not in torch.multiprocessing.get_all_start_methods():
         pytest.skip("fork multiprocessing context is not available")
     return "fork"

--- a/tests/test_per_worker_seed.py
+++ b/tests/test_per_worker_seed.py
@@ -1,12 +1,15 @@
 """Tests for worker-aware seed functionality in Compose."""
 
 import multiprocessing
+import pickle
+import random
 import sys
 
 import numpy as np
 import pytest
 
 import albumentations as A
+from albumentations.core.random_utils import _derive_effective_seed, _RuntimeRngContext
 
 try:
     import torch
@@ -69,6 +72,82 @@ if _TORCH_AVAILABLE:
                 augmented = self.transform(image=image)
                 image = augmented["image"]
             return float(np.sum(image))
+
+    class DropoutPositionDataset(torch.utils.data.Dataset):
+        """Dataset that exposes sampled dropout geometry for DataLoader RNG regression tests."""
+
+        def __init__(self, *, use_compose: bool, seed: int | None = None):
+            dropout = A.CoarseDropout(
+                num_holes_range=(1, 1),
+                hole_height_range=(0.25, 0.25),
+                hole_width_range=(0.25, 0.25),
+                fill=0,
+                p=1.0,
+            )
+            if use_compose:
+                self.transform = A.Compose([dropout], seed=seed)
+            else:
+                dropout.set_random_seed(seed)
+                self.transform = dropout
+            self.data = np.ones((64, 32, 32, 3), dtype=np.uint8) * 255
+
+        def __len__(self):
+            return len(self.data)
+
+        def __getitem__(self, idx):
+            result = self.transform(image=self.data[idx])
+            coords = np.argwhere(result["image"][:, :, 0] == 0)
+            y_min, x_min = coords.min(axis=0)
+            y_max, x_max = coords.max(axis=0) + 1
+            return torch.tensor([y_min, x_min, y_max, x_max], dtype=torch.int64)
+
+
+def _fork_worker_context() -> str:
+    if not _TORCH_AVAILABLE:
+        pytest.skip("PyTorch not available")
+    if sys.platform == "win32":
+        pytest.skip("fork multiprocessing context is not available on Windows")
+    if "fork" not in torch.multiprocessing.get_all_start_methods():
+        pytest.skip("fork multiprocessing context is not available")
+    return "fork"
+
+
+def _first_batches_across_epochs(
+    dataset: "torch.utils.data.Dataset",
+    *,
+    generator_seed: int = 137,
+    num_workers: int = 4,
+    epochs: int = 3,
+    persistent_workers: bool = False,
+) -> list[list[list[int]]]:
+    generator = torch.Generator()
+    generator.manual_seed(generator_seed)
+    loader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=16,
+        shuffle=False,
+        num_workers=num_workers,
+        persistent_workers=persistent_workers,
+        generator=generator,
+        multiprocessing_context=_fork_worker_context(),
+    )
+
+    first_batches = []
+    if persistent_workers:
+        for _epoch in range(epochs):
+            for batch_index, batch in enumerate(loader):
+                if batch_index == 0:
+                    first_batches.append(batch.tolist())
+        return first_batches
+
+    for _epoch in range(epochs):
+        first_batches.append(next(iter(loader)).tolist())
+    return first_batches
+
+
+def _assert_any_epoch_differs(first_batches: list[list[list[int]]]) -> None:
+    unique_batches = {tuple(tuple(position) for position in batch) for batch in first_batches}
+    assert len(unique_batches) > 1, f"All epochs produced identical dropout positions: {first_batches}"
 
 
 def test_worker_seed_without_torch():
@@ -189,6 +268,50 @@ def test_dataloader_epoch_diversity():
     )
 
 
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+def test_unseeded_compose_dataloader_respawns_use_new_worker_seed():
+    """Unseeded Compose should not replay identical dropout geometry when workers respawn."""
+    first_batches = _first_batches_across_epochs(DropoutPositionDataset(use_compose=True))
+
+    _assert_any_epoch_differs(first_batches)
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+def test_unseeded_direct_transform_dataloader_respawns_use_new_worker_seed():
+    """Direct BasicTransform usage should get the same worker RNG protection as Compose."""
+    first_batches = _first_batches_across_epochs(DropoutPositionDataset(use_compose=False))
+
+    _assert_any_epoch_differs(first_batches)
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+def test_seeded_compose_dataloader_reproducible_with_same_torch_generator_seed():
+    """Compose seed plus DataLoader generator seed should reproduce the worker-derived sequence."""
+    first_run = _first_batches_across_epochs(
+        DropoutPositionDataset(use_compose=True, seed=137),
+        generator_seed=138,
+    )
+    second_run = _first_batches_across_epochs(
+        DropoutPositionDataset(use_compose=True, seed=137),
+        generator_seed=138,
+    )
+
+    assert first_run == second_run
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="PyTorch not available")
+def test_persistent_workers_advance_rng_across_epochs():
+    """Persistent workers should keep advancing RNG instead of resetting to worker seed every call."""
+    first_batches = _first_batches_across_epochs(
+        DropoutPositionDataset(use_compose=True, seed=137),
+        generator_seed=139,
+        num_workers=2,
+        persistent_workers=True,
+    )
+
+    _assert_any_epoch_differs(first_batches)
+
+
 def test_compose_serialization():
     """Test that Compose serialization works properly."""
     # Test with worker-aware seed (always enabled)
@@ -206,6 +329,78 @@ def test_compose_serialization():
     transform2 = A.from_dict(serialized)
     assert hasattr(transform2, "seed")
     assert transform2.seed == 137
+
+
+def test_compose_serialization_preserves_base_seed_after_manual_random_state():
+    """Manual RNG state should not rewrite the user seed that serialization exposes."""
+    transform = A.Compose([A.HorizontalFlip(p=0.5)], seed=137)
+    transform.set_random_state(np.random.default_rng(138), random.Random(139))
+
+    serialized = transform.to_dict()
+
+    assert serialized["transform"]["seed"] == 137
+
+
+def test_derive_effective_seed():
+    """Effective seeds should cleanly separate user seed from worker seed."""
+    assert _derive_effective_seed(None, None) is None
+    assert _derive_effective_seed(137, None) == 137
+    assert _derive_effective_seed(None, 138) == 138
+    assert _derive_effective_seed(137, 138) == 275
+    assert _derive_effective_seed(2**32 - 1, 2) == 1
+
+
+def test_unpickled_compose_resets_runtime_context():
+    """Pickled Compose objects should re-sync against the worker context after unpickling."""
+    transform = A.Compose([A.HorizontalFlip(p=0.5)], seed=137)
+    transform._rng_context = _RuntimeRngContext(worker_seed=138, effective_seed=275)
+
+    restored = pickle.loads(pickle.dumps(transform))  # noqa: S301 - controlled round-trip in a test
+
+    assert restored.seed == 137
+    assert restored._base_seed == 137
+    assert restored._rng_context is None
+
+
+def test_unpickled_basic_transform_resets_runtime_context():
+    """Pickled direct transforms should re-sync against the worker context after unpickling."""
+    transform = A.CoarseDropout(p=1.0)
+    transform._rng_context = _RuntimeRngContext(worker_seed=138, effective_seed=138)
+
+    restored = pickle.loads(pickle.dumps(transform))  # noqa: S301 - controlled round-trip in a test
+
+    assert restored._base_seed is None
+    assert restored._rng_context is None
+
+
+def test_manual_compose_random_state_disables_worker_sync(monkeypatch):
+    """Explicit Compose RNG objects should stay under user control in worker contexts."""
+    transform = A.Compose([A.HorizontalFlip(p=0.5)], seed=137)
+    transform.set_random_state(np.random.default_rng(138), random.Random(139))
+    original_random_generator = transform.random_generator
+    monkeypatch.setattr(
+        "albumentations.core.composition._get_runtime_rng_context",
+        lambda _base_seed: _RuntimeRngContext(worker_seed=140, effective_seed=277),
+    )
+
+    transform._sync_runtime_random_state()
+
+    assert transform.random_generator is original_random_generator
+
+
+def test_manual_basic_transform_random_state_disables_worker_sync(monkeypatch):
+    """Explicit direct-transform RNG objects should stay under user control in worker contexts."""
+    transform = A.HorizontalFlip(p=0.5)
+    transform.set_random_state(np.random.default_rng(138), random.Random(139))
+    original_random_generator = transform.random_generator
+    monkeypatch.setattr(
+        "albumentations.core.transforms_interface._get_runtime_rng_context",
+        lambda _base_seed: _RuntimeRngContext(worker_seed=140, effective_seed=140),
+    )
+
+    transform._sync_runtime_random_state()
+
+    assert transform.random_generator is original_random_generator
 
 
 def test_effective_seed_calculation():


### PR DESCRIPTION
## Summary by Sourcery

Synchronize random number generator state with PyTorch DataLoader worker seeds across Compose and basic transforms to ensure correct per-worker behavior while preserving manual RNG control and reproducibility.

Bug Fixes:
- Fix RNG desynchronization when Compose and basic transforms are used inside PyTorch DataLoader workers, including across worker respawns and persistent workers.

Enhancements:
- Introduce a shared runtime RNG context utility to derive effective seeds from user seeds and DataLoader worker seeds and reuse it across composition and transform interfaces.
- Ensure pickled Compose and transform instances reset their runtime worker context on unpickling so they resynchronize with the active DataLoader worker on first use.
- Propagate runtime RNG context and manual/automatic state flags through cloned and nested compose objects so nested pipelines share consistent RNG streams.

Tests:
- Add regression tests covering DataLoader worker seed behavior for Compose and direct transforms, including respawned and persistent workers, serialization, manual RNG overrides, and effective seed derivation.