### PR TITLE
Fix GaussianBlur parity with Pillow

### DIFF
--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -33,7 +33,6 @@ __all__ = ["box_blur", "central_zoom", "defocus", "glass_blur", "mode_filter", "
 
 _PILLOW_FIXED_POINT_BITS = 24
 _PILLOW_FIXED_POINT_SCALE = 1 << _PILLOW_FIXED_POINT_BITS
-_PILLOW_FIXED_POINT_ROUNDING = 1 << (_PILLOW_FIXED_POINT_BITS - 1)
 _PILLOW_FIXED_POINT_SCALE_F32 = np.float32(_PILLOW_FIXED_POINT_SCALE)
 _PILLOW_F32_ONE = np.float32(1.0)
 _PILLOW_F32_TWO = np.float32(2.0)
@@ -492,49 +491,36 @@ def create_pillow_gaussian_kernel(sigma: float) -> np.ndarray:
     return kernel
 
 
-def _set_far_pixel_sums(img: ImageUInt8, far_pixel_sums: np.ndarray, axis: int, distance: int) -> None:
-    source = np.moveaxis(img, axis, 0)
-    destination = np.moveaxis(far_pixel_sums, axis, 0)
-    length = source.shape[0]
-    edge_length = min(distance, length)
-
-    np.copyto(destination[:edge_length], source[:1], casting="unsafe")
-    if edge_length < length:
-        np.copyto(destination[edge_length:], source[:-edge_length], casting="unsafe")
-        np.add(destination[:-edge_length], source[edge_length:], out=destination[:-edge_length])
-    np.add(destination[-edge_length:], source[-1:], out=destination[-edge_length:])
-
-
 def _pillow_gaussian_blur_uint8(
     img: ImageUInt8,
-    radius: int,
-    whole_weight: int,
-    far_weight: int,
+    kernel: np.ndarray,
 ) -> ImageUInt8:
+    # The uint32 weights and uint8 samples fit exactly in float64. Adding 0.5 in OpenCV and then truncating during
+    # the uint8 copy reproduces Pillow's fixed-point round-half-up operation without separate full-image passes.
+    normalized_kernel = kernel.astype(np.float64) / _PILLOW_FIXED_POINT_SCALE
+    horizontal_kernel = normalized_kernel[np.newaxis, :]
+    vertical_kernel = normalized_kernel[:, np.newaxis]
     result = np.array(img, copy=True, order="C")
     output = np.empty_like(result)
-    weighted_sum_i32 = np.empty(result.shape, dtype=np.int32)
-    far_pixel_sums = np.empty(result.shape, dtype=np.uint32)
-    distance = radius + 1
+    filtered = np.empty(result.shape, dtype=np.float64)
 
-    for axis in (1, 1, 1, 0, 0, 0):
-        kernel_size = (radius * 2 + 1, 1) if axis == 1 else (1, radius * 2 + 1)
-        cv2.boxFilter(
+    for filter_kernel in (
+        horizontal_kernel,
+        horizontal_kernel,
+        horizontal_kernel,
+        vertical_kernel,
+        vertical_kernel,
+        vertical_kernel,
+    ):
+        cv2.filter2D(
             result,
-            ddepth=cv2.CV_32S,
-            ksize=kernel_size,
-            dst=weighted_sum_i32,
-            normalize=False,
+            ddepth=cv2.CV_64F,
+            kernel=filter_kernel,
+            dst=filtered,
+            delta=0.5,
             borderType=cv2.BORDER_REPLICATE,
         )
-        weighted_sum = weighted_sum_i32.view(np.uint32)
-        np.multiply(weighted_sum, np.uint32(whole_weight), out=weighted_sum)
-        _set_far_pixel_sums(result, far_pixel_sums, axis, distance)
-        np.multiply(far_pixel_sums, np.uint32(far_weight), out=far_pixel_sums)
-        np.add(weighted_sum, far_pixel_sums, out=weighted_sum)
-        np.add(weighted_sum, np.uint32(_PILLOW_FIXED_POINT_ROUNDING), out=weighted_sum)
-        np.right_shift(weighted_sum, _PILLOW_FIXED_POINT_BITS, out=weighted_sum)
-        np.copyto(output, weighted_sum, casting="unsafe")
+        np.copyto(output, filtered, casting="unsafe")
         result, output = output, result
 
     return result
@@ -542,29 +528,26 @@ def _pillow_gaussian_blur_uint8(
 
 def _pillow_gaussian_blur_float32(
     img: ImageFloat32,
-    radius: int,
-    whole_weight: int,
-    far_weight: int,
+    kernel: np.ndarray,
 ) -> ImageFloat32:
-    kernel = np.full(radius * 2 + 3, np.float32(whole_weight / _PILLOW_FIXED_POINT_SCALE), dtype=np.float32)
-    kernel[[0, -1]] = np.float32(far_weight / _PILLOW_FIXED_POINT_SCALE)
-    identity = np.ones(1, dtype=np.float32)
+    normalized_kernel = kernel.astype(np.float32) / _PILLOW_FIXED_POINT_SCALE_F32
+    horizontal_kernel = normalized_kernel[np.newaxis, :]
+    vertical_kernel = normalized_kernel[:, np.newaxis]
     result = np.array(img, copy=True, order="C")
     output = np.empty_like(result)
 
-    for kernel_x, kernel_y in (
-        (kernel, identity),
-        (kernel, identity),
-        (kernel, identity),
-        (identity, kernel),
-        (identity, kernel),
-        (identity, kernel),
+    for filter_kernel in (
+        horizontal_kernel,
+        horizontal_kernel,
+        horizontal_kernel,
+        vertical_kernel,
+        vertical_kernel,
+        vertical_kernel,
     ):
-        cv2.sepFilter2D(
+        cv2.filter2D(
             result,
             ddepth=-1,
-            kernelX=kernel_x,
-            kernelY=kernel_y,
+            kernel=filter_kernel,
             dst=output,
             borderType=cv2.BORDER_REPLICATE,
         )
@@ -588,14 +571,13 @@ def pillow_gaussian_blur(img: ImageType, kernel: np.ndarray) -> ImageType:
         ImageType: Blurred image with the input shape and dtype.
 
     """
-    radius = (kernel.size - 3) // 2
     whole_weight = int(kernel[1])
     far_weight = int(kernel[0])
     if whole_weight == _PILLOW_FIXED_POINT_SCALE and far_weight == 0:
         return cast("ImageType", np.array(img, copy=True, order="C"))
     if img.dtype == np.uint8:
-        return _pillow_gaussian_blur_uint8(cast("ImageUInt8", img), radius, whole_weight, far_weight)
-    return _pillow_gaussian_blur_float32(cast("ImageFloat32", img), radius, whole_weight, far_weight)
+        return _pillow_gaussian_blur_uint8(cast("ImageUInt8", img), kernel)
+    return _pillow_gaussian_blur_float32(cast("ImageFloat32", img), kernel)
 
 
 def create_gaussian_kernel_input_array(size: int) -> np.ndarray:

--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -26,9 +26,20 @@ from pydantic import ValidationInfo
 
 from albumentations.augmentations.geometric.functional import scale
 from albumentations.augmentations.pixel.functional import convolve
-from albumentations.core.type_definitions import EIGHT, ImageType
+from albumentations.core.type_definitions import EIGHT, ImageFloat32, ImageType, ImageUInt8
 
 __all__ = ["box_blur", "central_zoom", "defocus", "glass_blur", "mode_filter", "zoom_blur"]
+
+
+_PILLOW_FIXED_POINT_BITS = 24
+_PILLOW_FIXED_POINT_SCALE = 1 << _PILLOW_FIXED_POINT_BITS
+_PILLOW_FIXED_POINT_ROUNDING = 1 << (_PILLOW_FIXED_POINT_BITS - 1)
+_PILLOW_FIXED_POINT_SCALE_F32 = np.float32(_PILLOW_FIXED_POINT_SCALE)
+_PILLOW_F32_ONE = np.float32(1.0)
+_PILLOW_F32_TWO = np.float32(2.0)
+_PILLOW_F32_THREE = np.float32(3.0)
+_PILLOW_F32_SIX = np.float32(6.0)
+_PILLOW_F32_TWELVE = np.float32(12.0)
 
 
 @preserve_channel_dim
@@ -391,19 +402,18 @@ def sample_odd_from_range(random_state: random.Random, low: int, high: int) -> i
 
 
 def create_gaussian_kernel(sigma: float, ksize: int = 0) -> np.ndarray:
-    """Create 2D Gaussian kernel (PIL-style). Sigma and ksize (0 = auto). Returns normalized
+    """Create a discrete 2D Gaussian kernel. Sigma and ksize (0 = auto). Returns normalized
     float32 kernel for separable or 2D convolution.
 
     Args:
         sigma (float): Standard deviation for Gaussian kernel.
-        ksize (int): Kernel size. If 0, size is computed as int(sigma * 3.5) * 2 + 1
-               to match PIL's implementation. Otherwise, must be positive and odd.
+        ksize (int): Kernel size. If 0, size is computed as int(sigma * 3.5) * 2 + 1.
+            Otherwise, must be positive and odd.
 
     Returns:
         np.ndarray: 2D normalized Gaussian kernel.
 
     """
-    # PIL's kernel creation approach
     size = int(sigma * 3.5) * 2 + 1 if ksize == 0 else ksize
 
     # Ensure odd size
@@ -421,19 +431,18 @@ def create_gaussian_kernel(sigma: float, ksize: int = 0) -> np.ndarray:
 
 
 def create_gaussian_kernel_1d(sigma: float, ksize: int = 0) -> np.ndarray:
-    """Create 1D Gaussian kernel (PIL-style). Sigma and ksize (0 = auto). For separable
+    """Create a discrete 1D Gaussian kernel. Sigma and ksize (0 = auto). For separable
     Gaussian blur; returns normalized float32 1D array.
 
     Args:
         sigma (float): Standard deviation for Gaussian kernel.
-        ksize (int): Kernel size. If 0, size is computed as int(sigma * 3.5) * 2 + 1
-               to match PIL's implementation. Otherwise, must be positive and odd.
+        ksize (int): Kernel size. If 0, size is computed as int(sigma * 3.5) * 2 + 1.
+            Otherwise, must be positive and odd.
 
     Returns:
         np.ndarray: 1D normalized Gaussian kernel.
 
     """
-    # PIL's kernel creation approach
     size = int(sigma * 3.5) * 2 + 1 if ksize == 0 else ksize
 
     # Ensure odd size
@@ -451,6 +460,142 @@ def create_gaussian_kernel_1d(sigma: float, ksize: int = 0) -> np.ndarray:
     x_f32 = x.astype(np.float32)
     kernel_1d = np.exp(np.float32(-0.5) * (x_f32 / np.float32(sigma)) ** 2)
     return (kernel_1d / reduce_sum(kernel_1d)).astype(np.float32)
+
+
+def create_pillow_gaussian_kernel(sigma: float) -> np.ndarray:
+    """Build the fixed-point extended-box kernel that Pillow uses to approximate Gaussian
+    blur, including fractional edge weights for exact uint8 rounding.
+
+    Args:
+        sigma (float): Standard deviation of the target Gaussian.
+
+    Returns:
+        np.ndarray: One-dimensional uint32 kernel in Pillow's 24-bit fixed-point scale.
+
+    """
+    sigma_f32 = np.float32(sigma)
+    variance = sigma_f32 * sigma_f32 / _PILLOW_F32_THREE
+    box_length = np.sqrt(_PILLOW_F32_TWELVE * variance + _PILLOW_F32_ONE)
+    integer_radius = np.floor((box_length - _PILLOW_F32_ONE) / _PILLOW_F32_TWO)
+    radius_plus_one = integer_radius + _PILLOW_F32_ONE
+    box_width = _PILLOW_F32_TWO * integer_radius + _PILLOW_F32_ONE
+    fractional_radius = box_width * (integer_radius * radius_plus_one - _PILLOW_F32_THREE * variance)
+    fractional_radius /= _PILLOW_F32_SIX * (variance - radius_plus_one * radius_plus_one)
+    box_radius = integer_radius + fractional_radius
+
+    radius = int(box_radius)
+    whole_weight = int(_PILLOW_FIXED_POINT_SCALE_F32 / (_PILLOW_F32_TWO * box_radius + _PILLOW_F32_ONE))
+    far_weight = (_PILLOW_FIXED_POINT_SCALE - (radius * 2 + 1) * whole_weight) // 2
+    kernel = np.full(radius * 2 + 3, whole_weight, dtype=np.uint32)
+    kernel[0] = far_weight
+    kernel[-1] = far_weight
+    return kernel
+
+
+def _set_far_pixel_sums(img: ImageUInt8, far_pixel_sums: np.ndarray, axis: int, distance: int) -> None:
+    source = np.moveaxis(img, axis, 0)
+    destination = np.moveaxis(far_pixel_sums, axis, 0)
+    length = source.shape[0]
+    edge_length = min(distance, length)
+
+    np.copyto(destination[:edge_length], source[:1], casting="unsafe")
+    if edge_length < length:
+        np.copyto(destination[edge_length:], source[:-edge_length], casting="unsafe")
+        np.add(destination[:-edge_length], source[edge_length:], out=destination[:-edge_length])
+    np.add(destination[-edge_length:], source[-1:], out=destination[-edge_length:])
+
+
+def _pillow_gaussian_blur_uint8(
+    img: ImageUInt8,
+    radius: int,
+    whole_weight: int,
+    far_weight: int,
+) -> ImageUInt8:
+    result = np.array(img, copy=True, order="C")
+    output = np.empty_like(result)
+    weighted_sum_i32 = np.empty(result.shape, dtype=np.int32)
+    far_pixel_sums = np.empty(result.shape, dtype=np.uint32)
+    distance = radius + 1
+
+    for axis in (1, 1, 1, 0, 0, 0):
+        kernel_size = (radius * 2 + 1, 1) if axis == 1 else (1, radius * 2 + 1)
+        cv2.boxFilter(
+            result,
+            ddepth=cv2.CV_32S,
+            ksize=kernel_size,
+            dst=weighted_sum_i32,
+            normalize=False,
+            borderType=cv2.BORDER_REPLICATE,
+        )
+        weighted_sum = weighted_sum_i32.view(np.uint32)
+        np.multiply(weighted_sum, np.uint32(whole_weight), out=weighted_sum)
+        _set_far_pixel_sums(result, far_pixel_sums, axis, distance)
+        np.multiply(far_pixel_sums, np.uint32(far_weight), out=far_pixel_sums)
+        np.add(weighted_sum, far_pixel_sums, out=weighted_sum)
+        np.add(weighted_sum, np.uint32(_PILLOW_FIXED_POINT_ROUNDING), out=weighted_sum)
+        np.right_shift(weighted_sum, _PILLOW_FIXED_POINT_BITS, out=weighted_sum)
+        np.copyto(output, weighted_sum, casting="unsafe")
+        result, output = output, result
+
+    return result
+
+
+def _pillow_gaussian_blur_float32(
+    img: ImageFloat32,
+    radius: int,
+    whole_weight: int,
+    far_weight: int,
+) -> ImageFloat32:
+    kernel = np.full(radius * 2 + 3, np.float32(whole_weight / _PILLOW_FIXED_POINT_SCALE), dtype=np.float32)
+    kernel[[0, -1]] = np.float32(far_weight / _PILLOW_FIXED_POINT_SCALE)
+    identity = np.ones(1, dtype=np.float32)
+    result = np.array(img, copy=True, order="C")
+    output = np.empty_like(result)
+
+    for kernel_x, kernel_y in (
+        (kernel, identity),
+        (kernel, identity),
+        (kernel, identity),
+        (identity, kernel),
+        (identity, kernel),
+        (identity, kernel),
+    ):
+        cv2.sepFilter2D(
+            result,
+            ddepth=-1,
+            kernelX=kernel_x,
+            kernelY=kernel_y,
+            dst=output,
+            borderType=cv2.BORDER_REPLICATE,
+        )
+        result, output = output, result
+
+    return result
+
+
+@preserve_channel_dim
+def pillow_gaussian_blur(img: ImageType, kernel: np.ndarray) -> ImageType:
+    """Blur an image with Pillow's three-pass extended-box Gaussian approximation, reproducing
+    uint8 rounding without importing Pillow at runtime.
+
+    Float32 inputs use the same normalized kernel and replicated borders without uint8 quantization.
+
+    Args:
+        img (ImageType): Input image.
+        kernel (np.ndarray): Fixed-point extended-box kernel from `create_pillow_gaussian_kernel`.
+
+    Returns:
+        ImageType: Blurred image with the input shape and dtype.
+
+    """
+    radius = (kernel.size - 3) // 2
+    whole_weight = int(kernel[1])
+    far_weight = int(kernel[0])
+    if whole_weight == _PILLOW_FIXED_POINT_SCALE and far_weight == 0:
+        return cast("ImageType", np.array(img, copy=True, order="C"))
+    if img.dtype == np.uint8:
+        return _pillow_gaussian_blur_uint8(cast("ImageUInt8", img), radius, whole_weight, far_weight)
+    return _pillow_gaussian_blur_float32(cast("ImageFloat32", img), radius, whole_weight, far_weight)
 
 
 def create_gaussian_kernel_input_array(size: int) -> np.ndarray:

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -656,8 +656,8 @@ class ModeFilter(ImageOnlyTransform):
 
 
 class GaussianBlur(ImageOnlyTransform):
-    """Smooth the image with a Gaussian kernel (weighted average; reduces noise and fine
-    detail). Kernel size and sigma are sampled randomly per call.
+    """Smooth an image with Gaussian blur to reduce noise and fine detail. Blur strength and
+    size are sampled independently on every call.
 
     This transform blurs the input image using a Gaussian filter with a random kernel size
     and sigma value. Gaussian blur is a widely used image processing technique that reduces
@@ -669,9 +669,9 @@ class GaussianBlur(ImageOnlyTransform):
             Default: (0.5, 3.0)
 
         blur_range (tuple[int, int]): Inclusive range of the Gaussian kernel size.
-            Both ends must be 0 or odd and >= 0. If set to (0, 0) (default), the kernel size
-            is computed from sigma as `int(sigma * 3.5) * 2 + 1` to exactly match PIL's
-            implementation.
+            Both ends must be 0 or odd and >= 0. The default `(0, 0)` uses Pillow's
+            three-pass extended-box approximation. Positive values use a discrete Gaussian
+            kernel with the sampled size.
             Default: (0, 0)
 
         p (float): Probability of applying the transform. Default: 0.5
@@ -686,13 +686,11 @@ class GaussianBlur(ImageOnlyTransform):
         Any
 
     Note:
-        - When blur_range=(0, 0) (default), this implementation exactly matches PIL's
-          GaussianBlur behavior:
-          * Kernel size is computed as int(sigma * 3.5) * 2 + 1
-          * Gaussian values are computed using the standard formula
-          * Kernel is normalized to preserve image luminance
-        - When blur_range has positive values, the kernel size is randomly sampled from
-          that range regardless of sigma, which might result in inconsistent blur effects.
+        - For uint8 images, `blur_range=(0, 0)` matches Pillow's `GaussianBlur` pixel for
+          pixel, including its fixed-point rounding and replicated border handling.
+        - Float32 images use the same extended-box approximation without uint8 quantization.
+        - Positive `blur_range` values select a discrete Gaussian kernel independently of
+          sigma, so some size and sigma combinations can truncate the blur substantially.
         - The default sigma range (0.5, 3.0) provides a good balance between subtle
           and strong blur effects:
           * sigma=0.5 results in a subtle blur
@@ -710,7 +708,7 @@ class GaussianBlur(ImageOnlyTransform):
         >>> cv2.circle(image, (150, 150), 30, (0, 255, 0), -1)  # Green circle
         >>> cv2.putText(image, "Sample Text", (50, 50), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
         >>>
-        >>> # Example 1: Default Gaussian blur (automatic kernel size)
+        >>> # Example 1: Default Pillow-compatible Gaussian blur
         >>> default_blur = A.Compose([
         ...     A.GaussianBlur(p=1.0)  # Using default parameters
         ... ])
@@ -723,7 +721,7 @@ class GaussianBlur(ImageOnlyTransform):
         >>> light_blur = A.Compose([
         ...     A.GaussianBlur(
         ...         sigma_range=(0.2, 0.5),  # Small sigma for subtle blur
-        ...         blur_range=(0, 0),       # Auto-compute kernel size
+        ...         blur_range=(0, 0),       # Use Pillow-compatible automatic blur
         ...         p=1.0
         ...     )
         ... ])
@@ -736,7 +734,7 @@ class GaussianBlur(ImageOnlyTransform):
         >>> strong_blur = A.Compose([
         ...     A.GaussianBlur(
         ...         sigma_range=(3.0, 7.0),  # Larger sigma for stronger blur
-        ...         blur_range=(0, 0),       # Auto-compute kernel size
+        ...         blur_range=(0, 0),       # Use Pillow-compatible automatic blur
         ...         p=1.0
         ...     )
         ... ])
@@ -816,13 +814,17 @@ class GaussianBlur(ImageOnlyTransform):
         kernel: np.ndarray,
         **params: Any,
     ) -> ImageType:
+        if params.get("pillow_mode", False):
+            return fblur.pillow_gaussian_blur(img, kernel)
         return fpixel.separable_convolve(img, kernel=kernel)
 
-    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, np.ndarray]:
+    def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         sigma = self.py_random.uniform(*self.sigma_range)
         ksize = self.py_random.randint(*self.blur_range)
         self.applied_config = {"sigma_range": sigma, "blur_range": ksize}
-        return {"kernel": fblur.create_gaussian_kernel_1d(sigma, ksize)}
+        if ksize == 0:
+            return {"kernel": fblur.create_pillow_gaussian_kernel(sigma), "pillow_mode": True}
+        return {"kernel": fblur.create_gaussian_kernel_1d(sigma, ksize), "pillow_mode": False}
 
 
 class GlassBlur(ImageOnlyTransform):

--- a/tests/functional/test_blur.py
+++ b/tests/functional/test_blur.py
@@ -43,12 +43,12 @@ def test_sample_odd_from_range(low: int, high: int, expected_range: set[int]):
     assert results == expected_range, f"Failed for low={low}, high={high}"
 
 
-def create_pil_kernel(radius):
-    """Helper function to extract PIL's Gaussian kernel for comparison"""
-    size = int(radius * 3.5) * 2 + 1
+def create_reference_gaussian_kernel(sigma: float) -> np.ndarray:
+    """Build the discrete Gaussian kernel used to check the functional helper."""
+    size = int(sigma * 3.5) * 2 + 1
     kernel = []
-    sigma2 = radius * radius
-    scale = 1.0 / (radius * np.sqrt(2.0 * np.pi))
+    sigma2 = sigma * sigma
+    scale = 1.0 / (sigma * np.sqrt(2.0 * np.pi))
 
     for i in range(-size // 2 + 1, size // 2 + 1):
         x = i * 1.0
@@ -111,11 +111,11 @@ def test_kernel_symmetry(sigma):
 
 
 @pytest.mark.parametrize("sigma", [0.5, 1.0, 2.0, 3.0])
-def test_matches_pil_kernel(sigma):
-    """Test that our kernel matches PIL's kernel"""
+def test_matches_reference_gaussian_kernel(sigma):
+    """Test that the functional helper matches the reference Gaussian formula."""
     our_kernel = fblur.create_gaussian_kernel(sigma, 0)
-    pil_kernel = create_pil_kernel(sigma)
-    np.testing.assert_allclose(our_kernel, pil_kernel, rtol=1e-5)
+    reference_kernel = create_reference_gaussian_kernel(sigma)
+    np.testing.assert_allclose(our_kernel, reference_kernel, rtol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -148,13 +148,12 @@ def test_1d_kernel_peak_values(sigma, ksize, expected_max_value):
     assert np.abs(kernel.max() - expected_max_value) < 0.01
 
 
-def test_kernel_visual_comparison():
-    """Visual test to compare kernels (useful for debugging)"""
+def test_gaussian_kernel_matches_reference():
     sigma = 2.0
     our_kernel = fblur.create_gaussian_kernel(sigma, 0)
-    pil_kernel = create_pil_kernel(sigma)
+    reference_kernel = create_reference_gaussian_kernel(sigma)
 
-    np.testing.assert_allclose(our_kernel, pil_kernel, rtol=1e-5)
+    np.testing.assert_allclose(our_kernel, reference_kernel, rtol=1e-5)
 
 
 @pytest.mark.parametrize("ksize", [3, 5, 7, 11, 15])

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -1,13 +1,13 @@
 import warnings
 from typing import Any
 
-import cv2
 import numpy as np
 import pytest
 from PIL import Image, ImageFilter
 
 import albumentations as A
 from albumentations.augmentations.blur import functional as fblur
+from albumentations.augmentations.pixel import functional as fpixel
 from albumentations.core.transforms_interface import BasicTransform
 from tests.conftest import UINT8_IMAGES
 
@@ -186,58 +186,71 @@ def test_process_blur_range_rejects_scalar(scalar: Any) -> None:
         fblur.process_blur_range(scalar, info, min_value=0)
 
 
-def compute_sharpness(image: np.ndarray) -> float:
-    kernel = np.array(
+def apply_pillow_gaussian_blur(image: np.ndarray, radius: float) -> np.ndarray:
+    """Apply Pillow's GaussianBlur to every supported channel layout."""
+    if image.shape[-1] == 1:
+        result = np.array(Image.fromarray(image[..., 0]).filter(ImageFilter.GaussianBlur(radius=radius)))
+        return result[..., None]
+    if image.shape[-1] in {3, 4}:
+        return np.array(Image.fromarray(image).filter(ImageFilter.GaussianBlur(radius=radius)))
+
+    return np.stack(
         [
-            [-1, -1, -1],
-            [-1, 8, -1],
-            [-1, -1, -1],
+            np.array(Image.fromarray(image[..., channel]).filter(ImageFilter.GaussianBlur(radius=radius)))
+            for channel in range(image.shape[-1])
         ],
+        axis=-1,
     )
-    edges = cv2.filter2D(image.astype(np.float32), -1, kernel)
-    return np.std(edges)
 
 
-def test_gaussian_blur_matches_pil():
-    # Create a test image with high-frequency details
-    image = np.zeros((100, 100, 1), dtype=np.uint8)
-    image[::10, :] = 255  # horizontal lines
-    image[:, ::10] = 255  # vertical lines
+@pytest.mark.parametrize("radius", [0.0, 0.1, 0.25, 0.5, 0.75, 1.0, 2.0, 3.0])
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
+@pytest.mark.parametrize("image_shape", [(2, 3), (9, 11)])
+def test_gaussian_blur_auto_kernel_matches_pillow(
+    radius: float,
+    num_channels: int,
+    image_shape: tuple[int, int],
+) -> None:
+    rng = np.random.default_rng(137)
+    image = rng.integers(0, 256, (*image_shape, num_channels), dtype=np.uint8)
+    image[0, 0] = 255
+    image[-1, -1] = 0
 
-    # Test points
-    sigmas = np.linspace(0.2, 10, 50)
+    expected = apply_pillow_gaussian_blur(image, radius)
+    transform = A.GaussianBlur(blur_range=(0, 0), sigma_range=(radius, radius), p=1.0)
+    result = transform(image=image)["image"]
 
-    # Get blur progression for PIL
-    pil_sharpness = []
-    alb_sharpness = []
+    np.testing.assert_array_equal(result, expected)
 
-    pil_image = Image.fromarray(image[:, :, 0])
 
-    for sigma in sigmas:
-        sigma_value = float(sigma)
+def test_gaussian_blur_auto_kernel_preserves_float32_contract() -> None:
+    rng = np.random.default_rng(137)
+    image = rng.random((17, 13, 5), dtype=np.float32)
+    transform = A.GaussianBlur(blur_range=(0, 0), sigma_range=(0.75, 0.75), p=1.0)
 
-        # PIL blur
-        pil_blurred = pil_image.filter(ImageFilter.GaussianBlur(radius=sigma_value))
-        pil_sharpness.append(compute_sharpness(np.array(pil_blurred)))
+    result = transform(image=image)["image"]
 
-        # Albumentations blur
-        alb_blurred = A.GaussianBlur(blur_range=(0, 0), sigma_range=(sigma_value, sigma_value), p=1.0)(image=image)[
-            "image"
-        ]
-        alb_sharpness.append(compute_sharpness(alb_blurred))
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype
+    assert result.min() >= 0
+    assert result.max() <= 1
 
-    # Convert to numpy arrays for easier comparison
-    pil_sharpness = np.array(pil_sharpness)
-    alb_sharpness = np.array(alb_sharpness)
 
-    # Compare curves directly using absolute differences
-    abs_diff = np.abs(pil_sharpness - alb_sharpness)
-    mean_diff = np.mean(abs_diff)
-    max_diff = np.max(abs_diff)
+def test_gaussian_blur_explicit_kernel_uses_discrete_gaussian() -> None:
+    rng = np.random.default_rng(137)
+    image = rng.integers(0, 256, (17, 13, 3), dtype=np.uint8)
+    sigma = 1.25
+    kernel_size = 5
+    expected = fpixel.separable_convolve(image, fblur.create_gaussian_kernel_1d(sigma, kernel_size))
+    transform = A.GaussianBlur(
+        blur_range=(kernel_size, kernel_size),
+        sigma_range=(sigma, sigma),
+        p=1.0,
+    )
 
-    # Assert reasonable absolute differences
-    assert mean_diff < 10, f"Average absolute difference too high: {mean_diff:.2f}"
-    assert max_diff < 83, f"Maximum absolute difference too high: {max_diff:.2f}"
+    result = transform(image=image)["image"]
+
+    np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])


### PR DESCRIPTION
## Summary

- implement Pillow's three-pass extended-box approximation for `GaussianBlur(blur_range=(0, 0))`
- reproduce Pillow's 24-bit fixed-point rounding and replicated borders for uint8 images
- keep explicit positive kernel sizes on the existing discrete Gaussian path
- add pixel-exact coverage for multiple radii, image sizes, borders, and 1/3/5-channel images
- optimize automatic-kernel construction from about 4.39 µs to 1.68 µs
- replace multiple fixed-point NumPy array passes with an exact buffered OpenCV filter path

## Root cause

Automatic mode used a single truncated discrete Gaussian convolution while documenting exact Pillow compatibility. Pillow instead applies three extended-box passes per axis, with fixed-point weights, per-pass uint8 rounding, and replicated borders.

## Compatibility and performance

Automatic uint8 output intentionally changes to match Pillow exactly. Float32 uses the same extended-box approximation without uint8 quantization. Explicit positive `blur_range` behavior is unchanged, and replay data without the new mode flag remains compatible.

The required 256/512/1024 × 1/3/5-channel matrix was measured for both uint8 and float32, as isolated functions and through Compose, at sigma 2. After optimizing the exact path:

- uint8 isolated: 3.56–4.00× slower than the previous incorrect algorithm (median 3.80×)
- uint8 Compose: 3.46–3.82× slower (median 3.68×)
- float32 isolated: 0.98–1.59× slower (median 1.23×)
- float32 Compose: 1.02–1.62× slower (median 1.20×)
- compared with the first PR implementation, the optimized uint8 path is 1.25–1.51× faster

Exact Pillow semantics still require six rounded 1D passes. The remaining regression is the cost of those semantics rather than transform dispatch or kernel construction. Performance-sensitive callers can select an explicit positive `blur_range` to retain the discrete Gaussian path. The implementation has no Pillow runtime dependency.

The full matrix and rejected backend candidates are recorded in the resolved review thread.

## Validation

- issue reproducer: Pillow center 249, AlbumentationsX center 249, maximum pixel difference 0
- focused blur tests: 207 passed
- `uv run pytest -m "not slow"`: 11,522 passed, 42 skipped, 38 deselected
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`

Fixes #360

## Summary by Sourcery

Align GaussianBlur automatic mode with Pillow’s GaussianBlur behavior while preserving explicit kernel behavior and updating documentation accordingly.

New Features:
- Add Pillow-compatible Gaussian blur path using a three-pass extended-box approximation for automatic blur_range=(0, 0).

Bug Fixes:
- Ensure uint8 GaussianBlur output matches Pillow pixel-wise, including fixed-point rounding and replicated border handling.
- Preserve float32 GaussianBlur behavior while using the same extended-box approximation without uint8 quantization.
- Keep explicit positive blur_range values on the discrete Gaussian path to avoid altering existing behavior.

Enhancements:
- Introduce optimized construction of automatic Gaussian kernels via a fixed-point extended-box representation.
- Refine GaussianBlur docs and examples to clearly describe Pillow-compatible automatic mode and discrete kernel mode semantics.

Tests:
- Replace heuristic GaussianBlur/Pillow comparison with pixel-exact coverage across radii, image sizes, borders, and channel counts.
- Add tests ensuring float32 automatic mode respects value range contracts and explicit kernels use the discrete Gaussian implementation.