### PR TITLE
perf(augmentations): optimize superpixels and elastic maps

### DIFF
--- a/albumentations/augmentations/geometric/_functional_distortion.py
+++ b/albumentations/augmentations/geometric/_functional_distortion.py
@@ -103,25 +103,17 @@ def upscale_distortion_maps(
     if (map_height, map_width) == (height, width):
         return map_x, map_y
 
-    y_coords, x_coords = np.meshgrid(
-        np.arange(map_height, dtype=np.float32),
-        np.arange(map_width, dtype=np.float32),
-        indexing="ij",
-    )
-    dx = map_x - x_coords
-    dy = map_y - y_coords
+    dx = map_x - np.arange(map_width, dtype=np.float32)
+    dy = map_y - np.arange(map_height, dtype=np.float32)[:, None]
 
     scale_y = 1 if height == 1 or map_height == 1 else (map_height - 1) / (height - 1)
     scale_x = 1 if width == 1 or map_width == 1 else (map_width - 1) / (width - 1)
     dx = cv2.resize(dx, (width, height), interpolation=interpolation) / scale_x
     dy = cv2.resize(dy, (width, height), interpolation=interpolation) / scale_y
 
-    y_coords, x_coords = np.meshgrid(
-        np.arange(height, dtype=np.float32),
-        np.arange(width, dtype=np.float32),
-        indexing="ij",
-    )
-    return x_coords + dx, y_coords + dy
+    dx += np.arange(width, dtype=np.float32)
+    dy += np.arange(height, dtype=np.float32)[:, None]
+    return dx, dy
 
 
 def generate_displacement_fields(
@@ -166,11 +158,12 @@ def generate_displacement_fields(
         if max_abs > 1e-6:
             fields /= max_abs
     else:  # uniform is already normalized to [-1, 1]
-        fields = random_generator.uniform(
-            -1,
-            1,
-            size=(1 if same_dxdy else 2, *image_shape[:2]),
-        ).astype(np.float32)
+        fields = random_generator.random(
+            (1 if same_dxdy else 2, *image_shape[:2]),
+            dtype=np.float32,
+        )
+        fields *= 2
+        fields -= 1
 
     # # Apply Gaussian blur if needed using fast OpenCV operations
     # When kernel_size is (0,0) cv2.GaussianBlur uses automatic kernel size. Kernel == (0,0) is NOT a noop.

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -452,13 +452,10 @@ class ElasticTransform(BaseDistortion):
             noise_distribution=self.noise_distribution,
         )
 
-        y_coords, x_coords = np.meshgrid(
-            np.arange(scaled_height, dtype=np.float32),
-            np.arange(scaled_width, dtype=np.float32),
-            indexing="ij",
-        )
-        map_x = (x_coords + dx).astype(np.float32)
-        map_y = (y_coords + dy).astype(np.float32)
+        map_y = dy.copy() if self.same_dxdy else dy
+        map_x = dx
+        map_x += np.arange(scaled_width, dtype=np.float32)
+        map_y += np.arange(scaled_height, dtype=np.float32)[:, None]
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
         return {

--- a/albumentations/augmentations/pixel/_functional_torchvision.py
+++ b/albumentations/augmentations/pixel/_functional_torchvision.py
@@ -11,7 +11,6 @@ from ._functional_color import (
     to_gray_weighted_average,
 )
 from ._functional_shared import (
-    MAX_VALUES_BY_DTYPE,
     ImageType,
     ImageUInt8,
     add_weighted,
@@ -27,11 +26,45 @@ from ._functional_shared import (
     multiply_add,
     np,
     preserve_channel_dim,
-    reduce_sum,
     std,
     sz_lut,
     uint8_io,
 )
+
+
+def _replace_segments_with_mean(
+    image: np.ndarray,
+    segments: np.ndarray,
+    replace_samples: Sequence[bool],
+) -> np.ndarray:
+    unique_labels, inverse_labels = np.unique(segments, return_inverse=True)
+    inverse_labels = inverse_labels.reshape(-1)
+    replace_start = 1 if unique_labels[0] == 0 else 0
+    num_replaceable = len(unique_labels) - replace_start
+    if num_replaceable == 0:
+        return image.copy()
+
+    replace_by_label = np.zeros(len(unique_labels), dtype=bool)
+    replace_by_label[replace_start:] = np.resize(
+        np.asarray(replace_samples, dtype=bool),
+        num_replaceable,
+    )
+    replace_mask = replace_by_label[inverse_labels]
+
+    result = image.copy()
+    result_flat = result.reshape(-1, result.shape[-1])
+    counts = np.bincount(inverse_labels, minlength=len(unique_labels))
+
+    for channel_index in range(result.shape[-1]):
+        sums = np.bincount(
+            inverse_labels,
+            weights=result_flat[:, channel_index],
+            minlength=len(unique_labels),
+        )
+        segment_means = np.rint(sums / counts).astype(np.uint8)
+        result_flat[replace_mask, channel_index] = segment_means[inverse_labels[replace_mask]]
+
+    return result
 
 
 @float32_io
@@ -342,38 +375,7 @@ def superpixels(
         compactness=10,
     )
 
-    min_value = 0
-    max_value = MAX_VALUES_BY_DTYPE[image.dtype]
-    image = np.copy(image)
-
-    num_channels = get_num_channels(image)
-
-    for c in range(num_channels):
-        image_sp_c = image[..., c]
-        # Get unique segment labels (skip 0 if it exists as it's typically background)
-        unique_labels = np.unique(segments)
-        if unique_labels[0] == 0:
-            unique_labels = unique_labels[1:]
-
-        # Calculate mean intensity for each segment
-        for idx, label in enumerate(unique_labels):
-            # with mod here, because slic can sometimes create more superpixel than requested.
-            # replace_samples then does not have enough values, so we just start over with the first one again.
-            if replace_samples[idx % len(replace_samples)]:
-                mask = segments == label
-                mean_intensity = float(mean(image_sp_c[mask]))
-
-                if image_sp_c.dtype.kind in ["i", "u", "b"]:
-                    # After rounding the value can end up slightly outside of the value_range. Hence, we need to clip.
-                    # We do clip via min(max(...)) instead of np.clip because
-                    # the latter one does not seem to keep dtypes for dtypes with large itemsizes (e.g. uint64).
-                    value: int | float
-                    value = int(np.round(mean_intensity))
-                    value = min(max(value, min_value), max_value)
-                else:
-                    value = mean_intensity
-
-                image_sp_c[mask] = value
+    image = _replace_segments_with_mean(image, segments, replace_samples)
 
     return fgeometric.resize(image, orig_shape[:2], interpolation) if orig_shape != image.shape else image
 
@@ -403,6 +405,7 @@ def slic(
     # Normalize image to [0, 1] range
     max_val = np.float32(image.max())
     image_normalized = image.astype(np.float32) / (max_val + np.float32(1e-6))
+    single_channel = image_normalized.shape[-1] == 1
 
     # Initialize cluster centers via meshgrid
     grid_step = int((num_pixels / n_segments) ** 0.5)
@@ -410,9 +413,15 @@ def slic(
     y_range = np.arange(grid_step // 2, height, grid_step)
     xx_grid, yy_grid = np.meshgrid(x_range, y_range)
     centers = np.column_stack([xx_grid.ravel(), yy_grid.ravel()]).astype(np.float32)
+    y_coordinates, x_coordinates = np.indices((height, width), dtype=np.float64)
+    x_coordinates_flat = x_coordinates.reshape(-1)
+    y_coordinates_flat = y_coordinates.reshape(-1)
 
     # Initialize labels and distances
     labels = np.full((height, width), -1, dtype=np.int32)
+    if len(centers) == 0:
+        return labels
+
     distances = np.full((height, width), np.inf, dtype=np.float32)
 
     inv_grid_step_sq = np.float32(1.0 / (grid_step * grid_step))
@@ -426,7 +435,16 @@ def slic(
 
             crop = image_normalized[y_low:y_high, x_low:x_high]
             color_diff = crop - image_normalized[y, x]
-            color_distance = reduce_sum(color_diff**2, axis=-1)
+            if single_channel:
+                color_distance = color_diff[..., 0] ** 2
+            else:
+                color_distance = np.einsum(
+                    "...c,...c->...",
+                    color_diff,
+                    color_diff,
+                    dtype=np.float32,
+                    optimize=False,
+                )
 
             yy, xx = np.ogrid[y_low:y_high, x_low:x_high]
             spatial_distance = ((yy - y) ** 2 + (xx - x) ** 2) * inv_grid_step_sq
@@ -438,11 +456,21 @@ def slic(
             dist_slice[mask] = distance[mask]
             labels[y_low:y_high, x_low:x_high][mask] = i
 
-        for i in range(len(centers)):
-            mask = labels == i
-            if np.any(mask):
-                ys, xs = np.where(mask)
-                centers[i] = [mean(xs.astype(np.float32)), mean(ys.astype(np.float32))]
+        labels_flat = labels.reshape(-1)
+        counts = np.bincount(labels_flat, minlength=len(centers))
+        nonempty = counts > 0
+        x_sums = np.bincount(
+            labels_flat,
+            weights=x_coordinates_flat,
+            minlength=len(centers),
+        )
+        y_sums = np.bincount(
+            labels_flat,
+            weights=y_coordinates_flat,
+            minlength=len(centers),
+        )
+        centers[nonempty, 0] = x_sums[nonempty] / counts[nonempty]
+        centers[nonempty, 1] = y_sums[nonempty] / counts[nonempty]
 
     return labels
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -14,6 +14,7 @@ from sklearn.decomposition import NMF
 
 import albumentations.augmentations.blur.functional as fblur
 import albumentations.augmentations.geometric.functional as fgeometric
+import albumentations.augmentations.pixel._functional_torchvision as ftorchvision
 import albumentations.augmentations.pixel.functional as fpixel
 from albumentations.core.type_definitions import d4_group_elements
 from tests.conftest import (
@@ -1144,6 +1145,53 @@ def test_fancy_pca_zero_alpha(shape, dtype):
     result = fpixel.fancy_pca(image, alpha_vector)
 
     np.testing.assert_array_equal(image, result)
+
+
+@pytest.mark.parametrize(
+    ("channels", "expected_hash"),
+    [
+        (1, "3f7d5fd9af229099078be43a5119cc70a1ffb3487e0fb933e89db31ac667a1a0"),
+        (3, "f1e44bb1c912d89a4393343f0caec246d12707511a3099d450591f9e24b1879c"),
+        (5, "3b074bf63f9fe72f4c5839ab24b0e15fc49fe091697ab1cec2299117a8db63f4"),
+    ],
+)
+def test_slic_output_regression(channels, expected_hash):
+    image = np.random.default_rng(137).integers(0, 256, (17, 23, channels), dtype=np.uint8)
+
+    labels = fpixel.slic(image, n_segments=13)
+
+    assert hashlib.sha256(labels.tobytes()).hexdigest() == expected_hash
+
+
+@pytest.mark.parametrize("channels", [1, 3, 5])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_superpixels_segment_mean_replacement(monkeypatch, channels, dtype):
+    image_uint8 = np.arange(2 * 4 * channels, dtype=np.uint8).reshape(2, 4, channels)
+    image = image_uint8 if dtype == np.uint8 else image_uint8.astype(np.float32) / 255
+    segments = np.array(
+        [
+            [0, 0, 1, 1],
+            [2, 2, 3, 3],
+        ],
+        dtype=np.int32,
+    )
+    monkeypatch.setattr(ftorchvision, "slic", lambda image, n_segments, compactness: segments)
+
+    result = fpixel.superpixels(
+        image,
+        n_segments=3,
+        replace_samples=[True, False],
+        max_size=None,
+        interpolation=cv2.INTER_NEAREST,
+    )
+
+    expected_uint8 = image_uint8.copy()
+    for segment_label in (1, 3):
+        segment_mask = segments == segment_label
+        expected_uint8[segment_mask] = np.rint(image_uint8[segment_mask].mean(axis=0)).astype(np.uint8)
+    expected = expected_uint8 if dtype == np.uint8 else expected_uint8.astype(np.float32) / 255
+
+    np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Replace per-segment mask scans and per-center coordinate extraction in `Superpixels`/SLIC with vectorized `numpy.bincount` aggregation.
- Specialize single-channel and multichannel SLIC color-distance reductions and reuse coordinate arrays across iterations.
- Remove full coordinate `meshgrid` allocations from ElasticTransform map construction and map upscaling.
- Generate uniform displacement fields directly as `float32` and use in-place coordinate updates.
- Add SLIC output regression hashes and segment-mean replacement coverage for 1, 3, and 5 channels and uint8/float32 inputs.

## Why

The hot paths repeatedly scanned full label maps once per segment and allocated full-size coordinate grids and intermediate arrays. This made Superpixels scale poorly with the number of segments and added avoidable memory traffic to ElasticTransform. The changes keep the implementation on the existing NumPy/OpenCV stack; no scikit-image, Numba, or other dependency is added.

## Performance

Benchmarked with NumPy 2.2.6, OpenCV 5.0.0, one OpenCV thread, OpenCL disabled, and a 9-case matrix covering 256/512/1024-pixel square images with 1/3/5 channels:

- Superpixels functional API: 3.00–4.04x faster, 3.26x median.
- Superpixels through Compose: 2.93–3.83x faster, 3.47x median.
- Full-resolution ElasticTransform: about 5% median improvement.
- ElasticTransform with `map_resolution=0.5`: about 9% median improvement.

The optimized SLIC labels matched the previous implementation exactly across 129 random and structured comparison cases. One intentional numerical compatibility note: direct float32 sampling preserves seeded determinism and the uniform distribution, but the exact uniform-noise sequence for a given seed differs from the previous float64-then-cast path.

## Validation

- `uv run pytest -m "not slow"`: 11,431 passed, 42 skipped, 38 deselected, 9 xfailed, 3 xpassed.
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`
- Dedicated SLIC/Superpixels regression tests and distortion map-resolution tests.

## Summary by Sourcery

Optimize Superpixels/SLIC and elastic distortion map generation for better performance while preserving existing behavior.

New Features:
- Add regression tests for SLIC label outputs across multiple channel configurations and dedicated tests for Superpixels segment-mean replacement on uint8 and float32 inputs.

Enhancements:
- Refactor Superpixels segment-mean replacement to use vectorized label aggregation across channels, improving scalability with many segments.
- Improve SLIC center updates and color-distance computation using precomputed coordinate grids and specialized single- vs multi-channel reductions.
- Streamline elastic distortion map generation and upscaling by avoiding full meshgrid allocations and generating uniform displacement fields directly in float32.

Tests:
- Extend functional tests to cover SLIC output stability via hash-based regression and to validate Superpixels mean replacement behavior for different channel counts and dtypes.