### PR TITLE
feat: allow RandomRotate90 to sample from a subset of C4 group elements

### DIFF
--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -197,7 +197,11 @@ class RandomRotate90(DualTransform):
             group_element = self.random_generator.choice(self.group_elements)
         else:
             group_element = self.random_generator.choice(c4_group_elements)
-        self.applied_config = {"group_element": group_element}
+
+        # Explicitly clear group_elements so that _build_applied_config() does not
+        # merge the unused constructor tuple (e.g. ("r90", "r270")) into the record,
+        # which would cause InitSchema to reject the replay as mutually exclusive.
+        self.applied_config = {"group_element": group_element, "group_elements": None}
         return {"group_element": group_element}
 
     def apply_to_bboxes(

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -11,6 +11,8 @@ from typing import Any, Literal
 import cv2
 import numpy as np
 from albucore import warp_affine
+from pydantic import model_validator
+from typing_extensions import Self
 
 from albumentations.augmentations.crops import functional as fcrops
 from albumentations.augmentations.geometric.transforms import Affine
@@ -53,6 +55,9 @@ class RandomRotate90(DualTransform):
     - With p=0.8: Each rotation angle has 0.2 probability, and no transform has 0.2 probability
     - With p=0.5: Each rotation angle has 0.125 probability, and no transform has 0.5 probability
 
+    When `group_elements` is specified, the configured rotations are sampled uniformly.
+    If `"e"` is excluded from the subset, the transform never returns the identity when applied.
+
     Common applications:
     - Aerial/satellite imagery: Objects can appear in any orientation
     - Medical imaging: Scans/slides may not have a consistent orientation
@@ -74,7 +79,8 @@ class RandomRotate90(DualTransform):
         - Properly represents the dihedral group D4 symmetries
         - Avoids potential correlation between separate rotation and flip augmentations
 
-        `inverse()` requires `group_element` to be set explicitly; raises `ValueError` otherwise.
+    `inverse()` requires `group_element` to be set explicitly; it is not available when
+    sampling randomly with `group_elements` or the default random mode.
 
     When `group_element` is specified, the transform is deterministic—useful for TTA (Test Time
     Augmentation) where you need to apply each of the 4 rotations (0°, 90°, 180°, 270°) explicitly
@@ -89,6 +95,9 @@ class RandomRotate90(DualTransform):
         group_element (Literal['e', 'r90', 'r180', 'r270'] | None): If set, always apply this
             C4 group element: "e"=identity, "r90"=90°, "r180"=180°, "r270"=270° counterclockwise.
             Use for TTA. Default: None (random choice).
+        group_elements (tuple[Literal["e", "r90", "r180", "r270"], ...] | None): If set, sample uniformly
+            from the provided non-empty subset of C4 group elements. Invalid or empty subsets raise `ValueError`.
+            Mutually exclusive with `group_element`. Default: None (random choice).
 
     Targets:
         image, mask, bboxes, keypoints, volume, mask3d
@@ -147,14 +156,31 @@ class RandomRotate90(DualTransform):
 
     class InitSchema(BaseTransformInitSchema):
         group_element: Literal["e", "r90", "r180", "r270"] | None
+        group_elements: tuple[Literal["e", "r90", "r180", "r270"], ...] | None
+
+        @model_validator(mode="after")
+        def _validate_group_config(self) -> Self:
+            if self.group_element is not None and self.group_elements is not None:
+                raise ValueError("group_element and group_elements are mutually exclusive")
+
+            if self.group_elements is not None:
+                if not self.group_elements:
+                    raise ValueError("group_elements must be a non-empty subset of C4 group elements")
+
+                if len(self.group_elements) != len(set(self.group_elements)):
+                    raise ValueError("group_elements must not contain duplicate elements")
+
+            return self
 
     def __init__(
         self,
         p: float = 1,
         group_element: Literal["e", "r90", "r180", "r270"] | None = None,
+        group_elements: tuple[Literal["e", "r90", "r180", "r270"], ...] | None = None,
     ):
         super().__init__(p=p)
         self.group_element = group_element
+        self.group_elements = group_elements
 
     def apply(
         self,
@@ -167,6 +193,8 @@ class RandomRotate90(DualTransform):
     def get_params(self) -> dict[str, Literal["e", "r90", "r180", "r270"]]:
         if self.group_element is not None:
             group_element = self.group_element
+        elif self.group_elements is not None:
+            group_element = self.random_generator.choice(self.group_elements)
         else:
             group_element = self.random_generator.choice(c4_group_elements)
         self.applied_config = {"group_element": group_element}

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -950,6 +950,7 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
         {"interpolation": cv2.INTER_CUBIC, "mask_interpolation": cv2.INTER_LINEAR, "area_for_downscale": "image_mask"},
     ),
     ("fixed-element", A.RandomRotate90, {"group_element": "r90"}),
+    ("subset-elements", A.RandomRotate90, {"group_elements": ("r90", "r270")}),
     ("downscale-aware", A.RandomScale, {"mask_interpolation": cv2.INTER_LINEAR, "area_for_downscale": "image_mask"}),
     ("variable-intensity", A.RandomShadow, {"shadow_intensity_range": (0.2, 0.7)}),
     (

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2227,6 +2227,26 @@ def test_random_rotate90_records_sampled_group_element_in_applied_config(
     assert result.shape == image.shape
 
 
+def test_random_rotate90_group_elements_applied_config_round_trip() -> None:
+    """Recorded applied_config with group_elements must be replay-valid.
+
+    Regression: when group_elements is set, the recorded applied_config must not
+    contain both group_element and group_elements, which would cause
+    Compose.from_applied_transforms() to raise a ValueError.
+    """
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+    transform = A.Compose(
+        [A.RandomRotate90(p=1.0, group_elements=("r90", "r270"))],
+        save_applied_params=True,
+        strict=True,
+    )
+    result = transform(image=image)
+    # Must not raise ValueError about mutually exclusive group_element/group_elements
+    replay = A.Compose.from_applied_transforms(result["applied_transforms"])
+    replay_result = replay(image=image)
+    np.testing.assert_array_equal(result["image"], replay_result["image"])
+
+
 def test_random_rotate90_group_elements_serialization() -> None:
     """Serializing and deserializing preserves group_elements behavior."""
     image = np.arange(64 * 64 * 3, dtype=np.uint8).reshape(64, 64, 3)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2172,6 +2172,82 @@ def test_random_rotate90_tta_deterministic(group_element):
     np.testing.assert_array_equal(results[1], results[2])
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        (
+            {"group_element": "r90", "group_elements": ("r90", "r270")},
+            "mutually exclusive",
+        ),
+        (
+            {"group_elements": ()},
+            "non-empty",
+        ),
+        (
+            {"group_elements": ("r90", "foo")},
+            "Input should be 'e', 'r90', 'r180' or 'r270'",
+        ),
+        (
+            {"group_elements": ("r90", "r90", "r180")},
+            "group_elements must not contain duplicate elements",
+        ),
+    ],
+)
+def test_random_rotate90_group_elements_validation(kwargs: dict, match: str) -> None:
+    """Invalid group_elements configurations raise a ValueError."""
+    with pytest.raises(ValueError, match=match):
+        A.RandomRotate90(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("transform", "expected_elements"),
+    [
+        (
+            A.RandomRotate90(p=1.0),
+            {"e", "r90", "r180", "r270"},
+        ),
+        (
+            A.RandomRotate90(p=1.0, group_elements=("r90", "r270")),
+            {"r90", "r270"},
+        ),
+    ],
+)
+def test_random_rotate90_records_sampled_group_element_in_applied_config(
+    transform: A.RandomRotate90,
+    expected_elements: set[str],
+) -> None:
+    """The sampled rotation element is recorded in the applied configuration."""
+    image = np.arange(64 * 64 * 3, dtype=np.uint8).reshape(64, 64, 3)
+    transform.set_random_seed(137)
+
+    result = transform(image=image)["image"]
+    applied_config = transform.get_applied_config()
+
+    assert applied_config["group_element"] in expected_elements
+    assert result.shape == image.shape
+
+
+def test_random_rotate90_group_elements_serialization() -> None:
+    """Serializing and deserializing preserves group_elements behavior."""
+    image = np.arange(64 * 64 * 3, dtype=np.uint8).reshape(64, 64, 3)
+
+    transform = A.RandomRotate90(p=1.0, group_elements=("r90", "r270"))
+    transform.set_random_seed(137)
+
+    result = transform(image=image)["image"]
+
+    serialized = A.to_dict(transform)
+    deserialized = A.from_dict(serialized)
+
+    assert deserialized is not None
+    assert deserialized.group_elements == ("r90", "r270")
+
+    deserialized.set_random_seed(137)
+    deserialized_result = deserialized(image=image)["image"]
+
+    np.testing.assert_array_equal(result, deserialized_result)
+
+
 @pytest.mark.parametrize("group_element", ["e", "r90", "h", "t"])
 def test_square_symmetry_tta_same_as_d4(group_element):
     """SquareSymmetry with group_element produces same result as D4."""
@@ -2216,6 +2292,13 @@ def test_random_rotate90_inverse_roundtrip(group_element: str) -> None:
 def test_random_rotate90_inverse_requires_group_element() -> None:
     """inverse() on RandomRotate90 without group_element raises ValueError."""
     aug = A.RandomRotate90(p=1)
+    with pytest.raises(ValueError, match="group_element"):
+        aug.inverse()
+
+
+def test_random_rotate90_inverse_requires_deterministic_group_element() -> None:
+    """inverse() on RandomRotate90 with group_elements raises ValueError."""
+    aug = A.RandomRotate90(p=1, group_elements=("r90", "r270"))
     with pytest.raises(ValueError, match="group_element"):
         aug.inverse()
 


### PR DESCRIPTION
Closes: https://github.com/albumentations-team/AlbumentationsX/issues/314

## Summary by Sourcery

Add configurable subset-based sampling of C4 rotation elements to RandomRotate90 and document its impact on randomness and inversion behavior.

New Features:
- Allow RandomRotate90 to sample uniformly from a user-provided non-empty subset of C4 group elements via a new group_elements parameter.
- Record the actually sampled C4 group element in the transform's applied configuration for inspection.

Enhancements:
- Add validation to disallow invalid, empty, or duplicate group_elements and to enforce mutual exclusivity with group_element.
- Clarify and enforce that inverse() is only available for deterministic RandomRotate90 configurations, not when sampling randomly with group_elements or the default mode.
- Ensure group_elements configuration is preserved across serialization and deserialization of RandomRotate90 transforms.

Tests:
- Add tests covering group_elements validation rules, recording of sampled group elements, serialization/deserialization of group_elements, and inverse() behavior when using random sampling.