### PR TITLE
perf(illumination): accelerate WaterRefraction with NumKong

### DIFF
--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Literal, cast
 
+import numkong as nk
+
 from ._functional_noise import (
     DIAMOND_KERNEL,
     SQUARE_KERNEL,
@@ -1163,7 +1165,14 @@ def generate_water_displacement_maps(
         wave_y = np.sin(angle)
 
         projection = x * wave_x + y * wave_y
-        displacement = amp * np.sin(2 * np.pi * freq * projection + phase)
+        phase_field = 2 * np.pi * freq * projection + phase
+        sine = nk.sin(phase_field.reshape(-1))
+        if sine is None:
+            raise RuntimeError("nk.sin returned None")
+        displacement_buffer = nk.scale(sine, alpha=amp, beta=0.0)
+        if displacement_buffer is None:
+            raise RuntimeError("nk.scale returned None")
+        displacement = np.asarray(displacement_buffer).reshape(height, width)
 
         dx += displacement * (-wave_y)
         dy += displacement * wave_x


### PR DESCRIPTION
## Summary

Replace the dense NumPy `sin` followed by scalar multiplication in `generate_water_displacement_maps` with NumKong 7.7.0 `sin` and `scale` kernels.

The projection and displacement accumulation remain on their existing NumPy path. This captures a repeatable speedup while preserving the current output in the correctness controls.

## Performance

Measured on Apple arm64 with NumKong 7.7.0, NumPy 2.2.6, and OpenCV 5.0.0. Values are median milliseconds.

| Direct map size | NumPy baseline | This PR | Improvement |
|---:|---:|---:|---:|
| 256² | 3.1593 | 2.6610 | 15.8% |
| 512² | 12.3172 | 11.0120 | 10.6% |
| 1024² | 47.0450 | 42.1617 | 10.4% |

The full `A.Compose([A.WaterRefraction(...)])` route improved in every tested cell of the 256/512/1024 × C=1/3/5 grid:

| dtype | 256² | 512² | 1024² |
|---|---:|---:|---:|
| `uint8`, C=1/3/5 | 17.4% / 13.6% / 9.3% | 8.4% / 13.8% / 12.9% | 11.6% / 11.6% / 16.1% |
| `float32`, C=1/3/5 | 5.8% / 8.5% / 8.3% | 12.4% / 10.4% / 12.0% | 12.5% / 10.2% / 12.1% |

A more aggressive all-NumKong pipeline was also evaluated and was roughly 2.2–3.1× faster, but it introduced small numerical changes to the displacement maps. This PR keeps the conservative path.

## Correctness

The optimized displacement maps were bit-identical to the NumPy baseline in direct 64², 256², and 512² controls. Full Compose outputs were also bit-identical for 512² × C=3 controls in both `uint8` and `float32`.

Related NumKong request and benchmark evidence: https://github.com/ashvardanian/NumKong/issues/365

## Validation

- `uv run pytest -m "not slow"` — 11,434 passed, 42 skipped, 38 deselected, 9 xfailed, 3 xpassed
- `uv run python -m tools.quality_gate fast`
- commit-time pre-commit hooks

## Summary by Sourcery

New Features:
- Integrate NumKong sine and scale kernels into water displacement map computation for improved performance.