### PR TITLE
chore(release): bump version to 2.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.3.5"
+version = "2.3.6"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volumes, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.3.5"
+version = "2.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## Summary

- Bump the AlbumentationsX package version from 2.3.5 to 2.3.6 in `pyproject.toml`.
- Keep the local project entry in `uv.lock` synchronized.

This prepares the 2.3.6 release so built distributions report the new version.

## Validation

- `uv run python tools/quality_gate.py fast` (259 contract tests passed, plus repository quality checks)
- `pre-commit run --files pyproject.toml uv.lock`
- Built the wheel and source distribution with `uv build`
- Verified the source tree and both built artifacts with `tools/verify_legal_integrity.py`
- Confirmed the wheel metadata reports `Version: 2.3.6`

## Summary by Sourcery

Build:
- Bump AlbumentationsX project version from 2.3.5 to 2.3.6 in pyproject configuration and align lockfile metadata.