### PR TITLE
Fix release bundle hidden-file transport

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -719,6 +719,7 @@ jobs:
         with:
           name: ${{ steps.finalize.outputs.artifact_name }}
           path: ${{ runner.temp }}/release-bundle/
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 90
       - name: Upload failed preflight diagnostics

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           name: verified-release-bundle
           path: ${{ github.workspace }}/release-bundle/
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
 

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -89,6 +89,7 @@ def test_coverage_and_pytorch_are_not_duplicated_across_matrix_cells() -> None:
 def test_version_bump_preflight_builds_publishable_bundle_in_core_profile() -> None:
     workflow = _workflow()
     job = workflow["jobs"]["release_preflight"]
+    upload_step = next(step for step in job["steps"] if step["name"] == "Upload publishable release bundle")
     run_text = "\n".join(str(step.get("run", "")) for step in job["steps"])
     policy_run_text = "\n".join(str(step.get("run", "")) for step in workflow["jobs"]["security_policy"]["steps"])
 
@@ -97,6 +98,7 @@ def test_version_bump_preflight_builds_publishable_bundle_in_core_profile() -> N
     assert "dependency-group: ci-release" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert 'uv build --out-dir "${RUNNER_TEMP}/release-bundle/dist"' in run_text
     assert "${{ runner.temp }}/release-bundle/" in WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert upload_step["with"]["include-hidden-files"] is True
     assert "tools.release_bundle finalize" in run_text
     assert "python -m tools.performance_budget summarize" in run_text
     assert "python tools/performance_budget.py" not in run_text

--- a/tests/test_release_bundle.py
+++ b/tests/test_release_bundle.py
@@ -145,6 +145,55 @@ def test_verify_bundle_rejects_payload_tampering(tmp_path: Path) -> None:
         )
 
 
+def test_verify_bundle_accepts_known_legacy_upload_artifact_omission(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    bundle = _bundle(repository)
+    gitignore = bundle / "dist" / ".gitignore"
+    gitignore.write_text("*", encoding="utf-8")
+    manifest = finalize_bundle(bundle, repository, checks=REQUIRED_CHECKS)
+    gitignore.unlink()
+
+    verified = verify_bundle(
+        bundle,
+        expected_version="2.3.3",
+        expected_source_digest=source_digest(repository),
+    )
+
+    assert verified == manifest
+
+
+def test_verify_bundle_rejects_legacy_omission_with_unexpected_digest(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    bundle = _bundle(repository)
+    gitignore = bundle / "dist" / ".gitignore"
+    gitignore.write_text("unexpected", encoding="utf-8")
+    finalize_bundle(bundle, repository, checks=REQUIRED_CHECKS)
+    gitignore.unlink()
+
+    with pytest.raises(BundleError, match=r"missing or is not regular: dist/\.gitignore"):
+        verify_bundle(
+            bundle,
+            expected_version="2.3.3",
+            expected_source_digest=source_digest(repository),
+        )
+
+
+def test_verify_bundle_rejects_legacy_omission_for_another_version(tmp_path: Path) -> None:
+    repository = _repository(tmp_path, version="2.3.4")
+    bundle = _bundle(repository, version="2.3.4")
+    gitignore = bundle / "dist" / ".gitignore"
+    gitignore.write_text("*", encoding="utf-8")
+    finalize_bundle(bundle, repository, checks=REQUIRED_CHECKS)
+    gitignore.unlink()
+
+    with pytest.raises(BundleError, match=r"missing or is not regular: dist/\.gitignore"):
+        verify_bundle(
+            bundle,
+            expected_version="2.3.4",
+            expected_source_digest=source_digest(repository),
+        )
+
+
 def test_verify_bundle_rejects_expired_manifest(tmp_path: Path) -> None:
     repository = _repository(tmp_path)
     bundle = _bundle(repository)

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -70,13 +70,18 @@ def test_release_workflow_contains_only_identity_and_delivery_steps() -> None:
 
 def test_release_workflow_delivers_one_verified_bundle_to_both_destinations() -> None:
     jobs = _workflow()["jobs"]
+    resolve_job = jobs["resolve_release_bundle"]
     attach_job = jobs["attach_release_assets"]
     pypi_job = jobs["publish_to_pypi"]
+    handoff_step = next(
+        step for step in resolve_job["steps"] if step["name"] == "Hand verified bundle to delivery jobs"
+    )
 
     assert attach_job["needs"] == "resolve_release_bundle"
     assert attach_job["permissions"] == {"actions": "read", "contents": "write"}
     assert pypi_job["needs"] == "attach_release_assets"
     assert pypi_job["permissions"] == {"actions": "read", "contents": "read", "id-token": "write"}
+    assert handoff_step["with"]["include-hidden-files"] is True
     assert "verified-release-bundle" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "packages-dir: release-bundle/dist" in WORKFLOW_PATH.read_text(encoding="utf-8")
 

--- a/tools/release_bundle.py
+++ b/tools/release_bundle.py
@@ -27,6 +27,10 @@ SCHEMA_VERSION = 1
 MANIFEST_NAME = "release-manifest.json"
 DEFAULT_RETENTION_DAYS = 90
 DEFAULT_WORKFLOW_PATH = ".github/workflows/pr.yml"
+# GitHub upload-artifact omitted this uv-generated hidden file before hidden-file uploads were enabled.
+LEGACY_TRANSPORT_OMISSIONS = {
+    ("2.3.3", "dist/.gitignore"): "sha256:684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1",
+}
 REQUIRED_CHECKS = frozenset(
     {
         "clean_install",
@@ -368,11 +372,12 @@ def _parse_timestamp(value: Any, label: str) -> datetime:
     return parsed.astimezone(timezone.utc)
 
 
-def _validated_artifacts(bundle_dir: Path, artifacts: Any) -> dict[str, str]:
+def _validated_artifacts(bundle_dir: Path, artifacts: Any, version: str) -> tuple[dict[str, str], set[str]]:
     if not isinstance(artifacts, dict) or not artifacts:
         msg = "Release manifest artifacts must be a non-empty mapping"
         raise BundleError(msg)
     validated: dict[str, str] = {}
+    omitted: set[str] = set()
     for raw_path, raw_digest in artifacts.items():
         if not isinstance(raw_path, str) or not isinstance(raw_digest, str):
             msg = "Release manifest artifact paths and digests must be strings"
@@ -382,6 +387,14 @@ def _validated_artifacts(bundle_dir: Path, artifacts: Any) -> dict[str, str]:
             msg = f"Release manifest contains an unsafe artifact path: {raw_path!r}"
             raise BundleError(msg)
         path = bundle_dir.joinpath(*relative.parts)
+        if (
+            not path.is_symlink()
+            and not path.exists()
+            and LEGACY_TRANSPORT_OMISSIONS.get((version, raw_path)) == raw_digest
+        ):
+            validated[raw_path] = raw_digest
+            omitted.add(raw_path)
+            continue
         if path.is_symlink() or not path.is_file():
             msg = f"Release manifest artifact is missing or is not regular: {raw_path}"
             raise BundleError(msg)
@@ -390,7 +403,7 @@ def _validated_artifacts(bundle_dir: Path, artifacts: Any) -> dict[str, str]:
             msg = f"Release artifact digest mismatch for {raw_path}: {actual_digest} != {raw_digest}"
             raise BundleError(msg)
         validated[raw_path] = raw_digest
-    return validated
+    return validated, omitted
 
 
 def _read_manifest(bundle_dir: Path) -> dict[str, Any]:
@@ -444,9 +457,9 @@ def _validate_manifest_identity(
 
 
 def _validate_manifest_payload(bundle_dir: Path, manifest: dict[str, Any], version: str) -> None:
-    validated_artifacts = _validated_artifacts(bundle_dir, manifest["artifacts"])
+    validated_artifacts, omitted_artifacts = _validated_artifacts(bundle_dir, manifest["artifacts"], version)
     actual_payload = set(_payload_files(bundle_dir))
-    if actual_payload != set(validated_artifacts):
+    if actual_payload != set(validated_artifacts) - omitted_artifacts:
         msg = "Release bundle payload does not exactly match the manifest"
         raise BundleError(msg)
     wheel, sdist, sbom, report, checksums = _required_publish_files(bundle_dir, version)


### PR DESCRIPTION
## Summary

- Preserve hidden files when uploading the PR release bundle and when handing a verified bundle to delivery jobs.
- Accept the one known transport omission in the existing `2.3.3` bundle: `dist/.gitignore` with its exact recorded SHA-256.
- Keep every publishable distribution, checksum, SBOM, report, and evidence file under the existing byte-for-byte verification.

## Root cause

`uv build` created `dist/.gitignore` containing `*`. Release preflight recorded that file in `release-manifest.json`, while `actions/upload-artifact` excluded hidden files by default. Recovery run [29475624993](https://github.com/albumentations-team/AlbumentationsX/actions/runs/29475624993) therefore found and downloaded the correct PR artifact, then rejected it because that single non-publishable file was absent.

The compatibility rule is limited to version `2.3.3`, path `dist/.gitignore`, and SHA-256 `684888c0ebb17f374298b65ee2807526c066094c701bcc7ebbe1c1095f494fc1`. Other versions, paths, or digests still fail verification.

## Impact

After merge, the existing `2.3.3` bundle can be delivered without rebuilding the wheel or source distribution. Future bundle uploads preserve hidden files across both artifact boundaries.

## Validation

- Downloaded bundle from PR workflow run `29424768670` passes `tools.release_bundle verify` locally.
- `12042 passed, 45 skipped, 38 deselected, 9 xfailed, 3 xpassed` in the non-slow test suite.
- Focused release/workflow tests: `31 passed`.
- `tools.quality_gate fast` and all pre-commit hooks passed.
- `zizmor` reported no findings.
- Fresh wheel and sdist passed legal-integrity verification and `twine check`.
