### PR TITLE
fix(release): recover bundles when run metadata omits PRs

### DIFF
--- a/.github/workflows/antigravity-pr-checks.yml
+++ b/.github/workflows/antigravity-pr-checks.yml
@@ -93,7 +93,6 @@ jobs:
 
       - name: Run Antigravity pull request review
         if: steps.plan.outputs.antigravity == 'true'
-        id: gemini_review
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         env:
           GEMINI_CLI_TRUST_WORKSPACE: "true"
@@ -152,15 +151,10 @@ jobs:
 
       - name: Prepare review artifact
         if: steps.plan.outputs.antigravity == 'true'
-        env:
-          REVIEW_BODY: ${{ steps.gemini_review.outputs.summary }}
-        run: |
-          if [ -z "${REVIEW_BODY}" ]; then
-            echo "::error::Gemini returned an empty pull request review."
-            exit 1
-          fi
-
-          printf '%s\n' "${REVIEW_BODY}" > .antigravity/review.md
+        run: >-
+          python -m tools.antigravity_review
+          --input gemini-artifacts/stdout.log
+          --output .antigravity/review.md
 
       - name: Upload review artifact
         if: steps.plan.outputs.antigravity == 'true'

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -3,9 +3,18 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to recover
+        required: true
+        type: string
 
 permissions:
   contents: read
+
+env:
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
 
 jobs:
   resolve_release_bundle:
@@ -20,12 +29,27 @@ jobs:
       package_version: ${{ steps.metadata.outputs.package_version }}
       source_digest: ${{ steps.metadata.outputs.source_digest }}
     steps:
-      - name: Checkout released tag
+      - name: Require recovery from the default branch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]]; then
+            echo "Release recovery must run from ${DEFAULT_BRANCH}, not ${GITHUB_REF}." >&2
+            exit 1
+          fi
+      - name: Checkout release automation
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: release-automation
+          persist-credentials: false
+      - name: Checkout released source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          path: released-source
           persist-credentials: false
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ env.RELEASE_TAG }}
       - name: Set up release identity runtime
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
         with:
@@ -34,15 +58,15 @@ jobs:
           python-version: "3.12"
       - name: Verify tag and compute released source identity
         id: metadata
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        working-directory: release-automation
         run: >-
           python -m tools.release_bundle metadata
-          --source-root .
+          --source-root "${GITHUB_WORKSPACE}/released-source"
           --expected-tag "${RELEASE_TAG}"
           --github-output "${GITHUB_OUTPUT}"
       - name: Resolve matching successful PR artifact
         id: resolve
+        working-directory: release-automation
         env:
           ARTIFACT_NAME: ${{ steps.metadata.outputs.artifact_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -63,19 +87,20 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ steps.resolve.outputs.run_id }}
       - name: Verify immutable release bundle
+        working-directory: release-automation
         env:
           EXPECTED_SOURCE_DIGEST: ${{ steps.metadata.outputs.source_digest }}
           EXPECTED_VERSION: ${{ steps.metadata.outputs.package_version }}
         run: >-
           python -m tools.release_bundle verify
-          --bundle-dir release-bundle
+          --bundle-dir "${GITHUB_WORKSPACE}/release-bundle"
           --expected-version "${EXPECTED_VERSION}"
           --expected-source-digest "${EXPECTED_SOURCE_DIGEST}"
       - name: Hand verified bundle to delivery jobs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: verified-release-bundle
-          path: release-bundle/
+          path: ${{ github.workspace }}/release-bundle/
           if-no-files-found: error
           retention-days: 7
 
@@ -96,6 +121,7 @@ jobs:
       - name: Attach verified files to GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: |
             release-bundle/dist/*.whl
             release-bundle/dist/*.tar.gz

--- a/tests/test_antigravity_review.py
+++ b/tests/test_antigravity_review.py
@@ -1,0 +1,105 @@
+"""Tests for sanitizing Gemini output before publishing PR reviews."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.antigravity_review import ReviewError, main, prepare_review
+
+
+def test_prepare_review_rejects_empty_response_without_publishing_diagnostics(tmp_path: Path) -> None:
+    gemini_output = tmp_path / "stdout.log"
+    review_path = tmp_path / "review.md"
+    gemini_output.write_text(
+        json.dumps(
+            {
+                "response": "",
+                "stats": {"models": {"gemini": {"tokens": {"total": 3869}}}},
+                "error": {
+                    "type": "INVALID_STREAM",
+                    "message": "The model returned an empty response or malformed tool call.",
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ReviewError, match="INVALID_STREAM"):
+        prepare_review(gemini_output, review_path)
+
+    assert not review_path.exists()
+
+
+def test_prepare_review_publishes_only_the_validated_response(tmp_path: Path) -> None:
+    gemini_output = tmp_path / "stdout.log"
+    review_path = tmp_path / "review.md"
+    response = "## Antigravity Review\n\nNo actionable findings."
+    gemini_output.write_text(
+        json.dumps(
+            {
+                "response": response,
+                "stats": {"models": {"gemini": {"tokens": {"total": 137}}}},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    prepare_review(gemini_output, review_path)
+
+    assert review_path.read_text(encoding="utf-8") == response + "\n"
+
+
+def test_prepare_review_rejects_non_review_text(tmp_path: Path) -> None:
+    gemini_output = tmp_path / "stdout.log"
+    review_path = tmp_path / "review.md"
+    gemini_output.write_text(json.dumps({"response": '{"error": "INVALID_STREAM"}'}), encoding="utf-8")
+
+    with pytest.raises(ReviewError, match="heading"):
+        prepare_review(gemini_output, review_path)
+
+    assert not review_path.exists()
+
+
+def test_main_reports_invalid_stream_without_echoing_diagnostics(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    gemini_output = tmp_path / "stdout.log"
+    review_path = tmp_path / "review.md"
+    gemini_output.write_text(
+        json.dumps(
+            {
+                "response": "",
+                "stats": {"private_diagnostics": "must not be echoed"},
+                "error": {"type": "INVALID_STREAM"},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["--input", str(gemini_output), "--output", str(review_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "INVALID_STREAM" in captured.err
+    assert "private_diagnostics" not in captured.err
+
+
+def test_prepare_review_rejects_partial_response_with_error(tmp_path: Path) -> None:
+    gemini_output = tmp_path / "stdout.log"
+    review_path = tmp_path / "review.md"
+    gemini_output.write_text(
+        json.dumps(
+            {
+                "response": "## Antigravity Review\n\nPartial output.",
+                "error": {"type": "INVALID_STREAM"},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ReviewError, match="INVALID_STREAM"):
+        prepare_review(gemini_output, review_path)
+
+    assert not review_path.exists()

--- a/tests/test_antigravity_workflow.py
+++ b/tests/test_antigravity_workflow.py
@@ -82,3 +82,13 @@ def test_antigravity_isolates_model_execution_from_pr_write_access() -> None:
     assert "path: .antigravity/review.md" in model_job
     assert "include-hidden-files: true" in model_job
     assert "if-no-files-found: error" in model_job
+
+
+def test_antigravity_validates_cli_json_before_publishing_review() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python -m tools.antigravity_review" in workflow
+    assert "--input gemini-artifacts/stdout.log" in workflow
+    assert "--output .antigravity/review.md" in workflow
+    assert "steps.gemini_review.outputs.summary" not in workflow
+    assert "REVIEW_BODY" not in workflow

--- a/tests/test_release_bundle.py
+++ b/tests/test_release_bundle.py
@@ -171,14 +171,17 @@ def test_finalize_bundle_requires_complete_check_set(tmp_path: Path) -> None:
 class FakeGitHubAPI:
     """Fixture-backed GitHub API for artifact provenance tests."""
 
-    def __init__(self, responses: dict[str, dict[str, Any]]) -> None:
+    def __init__(self, responses: dict[str, dict[str, Any] | list[dict[str, Any]]]) -> None:
         self.responses = responses
 
-    def get_json(self, path: str) -> dict[str, Any]:
+    def get_json(self, path: str) -> dict[str, Any] | list[dict[str, Any]]:
         return self.responses[path]
 
 
-def _artifact_responses(*, merged_at: str | None = "2026-07-15T12:00:00Z") -> dict[str, dict[str, Any]]:
+def _artifact_responses(
+    *,
+    merged_at: str | None = "2026-07-15T12:00:00Z",
+) -> dict[str, dict[str, Any] | list[dict[str, Any]]]:
     artifact_name = "release-bundle-2.3.3-digest"
     return {
         "/repos/albumentations-team/AlbumentationsX/actions/artifacts?name=" + artifact_name + "&per_page=100": {
@@ -208,6 +211,27 @@ def _artifact_responses(*, merged_at: str | None = "2026-07-15T12:00:00Z") -> di
     }
 
 
+def _head_commit_fallback_responses(
+    *,
+    merged_at: str | None = "2026-07-15T12:00:00Z",
+    base_ref: str = "main",
+) -> dict[str, dict[str, Any] | list[dict[str, Any]]]:
+    responses = _artifact_responses()
+    run_path = "/repos/albumentations-team/AlbumentationsX/actions/runs/173"
+    run = responses[run_path]
+    assert isinstance(run, dict)
+    run["head_sha"] = "abc137"
+    run["pull_requests"] = []
+    responses["/repos/albumentations-team/AlbumentationsX/commits/abc137/pulls"] = [
+        {
+            "number": 305,
+            "merged_at": merged_at,
+            "base": {"ref": base_ref},
+        },
+    ]
+    return responses
+
+
 def test_resolve_artifact_requires_successful_merged_pr_run() -> None:
     resolved = resolve_artifact(
         FakeGitHubAPI(_artifact_responses()),
@@ -219,6 +243,40 @@ def test_resolve_artifact_requires_successful_merged_pr_run() -> None:
 
     assert resolved.artifact_id == 137
     assert resolved.run_id == 173
+
+
+def test_resolve_artifact_uses_head_commit_when_run_omits_pull_requests() -> None:
+    resolved = resolve_artifact(
+        FakeGitHubAPI(_head_commit_fallback_responses()),
+        repository="albumentations-team/AlbumentationsX",
+        artifact_name="release-bundle-2.3.3-digest",
+        workflow_path=".github/workflows/pr.yml",
+        default_branch="main",
+    )
+
+    assert resolved.artifact_id == 137
+    assert resolved.run_id == 173
+
+
+@pytest.mark.parametrize(
+    ("merged_at", "base_ref"),
+    [
+        (None, "main"),
+        ("2026-07-15T12:00:00Z", "release"),
+    ],
+)
+def test_resolve_artifact_rejects_head_commit_without_merged_default_branch_pr(
+    merged_at: str | None,
+    base_ref: str,
+) -> None:
+    with pytest.raises(BundleError, match="No unexpired release bundle"):
+        resolve_artifact(
+            FakeGitHubAPI(_head_commit_fallback_responses(merged_at=merged_at, base_ref=base_ref)),
+            repository="albumentations-team/AlbumentationsX",
+            artifact_name="release-bundle-2.3.3-digest",
+            workflow_path=".github/workflows/pr.yml",
+            default_branch="main",
+        )
 
 
 def test_resolve_artifact_rejects_unmerged_pr_run() -> None:

--- a/tests/test_release_bundle.py
+++ b/tests/test_release_bundle.py
@@ -288,3 +288,27 @@ def test_resolve_artifact_rejects_unmerged_pr_run() -> None:
             workflow_path=".github/workflows/pr.yml",
             default_branch="main",
         )
+
+
+def test_resolve_artifact_does_not_replace_reported_prs_with_head_commit_associations() -> None:
+    responses = _artifact_responses(merged_at=None)
+    run_path = "/repos/albumentations-team/AlbumentationsX/actions/runs/173"
+    run = responses[run_path]
+    assert isinstance(run, dict)
+    run["head_sha"] = "abc137"
+    responses["/repos/albumentations-team/AlbumentationsX/commits/abc137/pulls"] = [
+        {
+            "number": 306,
+            "merged_at": "2026-07-15T12:00:00Z",
+            "base": {"ref": "main"},
+        },
+    ]
+
+    with pytest.raises(BundleError, match="No unexpired release bundle"):
+        resolve_artifact(
+            FakeGitHubAPI(responses),
+            repository="albumentations-team/AlbumentationsX",
+            artifact_name="release-bundle-2.3.3-digest",
+            workflow_path=".github/workflows/pr.yml",
+            default_branch="main",
+        )

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -32,6 +32,23 @@ def test_release_workflow_resolves_bundle_by_tag_version_and_source_digest() -> 
     assert "steps.metadata.outputs.source_digest" in text
 
 
+def test_release_workflow_can_recover_an_existing_tag_from_main() -> None:
+    workflow = _workflow()
+    triggers = workflow.get("on", workflow.get(True, {}))
+    recovery_input = triggers["workflow_dispatch"]["inputs"]["release_tag"]
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert recovery_input["required"] is True
+    assert recovery_input["type"] == "string"
+    assert "github.event.release.tag_name || inputs.release_tag" in text
+    assert "path: release-automation" in text
+    assert "path: released-source" in text
+    assert "github.event_name == 'workflow_dispatch'" in text
+    assert '"refs/heads/${DEFAULT_BRANCH}"' in text
+    assert '--source-root "${GITHUB_WORKSPACE}/released-source"' in text
+    assert "tag_name: ${{ env.RELEASE_TAG }}" in text
+
+
 def test_release_workflow_contains_only_identity_and_delivery_steps() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     forbidden_commands = (

--- a/tools/antigravity_review.py
+++ b/tools/antigravity_review.py
@@ -1,0 +1,68 @@
+"""Validate Gemini CLI output before publishing an Antigravity PR review."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class ReviewError(ValueError):
+    """Raised when Gemini output does not contain a publishable review."""
+
+
+def _error_type(payload: dict[str, Any]) -> str | None:
+    error = payload.get("error")
+    if error is None:
+        return None
+    if not isinstance(error, dict) or not isinstance(error.get("type"), str):
+        return "UNKNOWN_ERROR"
+    return error["type"]
+
+
+def prepare_review(gemini_output: Path, review_path: Path) -> None:
+    """Validate one Gemini JSON response before creating its review artifact."""
+    payload = json.loads(gemini_output.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = "Gemini CLI output must be a JSON object"
+        raise ReviewError(msg)
+    error_type = _error_type(payload)
+    if error_type is not None:
+        msg = f"Gemini CLI returned an error instead of a complete review ({error_type})"
+        raise ReviewError(msg)
+    response = payload.get("response")
+    if not isinstance(response, str) or not response.strip():
+        msg = "Gemini CLI returned no publishable review (EMPTY_RESPONSE)"
+        raise ReviewError(msg)
+    review = response.strip()
+    if review.splitlines()[0] != "## Antigravity Review":
+        msg = "Gemini CLI response is missing the required Antigravity Review heading"
+        raise ReviewError(msg)
+    review_path.parent.mkdir(parents=True, exist_ok=True)
+    review_path.write_text(review + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse Antigravity review sanitizer arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate Gemini output and report failures without echoing its payload."""
+    args = parse_args(argv)
+    try:
+        prepare_review(args.input, args.output)
+    except (OSError, json.JSONDecodeError, ReviewError) as error:
+        print(f"Antigravity review error: {error}", file=sys.stderr)
+        return 1
+    print(f"Prepared Antigravity review artifact: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -572,6 +572,10 @@ def _check_release_workflow() -> list[str]:
     issues = _check_text_mentions(
         RELEASE_WORKFLOW,
         (
+            "workflow_dispatch",
+            "github.event.release.tag_name || inputs.release_tag",
+            "path: release-automation",
+            "path: released-source",
             "tools.release_bundle metadata",
             "--expected-tag",
             "tools.release_bundle resolve",
@@ -583,6 +587,7 @@ def _check_release_workflow() -> list[str]:
             "verified-release-bundle",
             "release-bundle/public/SHA256SUMS.txt",
             "softprops/action-gh-release",
+            "tag_name: ${{ env.RELEASE_TAG }}",
             "pypa/gh-action-pypi-publish",
             "packages-dir: release-bundle/dist",
         ),

--- a/tools/release_bundle.py
+++ b/tools/release_bundle.py
@@ -53,6 +53,7 @@ MANIFEST_KEYS = {
     "version",
 }
 REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
+GitHubResponse = dict[str, Any] | list[dict[str, Any]]
 
 
 class BundleError(ValueError):
@@ -81,8 +82,8 @@ class ResolvedArtifact:
 class GitHubAPI(Protocol):
     """Minimal interface required by the provenance resolver."""
 
-    def get_json(self, path: str) -> dict[str, Any]:
-        """Return one GitHub REST response as a JSON object."""
+    def get_json(self, path: str) -> GitHubResponse:
+        """Return one GitHub REST response as a JSON object or array."""
 
 
 class GitHubClient:
@@ -95,7 +96,7 @@ class GitHubClient:
         self.token = token
         self.api_url = api_url.rstrip("/")
 
-    def get_json(self, path: str) -> dict[str, Any]:
+    def get_json(self, path: str) -> GitHubResponse:
         """Fetch a GitHub REST endpoint without exposing the token in arguments or logs."""
         request = urllib.request.Request(
             f"{self.api_url}{path}",
@@ -108,8 +109,8 @@ class GitHubClient:
         )
         with urllib.request.urlopen(request, timeout=30) as response:
             data = json.load(response)
-        if not isinstance(data, dict):
-            msg = f"GitHub API endpoint {path} did not return a JSON object"
+        if not isinstance(data, (dict, list)):
+            msg = f"GitHub API endpoint {path} did not return a JSON object or array"
             raise BundleError(msg)
         return data
 
@@ -480,6 +481,55 @@ def verify_bundle(
     return manifest
 
 
+def _is_merged_into(pull_request: dict[str, Any], default_branch: str) -> bool:
+    pull_base = pull_request.get("base", {})
+    return (
+        pull_request.get("merged_at") is not None
+        and isinstance(pull_base, dict)
+        and pull_base.get("ref") == default_branch
+    )
+
+
+def _run_has_required_status(run: dict[str, Any], workflow_path: str) -> bool:
+    return (
+        run.get("event") == "pull_request"
+        and run.get("status") == "completed"
+        and run.get("conclusion") == "success"
+        and run.get("path") == workflow_path
+    )
+
+
+def _summary_identifies_merged_pr(
+    api: GitHubAPI,
+    repository: str,
+    summary: Any,
+    default_branch: str,
+) -> bool:
+    if not isinstance(summary, dict):
+        return False
+    base = summary.get("base", {})
+    number = summary.get("number")
+    if not isinstance(base, dict) or base.get("ref") != default_branch or not isinstance(number, int):
+        return False
+    pull_request = api.get_json(f"/repos/{repository}/pulls/{number}")
+    return isinstance(pull_request, dict) and _is_merged_into(pull_request, default_branch)
+
+
+def _head_commit_identifies_merged_pr(
+    api: GitHubAPI,
+    repository: str,
+    head_sha: Any,
+    default_branch: str,
+) -> bool:
+    if not isinstance(head_sha, str) or not head_sha:
+        return False
+    pull_requests = api.get_json(f"/repos/{repository}/commits/{head_sha}/pulls")
+    return isinstance(pull_requests, list) and any(
+        isinstance(pull_request, dict) and _is_merged_into(pull_request, default_branch)
+        for pull_request in pull_requests
+    )
+
+
 def _run_matches_release_policy(
     api: GitHubAPI,
     repository: str,
@@ -489,32 +539,14 @@ def _run_matches_release_policy(
     default_branch: str,
 ) -> bool:
     run = api.get_json(f"/repos/{repository}/actions/runs/{run_id}")
-    if (
-        run.get("event") != "pull_request"
-        or run.get("status") != "completed"
-        or run.get("conclusion") != "success"
-        or run.get("path") != workflow_path
-    ):
+    if not isinstance(run, dict) or not _run_has_required_status(run, workflow_path):
         return False
     pull_requests = run.get("pull_requests", [])
-    if not isinstance(pull_requests, list):
-        return False
-    for pull_request_summary in pull_requests:
-        if not isinstance(pull_request_summary, dict):
-            continue
-        base = pull_request_summary.get("base", {})
-        number = pull_request_summary.get("number")
-        if not isinstance(base, dict) or base.get("ref") != default_branch or not isinstance(number, int):
-            continue
-        pull_request = api.get_json(f"/repos/{repository}/pulls/{number}")
-        pull_base = pull_request.get("base", {})
-        if (
-            pull_request.get("merged_at") is not None
-            and isinstance(pull_base, dict)
-            and pull_base.get("ref") == default_branch
-        ):
-            return True
-    return False
+    if isinstance(pull_requests, list) and any(
+        _summary_identifies_merged_pr(api, repository, summary, default_branch) for summary in pull_requests
+    ):
+        return True
+    return _head_commit_identifies_merged_pr(api, repository, run.get("head_sha"), default_branch)
 
 
 def resolve_artifact(
@@ -531,6 +563,9 @@ def resolve_artifact(
         raise BundleError(msg)
     encoded_name = urllib.parse.quote(artifact_name, safe="")
     response = api.get_json(f"/repos/{repository}/actions/artifacts?name={encoded_name}&per_page=100")
+    if not isinstance(response, dict):
+        msg = "GitHub artifacts response is not a JSON object"
+        raise BundleError(msg)
     artifacts = response.get("artifacts", [])
     if not isinstance(artifacts, list):
         msg = "GitHub artifacts response does not contain an artifacts array"

--- a/tools/release_bundle.py
+++ b/tools/release_bundle.py
@@ -542,10 +542,10 @@ def _run_matches_release_policy(
     if not isinstance(run, dict) or not _run_has_required_status(run, workflow_path):
         return False
     pull_requests = run.get("pull_requests", [])
-    if isinstance(pull_requests, list) and any(
-        _summary_identifies_merged_pr(api, repository, summary, default_branch) for summary in pull_requests
-    ):
-        return True
+    if not isinstance(pull_requests, list):
+        return False
+    if pull_requests:
+        return any(_summary_identifies_merged_pr(api, repository, summary, default_branch) for summary in pull_requests)
     return _head_commit_identifies_merged_pr(api, repository, run.get("head_sha"), default_branch)
 
 


### PR DESCRIPTION
## Summary

- Resolve release-bundle provenance through the workflow `head_sha` when the Actions run API omits `pull_requests`.
- Keep the existing requirements: successful PR workflow, completed run, merged PR, and default-branch target.
- Add a default-branch `workflow_dispatch` recovery path for an already published tag.
- Run recovery with automation code from `main` while computing release identity from the immutable released tag.

## Root cause

Release `2.3.3` expected the exact artifact produced by PR #307, but GitHub returned an empty `pull_requests` array for its successful PR workflow run. The resolver treated that incomplete association metadata as a provenance failure even though the commit-to-PR endpoint identifies PR #307 as merged into `main`.

The release bundle remains unchanged and unexpired. The recovery path reuses that verified artifact and keeps publication delivery-only.

## Validation

- `uv run pytest -m "not slow"`: 12,032 passed, 45 skipped
- `uv run python -m tools.quality_gate fast`
- Focused CI and release workflow tests: 71 passed
- `uv run python -m tools.ci_matrix check`
- `uv run python -m tools.ci_shard check`
- `uv run zizmor --format=plain --min-severity=medium --min-confidence=medium .github`: no findings
- `pre-commit run --all-files`
- The fixed resolver selected the real `2.3.3` bundle from successful PR run `29424768670`.

## Recovery after merge

```bash
gh workflow run upload_to_pypi.yml --ref main -f release_tag=2.3.3
```

This attaches the verified wheel, source distribution, SBOM, correctness report, and checksums to the existing GitHub Release, then publishes the same wheel and source distribution to PyPI.
