### PR TITLE
chore(release): bump version to 2.3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.3.6"
+version = "2.3.7"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volumes, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.3.6"
+version = "2.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## Summary

- Bump the package version from 2.3.6 to 2.3.7 in `pyproject.toml`.
- Keep the editable project version in `uv.lock` aligned.

## Impact

Built wheels and source distributions now identify the release as 2.3.7. Runtime behavior is unchanged.

## Validation

- `uv run pytest -m "not slow"`: 12,648 passed
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`
- Source and artifact legal-integrity verification
- Fresh wheel and source-distribution build
- `twine check` on both artifacts

## Summary by Sourcery

Build:
- Update pyproject.toml and lockfile metadata to identify the release as version 2.3.7.