### PR TITLE
Bump version to 2.3.4

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -148,7 +148,7 @@ jobs:
           name: verified-release-bundle
           path: release-bundle
       - name: Publish distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: release-bundle/dist
           attestations: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.3.3"
+version = "2.3.4"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volumes, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.3.3"
+version = "2.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## Summary

- bump the package version from `2.3.3` to `2.3.4` in `pyproject.toml`
- keep the editable package entry in `uv.lock` synchronized

## Why

The project metadata still reports `2.3.3`; this aligns the package and lockfile with the `2.3.4` release.

## Impact

Built distributions and runtime package metadata will report version `2.3.4`.

## Validation

- `uv lock --check`
- `uv run pytest -m "not slow"` — 11,358 passed, 42 skipped, 38 deselected
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`

## Summary by Sourcery

Build:
- Update pyproject.toml project version from 2.3.3 to 2.3.4 and synchronize the editable package entry in uv.lock.