### PR TITLE
Fix balanced affine scale sampling ranges

### DIFF
--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -715,8 +715,8 @@ class Affine(DualTransform):
                 result_scale[key] = float(value)
             elif isinstance(value, tuple):
                 if balanced_scale:
-                    lower_interval = (value[0], 1.0) if value[0] < 1 else None
-                    upper_interval = (1.0, value[1]) if value[1] > 1 else None
+                    lower_interval = (value[0], min(value[1], 1.0)) if value[0] < 1 else None
+                    upper_interval = (max(value[0], 1.0), value[1]) if value[1] > 1 else None
 
                     if lower_interval is not None and upper_interval is not None:
                         selected_interval = random_state.choice(

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -613,6 +613,39 @@ def test_get_scale_balanced_scale_behavior():
     assert any(v < 1.0 for v in result.values()) or any(v > 1.0 for v in result.values())
 
 
+def test_get_scale_balanced_one_sided_ranges_stay_within_bounds():
+    scale = {"x": (0.5, 0.8), "y": (1.2, 1.5)}
+
+    for seed in range(100):
+        result = A.Affine._get_scale(scale, keep_ratio=False, balanced_scale=True, random_state=random.Random(seed))
+
+        assert scale["x"][0] <= result["x"] <= scale["x"][1]
+        assert scale["y"][0] <= result["y"] <= scale["y"][1]
+
+
+def test_get_scale_balanced_crossing_range_samples_both_sides_equally():
+    scale = {"x": (0.5, 2.0), "y": (0.5, 2.0)}
+    sampled_x = [
+        A.Affine._get_scale(scale, keep_ratio=False, balanced_scale=True, random_state=random.Random(seed))["x"]
+        for seed in range(1_000)
+    ]
+    below_one_count = sum(value < 1.0 for value in sampled_x)
+
+    assert all(scale["x"][0] <= value <= scale["x"][1] for value in sampled_x)
+    assert 450 <= below_one_count <= 550
+
+
+@pytest.mark.parametrize("scale_range", [(0.5, 0.8), (1.2, 1.5), (1.0, 1.0)])
+def test_get_scale_balanced_keep_ratio_stays_within_bounds(scale_range):
+    scale = {"x": scale_range, "y": scale_range}
+
+    for seed in range(100):
+        result = A.Affine._get_scale(scale, keep_ratio=True, balanced_scale=True, random_state=random.Random(seed))
+
+        assert scale_range[0] <= result["x"] <= scale_range[1]
+        assert result["y"] == result["x"]
+
+
 def test_get_scale_keep_ratio():
     scale = {"x": (0.5, 1.5), "y": (0.8, 1.2)}
     result = A.Affine._get_scale(scale, keep_ratio=True, balanced_scale=False, random_state=random.Random(42))

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -623,16 +623,29 @@ def test_get_scale_balanced_one_sided_ranges_stay_within_bounds():
         assert scale["y"][0] <= result["y"] <= scale["y"][1]
 
 
-def test_get_scale_balanced_crossing_range_samples_both_sides_equally():
-    scale = {"x": (0.5, 2.0), "y": (0.5, 2.0)}
-    sampled_x = [
-        A.Affine._get_scale(scale, keep_ratio=False, balanced_scale=True, random_state=random.Random(seed))["x"]
-        for seed in range(1_000)
-    ]
-    below_one_count = sum(value < 1.0 for value in sampled_x)
+def test_affine_balanced_one_sided_ranges_through_compose():
+    scale = {"x": (0.5, 0.8), "y": (1.2, 1.5)}
+    affine = A.Affine(scale=scale, keep_ratio=False, balanced_scale=True, p=1.0)
+    transform = A.Compose([affine], seed=137)
 
-    assert all(scale["x"][0] <= value <= scale["x"][1] for value in sampled_x)
-    assert 450 <= below_one_count <= 550
+    transform(image=SQUARE_UINT8_IMAGE)
+
+    sampled_scale = affine.applied_config["scale"]
+    assert scale["x"][0] <= sampled_scale["x"] <= scale["x"][1]
+    assert scale["y"][0] <= sampled_scale["y"] <= scale["y"][1]
+
+
+def test_get_scale_balanced_crossing_range_chooses_between_both_sides(mocker):
+    scale = {"x": (0.5, 2.0), "y": (0.5, 2.0)}
+    intervals = [(0.5, 1.0), (1.0, 2.0)]
+    random_state = mocker.Mock(spec=random.Random)
+    random_state.choice.side_effect = intervals
+    random_state.uniform.side_effect = lambda lower, upper: (lower + upper) / 2
+
+    result = A.Affine._get_scale(scale, keep_ratio=False, balanced_scale=True, random_state=random_state)
+
+    assert result == {"x": 0.75, "y": 1.5}
+    assert [args.args[0] for args in random_state.choice.call_args_list] == [intervals, intervals]
 
 
 @pytest.mark.parametrize("scale_range", [(0.5, 0.8), (1.2, 1.5), (1.0, 1.0)])


### PR DESCRIPTION
## Summary

- keep `Affine(balanced_scale=True)` samples within one-sided scale ranges
- preserve equal below/above-`1.0` interval selection when a range crosses `1.0`
- add regression coverage for independent axes, one-sided and crossing ranges, `(1.0, 1.0)`, and `keep_ratio=True`

## Root cause

The balanced sampler extended any below-`1.0` range up to `1.0` and any above-`1.0` range down to `1.0`. As a result, ranges that did not cross `1.0` could produce values outside the configured bounds.

## Impact

Users can enable balanced affine scaling without weakening one-sided scale constraints. Crossing ranges retain their existing balanced 50/50 side selection.

## Validation

- `uv run pytest -m "not slow"` — 11,357 passed
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`

Closes #312

## Summary by Sourcery

Fix balanced affine scale sampling to respect configured ranges while preserving equal sampling below and above 1.0 for crossing intervals.

Bug Fixes:
- Ensure balanced affine scaling stays within one-sided scale bounds instead of extending toward 1.0.
- Maintain approximately equal probability of sampling below and above 1.0 when scale ranges cross 1.0.

Tests:
- Add regression tests covering one-sided ranges, crossing ranges, keep_ratio=True, and degenerate (1.0, 1.0) scale configurations for balanced affine scaling.