### PR TITLE
Add explicit output clipping to Normalize

### DIFF
--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -92,11 +92,12 @@ class Normalize(ImageOnlyTransform):
     Note:
         - For "standard" normalization, `mean`, `std`, and `max_pixel_value` must be provided.
         - For other normalization types, these parameters are ignored.
-        - `normalization="min_max"` and `normalization="min_max_per_channel"` compute extrema from each input.
-          For fixed dataset bounds and [0, 1] output, use standard normalization with `mean=minimums`,
-          `std=maximums - minimums`, `max_pixel_value=1.0`, and `clip_range=(0.0, 1.0)`.
-        - For fixed dataset bounds and [-1, 1] output, use `mean=(minimums + maximums) / 2`,
-          `std=(maximums - minimums) / 2`, `max_pixel_value=1.0`, and `clip_range=(-1.0, 1.0)`.
+        - `normalization="min_max"` and `normalization="min_max_per_channel"` calculate bounds from the current input.
+          Keep `normalization="standard"` when using fixed bounds calculated from the whole dataset.
+        - For [0, 1] output, set `mean` to each channel's dataset minimum and `std` to that channel's range
+          (dataset maximum minus minimum). Set `max_pixel_value=1.0` and `clip_range=(0.0, 1.0)`.
+        - For [-1, 1] output, set `mean` to the midpoint between each channel's dataset minimum and maximum and
+          `std` to half of that range. Set `max_pixel_value=1.0` and `clip_range=(-1.0, 1.0)`.
         - For inception normalization, use mean values of (0.5, 0.5, 0.5).
         - For YOLO normalization, use mean values of (0, 0, 0) and std values of (1, 1, 1).
         - This transform is often used as a final step in image preprocessing pipelines to

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -50,18 +50,19 @@ __all__ = [
 
 
 class Normalize(ImageOnlyTransform):
-    """Applies various normalization techniques to an image. The specific normalization technique can be selected
-        with the `normalization` parameter.
+    """Normalize image intensities with fixed statistics or values computed from each image, with optional clipping
+    for bounded model inputs.
 
     Standard normalization is applied using the formula:
         `img = (img - mean * max_pixel_value) / (std * max_pixel_value)`.
         Other normalization techniques adjust the image based on global or per-channel statistics,
         or scale pixel values to a specified range.
+        If `clip_range` is provided, the transform clips the normalized float32 output to those bounds.
 
     Args:
-        mean (tuple[float, float] | float | None): Mean values for standard normalization.
+        mean (tuple[float, ...] | float | None): Mean values for standard normalization.
             For "standard" normalization, the default values are ImageNet mean values: (0.485, 0.456, 0.406).
-        std (tuple[float, float] | float | None): Standard deviation values for standard normalization.
+        std (tuple[float, ...] | float | None): Standard deviation values for standard normalization.
             For "standard" normalization, the default values are ImageNet standard deviation :(0.229, 0.224, 0.225).
         max_pixel_value (float | None): Maximum possible pixel value, used for scaling in standard normalization.
             Defaults to 255.0.
@@ -77,6 +78,9 @@ class Normalize(ImageOnlyTransform):
             - "min_max_per_channel": Scales each channel of the image pixel values to a [0, 1]
                 range based on the per-channel minimum and maximum pixel values.
 
+        clip_range (tuple[float, float] | None): Lower and upper bounds for the normalized output. The transform
+            clips after applying the selected normalization method. `None` leaves the normalized values unchanged.
+            Defaults to `None`.
         p (float): Probability of applying the transform. Defaults to 1.0.
 
     Targets:
@@ -88,6 +92,11 @@ class Normalize(ImageOnlyTransform):
     Note:
         - For "standard" normalization, `mean`, `std`, and `max_pixel_value` must be provided.
         - For other normalization types, these parameters are ignored.
+        - `normalization="min_max"` and `normalization="min_max_per_channel"` compute extrema from each input.
+          For fixed dataset bounds and [0, 1] output, use standard normalization with `mean=minimums`,
+          `std=maximums - minimums`, `max_pixel_value=1.0`, and `clip_range=(0.0, 1.0)`.
+        - For fixed dataset bounds and [-1, 1] output, use `mean=(minimums + maximums) / 2`,
+          `std=(maximums - minimums) / 2`, `max_pixel_value=1.0`, and `clip_range=(-1.0, 1.0)`.
         - For inception normalization, use mean values of (0.5, 0.5, 0.5).
         - For YOLO normalization, use mean values of (0, 0, 0) and std values of (1, 1, 1).
         - This transform is often used as a final step in image preprocessing pipelines to
@@ -106,7 +115,20 @@ class Normalize(ImageOnlyTransform):
         ... )
         >>> normalized_image = transform(image=image)["image"]
         >>>
-        >>> # Min-max normalization
+        >>> # Fixed dataset-level min-max normalization with clipping
+        >>> dataset_min = (0.1, 0.2, 0.3)
+        >>> dataset_max = (0.8, 0.9, 1.0)
+        >>> dataset_range = tuple(maximum - minimum for minimum, maximum in zip(dataset_min, dataset_max))
+        >>> transform_fixed_minmax = A.Normalize(
+        ...     mean=dataset_min,
+        ...     std=dataset_range,
+        ...     max_pixel_value=1.0,
+        ...     clip_range=(0.0, 1.0),
+        ...     p=1.0,
+        ... )
+        >>> normalized_image_fixed = transform_fixed_minmax(image=image.astype(np.float32) / 255.0)["image"]
+        >>>
+        >>> # Per-image min-max normalization derives new extrema from this image
         >>> transform_minmax = A.Normalize(normalization="min_max", p=1.0)
         >>> normalized_image_minmax = transform_minmax(image=image)["image"]
 
@@ -127,6 +149,14 @@ class Normalize(ImageOnlyTransform):
             "min_max",
             "min_max_per_channel",
         ]
+        clip_range: Annotated[tuple[float, float], AfterValidator(nondecreasing)] | None
+
+        @field_validator("clip_range")
+        @classmethod
+        def _validate_clip_range(cls, value: tuple[float, float] | None) -> tuple[float, float] | None:
+            if value is not None and not np.isfinite(value).all():
+                raise ValueError(f"clip_range bounds must be finite. Got {value}")
+            return value
 
         @model_validator(mode="after")
         def _validate_normalization(self) -> Self:
@@ -153,6 +183,8 @@ class Normalize(ImageOnlyTransform):
             "min_max_per_channel",
         ] = "standard",
         p: float = 1.0,
+        *,
+        clip_range: tuple[float, float] | None = None,
     ):
         super().__init__(p=p)
         self.mean = mean
@@ -167,15 +199,23 @@ class Normalize(ImageOnlyTransform):
             self.denominator = np.array([], dtype=np.float32)
         self.max_pixel_value = max_pixel_value
         self.normalization = normalization
+        self.clip_range = clip_range
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if self.normalization == "standard":
-            return normalize(
+            normalized = normalize(
                 img,
                 self.mean_np,
                 self.denominator,
             )
-        return normalize_per_image(img, self.normalization)
+        else:
+            normalized = normalize_per_image(img, self.normalization)
+
+        if self.clip_range is None:
+            return normalized
+        if normalized is img:
+            return np.clip(normalized, *self.clip_range)
+        return np.clip(normalized, *self.clip_range, out=normalized)
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self.apply(images, **params)

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -906,6 +906,7 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
         {"allow_shifted": False, "angle_range": (30, 60), "direction_range": (-0.5, 0.5)},
     ),
     ("per-image", A.Normalize, {"normalization": "image"}),
+    ("clipped-output", A.Normalize, {"clip_range": (-1.0, 1.0)}),
     (
         "fisheye-direct",
         A.OpticalDistortion,

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,143 @@
+import json
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import albumentations as A
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("clip_range", [(0.0, 1.0), (-1.0, 1.0)])
+@pytest.mark.parametrize(
+    ("mean", "std"),
+    [
+        (60.0, 20.0),
+        ((20.0, 40.0, 60.0, 80.0, 100.0), (5.0, 10.0, 15.0, 20.0, 25.0)),
+    ],
+    ids=["scalar-statistics", "per-channel-statistics"],
+)
+def test_normalize_standard_clips_output(
+    dtype: type[np.generic],
+    clip_range: tuple[float, float],
+    mean: float | tuple[float, ...],
+    std: float | tuple[float, ...],
+) -> None:
+    coefficients = np.array([-2.0, -0.5, 0.0, 0.5, 2.0], dtype=np.float32).reshape(-1, 1, 1)
+    mean_array = np.asarray(mean, dtype=np.float32)
+    std_array = np.asarray(std, dtype=np.float32)
+    image = np.broadcast_to(mean_array + coefficients * std_array, (5, 1, 5)).astype(dtype).copy()
+    original = image.copy()
+
+    result = A.Compose(
+        [
+            A.Normalize(
+                mean=mean,
+                std=std,
+                max_pixel_value=1.0,
+                clip_range=clip_range,
+                p=1.0,
+            ),
+        ],
+    )(image=image)["image"]
+
+    expected = (image.astype(np.float32) - mean_array) / std_array
+    np.clip(expected, *clip_range, out=expected)
+
+    assert result.dtype == np.float32
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(image, original)
+
+
+@pytest.mark.parametrize(
+    ("target_name", "shape"),
+    [
+        ("image", (2, 3, 2)),
+        ("images", (2, 2, 3, 2)),
+        ("volume", (2, 2, 3, 2)),
+        ("volumes", (2, 2, 2, 3, 2)),
+    ],
+)
+def test_normalize_clip_range_applies_to_all_image_targets(target_name: str, shape: tuple[int, ...]) -> None:
+    data = np.linspace(-2.0, 2.0, num=np.prod(shape), dtype=np.float32).reshape(shape)
+    original = data.copy()
+    transform = A.Compose(
+        [A.Normalize(mean=0.0, std=1.0, max_pixel_value=1.0, clip_range=(-0.5, 0.75), p=1.0)],
+    )
+
+    result = transform(**{target_name: data})[target_name]
+
+    np.testing.assert_array_equal(result, np.clip(original, -0.5, 0.75))
+    np.testing.assert_array_equal(data, original)
+
+
+@pytest.mark.parametrize("normalization", ["image", "image_per_channel", "min_max", "min_max_per_channel"])
+def test_normalize_clip_range_applies_after_per_image_normalization(normalization: str) -> None:
+    image = np.array(
+        [
+            [[0, 10, 100], [1, 30, 80], [2, 50, 60]],
+            [[3, 70, 40], [4, 90, 20], [5, 110, 0]],
+        ],
+        dtype=np.float32,
+    )
+    baseline = A.Compose([A.Normalize(normalization=normalization, p=1.0)])(image=image)["image"]
+
+    result = A.Compose([A.Normalize(normalization=normalization, clip_range=(0.25, 0.75), p=1.0)])(
+        image=image,
+    )["image"]
+
+    np.testing.assert_array_equal(result, np.clip(baseline, 0.25, 0.75))
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_normalize_explicit_none_preserves_existing_output(dtype: type[np.generic]) -> None:
+    rng = np.random.default_rng(137)
+    if dtype == np.uint8:
+        image = rng.integers(0, 256, (16, 12, 5), dtype=dtype)
+    else:
+        image = rng.random((16, 12, 5), dtype=np.float32)
+    kwargs = {
+        "mean": (0.1, 0.2, 0.3, 0.4, 0.5),
+        "std": (0.2, 0.3, 0.4, 0.5, 0.6),
+        "max_pixel_value": 1.0,
+        "p": 1.0,
+    }
+
+    expected = A.Compose([A.Normalize(**kwargs)])(image=image)["image"]
+    result = A.Compose([A.Normalize(**kwargs, clip_range=None)])(image=image)["image"]
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_normalize_clip_range_serialization_round_trip() -> None:
+    image = np.array([[[-2.0], [0.5], [3.0]]], dtype=np.float32)
+    transform = A.Normalize(
+        mean=0.0,
+        std=1.0,
+        max_pixel_value=1.0,
+        clip_range=(-1.0, 1.0),
+        p=1.0,
+    )
+    serialized = json.loads(json.dumps(A.to_dict(transform), allow_nan=False))
+
+    restored = A.from_dict(serialized)
+
+    assert restored.clip_range == (-1.0, 1.0)
+    np.testing.assert_array_equal(restored(image=image)["image"], transform(image=image)["image"])
+
+
+@pytest.mark.parametrize(
+    "clip_range",
+    [
+        (1.0, 0.0),
+        (0.0,),
+        (0.0, 0.5, 1.0),
+        (np.nan, 1.0),
+        (0.0, np.inf),
+        (-np.inf, 1.0),
+        ("low", "high"),
+    ],
+)
+def test_normalize_rejects_invalid_clip_range(clip_range: tuple[object, ...]) -> None:
+    with pytest.raises(ValueError):
+        A.Normalize(clip_range=cast("Any", clip_range))


### PR DESCRIPTION
## Summary

- add a keyword-only `clip_range` argument to `Normalize`
- validate that clipping bounds are finite and ordered
- clip after standard or per-image normalization for images, image batches, volumes, and volume batches
- document fixed dataset min-max scaling separately from per-image min-max modes
- cover high-channel scalar and per-channel statistics, serialization, invalid bounds, and the unchanged `None` path

## Why

`Normalize` already expresses fixed dataset-level min-max scaling through `mean`, `std`, and `max_pixel_value`, but values outside the configured dataset bounds continue through the affine mapping. Scientific and hyperspectral pipelines that require bounded model inputs currently need a custom transform solely for the final clip.

`clip_range=(low, high)` makes that final operation explicit. The default remains `None`, which returns through the existing normalization path without an additional array pass.

## Compatibility and performance

The new argument is keyword-only, so existing positional calls remain valid. Clipping reuses the owned float32 normalization output in place; identity normalization allocates a result before clipping so caller-owned input is not mutated.

The disabled path was benchmarked through direct transform calls and `Compose` for uint8 and float32 inputs at 256, 512, and 1024 pixels with 1, 3, and 5 channels. Stabilized `Compose` medians remained within measurement variance of the legacy implementation. One-pass `np.clip` was about twice as fast as separate minimum and maximum passes and avoids another output-sized allocation when ownership permits reuse.

## Validation

- `uv run pytest -m "not slow"` — 12,648 passed
- `uv run pytest -q tests/contracts tests/test_serialization.py` — 2,578 passed
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`

Closes #364

## Summary by Sourcery

Add optional clipping to Normalize outputs for bounded model inputs while preserving existing behavior when clipping is not configured.

New Features:
- Introduce a keyword-only clip_range argument to Normalize to bound normalized outputs for images, image batches, volumes, and volume batches.

Enhancements:
- Document how to use standard normalization parameters to achieve fixed dataset-level min-max scaling with explicit clipping.
- Support serialization and deserialization of Normalize with clip_range and validate that clipping bounds are finite and nondecreasing.

Tests:
- Add comprehensive tests covering clipping behavior for standard and per-image normalization modes, multiple dtypes and targets, serialization round trip, explicit None behavior, and rejection of invalid clip_range values.