### PR TITLE
Fix instance binding alignment after bbox filtering

### DIFF
--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -1232,6 +1232,7 @@ def filter_bboxes_with_mask(
 
     keep_mask = (
         (denormalized_box_areas >= epsilon)
+        & (clipped_box_areas >= epsilon)
         & (clipped_box_areas >= min_area - epsilon)
         & (clipped_box_areas / (denormalized_box_areas + epsilon) >= min_visibility)
         & (clipped_widths >= min_width - epsilon)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -594,12 +594,12 @@ class BaseCompose(Serializable):
         processor (e.g. bbox filter) on matching data keys. Returns filtered data dict.
 
         When `instance_binding` is active and the bbox processor drops rows, this method
-        mirrors that survival decision onto `masks` (positionally) and `keypoints` (by
-        surviving `_bbox_instance_id` value) so the structural invariant
-        `len(masks) == len(bboxes)` and "no orphan keypoints" is upheld at every transform
-        boundary. Without this mirror-drop the resync would have to reconstruct the
-        survival decision from snapshot state — phase 3b of the rewrite collapses that
-        machinery into a single keep-mask plumbed straight from `BboxProcessor`.
+        mirrors that survival decision onto `masks` rows or `mask` channels (positionally)
+        and `keypoints` (by surviving `_bbox_instance_id` value) so bound targets remain
+        aligned at every transform boundary. Without this mirror-drop the resync would have
+        to reconstruct the survival decision from snapshot state — phase 3b of the rewrite
+        collapses that machinery into a single keep-mask plumbed straight from
+        `BboxProcessor`.
 
         Args:
             data (dict[str, Any]): Dictionary containing transformed data
@@ -640,15 +640,15 @@ class BaseCompose(Serializable):
 
         1. Pre-filter realignment. Some transforms (CoarseDropout, Crop with `min_area`,
            etc.) drop bbox rows inside their own `apply_to_bboxes` without touching the
-           mask stack. At this point `len(masks) > len(bboxes)` and the surviving bboxes
-           carry their original `_bbox_instance_id` in the last column. That id is the row
-           index into the still-id-indexed mask stack, so we fancy-index masks down to the
-           surviving id set and drop keypoints whose `_kp_instance_id` is no longer present.
-           This collapses the legacy "id-indexed masks + sparse ids" layout into the
-           positional layout the rest of this method assumes.
+           bound masks. The surviving bboxes carry their original `_bbox_instance_id` in
+           the last column. That id selects a row in `masks` or a channel in `mask`, so we
+           fancy-index the bound masks down to the surviving id set and drop keypoints whose
+           `_kp_instance_id` is no longer present. This collapses the legacy "id-indexed
+           masks + sparse ids" layout into the positional layout the rest of this method
+           assumes.
         2. BboxProcessor filter + post-filter mirror. Standard `filter_with_keep_mask` on
-           bboxes; mirror the resulting `keep_mask` positionally onto masks and by
-           surviving id onto keypoints.
+           bboxes; mirror the resulting `keep_mask` positionally onto mask rows or channels
+           and by surviving id onto keypoints.
         """
         bboxes_pre = data.get("bboxes")
         if isinstance(bboxes_pre, np.ndarray) and bboxes_pre.shape[0] > 0:
@@ -675,14 +675,20 @@ class BaseCompose(Serializable):
         pre_bbox_ids: np.ndarray,
         n_pre: int,
     ) -> None:
-        """Drop mask rows / keypoints whose ids are not in `pre_bbox_ids` so the in-flight `data`
-        is positionally aligned BEFORE the bbox-processor's own filter runs.
+        """Drop bound mask rows or channels and keypoints absent from `pre_bbox_ids` so data remains positionally
+        aligned before the bbox processor's filter runs.
         """
         if "masks" in binding:
             masks_pre = data.get("masks")
             if isinstance(masks_pre, np.ndarray) and len(masks_pre) > n_pre:
                 valid = pre_bbox_ids[(pre_bbox_ids >= 0) & (pre_bbox_ids < len(masks_pre))]
                 data["masks"] = masks_pre[valid] if valid.shape[0] > 0 else masks_pre[:0]
+        elif "mask" in binding:
+            mask_pre = data.get("mask")
+            if isinstance(mask_pre, np.ndarray) and mask_pre.ndim >= 3 and mask_pre.shape[-1] > n_pre:
+                channel_count = mask_pre.shape[-1]
+                valid = pre_bbox_ids[(pre_bbox_ids >= 0) & (pre_bbox_ids < channel_count)]
+                data["mask"] = mask_pre[..., valid] if valid.shape[0] > 0 else mask_pre[..., :0]
         if "keypoints" in binding:
             kps_pre = data.get("keypoints")
             if isinstance(kps_pre, np.ndarray) and kps_pre.shape[0] > 0:
@@ -726,13 +732,17 @@ class BaseCompose(Serializable):
         pre_bbox_ids: np.ndarray,
         n_pre: int,
     ) -> None:
-        """Mirror the bbox-processor's positional `keep_mask` onto masks (positional) and
-        keypoints (by surviving `_kp_instance_id`) so all three arrays stay row-aligned.
+        """Mirror the bbox processor's positional keep mask onto bound mask rows or channels and keypoints by
+        surviving instance id so all targets stay aligned.
         """
         if "masks" in binding:
             masks = data.get("masks")
             if isinstance(masks, np.ndarray) and len(masks) == n_pre:
                 data["masks"] = masks[keep_mask]
+        elif "mask" in binding:
+            mask = data.get("mask")
+            if isinstance(mask, np.ndarray) and mask.ndim >= 3 and mask.shape[-1] == n_pre:
+                data["mask"] = mask[..., keep_mask]
         if "keypoints" in binding:
             kps = data.get("keypoints")
             if isinstance(kps, np.ndarray) and kps.shape[0] > 0:

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1556,6 +1556,8 @@ class Compose(BaseCompose, HubMixin):
 
         """
         if self.main_compose:
+            self._filter_bound_bboxes_before_postprocess(data)
+
             for p in self.processors.values():
                 p.postprocess(data)
 
@@ -1571,6 +1573,22 @@ class Compose(BaseCompose, HubMixin):
             self._remove_grayscale_channels(data)
 
         return data
+
+    def _filter_bound_bboxes_before_postprocess(self, data: dict[str, Any]) -> None:
+        """Filter bound bboxes at the final boundary and mirror their keep mask before postprocessing removes internal
+        instance ids required to align masks and keypoints.
+        """
+        binding = self._instance_binding
+        if binding is None or "bboxes" not in binding:
+            return
+
+        bbox_processor = self.processors.get("bboxes")
+        if not isinstance(bbox_processor, BboxProcessor):
+            return
+
+        shape = get_shape(data, self._additional_targets)
+        self._bbox_filter_with_mirror(bbox_processor, data, shape, binding)
+        self._resync_instance_ids(data)
 
     def _remove_grayscale_channels(self, data: dict[str, Any]) -> None:
         """Strip the trailing channel dimension that `_add_grayscale_channels` added,

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -20,6 +20,7 @@ from albumentations.core.bbox_utils import (
     convert_bboxes_to_albumentations,
     denormalize_bboxes,
     filter_bboxes,
+    filter_bboxes_with_mask,
     mask_to_bboxes,
     masks_from_bboxes,
     normalize_bboxes,
@@ -1027,6 +1028,23 @@ def test_filter_bboxes_clipping():
 
     expected = np.array([[0.0, 0.0, 1.0, 1.0], [0.3, 0.3, 0.4, 0.4]])
     np.testing.assert_allclose(result, expected, rtol=1e-5)
+
+
+def test_filter_bboxes_rejects_fully_clipped_box_with_zero_thresholds():
+    bboxes = np.array([[-0.1, -0.1, 0.0, 0.0], [0.25, 0.25, 0.75, 0.75]])
+
+    filtered, keep_mask = filter_bboxes_with_mask(
+        bboxes,
+        (100, 100),
+        "hbb",
+        min_area=0,
+        min_visibility=0,
+        min_width=0,
+        min_height=0,
+    )
+
+    np.testing.assert_array_equal(filtered, bboxes[1:])
+    np.testing.assert_array_equal(keep_mask, [False, True])
 
 
 def test_filter_bboxes_noop():

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -774,6 +774,27 @@ class TestInstanceBindingCallState:
 
 
 class TestChannelMask:
+    @staticmethod
+    def _filtering_data() -> tuple[np.ndarray, list[dict[str, Any]]]:
+        image = np.zeros((128, 128, 3), dtype=np.uint8)
+        outside_mask = np.zeros((128, 128), dtype=np.uint8)
+        outside_mask[:4, :4] = 1
+        surviving_mask = np.zeros((128, 128), dtype=np.uint8)
+        surviving_mask[40:80, 40:80] = 3
+        instances = [
+            {
+                "mask": outside_mask,
+                "bbox": np.array([0, 0, 4, 4], dtype=np.float32),
+                "bbox_labels": {"class_id": 11},
+            },
+            {
+                "mask": surviving_mask,
+                "bbox": np.array([40, 40, 80, 80], dtype=np.float32),
+                "bbox_labels": {"class_id": 33},
+            },
+        ]
+        return image, instances
+
     def test_mask_channel_binding(self) -> None:
         transform = A.Compose(
             [A.NoOp(p=1)],
@@ -796,6 +817,50 @@ class TestChannelMask:
         result = transform(image=image, instances=instances)
         assert len(result["instances"]) == 2
         assert result["instances"][0]["mask"].shape == (100, 100)
+
+    @pytest.mark.parametrize("check_each_transform", [True, False])
+    def test_bbox_filter_keeps_mask_channels_aligned(self, check_each_transform: bool) -> None:
+        image, instances = self._filtering_data()
+        transform = A.Compose(
+            [A.Crop(x_min=32, y_min=32, x_max=96, y_max=96, p=1)],
+            bbox_params=A.BboxParams(
+                coord_format="pascal_voc",
+                label_fields=["class_id"],
+                check_each_transform=check_each_transform,
+            ),
+            instance_binding=["mask", "bboxes"],
+            telemetry=False,
+        )
+
+        result = transform(image=image, instances=instances)
+
+        assert len(result["instances"]) == 1
+        instance = result["instances"][0]
+        assert instance["bbox_labels"]["class_id"] == 33
+        np.testing.assert_array_equal(instance["bbox"], [8, 8, 48, 48])
+        assert instance["mask"].sum() == 4800
+        assert instance["mask"].max() == 3
+
+    def test_transform_prefilter_keeps_mask_channels_aligned(self) -> None:
+        def drop_first_bbox(bboxes: np.ndarray, **params: Any) -> np.ndarray:
+            return bboxes[1:]
+
+        image, instances = self._filtering_data()
+        transform = A.Compose(
+            [A.Lambda(bboxes=drop_first_bbox, p=1)],
+            bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+            instance_binding=["mask", "bboxes"],
+            telemetry=False,
+        )
+
+        result = transform(image=image, instances=instances)
+
+        assert len(result["instances"]) == 1
+        instance = result["instances"][0]
+        assert instance["bbox_labels"]["class_id"] == 33
+        np.testing.assert_array_equal(instance["bbox"], [40, 40, 80, 80])
+        assert instance["mask"].sum() == 4800
+        assert instance["mask"].max() == 3
 
 
 class TestMixingTransformsInstanceBinding:

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -133,6 +133,50 @@ class TestUnpackRepack:
 
 
 class TestBboxFiltering:
+    @pytest.mark.parametrize("check_each_transform", [True, False])
+    def test_final_bbox_filter_keeps_bound_instance_targets_aligned(self, check_each_transform: bool) -> None:
+        image = np.zeros((128, 128, 3), dtype=np.uint8)
+        outside_mask = np.zeros((128, 128), dtype=np.uint8)
+        outside_mask[:4, :4] = 1
+        surviving_mask = np.zeros((128, 128), dtype=np.uint8)
+        surviving_mask[40:80, 40:80] = 3
+        instances = [
+            {
+                "mask": outside_mask,
+                "bbox": np.array([0, 0, 4, 4], dtype=np.float32),
+                "keypoints": np.array([[2, 2]], dtype=np.float32),
+                "bbox_labels": {"class_id": 11},
+            },
+            {
+                "mask": surviving_mask,
+                "bbox": np.array([40, 40, 80, 80], dtype=np.float32),
+                "keypoints": np.array([[50, 50]], dtype=np.float32),
+                "bbox_labels": {"class_id": 33},
+            },
+        ]
+        transform = A.Compose(
+            [A.Crop(x_min=32, y_min=32, x_max=96, y_max=96, p=1)],
+            bbox_params=A.BboxParams(
+                coord_format="pascal_voc",
+                label_fields=["class_id"],
+                min_visibility=0,
+                check_each_transform=check_each_transform,
+            ),
+            keypoint_params=A.KeypointParams(coord_format="xy"),
+            instance_binding=["masks", "bboxes", "keypoints"],
+            telemetry=False,
+        )
+
+        result = transform(image=image, instances=instances)
+
+        assert len(result["instances"]) == 1
+        instance = result["instances"][0]
+        assert instance["bbox_labels"]["class_id"] == 33
+        np.testing.assert_array_equal(instance["bbox"], [8, 8, 48, 48])
+        assert instance["mask"].sum() == 4800
+        assert instance["mask"].max() == 3
+        np.testing.assert_array_equal(instance["keypoints"], [[18, 18]])
+
     def test_removed_bbox_removes_mask_and_keypoints(self) -> None:
         transform = A.Compose(
             [A.Crop(x_min=0, y_min=0, x_max=55, y_max=55, p=1)],


### PR DESCRIPTION
## Summary

- reject fully clipped, zero-area bboxes even when all user thresholds are zero
- mirror the final bbox keep mask onto bound masks and keypoints before processor postprocessing removes internal instance IDs
- add regression coverage for both `check_each_transform=True` and `check_each_transform=False`

## Root cause

A fully outside bbox could survive the first filter after clipping to zero area, then be removed by a later filter after internal instance IDs had been stripped. Repacking therefore combined the surviving bbox and label with the removed instance's mask and keypoints.

## Validation

- `uv run pytest -q tests/test_bbox.py tests/test_instance_binding.py` — 468 passed
- `uv run pytest -m "not slow"` — 11,349 passed, 42 skipped, 38 deselected
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`

Closes #342.

## Summary by Sourcery

Ensure instance binding keeps masks and keypoints aligned with bboxes when final bbox filtering occurs after clipping and before processor postprocessing.

Bug Fixes:
- Prevent fully clipped, zero-area bboxes from surviving filtering when all threshold parameters are zero.
- Maintain alignment between kept bboxes and their bound masks and keypoints at the final filtering stage before instance IDs are removed.

Enhancements:
- Add a dedicated pre-postprocess step to mirror bbox keep masks onto bound instance targets and resync instance IDs.

Tests:
- Add regression tests covering bbox filtering edge cases with fully clipped boxes and instance binding alignment for both check_each_transform=True and False.