### PR TITLE
docs(performance): add systematic optimization skill

### DIFF
--- a/.codex/skills/add-transform/SKILL.md
+++ b/.codex/skills/add-transform/SKILL.md
@@ -21,6 +21,9 @@ Put the transform in the most specific matching subpackage:
 
 ## 2. Functional layer first
 
+Read `../performance-optimization/SKILL.md` and its required reference completely before implementing the functional
+kernel.
+
 Add the pure function in the corresponding `functional.py` file (no class state, no RNG):
 
 ```python
@@ -30,8 +33,11 @@ def my_transform(img: np.ndarray, param1: float, param2: int) -> np.ndarray:
 
 - Accept `np.ndarray`, return `np.ndarray`
 - No randomness — all random values come from `get_params` / `get_params_dependent_on_data`
-- Prefer `cv2` over numpy for performance (see benchmarking rules)
-- Use `cv2.LUT` for lookup-based pixel ops (fastest)
+- Delete redundant work and full-array passes before selecting a backend
+- Compare applicable NumPy, OpenCV, NumKong, StringZilla, and LUT implementations
+- Consider `np.bincount` for repeated reductions over dense non-negative integer labels
+- Move a reusable atomic image operation into Albucore instead of duplicating it locally
+- Use in-place operations only when ownership and aliasing make mutation safe
 - Use `@uint8_io` / `@float32_io` decorators if dtype conversion is needed
 
 ## 3. Write the transform class

--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -7,6 +7,10 @@ description: Run performance benchmarks for transform changes. Use when the user
 
 Any change touching `apply_*`, `functional.py`, `get_params`, `get_params_dependent_on_data`, `composition.py`, or `transforms_interface.py` **must** include benchmark results.
 
+Before designing the benchmark, read `../performance-optimization/SKILL.md` and its required reference completely.
+Use that workflow to define candidates and the dimension that controls each candidate, such as label density for
+`bincount`, channel layout for LUTs, or output size and dtype for random generation.
+
 ## Standard Matrix
 
 Always benchmark all 9 combinations:

--- a/.codex/skills/performance-optimization/SKILL.md
+++ b/.codex/skills/performance-optimization/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: performance-optimization
+description: Systematic performance audit for AlbumentationsX runtime code. Use whenever implementing, reviewing, profiling, or optimizing transforms, functional kernels, apply methods, random generation, reductions, label maps, dtype conversions, batch paths, allocation-heavy code, backend routing, or code that may belong in Albucore.
+---
+
+# Performance Optimization
+
+Read `references/performance-optimization.md` completely before inspecting or changing runtime code. It is the
+in-repository fallback copy of Albucore's canonical `docs/performance-optimization.md`, so the guide remains available
+when the Albucore checkout is absent.
+
+When changing the guide, update the canonical Albucore document first and keep the bundled copy synchronized.
+When both repositories are available, verify exact synchronization with
+`cmp -s ../albucore/docs/performance-optimization.md .codex/skills/performance-optimization/references/performance-optimization.md`.
+A mismatch blocks completion.
+
+## Workflow
+
+1. Establish correctness and performance baselines before editing.
+2. Run every stage of the guide's optimization pass. Do not stop after finding the first plausible improvement.
+3. Treat every backend, vectorization, LUT, random-generation, `bincount`, and in-place proposal as a benchmark
+   hypothesis.
+4. Check the repository boundary. Move a reusable image-processing atom into Albucore instead of duplicating it in
+   transforms.
+5. Read `../benchmark/SKILL.md` completely and benchmark both the isolated kernel and the `Compose` route on its
+   required size, channel, and dtype matrix.
+6. Add correctness tests before accepting a faster path. Preserve shapes, dtypes, values, annotations, aliasing, and
+   seeded-replay contracts unless the change explicitly documents a compatibility break.
+7. Run the project validation workflow after the final implementation.
+
+## AlbumentationsX Boundary
+
+Keep transform policy, parameter sampling, target dispatch, and annotation semantics in AlbumentationsX.
+
+Propose an Albucore primitive when an operation:
+
+- is useful to more than one transform or image-processing caller;
+- has stable array semantics independent of transform policy;
+- benefits from dtype, channel, contiguity, or backend routing;
+- can be tested and benchmarked as an atomic operation.
+
+Do not create a local helper merely to avoid coordinating an Albucore change when the operation satisfies these
+conditions.
+
+## Required Handoff
+
+Report:
+
+- work deleted or avoided;
+- full-array passes, copies, conversions, and allocations removed;
+- vectorization and grouped-reduction candidates evaluated;
+- LUT, random-generator, and backend candidates compared;
+- safe in-place opportunities taken or rejected with a reason;
+- operations moved or proposed for Albucore;
+- correctness evidence and benchmark matrix;
+- regressions, compatibility changes, and rejected candidates.

--- a/.codex/skills/performance-optimization/agents/openai.yaml
+++ b/.codex/skills/performance-optimization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Performance Optimization"
+  short_description: "Systematic performance review for runtime code"
+  default_prompt: "Use $performance-optimization to audit and optimize this runtime path with benchmark evidence."

--- a/.codex/skills/performance-optimization/references/performance-optimization.md
+++ b/.codex/skills/performance-optimization/references/performance-optimization.md
@@ -64,9 +64,13 @@ Benchmark the original loop as a real candidate.
 and weighted sums in one compiled pass:
 
 ```python
-counts = np.bincount(labels, minlength=num_labels)
-sum_x = np.bincount(labels, weights=x_coordinates, minlength=num_labels)
-sum_y = np.bincount(labels, weights=y_coordinates, minlength=num_labels)
+labels_1d = labels.ravel()
+x_coordinates_1d = x_coordinates.ravel()
+y_coordinates_1d = y_coordinates.ravel()
+
+counts = np.bincount(labels_1d, minlength=num_labels)
+sum_x = np.bincount(labels_1d, weights=x_coordinates_1d, minlength=num_labels)
+sum_y = np.bincount(labels_1d, weights=y_coordinates_1d, minlength=num_labels)
 
 nonempty = counts > 0
 center_x = sum_x[nonempty] / counts[nonempty]
@@ -226,9 +230,14 @@ The stats API already routes selected uint8 and low-channel reductions through N
 OpenCV where they win. Reimplementing these reductions inside AlbumentationsX loses both the routing and its benchmark
 coverage.
 
-Use `docs/numkong-performance.md` for current NumKong route evidence and
-`docs/performance-regressions-plan.md` for known router regressions. Regenerate or extend the relevant benchmark when a
-route changes; do not update a threshold from an isolated microbenchmark alone.
+In the Albucore checkout, use `docs/numkong-performance.md` for current NumKong route evidence and
+`docs/performance-regressions-plan.md` for known router regressions. When using the bundled fallback from an
+AlbumentationsX checkout, read the same files under `../albucore/docs/` if a sibling Albucore checkout is available.
+If it is absent, these supporting documents are unavailable: use repository-local benchmarks for candidate discovery
+and defer Albucore route or threshold changes until the canonical evidence can be checked.
+
+Regenerate or extend the relevant benchmark when a route changes; do not update a threshold from an isolated
+microbenchmark alone.
 
 ## Preserve behavior before measuring speed
 

--- a/.codex/skills/performance-optimization/references/performance-optimization.md
+++ b/.codex/skills/performance-optimization/references/performance-optimization.md
@@ -1,0 +1,278 @@
+# Performance Optimization Workflow
+
+Use this workflow whenever implementing, reviewing, or profiling runtime code in Albucore or AlbumentationsX. Its
+order matters: remove work before making the remaining work faster. Treat every proposed optimization as a hypothesis
+until correctness tests and representative benchmarks support it.
+
+This file is canonical at `albucore/docs/performance-optimization.md`. AlbumentationsX keeps a synchronized fallback
+copy under `.codex/skills/performance-optimization/references/` so its performance skill can load the guide without a
+sibling Albucore checkout.
+
+## Run the optimization pass in this order
+
+### 1. Delete work first
+
+Look for work that does not need to happen:
+
+- redundant validation, conversions, clipping, copies, reshapes, and contiguity fixes;
+- repeated calculations whose inputs do not change;
+- identity operations and empty inputs that can return early;
+- temporary arrays whose result is immediately overwritten;
+- setup repeated per image that can run once per batch;
+- duplicate kernels already available in Albucore.
+
+Use `np.empty` instead of zero-initialized storage when every element will be overwritten. Hoist invariant setup out
+of loops. Deleting a full-array pass usually beats making that pass faster.
+
+### 2. Reduce memory traffic and allocations
+
+Count full-array reads and writes, not only Python statements. Image kernels are often limited by memory bandwidth.
+
+- Fuse compatible arithmetic and reductions.
+- Use one-dimensional coordinate arrays, broadcasting, or `np.ogrid` instead of materializing full `meshgrid`
+  coordinates.
+- Reuse output buffers when ownership is clear.
+- Avoid full-array `astype`, `copy`, and `ascontiguousarray` calls unless the selected backend earns their cost.
+- Keep working arrays `float32` unless correctness requires wider precision.
+- Preallocate outside repeated loops and reset only the data that must change.
+- Prefer a view when downstream code accepts its strides and ownership.
+- Choose sparse coordinates, rectangles, or indices instead of a dense image-sized mask when the affected set is
+  small; use dense array operations when the set is large.
+
+Measure peak memory or allocation counts when the change targets allocations. A lower wall time with much higher peak
+memory is not an unconditional win.
+
+### 3. Vectorize the right dimension
+
+Inspect loops over pixels, labels, channels, images, frames, depth slices, boxes, and keypoints.
+
+- Replace pixel loops with array operations.
+- Batch random draws and repeated setup.
+- Vectorize across independent annotations when the temporary arrays remain bounded.
+- Keep a preallocated loop when broadcasting creates expensive strided access or a much larger temporary.
+- Specialize common channel layouts only when the benchmark supports the branch.
+
+`np.vectorize` and `np.frompyfunc` still execute Python callables element by element. They do not satisfy this
+vectorization pass.
+
+Vectorization can lose on tiny arrays, high-channel strided views, or operations with large broadcasted temporaries.
+Benchmark the original loop as a real candidate.
+
+### 4. Use `bincount` for dense integer-label reductions
+
+`np.bincount` is a segmented reduction. For non-negative integer label `labels[i]`, it can compute per-label counts
+and weighted sums in one compiled pass:
+
+```python
+counts = np.bincount(labels, minlength=num_labels)
+sum_x = np.bincount(labels, weights=x_coordinates, minlength=num_labels)
+sum_y = np.bincount(labels, weights=y_coordinates, minlength=num_labels)
+
+nonempty = counts > 0
+center_x = sum_x[nonempty] / counts[nonempty]
+center_y = sum_y[nonempty] / counts[nonempty]
+```
+
+This replaces code that constructs `labels == label` for every label. The old pattern scans `N` elements `K` times
+and allocates `K` boolean masks. The grouped form performs a small fixed number of `O(N + K)` passes.
+
+Consider `bincount` for:
+
+- component sizes and per-component sums or means;
+- superpixel statistics and cluster-center updates;
+- class or label histograms;
+- confusion matrices after mapping a label pair to one integer bin;
+- repeated reductions over dense region IDs.
+
+Check these constraints before adopting it:
+
+- labels must be non-negative integers;
+- output size follows the largest label, so sparse large IDs need remapping;
+- `weights=` returns floating-point sums and may change accumulation precision;
+- negative or ignored labels need filtering or an explicit offset;
+- `np.unique(..., return_inverse=True)` can compress sparse IDs, but sorting and remapping may erase the gain;
+- a few labels, a small input, or a one-time scan may favor the existing implementation.
+
+For reductions other than counts and sums, also benchmark `np.minimum.at`, `np.maximum.at`, `np.logical_or.at`, or
+sorting followed by `ufunc.reduceat`. Repeated-index `ufunc.at` operations preserve scatter semantics but can be slower
+than `bincount`; they are candidates, not automatic replacements.
+
+Benchmark label cardinality and density, including the common small-label case. In AlbumentationsX audits,
+`bincount` greatly accelerated SLIC and superpixel means, did not improve component point sampling, and slowed the
+common 4-by-4 bbox-grid case. Use it as a candidate, never as a blanket rewrite.
+
+### 5. Check whether the operation is a LUT
+
+For a true pointwise mapping from uint8 input values to output values, compare:
+
+- Albucore's LUT router;
+- OpenCV LUT;
+- StringZilla translation;
+- NumPy indexing or direct arithmetic.
+
+Include shared and per-channel tables, contiguous and non-contiguous input, and channels above OpenCV's common
+four-channel limit. A direct bitwise operation can beat every LUT for a bit mask.
+
+Keep floating-point LUT tables `float32`. A float64 table can force a full float64 output and an expensive conversion
+back to float32.
+
+### 6. Compare complete backend implementations
+
+For each atomic operation, benchmark viable implementations end to end:
+
+- NumPy;
+- OpenCV;
+- NumKong;
+- StringZilla;
+- a LUT route;
+- a small Python or `math` implementation when the data is scalar or tiny.
+
+Include dispatch, dtype conversion, contiguity, allocation, clipping, and output-shape repair in the timing. A fast
+kernel that requires a full-size copy can lose at the public API.
+
+Route only where evidence wins. Thresholds may depend on dtype, rank, size, channel count, contiguity, scalar versus
+per-channel parameters, and in-place versus allocating mode. Existing Albucore routes demonstrate that no backend is
+globally fastest:
+
+- NumKong wins selected reductions, moments, blends, scales, and small distance matrices;
+- NumPy wins other float32 and high-channel paths;
+- OpenCV wins many dense image operations but has channel and layout constraints;
+- StringZilla is competitive for selected uint8 translation paths.
+
+### 7. Compare random-generation paths
+
+Choose random generation by workload and contract:
+
+- Python `random.Random` is a strong candidate for a few scalar parameters or choices.
+- NumPy `Generator` is the primary candidate for vectors, masks, noise fields, shuffles, and distributions.
+- OpenCV random fill can be benchmarked when it writes directly into an existing dense buffer.
+
+Measure generation and required post-processing together. Compare direct dtype generation, vectorized draws, bounds,
+temporary casts, and in-place scaling.
+
+For sparse dropout or impulse noise, compare generating a dense random mask with sampling sparse flat indices and
+scattering values. For channel-shared noise, do not generate independent channel data that will be discarded.
+
+Preserve seeded behavior, per-transform generator isolation, thread safety, and replay semantics. OpenCV's global RNG
+or a different NumPy dtype path may be faster while changing those contracts. Treat a changed random sequence as an
+explicit compatibility decision, not an invisible optimization.
+
+### 8. Move reusable atomic operations into Albucore
+
+AlbumentationsX owns transform policy, parameter sampling, target dispatch, and annotation semantics. Albucore owns
+reusable array kernels and benchmark-driven backend routing.
+
+Move an operation to Albucore when it:
+
+- appears in multiple transforms or has clear reuse beyond one transform;
+- has stable array semantics independent of augmentation policy;
+- benefits from dtype, layout, channel, size, or backend routing;
+- can expose a small typed API with direct correctness tests and microbenchmarks.
+
+Do not move transform-specific sampling or target semantics. Avoid parallel local helpers that implement the same
+atomic operation differently.
+
+### 9. Make safe operations in-place
+
+Prefer `out=`, OpenCV `dst=`, and Albucore `inplace=True` when all aliasing conditions hold:
+
+- the input may be modified under the public contract;
+- no later calculation needs the original values;
+- source and destination overlap is supported by the backend;
+- shared arrays or views do not make the mutation observable elsewhere;
+- dtype and shape already match the destination.
+
+In-place is not automatically faster. It can trigger copies for non-contiguous views, block fusion, or corrupt
+read-after-write calculations. Benchmark both modes and test aliasing explicitly.
+
+### 10. Specialize and route only after the simpler pass
+
+After removing work and comparing straight implementations, consider routing by:
+
+- uint8 versus float32;
+- scalar versus per-channel parameters;
+- 1, 3, 4, and high-channel inputs;
+- image, batch, volume, and batch-of-volumes rank;
+- contiguous versus strided input;
+- small versus large arrays;
+- dense versus sparse labels;
+- allocating versus in-place output.
+
+Keep the number of branches justified by durable benchmark regions. Do not add a threshold for noisy single-machine
+measurements.
+
+### 11. Measure dispatch and pipeline overhead
+
+An isolated kernel speedup may disappear behind transform dispatch, conversion decorators, target routing, or
+`Compose`. Benchmark the layer users execute.
+
+For AlbumentationsX, measure both the direct functional call and the transform through `Compose`. For batch-capable
+transforms, compare per-image dispatch with `apply_to_images` and include setup reuse.
+
+For Albucore, benchmark the public router, not only its private backend. Include non-square inputs, supported dtypes,
+1/3/high-channel cases, and relevant batch or volume ranks.
+
+## Reuse existing Albucore routes
+
+Check these shared entry points before writing a local kernel:
+
+- `albucore.apply_uint8_lut` and `albucore.sz_lut` for benchmark-routed uint8 tables;
+- `albucore.stats` for `sum`, `mean`, `std`, and `mean_std` across images, batches, and volumes;
+- Albucore arithmetic and weighted routers for add, multiply, normalize, power, blend, and fused multiply-add;
+- Albucore geometric and resize functions for channel-safe OpenCV routing;
+- `pairwise_distances_squared` for the routed small-set NumKong and larger NumPy paths.
+
+The stats API already routes selected uint8 and low-channel reductions through NumKong while retaining NumPy or
+OpenCV where they win. Reimplementing these reductions inside AlbumentationsX loses both the routing and its benchmark
+coverage.
+
+Use `docs/numkong-performance.md` for current NumKong route evidence and
+`docs/performance-regressions-plan.md` for known router regressions. Regenerate or extend the relevant benchmark when a
+route changes; do not update a threshold from an isolated microbenchmark alone.
+
+## Preserve behavior before measuring speed
+
+Create a correctness baseline before editing:
+
+- exact output or a justified numerical tolerance;
+- shape, dtype, range, and channel preservation;
+- empty and degenerate inputs;
+- annotations and label semantics;
+- mutation and aliasing behavior;
+- deterministic and replay behavior for seeded transforms.
+
+Use a copied reference implementation or regression vectors when replacing an algorithmic inner loop. Performance
+does not justify an unreviewed output change.
+
+## Benchmark every candidate, including rejected ones
+
+Use the repository benchmark skill and policy. At minimum:
+
+- run old and new code on the same machine and environment;
+- control OpenCV and BLAS threads;
+- include warmup and enough repetitions for stable timing;
+- report versions, dtype, shape, channels, parameters, and allocation mode;
+- cover the full required size and channel matrix;
+- compare direct and routed/public execution;
+- investigate any cell that regresses by more than the project threshold;
+- retain a short record of rejected candidates and the cases where they lost.
+
+Vary the dimension that controls the proposed optimization. For `bincount`, sweep label count and density. For LUTs,
+sweep table layout and channels. For random generation, sweep output size and dtype. For backend routing, sweep both
+sides of every proposed threshold.
+
+## Required review record
+
+Every performance task should report:
+
+- work deleted or avoided;
+- full-array passes, copies, conversions, and allocations removed;
+- loops reviewed and vectorization decisions;
+- grouped integer-label reductions reviewed, including `bincount`;
+- LUT applicability and candidates;
+- random-generation candidates;
+- NumPy, OpenCV, NumKong, StringZilla, and Python candidates that apply;
+- reusable atoms moved or proposed for Albucore;
+- safe in-place opportunities;
+- correctness evidence;
+- benchmark matrix, wins, regressions, and rejected candidates.

--- a/.codex/skills/review-transform/SKILL.md
+++ b/.codex/skills/review-transform/SKILL.md
@@ -52,14 +52,18 @@ Run these checks in order. Report issues with severity: 🔴 Critical, 🟡 Impo
 
 ## 6. Performance (🟡 Important)
 
+Read `../performance-optimization/SKILL.md` and its required reference completely before reviewing this section.
+
 Priority order to check:
-1. **`cv2.LUT`** used for pixel lookup operations (fastest)
-2. **`albucore.resize` not `cv2.resize`** for image resizing (handles 5+ channels, INTER_AREA, etc.)
-3. **`cv2` over numpy** for image ops where applicable
-4. **Vectorized numpy** instead of Python loops
-5. **In-place ops** where safe (avoid unnecessary `.copy()`)
-6. No repeated array allocations in tight loops
-7. Expensive computations cached in `get_params` / `get_params_dependent_on_data`
+1. Delete redundant work, full-array passes, conversions, and copies.
+2. Vectorize loops when the benchmark supports the resulting memory layout.
+3. Use grouped reductions such as `np.bincount` instead of repeated per-label full-array masks when labels are dense.
+4. Compare LUT, NumPy, OpenCV, NumKong, and StringZilla implementations where applicable.
+5. Compare Python, NumPy, and OpenCV random generation without breaking seeded isolation or replay.
+6. Use `albucore.resize`, not `cv2.resize`, for image resizing.
+7. Move reusable atomic image operations into Albucore.
+8. Use in-place operations where ownership and aliasing make them safe.
+9. Cache expensive setup in `get_params` / `get_params_dependent_on_data` or once per batch.
 
 ### Batch Optimization Checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@ Project-specific skills live in `.codex/skills`. Use the matching skill whenever
 - `internal-workspace`
 - `license-integrity`
 - `mixing-transforms`
+- `performance-optimization`
 - `release-notes`
 - `review-transform`
 - `validate-and-fix`
+
+Use `performance-optimization` whenever implementing, reviewing, profiling, or optimizing runtime code. The skill
+loads Albucore's canonical performance workflow, including delete-first review, vectorization, grouped reductions,
+LUT and random-generator selection, backend comparison, Albucore extraction, and safe in-place operations.

--- a/docs/contributing/codex_guidelines.md
+++ b/docs/contributing/codex_guidelines.md
@@ -116,6 +116,8 @@ def __init__(self, brightness: float | tuple[float, float] = 0.2):
 
 #### Performance Decision Rules
 
+- **Run the repo-local `performance-optimization` skill** for runtime changes. It loads Albucore's canonical workflow
+  and requires delete-first, allocation, vectorization, LUT, RNG, backend, extraction, and in-place checks.
 - **Do not blindly replace NumPy with cv2**. Benchmark the exact shape/dtype/channel matrix.
 - **LUTs are not always best**. For operations that are literally bit masks, prefer direct bitwise operations
   such as `img & np.uint8(mask)`.
@@ -129,6 +131,8 @@ def __init__(self, brightness: float | tuple[float, float] = 0.2):
   `np.arange(..., dtype=np.float32)` and `cv2.sqrt(..., dst=...)` can be faster and simpler.
 - **Sparse multi-channel replacement can favor copy + assignment**. Benchmark threshold-dependent mask paths;
   nested `np.where` is not automatically faster.
+- **Treat integer labels as grouped data**. Benchmark `np.bincount` for dense non-negative labels when code repeatedly
+  scans `labels == label`; include sparse IDs and the common small-label case because remapping can erase the gain.
 
 ### Batch Optimization (`apply_to_images`)
 

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -760,6 +760,10 @@ Examples:
 
 When writing or reviewing performance-sensitive code (functional layer, apply methods, core pipeline), apply these techniques in priority order:
 
+Use the repo-local `performance-optimization` skill for the complete workflow. It loads Albucore's canonical
+performance guide and requires a delete-first pass, backend comparison, correctness baseline, and representative
+benchmarks.
+
 ### 1. Eliminate Python Loops Over Pixels
 
 Python `for y in range(h): for x in range(w):` loops are ~100x slower than vectorized numpy. Replace with:
@@ -768,7 +772,22 @@ Python `for y in range(h): for x in range(w):` loops are ~100x slower than vecto
 - `np.einsum` for weighted sums over control points
 - Scatter-update via fancy indexing (`arr[ys, xs] = vals`) instead of per-pixel assignment
 
-### 2. Use `cv2.LUT` / `sz_lut` for uint8 Pixel-Wise Transforms
+### 2. Eliminate Per-Label Full-Array Scans
+
+When integer labels are dense and non-negative, use `np.bincount` as a grouped reduction instead of constructing one
+full-image mask per label:
+
+```python
+counts = np.bincount(labels, minlength=num_labels)
+weighted_sums = np.bincount(labels, weights=values, minlength=num_labels)
+means = weighted_sums / counts
+```
+
+This can replace `for label: mask = labels == label` for component sizes, sums, means, histograms, and cluster-center
+updates. Benchmark small label counts too: sparse IDs require remapping, `weights=` changes accumulation precision,
+and `np.unique(..., return_inverse=True)` may cost more than the scans it replaces.
+
+### 3. Use `cv2.LUT` / `sz_lut` for uint8 Pixel-Wise Transforms
 
 Any function `f(pixel) -> pixel` on uint8 data should build a 256-entry LUT and apply it via `sz_lut(img, lut, inplace=...)`. This is orders of magnitude faster than per-pixel numpy.
 
@@ -783,7 +802,7 @@ result = img & mask
 For multichannel bit masks, benchmark broadcasted `img & masks` against a preallocated per-channel loop. Broadcasting
 small per-channel masks can create slow strided operations.
 
-### 3. Vectorize LUT and Array Construction
+### 4. Vectorize LUT and Array Construction
 
 Replace Python list comprehensions with numpy vectorized equivalents:
 
@@ -796,7 +815,7 @@ indices = np.arange(256, dtype=np.uint8)
 lut = np.where(indices >= thresh, max_val - indices, indices)
 ```
 
-### 4. Use `out=` for In-Place Operations
+### 5. Use `out=` for In-Place Operations
 
 Avoid allocating temporaries on image-sized arrays:
 
@@ -811,14 +830,14 @@ np.clip(result, 0, 1, out=result)
 
 Key functions with `out=` support: `np.clip`, `np.multiply`, `np.add`, `np.divide`.
 
-### 5. Avoid Float64 Waste
+### 6. Avoid Float64 Waste
 
 Numpy defaults to float64. Always specify `dtype=np.float32` for:
 
 - `np.arange`, `np.linspace`, `np.zeros`, `np.ones`, `np.full`
 - `np.meshgrid` inputs (pass float32 arrays)
 
-### 6. Fuse Multi-Step Operations
+### 7. Fuse Multi-Step Operations
 
 Replace chains of temporary allocations with single calls:
 
@@ -830,10 +849,11 @@ result = img + alpha * (img - blurred)
 result = add_weighted(img, 1.0 + alpha, blurred, -alpha)
 ```
 
-### 7. Choose OpenCV vs NumPy by Benchmark
+### 8. Choose Backends by Benchmark
 
-OpenCV is often faster for image-sized dense operations, but not automatically. Benchmark the exact dtype, shape, and
-channel matrix before switching.
+Compare NumPy, OpenCV, NumKong, StringZilla, and LUT implementations that can express the complete operation. Include
+dispatch, conversion, contiguity, clipping, and allocation costs. Benchmark the exact dtype, shape, and channel matrix
+before switching.
 
 - Use scalar NumPy bitwise, for example `img & np.uint8(mask)`, when the operation has a scalar mask.
 - Use `cv2.bitwise_*` only when both operands are dense contiguous arrays and `dst=` can reuse output.
@@ -843,7 +863,7 @@ channel matrix before switching.
 - For sparse multi-channel replacement, copy plus masked assignment can beat nested `np.where`; benchmark the
   density threshold.
 
-### 8. Preallocate Outside Loops
+### 9. Preallocate Outside Loops
 
 Move `np.zeros` / `np.empty` calls outside loops and reset with `arr[:] = 0`:
 
@@ -860,16 +880,20 @@ for item in items:
     cv2.fillPoly(mask, ...)
 ```
 
-### 9. Skip Redundant Work in Hot Paths
+### 10. Skip Redundant Work in Hot Paths
 
 - Guard `np.ascontiguousarray` with `if not arr.flags["C_CONTIGUOUS"]`
 - Use `first_result[np.newaxis]` instead of `np.array([first_result])` for batch-of-one
 - Precompute loop-invariant expressions (e.g., `inv_sq = 1.0 / (step * step)`)
 - Use `np.where(mask)` instead of `np.argwhere(mask)` — returns tuple of 1D arrays instead of 2D index array
 
-### 10. Vectorize Random Number Generation
+### 11. Compare and Vectorize Random Number Generation
 
-Replace per-element Python RNG loops with single numpy calls:
+Use Python `random.Random` for a few scalar choices and NumPy `Generator` for arrays as starting candidates. Benchmark
+Python, NumPy, and OpenCV random generation when more than one can express the workload. Preserve per-transform seeded
+isolation and replay behavior; OpenCV's global RNG may make it ineligible even when its kernel is fast.
+
+Replace per-element Python RNG loops with single NumPy calls:
 
 ```python
 # Slow


### PR DESCRIPTION
## Summary

- Add a repo-local `performance-optimization` skill for every runtime implementation, review, profile, or optimization task.
- Bundle a byte-identical fallback of the canonical Albucore performance guide so the skill remains usable without a sibling checkout.
- Load the workflow from `add-transform`, `benchmark`, and `review-transform` and make it mandatory from `AGENTS.md`.
- Expand contributor guidance for delete-first review, dense-label `numpy.bincount` reductions, complete backend comparisons, random generation, reusable Albucore atoms, and safe in-place operations.

Canonical companion: [albucore #114](https://github.com/albumentations-team/albucore/pull/114).

## Why

The existing guidance recommended vectorized NumPy, LUTs, and in-place operations, but it did not require a complete ordered audit. It also contained unconditional OpenCV/LUT advice in `add-transform` and `review-transform`, which conflicts with benchmark-driven backend routing.

The new skill starts by deleting work and reducing memory traffic. It then evaluates vectorization, grouped reductions, LUTs, random generators, NumPy/OpenCV/NumKong/StringZilla implementations, Albucore extraction, and alias-safe in-place paths. Each candidate must be benchmarked on the dimension that controls it; for `bincount`, that includes label count and density.

## Validation

- Skill creator `quick_validate.py`: passed.
- Bundled guide is byte-identical to the canonical Albucore document.
- `uv run pytest -q -m "not slow"`: 11,431 passed, 42 skipped, 38 deselected, 9 xfailed, 3 xpassed.
- Targeted `pre-commit run --files ...`: passed.

## Summary by Sourcery

Introduce a repo-local performance optimization skill and make it the standard workflow for implementing and reviewing runtime performance changes.

Enhancements:
- Update coding and Codex guidelines to require the performance-optimization skill and emphasize delete-first reviews, grouped reductions, backend comparisons, and safe in-place operations.
- Refine performance advice for transforms, including use of np.bincount for dense integer labels, backend and RNG selection, and Albucore extraction of reusable kernels.
- Align add-transform, review-transform, and benchmark skills with the new systematic performance workflow and require reading it before functional or benchmarking work.
- Bundle a synchronized fallback copy of Albucore’s canonical performance optimization guide and expose it via a new performance-optimization skill with OpenAI agent metadata.

Documentation:
- Expand contributor documentation with detailed performance optimization workflow, label-reduction guidance, backend selection rules, and random generation best practices.