### PR TITLE
docs(ci): document CodeQL fork limitation

### DIFF
--- a/docs/maintaining/ci-greenfield-plan.md
+++ b/docs/maintaining/ci-greenfield-plan.md
@@ -42,11 +42,13 @@ The repository implementation now follows this design:
 - security, legal, packaging, ASV, and Antigravity work is routed by relevance.
 
 The main-branch repository ruleset now requires `PR plan`, `Fast checks`,
-`Correctness`, and `Security and policy`. Exact `Analyze (*)`, matrix-leaf, and
-`ASV benchmark evidence` contexts have been removed; the existing `CodeQL` and
-`license/cla` gates remain required. Hosted-runner p50/p95 still need to be
-measured over multiple post-cutover runs, so the service levels below remain
-targets rather than measured guarantees.
+`Correctness`, `Security and policy`, and `license/cla`. Exact `Analyze (*)`,
+matrix-leaf, `ASV benchmark evidence`, and `CodeQL` contexts have been removed.
+Default setup does not analyze pull requests from forks, so a globally required
+`CodeQL` context would block external contributions without creating an
+analysis. Hosted-runner p50/p95 still need to be measured over multiple
+post-cutover runs, so the service levels below remain targets rather than
+measured guarantees.
 
 ## What the current checks are doing
 
@@ -120,6 +122,10 @@ change. The pull request already has the stable `Code scanning results / CodeQL`
 gate and a successful Python analysis. A stale dynamic job name should not also
 be required globally.
 
+The aggregate `CodeQL` context is also unsuitable as a global requirement while
+the repository uses default setup. GitHub excludes pull requests from forks
+from default-setup analysis, so those pull requests never report the context.
+
 ### ASV, not AST
 
 ASV means **airspeed velocity**. It is the Python benchmarking framework used
@@ -168,11 +174,10 @@ always creates:
 3. `Correctness`
 4. `Security and policy`
 5. The existing external `license/cla` gate
-6. The GitHub code-scanning results rule, if the repository wants code scanning
-   to block merges
 
 Do not require individual matrix cells, ASV leaf jobs, CodeQL language jobs,
-OpenSSF Scorecard, Antigravity, Sourcery, or coverage-upload jobs.
+the aggregate `CodeQL` context from default setup, OpenSSF Scorecard,
+Antigravity, Sourcery, or coverage-upload jobs.
 
 The four repository-owned gates should be aggregation jobs with fixed names.
 They run with `if: always()`, inspect the router plan plus every relevant leaf
@@ -320,20 +325,23 @@ names. They are implementation details of a dynamic analysis matrix.
 
 Preferred policy:
 
-- keep the repository's stable GitHub code-scanning results rule as the merge
-  gate;
+- keep CodeQL enabled for same-repository pull requests, pushes to the default
+  branch, and weekly scans;
+- do not require the aggregate `CodeQL` context while default setup excludes
+  pull requests from forks;
 - run Python analysis for runtime or Python tooling changes;
 - run Actions analysis for workflow/local-action changes;
 - run the complete scan on the default branch and weekly;
 - do not run a language analysis for Markdown-only changes.
 
-GitHub default setup has limited trigger control. If selective CodeQL execution
-is important, migrate to
+GitHub default setup has limited trigger control and excludes pull requests
+from forks. If every pull request must pass CodeQL, or selective execution is
+important, migrate to
 [advanced setup](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types)
 in a separate change, and disable default setup before enabling the advanced
 workflow. Do not run both configurations accidentally. Advanced setup permits
-normal workflow triggers and CodeQL path configuration; the repository should
-validate the resulting security coverage before changing the ruleset.
+normal workflow triggers and CodeQL path configuration. Validate one
+fork-based pull request before adding CodeQL back to the required merge gates.
 
 ### Legal integrity
 
@@ -542,10 +550,10 @@ trail for the order and safety conditions behind the design.
    checks.
 2. Remove stale/dynamic `Analyze (actions)` and language-specific `Analyze (*)`
    contexts from required status checks.
-3. Keep the stable GitHub code-scanning results rule if code scanning should
-   block merges.
-4. Verify with one Markdown-only PR, one source PR, and one workflow-only PR
-   that every required context reports a final result.
+3. Remove the aggregate `CodeQL` context while default setup excludes pull
+   requests from forks.
+4. Verify with one fork-based PR, one Markdown-only PR, one source PR, and one
+   workflow-only PR that every required context reports a final result.
 
 This phase fixes the current pending state without redesigning test coverage.
 

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -23,10 +23,14 @@ closed when a selected leaf is missing, skipped, cancelled, or failed. A leaf
 that the router did not select may be skipped without leaving the pull request
 waiting for a status that will never arrive.
 
-Keep the external CLA check and GitHub's stable code-scanning results rule when
-they are part of repository policy. Do not require dynamic CodeQL leaf names
-such as `Analyze (actions)` or `Analyze (python)`. Do not require advisory ASV
-or AI-review jobs.
+Keep the external CLA check. Do not require the `CodeQL` status while code
+scanning uses GitHub default setup: default setup excludes pull requests from
+forks, so external contributions never report that status. Keep CodeQL enabled
+for same-repository pull requests, pushes to `main`, and weekly scans. If every
+pull request must pass CodeQL, migrate to advanced setup and verify a fork-based
+pull request before adding a stable required gate. Do not require dynamic
+CodeQL leaf names such as `Analyze (actions)` or `Analyze (python)`, advisory
+ASV jobs, or AI-review jobs.
 
 Direct pushes to `main` are outside the maintenance policy and should be
 blocked by the repository ruleset. Repository workflows use pull-request,
@@ -140,10 +144,13 @@ Nightly and release-candidate workflows run the complete 3 × 5 base suite.
 They also retain lower-bound, property/regression, optional-extra, PyTorch,
 performance, and release artifact evidence where appropriate.
 
-CodeQL is managed by GitHub default setup. Do not add an advanced CodeQL
-workflow while default setup is enabled, because duplicate configurations can
-reject SARIF uploads. Selective language analysis should be handled as a
-separate default-to-advanced migration.
+CodeQL is managed by GitHub default setup. GitHub's
+[default-setup trigger policy](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types)
+excludes pull requests from forks, so the repository ruleset must not require
+the `CodeQL` status. Do not add an advanced CodeQL workflow while default setup
+is enabled, because duplicate configurations can reject SARIF uploads. Treat
+mandatory fork analysis or selective language analysis as a separate
+default-to-advanced migration.
 
 ## Antigravity pull-request reviews
 


### PR DESCRIPTION
## Summary

- Document that GitHub CodeQL default setup does not analyze pull requests from forks.
- Align the versioned CI policy with the live `main` ruleset, which requires `license/cla`, `PR plan`, `Fast checks`, `Correctness`, and `Security and policy`.
- Require a validated advanced-setup migration before CodeQL can become a mandatory gate for every pull request.

## Root cause

PR #340 originated from a fork. Default setup never created its `CodeQL` status, while the `main` ruleset required that status, so GitHub waited indefinitely. The live ruleset has already been corrected; this PR records the constraint and prevents the broken requirement from being restored.

## Validation

- `pre-commit run --all-files`
- `uv run pytest` — 11,511 passed, 42 skipped, 9 xfailed, 3 xpassed
- Verified on fork PR #349 that `CodeQL` is no longer listed as an expected required context

## Summary by Sourcery

Document CodeQL default-setup limitations for forked pull requests and adjust CI policy guidance to avoid requiring non-reporting CodeQL contexts.

Documentation:
- Explain that GitHub CodeQL default setup does not analyze pull requests from forks and that its aggregate status must not be a global required check under that setup.
- Update CI greenfield and CI policy docs to require core aggregation gates and CLA while explicitly excluding the aggregate CodeQL context and dynamic CodeQL leaf jobs from required checks.
- Clarify that repositories needing mandatory CodeQL on all pull requests should first migrate from default to advanced setup, validate fork-based PRs, and only then reintroduce CodeQL as a required merge gate.