### PR TITLE
fix(ci): prevent Antigravity turn-limit failures

### DIFF
--- a/.github/workflows/antigravity-pr-checks.yml
+++ b/.github/workflows/antigravity-pr-checks.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Run Antigravity pull request review
         if: steps.plan.outputs.antigravity == 'true'
+        id: gemini_review
+        continue-on-error: true
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
         env:
           GEMINI_CLI_TRUST_WORKSPACE: "true"
@@ -101,8 +103,8 @@ jobs:
           gcp_project_id: ${{ vars.ANTIGRAVITY_GCP_PROJECT_ID }}
           gcp_service_account: ${{ vars.ANTIGRAVITY_GCP_SERVICE_ACCOUNT }}
           gcp_workload_identity_provider: ${{ vars.ANTIGRAVITY_GCP_WIF_PROVIDER }}
-          gemini_cli_version: ${{ vars.GEMINI_CLI_VERSION }}
-          gemini_debug: ${{ fromJSON(vars.GEMINI_DEBUG || 'false') }}
+          gemini_cli_version: ${{ vars.GEMINI_CLI_VERSION || '0.51.0' }}
+          gemini_debug: "true"
           gemini_model: ${{ vars.GEMINI_MODEL }}
           github_pr_number: ${{ github.event.pull_request.number }}
           use_vertex_ai: "true"
@@ -111,7 +113,7 @@ jobs:
           settings: |
             {
               "model": {
-                "maxSessionTurns": 50
+                "maxSessionTurns": -1
               },
               "context": {
                 "fileFiltering": {
@@ -143,11 +145,34 @@ jobs:
 
             Focus on demonstrable correctness bugs, security issues, behavioral regressions, maintainability risks,
             and missing tests or documentation. Read relevant trusted-base files when the diff alone is insufficient.
+            Batch related file reads with `read_many_files` to conserve tool turns. Finish before the job timeout.
+            Report any additional context you could not inspect as residual risk.
             Do not modify files, request clarification, or attempt to call GitHub or shell tools.
 
             Return concise GitHub-flavored Markdown beginning with `## Antigravity Review`. List findings first,
             ordered by severity, and include the file path and changed line number for each finding. If there are no
             actionable findings, state that explicitly and mention only material residual test or operational risk.
+
+      - name: Upload Gemini failure diagnostics
+        if: >-
+          ${{
+            always() &&
+            steps.plan.outputs.antigravity == 'true' &&
+            steps.gemini_review.outcome == 'failure'
+          }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: antigravity-gemini-diagnostics-${{ github.event.pull_request.number }}
+          path: |
+            gemini-artifacts/stdout.log
+            gemini-artifacts/stderr.log
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Fail after preserving Gemini diagnostics
+        if: steps.gemini_review.outcome == 'failure'
+        run: exit 1
 
       - name: Prepare review artifact
         if: steps.plan.outputs.antigravity == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -394,9 +394,9 @@ jobs:
         shell: bash
         run: |
           python -c 'import json, os, pathlib; pathlib.Path("targets.z").write_bytes(b"\0".join(path.encode() for path in json.loads(os.environ["PYTEST_TARGETS"])) + b"\0")'
-          mapfile -d '' -t test_files < targets.z
-          python -m pytest "${test_files[@]}" \
-            -n 2 --dist=worksteal -m "not pytorch" --hypothesis-profile=ci-fast
+          xargs -0 python -m pytest \
+            -n 2 --dist=worksteal -m "not pytorch" --hypothesis-profile=ci-fast \
+            < targets.z
 
   pytorch:
     name: PyTorch tests

--- a/tests/test_antigravity_workflow.py
+++ b/tests/test_antigravity_workflow.py
@@ -40,6 +40,11 @@ def test_antigravity_review_is_pr_scoped_read_only_and_uses_vertex_ai() -> None:
     assert "GITHUB_PERSONAL_ACCESS_TOKEN" not in workflow
     assert "run_shell_command" not in workflow
     assert "mcpServers" not in workflow
+    assert "gemini_cli_version: ${{ vars.GEMINI_CLI_VERSION || '0.51.0' }}" in workflow
+    assert 'gemini_debug: "true"' in workflow
+    assert '"maxSessionTurns": -1' in workflow
+    assert "Batch related file reads" in workflow
+    assert "Finish before the job timeout" in workflow
 
     for tool in ("glob", "grep_search", "list_directory", "read_file", "read_many_files"):
         assert f'"{tool}"' in workflow
@@ -92,3 +97,20 @@ def test_antigravity_validates_cli_json_before_publishing_review() -> None:
     assert "--output .antigravity/review.md" in workflow
     assert "steps.gemini_review.outputs.summary" not in workflow
     assert "REVIEW_BODY" not in workflow
+
+
+def test_antigravity_preserves_diagnostics_when_gemini_fails() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    review_index = workflow.index("- name: Run Antigravity pull request review")
+    diagnostics_index = workflow.index("- name: Upload Gemini failure diagnostics")
+    failure_index = workflow.index("- name: Fail after preserving Gemini diagnostics")
+
+    assert review_index < diagnostics_index < failure_index
+    assert "id: gemini_review" in workflow
+    assert "continue-on-error: true" in workflow
+    assert "always() &&" in workflow
+    assert "steps.gemini_review.outcome == 'failure'" in workflow
+    assert "name: antigravity-gemini-diagnostics-${{ github.event.pull_request.number }}" in workflow
+    assert "gemini-artifacts/stdout.log" in workflow
+    assert "gemini-artifacts/stderr.log" in workflow
+    assert 'upload_artifacts: "false"' in workflow

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -74,6 +74,14 @@ def test_compatibility_shard_handoff_is_portable_to_macos_bash() -> None:
     assert "xargs -0 python -m pytest" in compatibility
 
 
+def test_targeted_test_handoff_is_portable_to_macos_bash() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    targeted = text.split("\n  targeted:\n", maxsplit=1)[1].split("\n  pytorch:\n", maxsplit=1)[0]
+
+    assert "mapfile" not in targeted
+    assert "xargs -0 python -m pytest" in targeted
+
+
 def test_coverage_and_pytorch_are_not_duplicated_across_matrix_cells() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     compatibility = text.split("\n  compatibility:\n", maxsplit=1)[1].split("\n  coverage:\n", maxsplit=1)[0]


### PR DESCRIPTION
## Summary

- remove the explicit 50-turn Gemini session cap and rely on the existing 10-minute job timeout
- pin the default Gemini CLI version to `0.51.0` while preserving the repository-variable override
- ask the reviewer to batch related file reads and finish within the job timeout
- enable debug output and preserve raw Gemini stdout/stderr as a one-day artifact before failing the job
- add workflow contract coverage for the turn budget and failure diagnostics

## Root cause

The second Antigravity attempt for PR #346 failed with `FatalTurnLimitedError` (code 53) after exhausting `maxSessionTurns: 50`. The earlier `INVALID_STREAM` message was a wrapper symptom rather than an `albucore` or test failure. The color, YOLO, and ripgrep messages were non-fatal warnings.

The workflow already has a 10-minute timeout, so the additional 50-turn cap was an arbitrary earlier cutoff. This change removes that cutoff without weakening the existing read-only tool allowlist or the trusted-base boundary.

## Validation

- `uv run pytest -m "not slow"` — 11,359 passed
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`
- `uv run python -m tools.ci_matrix check`
- `uv run python -m tools.ci_shard check`
- focused CI/workflow tests — 62 passed
- `uv run zizmor --format=plain --min-severity=medium --min-confidence=medium .github` — no findings

## Operational note

This workflow uses `pull_request_target`, so this PR's own run loads the current workflow from `main`, not the modified workflow from this branch. After merge, rerun or synchronize PR #346 to exercise the fix end to end.

## Summary by Sourcery

Adjust the Antigravity PR review workflow to rely on the job timeout instead of a fixed turn limit and improve failure diagnostics for Gemini-based reviews.

Bug Fixes:
- Prevent premature Antigravity review failures caused by an arbitrary Gemini session turn cap.

Enhancements:
- Default the Gemini CLI version in the Antigravity workflow while preserving the ability to override via repository variables.
- Enable Gemini debug output and instruct reviewers to batch file reads and complete within the job timeout.
- Capture and publish Gemini stdout/stderr as short-lived artifacts when the review step fails, then explicitly fail the job after preservation.

CI:
- Add assertions to the Antigravity workflow tests to cover Gemini configuration, turn-budget settings, and failure-diagnostics behavior.

Tests:
- Introduce a dedicated test to verify the ordering and conditions of the Gemini failure diagnostics and post-failure job behavior in the Antigravity workflow.