### PR TITLE
Vectorize Spatter batch processing

### DIFF
--- a/albumentations/augmentations/geometric/_functional_images.py
+++ b/albumentations/augmentations/geometric/_functional_images.py
@@ -770,7 +770,7 @@ def rot90(img: ImageType, group_element: Literal["e", "r90", "r180", "r270"]) ->
         result = cast("ImageType", cv2.rotate(cv2_input, rotate_code))
         return result[..., None] if num_channels == 1 else result
 
-    return cast("ImageType", np.rot90(img, rot90_count))
+    return np.rot90(img, rot90_count)
 
 
 def rot90_images(images: ImageType, group_element: Literal["e", "r90", "r180", "r270"]) -> ImageType:
@@ -793,7 +793,7 @@ def rot90_images(images: ImageType, group_element: Literal["e", "r90", "r180", "
 
     """
     rot90_count = C4_GROUP_ELEMENT_TO_K[group_element]
-    return cast("ImageType", np.rot90(images, k=rot90_count, axes=(1, 2)))
+    return np.rot90(images, k=rot90_count, axes=(1, 2))
 
 
 @preserve_channel_dim

--- a/albumentations/augmentations/geometric/_functional_images.py
+++ b/albumentations/augmentations/geometric/_functional_images.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from operator import index
-from typing import Literal, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 
 from ._functional_shared import (
     NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS,
@@ -770,7 +770,7 @@ def rot90(img: ImageType, group_element: Literal["e", "r90", "r180", "r270"]) ->
         result = cast("ImageType", cv2.rotate(cv2_input, rotate_code))
         return result[..., None] if num_channels == 1 else result
 
-    return np.rot90(img, rot90_count)
+    return cast("ImageType", cast("Any", np.rot90(img, rot90_count)))
 
 
 def rot90_images(images: ImageType, group_element: Literal["e", "r90", "r180", "r270"]) -> ImageType:
@@ -793,7 +793,7 @@ def rot90_images(images: ImageType, group_element: Literal["e", "r90", "r180", "
 
     """
     rot90_count = C4_GROUP_ELEMENT_TO_K[group_element]
-    return np.rot90(images, k=rot90_count, axes=(1, 2))
+    return cast("ImageType", cast("Any", np.rot90(images, k=rot90_count, axes=(1, 2))))
 
 
 @preserve_channel_dim

--- a/albumentations/augmentations/mixing/domain_adaptation_functional.py
+++ b/albumentations/augmentations/mixing/domain_adaptation_functional.py
@@ -646,5 +646,5 @@ def _match_cumulative_cdf(source: np.ndarray, template: np.ndarray) -> np.ndarra
     src_quantiles = np.cumsum(src_counts) / source.size
     tmpl_quantiles = np.cumsum(tmpl_counts) / template.size
 
-    interp_a_values = np.interp(src_quantiles, tmpl_quantiles, tmpl_values)
+    interp_a_values = cast("np.ndarray", np.interp(src_quantiles, tmpl_quantiles, tmpl_values))
     return interp_a_values[src_lookup].reshape(source.shape).astype(np.uint8)

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -1039,7 +1039,7 @@ def to_gray_max(img: ImageType) -> ImageType:
         any
 
     """
-    return np.max(img, axis=-1)
+    return cast("ImageType", np.max(img, axis=-1))
 
 
 @clipped

--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -110,7 +110,7 @@ def generate_plasma_pattern(
 
     # Recursively apply diamond-square steps
     for noise_scale in noise_scales:
-        plasma_grid = one_diamond_square_step(plasma_grid, noise_scale)
+        plasma_grid = one_diamond_square_step(plasma_grid, cast("float", noise_scale))
 
     return np.clip(
         _normalize_minmax_float32(plasma_grid[: target_shape[0], : target_shape[1]]),

--- a/albumentations/augmentations/pixel/_functional_shared.py
+++ b/albumentations/augmentations/pixel/_functional_shared.py
@@ -42,6 +42,7 @@ from albucore import (
     restore_xhwc_channel,
     std,
     sz_lut,
+    to_float,
     uint8_io,
 )
 
@@ -54,6 +55,7 @@ from albumentations.core.type_definitions import (
     MONO_CHANNEL_DIMENSIONS,
     NUM_MULTI_CHANNEL_DIMENSIONS,
     NUM_RGB_CHANNELS,
+    ImageFloat32,
     ImageType,
     ImageUInt8,
 )
@@ -82,6 +84,7 @@ __all__ = [
     "NUM_RGB_CHANNELS",
     "PCA",
     "Any",
+    "ImageFloat32",
     "ImageType",
     "ImageUInt8",
     "Literal",
@@ -123,6 +126,7 @@ __all__ = [
     "restore_xhwc_channel",
     "std",
     "sz_lut",
+    "to_float",
     "uint8_io",
     "warn",
 ]

--- a/albumentations/augmentations/pixel/_functional_weather.py
+++ b/albumentations/augmentations/pixel/_functional_weather.py
@@ -9,6 +9,7 @@ from ._functional_color import (
 )
 from ._functional_shared import (
     MAX_VALUES_BY_DTYPE,
+    ImageFloat32,
     ImageType,
     ImageUInt8,
     add,
@@ -17,11 +18,13 @@ from ._functional_shared import (
     clipped,
     cv2,
     float32_io,
+    from_float,
     maybe_process_in_chunks,
     non_rgb_error,
     np,
     preserve_channel_dim,
     reduce_sum,
+    to_float,
     uint8_io,
 )
 from ._functional_sharpness import (
@@ -725,6 +728,50 @@ def spatter_mud(img: ImageType, non_mud: np.ndarray, mud: np.ndarray) -> ImageTy
     return add(img * non_mud, mud, inplace=False)
 
 
+def _prepare_spatter_batch(images: ImageType) -> ImageFloat32:
+    return to_float(images) if images.dtype == np.uint8 else cast("ImageFloat32", images.copy(order="C"))
+
+
+def spatter_rain_batch(images: ImageType, rain: np.ndarray) -> ImageType:
+    """Apply a shared rain pattern to an RGB image batch using one vectorized float32 buffer for faster multi-image
+    processing while preserving the original dtype.
+
+    Args:
+        images (ImageType): RGB image batch in `(N, H, W, 3)` format.
+        rain (np.ndarray): Shared rain pattern in `(H, W, 3)` format.
+
+    Returns:
+        ImageType: Rain-spattered batch with the same dtype and shape as the input.
+
+    """
+    input_dtype = images.dtype
+    result = _prepare_spatter_batch(images)
+    np.add(result, rain, out=result)
+    np.clip(result, 0, 1, out=result)
+    return from_float(result, target_dtype=input_dtype) if input_dtype == np.uint8 else result
+
+
+def spatter_mud_batch(images: ImageType, non_mud: np.ndarray, mud: np.ndarray) -> ImageType:
+    """Apply shared mud layers to an RGB image batch using one vectorized float32 buffer for faster multi-image
+    processing while preserving the original dtype.
+
+    Args:
+        images (ImageType): RGB image batch in `(N, H, W, 3)` format.
+        non_mud (np.ndarray): Shared multiplicative background layer in `(H, W, 3)` format.
+        mud (np.ndarray): Shared additive mud layer in `(H, W, 3)` format.
+
+    Returns:
+        ImageType: Mud-spattered batch with the same dtype and shape as the input.
+
+    """
+    input_dtype = images.dtype
+    result = _prepare_spatter_batch(images)
+    np.multiply(result, non_mud, out=result)
+    np.add(result, mud, out=result)
+    np.clip(result, 0, 1, out=result)
+    return from_float(result, target_dtype=input_dtype) if input_dtype == np.uint8 else result
+
+
 def get_rain_params(
     liquid_layer: np.ndarray,
     color: np.ndarray,
@@ -936,5 +983,7 @@ __all__ = [
     "get_mud_params",
     "get_rain_params",
     "spatter_mud",
+    "spatter_mud_batch",
     "spatter_rain",
+    "spatter_rain_batch",
 ]

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -43,6 +43,12 @@ __all__ = [
     "Spatter",
 ]
 
+_SPATTER_BATCH_FALLBACK_WORKING_SET_BYTES = {
+    ("rain", "uint8"): 3 * 1024 * 1024,
+    ("mud", "uint8"): 6 * 1024 * 1024,
+    ("mud", "float32"): 24 * 1024 * 1024,
+}
+
 
 class RandomSnow(ImageOnlyTransform):
     """Add snow overlay via bleach (brightness threshold) or texture (noise-based overlay).
@@ -1351,6 +1357,32 @@ class Spatter(ImageOnlyTransform):
             return fpixel.spatter_rain(img, params["drops"])
 
         return fpixel.spatter_mud(img, params["non_mud"], params["mud"])
+
+    def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
+        if len(images) == 0:
+            return images
+
+        if images.ndim != 4:
+            raise ValueError("This transformation expects 3-channel images")
+
+        non_rgb_error(images)
+        fallback_threshold = _SPATTER_BATCH_FALLBACK_WORKING_SET_BYTES.get((params["mode"], images.dtype.name))
+        working_set = images.size * np.dtype(np.float32).itemsize
+        if fallback_threshold is not None and working_set >= fallback_threshold:
+            return ImageOnlyTransform.apply_to_images(self, images, **params)
+
+        result = images.astype(np.float32, order="C", copy=True)
+        if images.dtype == np.uint8:
+            np.divide(result, 255, out=result)
+
+        if params["mode"] == "rain":
+            np.add(result, params["drops"], out=result)
+        else:
+            np.multiply(result, params["non_mud"], out=result)
+            np.add(result, params["mud"], out=result)
+
+        np.clip(result, 0, 1, out=result)
+        return albucore.from_float(result, target_dtype=images.dtype) if images.dtype == np.uint8 else result
 
     def get_params_dependent_on_data(
         self,

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -1371,18 +1371,10 @@ class Spatter(ImageOnlyTransform):
         if fallback_threshold is not None and working_set >= fallback_threshold:
             return ImageOnlyTransform.apply_to_images(self, images, **params)
 
-        result = images.astype(np.float32, order="C", copy=True)
-        if images.dtype == np.uint8:
-            np.divide(result, 255, out=result)
-
         if params["mode"] == "rain":
-            np.add(result, params["drops"], out=result)
-        else:
-            np.multiply(result, params["non_mud"], out=result)
-            np.add(result, params["mud"], out=result)
+            return fpixel.spatter_rain_batch(images, params["drops"])
 
-        np.clip(result, 0, 1, out=result)
-        return albucore.from_float(result, target_dtype=images.dtype) if images.dtype == np.uint8 else result
+        return fpixel.spatter_mud_batch(images, params["non_mud"], params["mud"])
 
     def get_params_dependent_on_data(
         self,

--- a/benchmark/benchmarks/test_batch_matrix.py
+++ b/benchmark/benchmarks/test_batch_matrix.py
@@ -23,6 +23,8 @@ Factory = Callable[[], object]
 
 BATCH_SIZES = (4, 8)
 VOLUME_BATCH_SIZES = (2, 4)
+SPATTER_BATCH_SIZES = (2, 4, 8, 16)
+SPATTER_SIZES = ("small", "medium", "large")
 
 
 @dataclass(frozen=True)
@@ -44,6 +46,18 @@ IMAGE_BATCH_TRANSFORMS: Mapping[str, BatchSpec] = {
     "normalize": BatchSpec(lambda: albumentations.Normalize(p=1.0)),
     "random_brightness_contrast": BatchSpec(lambda: albumentations.RandomBrightnessContrast(p=1.0)),
     "resize": BatchSpec(lambda: albumentations.Resize(height=128, width=128, p=1.0)),
+    "spatter_mud": BatchSpec(
+        lambda: albumentations.Spatter(mode="mud", p=1.0),
+        channels=(3,),
+        sizes=SPATTER_SIZES,
+        batch_sizes=SPATTER_BATCH_SIZES,
+    ),
+    "spatter_rain": BatchSpec(
+        lambda: albumentations.Spatter(mode="rain", p=1.0),
+        channels=(3,),
+        sizes=SPATTER_SIZES,
+        batch_sizes=SPATTER_BATCH_SIZES,
+    ),
 }
 
 MASK_BATCH_TRANSFORMS: Mapping[str, BatchSpec] = {
@@ -98,6 +112,11 @@ def _cases(transforms: Mapping[str, BatchSpec], target_route: str) -> tuple[str,
 
 
 IMAGE_BATCH_CASES = _cases(IMAGE_BATCH_TRANSFORMS, "images")
+SPATTER_DIRECT_CASES = tuple(
+    case_id.replace("|images|", "|direct_images|", 1)
+    for case_id in IMAGE_BATCH_CASES
+    if case_id.startswith(("spatter_mud|", "spatter_rain|"))
+)
 MASK_BATCH_CASES = _cases(MASK_BATCH_TRANSFORMS, "images_and_masks")
 VOLUME_BATCH_CASES = _cases(VOLUME_BATCH_TRANSFORMS, "volumes_and_masks3d")
 
@@ -142,6 +161,57 @@ class TimeImageBatchMatrix:
 
     def time_transform(self, case_id: str) -> None:
         self.transform(**self.data)
+
+
+class TimeSpatterDirectBatchMatrix:
+    """Benchmark Spatter's direct `apply_to_images` route over the issue #40 matrix."""
+
+    params = (SPATTER_DIRECT_CASES,)
+    param_names = ("case_id",)
+
+    def setup(self, case_id: str) -> None:
+        name, _, size_name, channels, dtype_name, batch_size = _parse_batch_case(case_id)
+        mode = "mud" if name == "spatter_mud" else "rain"
+        self.transform = albumentations.Spatter(mode=mode, p=1.0)
+        self.transform.set_random_seed(137)
+        self.images = _make_image_batch(size_name, channels, dtype_from_name(dtype_name), batch_size)
+        self.transform(image=self.images[0])
+        self.params = self.transform.get_applied_params()
+
+    def time_apply_to_images(self, case_id: str) -> None:
+        self.transform.apply_to_images(self.images, **self.params)
+
+
+class PeakMemorySpatterBatchMatrix:
+    """Measure the largest Spatter batch working set for direct and Compose routes."""
+
+    params = (
+        tuple(
+            f"{route}|{mode}|{dtype_name}"
+            for route in ("direct", "compose")
+            for mode in ("rain", "mud")
+            for dtype_name in DTYPES
+        ),
+    )
+    param_names = ("case_id",)
+
+    def setup(self, case_id: str) -> None:
+        route, mode, dtype_name = case_id.split("|")
+        self.route = route
+        self.images = _make_image_batch("large", 3, dtype_from_name(dtype_name), 16)
+        self.transform = albumentations.Spatter(mode=mode, p=1.0)
+        if route == "compose":
+            self.compose = albumentations.Compose([self.transform], seed=137, strict=True)
+        else:
+            self.transform.set_random_seed(137)
+            self.transform(image=self.images[0])
+            self.params = self.transform.get_applied_params()
+
+    def peakmem_spatter_batch_large_rgb(self, case_id: str) -> None:
+        if self.route == "compose":
+            self.compose(images=self.images)
+        else:
+            self.transform.apply_to_images(self.images, **self.params)
 
 
 class TimeMaskBatchMatrix:

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -5,6 +5,7 @@ from albucore import to_float
 
 import albumentations as A
 from albumentations.augmentations.pixel import functional as fpixel
+from albumentations.core.transforms_interface import ImageOnlyTransform
 from tests.conftest import (
     IMAGES,
     RECTANGULAR_UINT8_IMAGE,
@@ -1960,6 +1961,200 @@ def test_enhance_apply_to_images_matches_per_image(mode, dtype):
     assert batched.shape == images.shape
     assert batched.dtype == images.dtype
     np.testing.assert_array_equal(batched, per_image)
+
+
+@pytest.mark.parametrize("mode", ["rain", "mud"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("seed", [137, 138, 139])
+@pytest.mark.parametrize("batch_size", [1, 2, 5])
+def test_spatter_apply_to_images_matches_inherited_fallback(mode, dtype, seed, batch_size):
+    rng = np.random.default_rng(seed)
+    source_shape = (batch_size, 37, 82, 3)
+    if dtype == np.uint8:
+        source = rng.integers(0, 256, source_shape, dtype=np.uint8)
+    else:
+        source = rng.random(source_shape, dtype=np.float32)
+
+    images = source[:, :, ::2, :]
+    images.setflags(write=False)
+    images_before = images.copy()
+    transform = A.Spatter(mode=mode, color=(137, 89, 211), p=1.0)
+    compose_result = A.Compose([transform], seed=seed, strict=True)(images=images)["images"]
+    params = transform.get_applied_params()
+    expected = ImageOnlyTransform.apply_to_images(transform, images, **params)
+    direct_result = transform.apply_to_images(images, **params)
+
+    assert direct_result.shape == images.shape
+    assert direct_result.dtype == images.dtype
+    assert direct_result.flags.c_contiguous
+    assert direct_result.flags.writeable
+    assert not np.shares_memory(direct_result, images)
+    assert not np.shares_memory(compose_result, images)
+    np.testing.assert_array_equal(images, images_before)
+    if dtype == np.uint8:
+        np.testing.assert_array_equal(direct_result, expected)
+        np.testing.assert_array_equal(compose_result, expected)
+    else:
+        np.testing.assert_allclose(direct_result, expected, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(compose_result, expected, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("mode", "effect_params"),
+    [
+        (
+            "rain",
+            {
+                "drops": np.array(
+                    [[[-1 / 255, 0.5 / 255, 1.5 / 255], [254.5 / 255, 255.5 / 255, 2]]],
+                    dtype=np.float32,
+                ),
+            },
+        ),
+        (
+            "mud",
+            {
+                "non_mud": np.array([[[1, 0.5, 2], [-1, 1, 1]]], dtype=np.float32),
+                "mud": np.array(
+                    [[[-1 / 255, 0.5 / 255, -0.5 / 255], [2, -0.5 / 255, 0.5 / 255]]],
+                    dtype=np.float32,
+                ),
+            },
+        ),
+    ],
+)
+def test_spatter_apply_to_images_uint8_clipping_and_half_rounding_boundaries(mode, effect_params):
+    images = np.array([[[[0, 0, 1], [255, 255, 254]]]], dtype=np.uint8)
+    transform = A.Spatter(mode=mode, p=1.0)
+    params = {"mode": mode, **effect_params}
+
+    expected = ImageOnlyTransform.apply_to_images(transform, images, **params)
+    actual = transform.apply_to_images(images, **params)
+
+    np.testing.assert_array_equal(actual, expected)
+    if mode == "rain":
+        np.testing.assert_array_equal(actual, np.array([[[[0, 0, 2], [255, 255, 255]]]], dtype=np.uint8))
+    else:
+        np.testing.assert_array_equal(actual, np.array([[[[0, 0, 2], [255, 254, 254]]]], dtype=np.uint8))
+
+
+@pytest.mark.parametrize("mode", ["rain", "mud"])
+def test_spatter_apply_to_images_float32_clipping_vectors(mode):
+    images = np.array([[[[-0.25, 0.25, 1.25]]]], dtype=np.float32)
+    transform = A.Spatter(mode=mode, p=1.0)
+    if mode == "rain":
+        params = {"mode": mode, "drops": np.array([[[-0.5, 0.5, 0.5]]], dtype=np.float32)}
+    else:
+        params = {
+            "mode": mode,
+            "non_mud": np.array([[[2, 2, 2]]], dtype=np.float32),
+            "mud": np.array([[[-0.5, 0.25, -0.25]]], dtype=np.float32),
+        }
+
+    expected = ImageOnlyTransform.apply_to_images(transform, images, **params)
+    actual = transform.apply_to_images(images, **params)
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+    np.testing.assert_array_equal(actual, np.array([[[[0, 0.75, 1]]]], dtype=np.float32))
+
+
+@pytest.mark.parametrize(
+    ("mode", "dtype", "height", "width", "batch_at_threshold"),
+    [
+        ("rain", np.uint8, 256, 256, 4),
+        ("mud", np.uint8, 256, 256, 8),
+        ("mud", np.float32, 512, 512, 8),
+    ],
+)
+def test_spatter_apply_to_images_switches_at_working_set_guard(
+    monkeypatch,
+    mode,
+    dtype,
+    height,
+    width,
+    batch_at_threshold,
+):
+    fallback_calls = 0
+
+    def fallback(transform, images, *args, **params):
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return np.full_like(images, 137 if dtype == np.uint8 else 0.5)
+
+    monkeypatch.setattr(ImageOnlyTransform, "apply_to_images", fallback)
+    transform = A.Spatter(mode=mode, p=1.0)
+    if mode == "rain":
+        params = {"mode": mode, "drops": np.zeros((height, width, 3), dtype=np.float32)}
+    else:
+        params = {
+            "mode": mode,
+            "non_mud": np.ones((height, width, 3), dtype=np.float32),
+            "mud": np.zeros((height, width, 3), dtype=np.float32),
+        }
+
+    below = np.zeros((batch_at_threshold - 1, height, width, 3), dtype=dtype)
+    below_result = transform.apply_to_images(below, **params)
+    assert fallback_calls == 0
+    np.testing.assert_array_equal(below_result, below)
+
+    at_threshold = np.zeros((batch_at_threshold, height, width, 3), dtype=dtype)
+    threshold_result = transform.apply_to_images(at_threshold, **params)
+    assert fallback_calls == 1
+    np.testing.assert_array_equal(
+        threshold_result,
+        np.full_like(at_threshold, 137 if dtype == np.uint8 else 0.5),
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_spatter_apply_to_images_preserves_empty_batch_identity(dtype):
+    images = np.empty((0, 17, 19, 3), dtype=dtype)
+    transform = A.Spatter(p=1.0)
+
+    assert transform.apply_to_images(images) is images
+    assert A.Compose([transform], seed=137, strict=True)(images=images)["images"] is images
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param((2, 17, 19, 1), id="one-channel"),
+        pytest.param((2, 17, 19, 5), id="five-channel"),
+        pytest.param((2, 17, 19), id="raw-grayscale"),
+        pytest.param((3, 3, 3), id="raw-grayscale-width-three"),
+    ],
+)
+def test_spatter_apply_to_images_rejects_non_rgb_batches(shape):
+    images = np.zeros(shape, dtype=np.uint8)
+    transform = A.Spatter(p=1.0)
+
+    with pytest.raises(ValueError, match="This transformation expects 3-channel images"):
+        transform.apply_to_images(images, mode="rain", drops=np.zeros((*shape[1:3], 3), dtype=np.float32))
+
+
+@pytest.mark.parametrize("mode", ["rain", "mud"])
+@pytest.mark.parametrize("target", ["volume", "volumes"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_spatter_batch_path_preserves_volume_routing(mode, target, dtype):
+    rng = np.random.default_rng(137)
+    if dtype == np.uint8:
+        volume = rng.integers(0, 256, (3, 17, 19, 3), dtype=np.uint8)
+    else:
+        volume = rng.random((3, 17, 19, 3), dtype=np.float32)
+    data = volume if target == "volume" else np.stack([volume, volume[::-1]], axis=0)
+    transform = A.Spatter(mode=mode, p=1.0)
+
+    actual = A.Compose([transform], seed=137, strict=True)(**{target: data})[target]
+    params = transform.get_applied_params()
+    if target == "volume":
+        expected = ImageOnlyTransform.apply_to_images(transform, data, **params)
+    else:
+        expected = np.stack([ImageOnlyTransform.apply_to_images(transform, item, **params) for item in data])
+
+    if dtype == np.uint8:
+        np.testing.assert_array_equal(actual, expected)
+    else:
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
 
 
 def test_enhance_invalid_mode_raises():

--- a/tests/test_benchmark_coverage.py
+++ b/tests/test_benchmark_coverage.py
@@ -25,7 +25,7 @@ def test_benchmark_coverage_details_account_for_every_public_transform() -> None
     )
     assert details["summary"]["contract_failures"] == 0
     assert details["contract_failures"] == []
-    assert details["summary"]["performance_contract_status_counts"]["batch"]["covered"] == 11
+    assert details["summary"]["performance_contract_status_counts"]["batch"]["covered"] == 12
     assert details["summary"]["performance_contract_status_counts"]["parameter_sensitivity"]["covered"] == 6
 
 
@@ -97,6 +97,30 @@ def test_benchmark_coverage_details_map_batch_matrix_to_public_transforms() -> N
         ("batch_matrix", "horizontal_flip|images_and_masks|small|1|uint8|4"),
         ("batch_matrix", "horizontal_flip|volumes_and_masks3d|small|1|uint8|2"),
     }.issubset({(case["layer"], case["case_id"]) for case in horizontal_flip["asv_cases"]})
+
+
+def test_benchmark_coverage_details_map_spatter_modes_to_batch_matrix() -> None:
+    spatter = _coverage_for("Spatter")
+
+    assert spatter["performance_contract"]["batch"]["status"] == "covered"
+    assert spatter["scenario_contract"]["channels"] == [3]
+    assert spatter["scenario_contract"]["dtypes"] == ["uint8", "float32"]
+    assert spatter["scenario_contract"]["batch_sizes"] == [2, 4, 8, 16]
+    assert spatter["scenario_contract"]["sizes"] == ["small", "medium", "large"]
+    assert {"compose_batch", "direct_batch"}.issubset(spatter["scenario_contract"]["scopes"])
+    assert "peakmem_spatter_batch_large_rgb" in spatter["scenario_contract"]["memory_cases"]
+    assert (
+        "memory",
+        "benchmarks.test_batch_matrix.PeakMemorySpatterBatchMatrix.peakmem_spatter_batch_large_rgb",
+    ) in {(case["layer"], case["benchmark"]) for case in spatter["asv_cases"]}
+    assert {
+        "spatter_mud|direct_images|large|3|float32|16",
+        "spatter_mud|images|small|3|uint8|4",
+        "spatter_rain|direct_images|small|3|uint8|2",
+        "spatter_mud|images|medium|3|float32|8",
+        "spatter_rain|images|small|3|uint8|4",
+        "spatter_rain|images|large|3|float32|16",
+    }.issubset({case["case_id"] for case in spatter["asv_cases"] if case["layer"] == "batch_matrix"})
 
 
 def test_benchmark_coverage_details_map_parameter_sensitivity_to_public_transforms() -> None:

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -35,6 +35,7 @@ from benchmarks.test_batch_matrix import (  # noqa: E402
     IMAGE_BATCH_TRANSFORMS,
     MASK_BATCH_CASES,
     MASK_BATCH_TRANSFORMS,
+    SPATTER_DIRECT_CASES,
     VOLUME_BATCH_CASES,
     VOLUME_BATCH_TRANSFORMS,
 )
@@ -245,6 +246,8 @@ BATCH_ALIAS_TO_TRANSFORM = {
     "random_brightness_contrast": "RandomBrightnessContrast",
     "random_rotate90": "RandomRotate90",
     "resize": "Resize",
+    "spatter_mud": "Spatter",
+    "spatter_rain": "Spatter",
     "transpose": "Transpose",
     "vertical_flip": "VerticalFlip",
 }
@@ -293,6 +296,7 @@ MEMORY_BENCHMARKS = (
     "peakmem_mosaic_small_rgb",
     "peakmem_normalize_large_rgb",
     "peakmem_resize_large_rgb",
+    "peakmem_spatter_batch_large_rgb",
     "peakmem_volume_pad_medium",
 )
 
@@ -307,6 +311,7 @@ MEMORY_COVERED_TRANSFORMS = frozenset(
         "PadIfNeeded3D",
         "RandomBrightnessContrast",
         "Resize",
+        "Spatter",
     },
 )
 
@@ -355,12 +360,14 @@ MEMORY_CASES_BY_TRANSFORM = {
     "PadIfNeeded3D": ("peakmem_volume_pad_medium",),
     "RandomBrightnessContrast": ("peakmem_batch_pipeline_medium_rgb",),
     "Resize": ("peakmem_resize_large_rgb",),
+    "Spatter": ("peakmem_spatter_batch_large_rgb",),
 }
 
 ASV_BENCHMARKS = {
     "annotation_scaling": "benchmarks.test_family_matrix.TimeAnnotationTargets.time_transform",
     "batch_image": "benchmarks.test_batch_matrix.TimeImageBatchMatrix.time_transform",
     "batch_mask": "benchmarks.test_batch_matrix.TimeMaskBatchMatrix.time_transform",
+    "batch_spatter_direct": "benchmarks.test_batch_matrix.TimeSpatterDirectBatchMatrix.time_apply_to_images",
     "batch_volume": "benchmarks.test_batch_matrix.TimeVolumeBatchMatrix.time_transform",
     "catalog_smoke": "benchmarks.test_catalog_smoke.TimeCatalogTransformSmoke.time_transform_compose",
     "direct_kernel_3d": "benchmarks.test_functional_kernels.TimeFunctional3DKernels.time_kernel",
@@ -373,6 +380,7 @@ ASV_BENCHMARKS = {
     "family_matrix_geometry": "benchmarks.test_family_matrix.TimeGeometryFullMatrix.time_transform",
     "family_matrix_pixel": "benchmarks.test_family_matrix.TimePixelFullMatrix.time_transform",
     "memory": "benchmarks.test_family_matrix.PeakMemoryHotPaths",
+    "memory_spatter": "benchmarks.test_batch_matrix.PeakMemorySpatterBatchMatrix",
     "parameter_sensitivity": "benchmarks.test_parameter_sensitivity.TimeParameterSensitivity.time_transform",
     "pytorch_tensor_2d": "pytorch_benchmarks.test_tensor.TimeToTensorV2",
     "pytorch_tensor_3d": "pytorch_benchmarks.test_tensor.TimeToTensor3D",
@@ -427,6 +435,7 @@ VOLUME_SIZE_ORDER = tuple(VOLUME_SIZES)
 DTYPE_ORDER = tuple(DTYPES)
 CHANNEL_ORDER = CHANNELS
 ANNOTATION_COUNT_ORDER = (10, 100, 1000)
+BATCH_SIZE_ORDER = (2, 4, 8, 16)
 
 AXIS_ORDERS: Mapping[str, tuple[Any, ...]] = {
     "annotation_counts": ANNOTATION_COUNT_ORDER,
@@ -673,6 +682,7 @@ def _parse_batch_case(case_id: str) -> dict[str, Any]:
     """Parse a batch matrix benchmark case id."""
     name, target_route, size_name, channels, dtype_name, batch_size = case_id.split("|")
     targets = {
+        "direct_images": ["images"],
         "images": ["images"],
         "images_and_masks": ["images", "masks"],
         "volumes_and_masks3d": ["masks3d", "volumes"],
@@ -730,7 +740,9 @@ def _target_matrix_scenario(case: Mapping[str, str], route: str, transform_name:
 
 def _batch_matrix_scenario(case: Mapping[str, str], route: str, transform_name: str) -> dict[str, Any]:
     """Return scenario metadata for a batch matrix case."""
-    return {**_parse_batch_case(case["case_id"]), "scope": "compose_batch"}
+    scenario = _parse_batch_case(case["case_id"])
+    scope = "direct_batch" if scenario["target_route"] == "direct_images" else "compose_batch"
+    return {**scenario, "scope": scope}
 
 
 def _parameter_sensitivity_scenario(case: Mapping[str, str], route: str, transform_name: str) -> dict[str, Any]:
@@ -880,7 +892,7 @@ def _scenario_contract(cases: Iterable[dict[str, Any]]) -> dict[str, Any]:
 
     return {
         "annotation_counts": _ordered(axes["annotation_counts"]),
-        "batch_sizes": _ordered(batch_sizes),
+        "batch_sizes": _ordered(batch_sizes, BATCH_SIZE_ORDER),
         "case_count": case_count,
         "channels": _ordered(axes["channels"], CHANNEL_ORDER),
         "configs": _ordered(axes["configs"]),
@@ -1057,6 +1069,13 @@ def _benchmark_case_index() -> dict[str, list[dict[str, str]]]:
     )
     _add_matrix_cases(
         cases,
+        benchmark=ASV_BENCHMARKS["batch_spatter_direct"],
+        case_ids=SPATTER_DIRECT_CASES,
+        layer="batch_matrix",
+        name_map=BATCH_ALIAS_TO_TRANSFORM,
+    )
+    _add_matrix_cases(
+        cases,
         benchmark=ASV_BENCHMARKS["batch_volume"],
         case_ids=VOLUME_BATCH_CASES,
         layer="batch_matrix",
@@ -1079,11 +1098,12 @@ def _benchmark_case_index() -> dict[str, list[dict[str, str]]]:
         )
     _add_direct_kernel_cases(cases)
     for transform_name, case_ids in MEMORY_CASES_BY_TRANSFORM.items():
+        memory_benchmark = ASV_BENCHMARKS["memory_spatter"] if transform_name == "Spatter" else ASV_BENCHMARKS["memory"]
         for case_id in case_ids:
             _add_asv_case(
                 cases,
                 transform_name,
-                benchmark=f"{ASV_BENCHMARKS['memory']}.{case_id}",
+                benchmark=f"{memory_benchmark}.{case_id}",
                 case_id=case_id,
                 layer="memory",
             )


### PR DESCRIPTION
## Summary

- add a vectorized `Spatter.apply_to_images` path for rain and mud batches while retaining guarded inherited fallbacks where they are faster or use less memory
- keep batch arithmetic in functional-layer helpers and use optimized `albucore.to_float` for uint8 input
- preserve RGB validation, empty-batch identity, clipping, dtype conversion, and volume routing for `uint8` and `float32`
- add focused correctness tests plus direct, Compose, and peak-memory benchmark coverage
- make NumPy return narrowing compatible with local and Python 3.10 Pyrefly checks

## Validation

- `uv run pytest -q tests/test_augmentations.py -k spatter tests/test_benchmark_coverage.py` — focused Spatter and benchmark coverage checks passed
- `uv run python -m tools.quality_gate fast` — passed after merging current main, including 1334 contract tests, Ruff, mypy, Pyrefly, pre-commit, CI matrix, benchmark coverage, performance budget, legal integrity, and regression vectors
- one-thread local benchmark over RGB 256/512/1024, `uint8`/`float32`, batch sizes 2/4/8/16, direct and Compose routes: active vectorized direct cells measured 1.018x–2.821x versus the inherited fallback, with no active regression above 5%; threshold-routed cells use the inherited fallback

Closes #40