### PR TITLE
[Bug] Align RandomBrightnessContrast with torchvision semantics

### DIFF
--- a/albumentations/augmentations/pixel/_functional_torchvision.py
+++ b/albumentations/augmentations/pixel/_functional_torchvision.py
@@ -278,7 +278,9 @@ def apply_brightness_contrast_torchvision(
     (clipped to valid range). This avoids re-reading the image after brightness is applied.
 
     For uint8 images the composition is pre-computed over all 256 input values into a single
-    256-entry LUT applied in one `cv2.LUT` call. For float32, two sequential clipped passes are used.
+    256-entry LUT. Contrast-then-brightness quantizes the intermediate contrast result before
+    composing the brightness LUT, matching torchvision's sequential uint8 operations. For float32,
+    two sequential clipped passes are used.
 
     Args:
         img (ImageType): Input image (uint8 or float32).
@@ -307,6 +309,8 @@ def apply_brightness_contrast_torchvision(
             lut = np.clip(lut * contrast_factor + mean_at_contrast * 255.0 * (1.0 - contrast_factor), 0.0, 255.0)
         else:
             lut = np.clip(lut * contrast_factor + mean_at_contrast * 255.0 * (1.0 - contrast_factor), 0.0, 255.0)
+            # Values are non-negative after clipping, so floor matches the uint8 cast between torchvision operations.
+            np.floor(lut, out=lut)
             lut = np.clip(lut * brightness_factor, 0.0, 255.0)
         return sz_lut(img, lut.astype(np.uint8), inplace=False)
 

--- a/albumentations/augmentations/pixel/_functional_torchvision.py
+++ b/albumentations/augmentations/pixel/_functional_torchvision.py
@@ -291,12 +291,9 @@ def apply_brightness_contrast_torchvision(
 
     """
     # Compute original grayscale mean once, normalised to [0, 1].
-    gray_for_mean = (
-        img
-        if is_grayscale_image(img)
-        else (to_gray_weighted_average(img) if is_rgb_image(img) else to_gray_average(img))
-    )
-    img_mean = float(mean(gray_for_mean))
+    # For non-RGB inputs, the global mean is unchanged by first averaging each
+    # pixel's channels, so no intermediate grayscale array is needed.
+    img_mean = float(mean(to_gray_weighted_average(img))) if is_rgb_image(img) else float(mean(img))
     if img.dtype == np.uint8:
         img_mean /= 255.0
 

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -12,6 +12,7 @@ from ._color_shared import (
     Field,
     ImageOnlyTransform,
     ImageType,
+    Self,
     VolumeType,
     albucore,
     batch_transform,
@@ -21,6 +22,7 @@ from ._color_shared import (
     is_grayscale_image,
     is_rgb_image,
     mean,
+    model_validator,
     nondecreasing,
     np,
 )
@@ -665,32 +667,22 @@ class Equalize(ImageOnlyTransform):
 
 
 class RandomBrightnessContrast(ImageOnlyTransform):
-    """Randomly adjust brightness and contrast with separate ranges. Simple and fast;
-    good baseline color augmentation for classification and detection.
-
-    This transform adjusts the brightness and contrast of an image simultaneously, allowing for
-    a wide range of lighting and contrast variations. It's particularly useful for data augmentation
-    in computer vision tasks, helping models become more robust to different lighting conditions.
+    """Adjust brightness and contrast with a torchvision-compatible default or an OpenCV-style model.
+    Useful for training models robust to lighting variation.
 
     Args:
-        brightness_range (tuple[float, float]): Factor range for changing brightness, sampled
-            per image. Values should typically be in the range [-1.0, 1.0], where 0 means no
-            change, 1.0 means maximum brightness, and -1.0 means minimum brightness.
-            Default: (-0.2, 0.2).
-
-        contrast_range (tuple[float, float]): Factor range for changing contrast, sampled per
-            image. Values should typically be in the range [-1.0, 1.0], where 0 means no change,
-            1.0 means maximum increase in contrast, and -1.0 means maximum decrease in contrast.
-            Default: (-0.2, 0.2).
-
-        brightness_by_max (bool): If True, adjusts brightness by scaling pixel values up to the
-            maximum value of the image's dtype. If False, uses the mean pixel value for adjustment.
-            Default: True.
-
-        ensure_safe_output (bool): If True, adjusts alpha and beta to prevent overflow/underflow.
-            This keeps output values inside the valid range for the image dtype without clipping.
-            Default: False.
-
+        brightness_range (tuple[float, float]): Range from which the brightness adjustment is
+            sampled. In the default torchvision-compatible mode, the multiplicative brightness
+            factor is `1 + adjustment`; both endpoints must be at least -1. In the OpenCV-style
+            mode, the adjustment is an additive fraction of the dtype maximum. Default: (-0.2, 0.2).
+        contrast_range (tuple[float, float]): Range from which the contrast adjustment is sampled.
+            The contrast factor is `1 + adjustment`. In the default torchvision-compatible mode,
+            both endpoints must be at least -1. Default: (-0.2, 0.2).
+        brightness_by_max (bool): Selects the photometric model. If False, use torchvision-compatible
+            multiplicative brightness and mean-centered contrast. If True, use the legacy OpenCV-style
+            affine formula with additive brightness scaled by the dtype maximum. Default: False.
+        ensure_safe_output (bool): If True, reduce the combined affine gain and offset as needed so
+            the complete input dtype range maps inside the output range without clipping. Default: False.
         p (float): Probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -703,55 +695,64 @@ class RandomBrightnessContrast(ImageOnlyTransform):
         Any
 
     Note:
-        - The order of operation is: contrast adjustment, then brightness adjustment.
-        - For uint8 images, the output is clipped to [0, 255] range.
-        - For float32 images, the output is clipped to [0, 1] range.
-        - The `brightness_by_max` parameter affects how brightness is adjusted:
-          * If True, brightness adjustment is more pronounced and can lead to more saturated results.
-          * If False, brightness adjustment is more subtle and preserves the overall lighting better.
-        - This transform is useful for:
-          * Simulating different lighting conditions
-          * Enhancing low-light or overexposed images
-          * Data augmentation to improve model robustness
+        - The default mode applies contrast first and brightness second, matching the corresponding
+          torchvision operations in that fixed order. `ColorJitter` randomizes operation order.
+        - RGB contrast uses the mean BT.601 grayscale luminance. Other multichannel inputs use the
+          mean of their per-pixel channel averages.
+        - A batch uses one sampled pair of factors but computes the contrast mean independently for
+          each image. Volumes compute it independently for each slice.
+        - Outputs are clipped to [0, 255] for uint8 and [0, 1] for float32 unless
+          `ensure_safe_output=True` first reduces the affine coefficients to avoid clipping.
 
     Mathematical Formulation:
-        Let a be the contrast adjustment factor and β be the brightness adjustment factor.
-        For each pixel value x:
-        1. Contrast adjustment: x' = clip((x - mean) * (1 + a) + mean)
-        2. Brightness adjustment:
-           If brightness_by_max is True:  x'' = clip(x' * (1 + β))
-           If brightness_by_max is False: x'' = clip(x' + β * max_value)
-        Where clip() ensures values stay within the valid range for the image dtype.
+        Let `delta_b` and `delta_c` be the sampled brightness and contrast adjustments,
+        `b = 1 + delta_b`, `c = 1 + delta_c`, `M` the dtype maximum, and `mu` the image's
+        grayscale mean.
+
+        With `brightness_by_max=False`:
+
+        1. `x_contrast = clip(c * x + (1 - c) * mu)`
+        2. `x_out = clip(b * x_contrast)`
+
+        With `brightness_by_max=True`:
+
+        `x_out = clip(c * x + delta_b * M)`
+
+        With `ensure_safe_output=True`, the default mode first combines its operations as
+        `gain = b * c` and `offset = b * (1 - c) * mu`, then reduces `gain` and `offset` so
+        `gain * x + offset` remains in range for every valid input value.
 
     Examples:
         >>> import numpy as np
         >>> import albumentations as A
         >>> image = np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)
 
-        # Default usage
+        # Torchvision-compatible brightness and mean-centered contrast
         >>> transform = A.RandomBrightnessContrast(p=1.0)
         >>> augmented_image = transform(image=image)["image"]
 
-        # Custom brightness and contrast limits
+        # Stronger torchvision-compatible factors: brightness 0.7-1.3, contrast 0.6-1.4
         >>> transform = A.RandomBrightnessContrast(
         ...     brightness_range=(-0.3, 0.3),
-        ...     contrast_range=(-0.3, 0.3),
+        ...     contrast_range=(-0.4, 0.4),
         ...     p=1.0,
         ... )
         >>> augmented_image = transform(image=image)["image"]
 
-        # Adjust brightness based on mean value
+        # Legacy OpenCV-style affine model with additive brightness
         >>> transform = A.RandomBrightnessContrast(
         ...     brightness_range=(-0.2, 0.2),
         ...     contrast_range=(-0.2, 0.2),
-        ...     brightness_by_max=False,
+        ...     brightness_by_max=True,
         ...     p=1.0,
         ... )
         >>> augmented_image = transform(image=image)["image"]
 
     References:
-        - Brightness: https://en.wikipedia.org/wiki/Brightness
-        - Contrast: https://en.wikipedia.org/wiki/Contrast_(vision)
+        - Torchvision brightness and contrast implementation:
+          https://docs.pytorch.org/vision/main/_modules/torchvision/transforms/v2/functional/_color.html
+        - OpenCV basic linear transformations:
+          https://docs.opencv.org/4.x/d3/dc1/tutorial_basic_linear_transform.html
 
     """
 
@@ -761,11 +762,24 @@ class RandomBrightnessContrast(ImageOnlyTransform):
         brightness_by_max: bool
         ensure_safe_output: bool
 
+        @model_validator(mode="after")
+        def validate_torchvision_factors(self) -> Self:
+            """Validate non-negative torchvision brightness and contrast factors. Reject adjustments
+            below -1 because they produce invalid negative multiplicative factors.
+            """
+            if not self.brightness_by_max:
+                for field_name in ("brightness_range", "contrast_range"):
+                    if getattr(self, field_name)[0] < -1:
+                        raise ValueError(
+                            f"{field_name} values must be greater than or equal to -1 when brightness_by_max=False",
+                        )
+            return self
+
     def __init__(
         self,
         brightness_range: tuple[float, float] = (-0.2, 0.2),
         contrast_range: tuple[float, float] = (-0.2, 0.2),
-        brightness_by_max: bool = True,
+        brightness_by_max: bool = False,
         ensure_safe_output: bool = False,
         p: float = 0.5,
     ):
@@ -783,8 +797,22 @@ class RandomBrightnessContrast(ImageOnlyTransform):
         **params: Any,
     ) -> ImageType:
         max_value = MAX_VALUES_BY_DTYPE[img.dtype]
-        # Scale beta according to brightness_by_max setting
-        beta = beta * max_value if self.brightness_by_max else beta * float(mean(img))
+
+        if not self.brightness_by_max:
+            brightness_factor = 1.0 + beta
+            if not self.ensure_safe_output:
+                return fpixel.apply_brightness_contrast_torchvision(
+                    img,
+                    brightness_factor=brightness_factor,
+                    contrast_factor=alpha,
+                    brightness_first=False,
+                )
+
+            image_mean = float(mean(fpixel.to_gray_weighted_average(img))) if is_rgb_image(img) else float(mean(img))
+            beta = brightness_factor * (1.0 - alpha) * image_mean
+            alpha *= brightness_factor
+        else:
+            beta *= max_value
 
         if self.ensure_safe_output:
             alpha, beta = fpixel.get_safe_brightness_contrast_params(
@@ -796,9 +824,16 @@ class RandomBrightnessContrast(ImageOnlyTransform):
         return albucore.multiply_add(img, alpha, beta, inplace=False)
 
     def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
+        if not self.brightness_by_max:
+            return self._apply_to_batch_same_shape(images, lambda image: self.apply(image, *args, **params))
         return self.apply(images, *args, **params)
 
     def apply_to_volumes(self, volumes: VolumeType, *args: Any, **params: Any) -> VolumeType:
+        if not self.brightness_by_max:
+            return self._apply_to_batch_same_shape(
+                volumes,
+                lambda volume: self.apply_to_volume(volume, *args, **params),
+            )
         return self.apply(volumes, *args, **params)
 
     def get_params_dependent_on_data(

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -769,7 +769,7 @@ class RandomBrightnessContrast(ImageOnlyTransform):
             """
             if not self.brightness_by_max:
                 for field_name in ("brightness_range", "contrast_range"):
-                    if getattr(self, field_name)[0] < -1:
+                    if min(getattr(self, field_name)) < -1:
                         raise ValueError(
                             f"{field_name} values must be greater than or equal to -1 when brightness_by_max=False",
                         )

--- a/benchmark/benchmarks/test_parameter_sensitivity.py
+++ b/benchmark/benchmarks/test_parameter_sensitivity.py
@@ -108,6 +108,18 @@ PARAMETER_SENSITIVITY_TRANSFORMS: Mapping[str, ParameterSensitivitySpec] = {
         params={"quality_range": (95, 95)},
         dtypes=("uint8",),
     ),
+    "random_brightness_contrast_torchvision": ParameterSensitivitySpec(
+        factory=lambda: albumentations.RandomBrightnessContrast(brightness_by_max=False, p=1.0),
+        public_transform="RandomBrightnessContrast",
+        parameter_scenario="torchvision_model",
+        params={"brightness_by_max": False},
+    ),
+    "random_brightness_contrast_opencv": ParameterSensitivitySpec(
+        factory=lambda: albumentations.RandomBrightnessContrast(brightness_by_max=True, p=1.0),
+        public_transform="RandomBrightnessContrast",
+        parameter_scenario="opencv_model",
+        params={"brightness_by_max": True},
+    ),
     "superpixels_segments_32": ParameterSensitivitySpec(
         factory=lambda: albumentations.Superpixels(n_segments_range=(32, 32), max_size=128, p=1.0),
         public_transform="Superpixels",

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -985,7 +985,8 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
     ),
     ("small-plasma", A.PlasmaBrightnessContrast, {"plasma_size": 64, "roughness": 2.0}),
     ("small-plasma", A.PlasmaShadow, {"shadow_intensity_range": (0.2, 0.5), "plasma_size": 64, "roughness": 2.0}),
-    ("safe-output", A.RandomBrightnessContrast, {"brightness_by_max": False, "ensure_safe_output": True}),
+    ("safe-output", A.RandomBrightnessContrast, {"ensure_safe_output": True}),
+    ("opencv-max", A.RandomBrightnessContrast, {"brightness_by_max": True}),
     (
         "padded-bottom-right",
         A.RandomCrop,

--- a/tests/test_benchmark_coverage.py
+++ b/tests/test_benchmark_coverage.py
@@ -26,7 +26,7 @@ def test_benchmark_coverage_details_account_for_every_public_transform() -> None
     assert details["summary"]["contract_failures"] == 0
     assert details["contract_failures"] == []
     assert details["summary"]["performance_contract_status_counts"]["batch"]["covered"] == 11
-    assert details["summary"]["performance_contract_status_counts"]["parameter_sensitivity"]["covered"] == 6
+    assert details["summary"]["performance_contract_status_counts"]["parameter_sensitivity"]["covered"] == 7
 
 
 def test_benchmark_coverage_details_expose_deep_hot_path_layers() -> None:

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -213,6 +213,31 @@ def test_random_brightness_contrast_matches_torchvision_brightness_and_contrast(
     assert np.abs(result.astype(np.int16) - expected.astype(np.int16)).max() <= 1
 
 
+def test_random_brightness_contrast_preserves_intermediate_uint8_quantization() -> None:
+    image = np.array(
+        [
+            [[17, 23, 35], [47, 7, 10]],
+            [[46, 37, 20], [14, 16, 18]],
+        ],
+        dtype=np.uint8,
+    )
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(9.0, 9.0),
+        contrast_range=(-0.9, -0.9),
+        p=1,
+    )
+
+    result = transform(image=image)["image"]
+    expected = np.asarray(
+        adjust_brightness(
+            adjust_contrast(Image.fromarray(image), 0.1),
+            10.0,
+        ),
+    )
+
+    np.testing.assert_array_equal(result, expected)
+
+
 def test_post_data_check():
     img = np.empty([100, 100, 3], dtype=np.uint8)
     bboxes = np.array(

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 from PIL import Image
 from torchvision.transforms import ColorJitter
+from torchvision.transforms.functional import adjust_brightness, adjust_contrast
 
 import albumentations as A
 from tests.conftest import RECTANGULAR_UINT8_IMAGE, SQUARE_UINT8_IMAGE, UINT8_IMAGES
@@ -185,6 +186,31 @@ def test_color_jitter(brightness, contrast, saturation, hue):
     res2 = np.array(pil_transform(pil_image))
 
     assert np.abs(res1.astype(np.int16) - res2.astype(np.int16)).max() <= 2
+
+
+def test_random_brightness_contrast_matches_torchvision_brightness_and_contrast():
+    image = np.array(
+        [
+            [[255, 0, 0], [0, 255, 0]],
+            [[0, 0, 255], [100, 120, 140]],
+        ],
+        dtype=np.uint8,
+    )
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(0.2, 0.2),
+        contrast_range=(0.5, 0.5),
+        p=1,
+    )
+
+    result = transform(image=image)["image"]
+    expected = np.asarray(
+        adjust_brightness(
+            adjust_contrast(Image.fromarray(image), 1.5),
+            1.2,
+        ),
+    )
+
+    assert np.abs(result.astype(np.int16) - expected.astype(np.int16)).max() <= 1
 
 
 def test_post_data_check():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -855,12 +855,27 @@ def test_random_brightness_contrast_max_mode_preserves_opencv_formula():
     "transform_kwargs",
     [
         {"brightness_range": (-1.1, 0.2)},
+        {"brightness_range": (0.2, -1.1)},
         {"contrast_range": (-1.1, 0.2)},
+        {"contrast_range": (0.2, -1.1)},
     ],
 )
-def test_random_brightness_contrast_torchvision_mode_rejects_negative_factors(transform_kwargs):
+def test_random_brightness_contrast_torchvision_mode_rejects_negative_factors(
+    transform_kwargs: dict[str, tuple[float, float]],
+) -> None:
     with pytest.raises(ValueError, match="must be greater than or equal to -1"):
         A.RandomBrightnessContrast(**transform_kwargs)
+
+
+def test_random_brightness_contrast_max_mode_allows_adjustments_below_negative_one() -> None:
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(-1.2, -1.1),
+        contrast_range=(-1.4, -1.3),
+        brightness_by_max=True,
+    )
+
+    assert transform.brightness_range == (-1.2, -1.1)
+    assert transform.contrast_range == (-1.4, -1.3)
 
 
 def test_perspective_keep_size():

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -734,6 +734,135 @@ def test_color_jitter_float_uint8_equal(brightness, contrast, saturation, hue):
         assert _max <= 2, f"Max: {_max}"
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_random_brightness_contrast_torchvision_mode_matches_expected_formula(dtype):
+    if dtype == np.uint8:
+        image = np.array([[[50], [100], [150]]], dtype=dtype)
+        expected = np.array([[[30], [120], [210]]], dtype=dtype)
+    else:
+        image = np.array([[[0.2], [0.4], [0.6]]], dtype=dtype)
+        expected = np.array([[[0.12], [0.48], [0.84]]], dtype=dtype)
+
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(0.2, 0.2),
+        contrast_range=(0.5, 0.5),
+        brightness_by_max=False,
+        p=1,
+    )
+
+    result = transform(image=image)["image"]
+
+    np.testing.assert_allclose(result, expected, atol=1e-6)
+
+
+def test_random_brightness_contrast_defaults_to_torchvision_semantics():
+    image = np.array([[[50], [100], [150]]], dtype=np.uint8)
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(0.2, 0.2),
+        contrast_range=(0.5, 0.5),
+        p=1,
+    )
+
+    result = transform(image=image)["image"]
+
+    np.testing.assert_array_equal(result, np.array([[[30], [120], [210]]], dtype=np.uint8))
+
+
+def test_random_brightness_contrast_torchvision_mode_uses_per_image_batch_means():
+    images = np.array(
+        [
+            [[[0], [100]]],
+            [[[100], [200]]],
+        ],
+        dtype=np.uint8,
+    )
+    expected = np.array(
+        [
+            [[[50], [50]]],
+            [[[150], [150]]],
+        ],
+        dtype=np.uint8,
+    )
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(0, 0),
+        contrast_range=(-1, -1),
+        brightness_by_max=False,
+        p=1,
+    )
+
+    result = transform(images=images)["images"]
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_random_brightness_contrast_torchvision_mode_uses_per_slice_volume_means():
+    volumes = np.array(
+        [
+            [[[[0], [100]]]],
+            [[[[100], [200]]]],
+        ],
+        dtype=np.uint8,
+    )
+    expected = np.array(
+        [
+            [[[[50], [50]]]],
+            [[[[150], [150]]]],
+        ],
+        dtype=np.uint8,
+    )
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(0, 0),
+        contrast_range=(-1, -1),
+        brightness_by_max=False,
+        p=1,
+    )
+
+    result = transform(volumes=volumes)["volumes"]
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_random_brightness_contrast_torchvision_mode_safe_output_uses_combined_coefficients():
+    image = np.array([[[50], [100], [150]]], dtype=np.uint8)
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(0.2, 0.2),
+        contrast_range=(0.5, 0.5),
+        brightness_by_max=False,
+        ensure_safe_output=True,
+        p=1,
+    )
+
+    result = transform(image=image)["image"]
+
+    np.testing.assert_array_equal(result, image)
+
+
+def test_random_brightness_contrast_max_mode_preserves_opencv_formula():
+    image = np.full((2, 2, 3), 100, dtype=np.uint8)
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(0.2, 0.2),
+        contrast_range=(0, 0),
+        brightness_by_max=True,
+        p=1,
+    )
+
+    result = transform(image=image)["image"]
+
+    np.testing.assert_array_equal(result, np.full_like(image, 151))
+
+
+@pytest.mark.parametrize(
+    "transform_kwargs",
+    [
+        {"brightness_range": (-1.1, 0.2)},
+        {"contrast_range": (-1.1, 0.2)},
+    ],
+)
+def test_random_brightness_contrast_torchvision_mode_rejects_negative_factors(transform_kwargs):
+    with pytest.raises(ValueError, match="must be greater than or equal to -1"):
+        A.RandomBrightnessContrast(**transform_kwargs)
+
+
 def test_perspective_keep_size():
     height, width = 100, 100
     img = np.zeros([height, width, 3], dtype=np.uint8)


### PR DESCRIPTION
## Summary

This fixes the contract mismatch documented in #372 by making [`RandomBrightnessContrast`](https://albumentations.ai/explore/transform/RandomBrightnessContrast/) use torchvision-compatible brightness and contrast by default.

In 2.3.7, the documentation described mean-centered contrast and multiplicative brightness, while the implementation performed one zero-centered affine operation and assigned the two `brightness_by_max` branches in the opposite way.

- `brightness_by_max=False` is now the default and applies mean-centered contrast followed by multiplicative brightness.
- `brightness_by_max=True` preserves the 2.3.7 OpenCV-style affine formula.
- Image batches compute a separate contrast mean per image; volumes compute it per slice.
- The schema rejects adjustments below `-1` in torchvision mode because they produce negative factors.
- Dedicated tests and ASV scenarios cover both photometric models.

## Formulas

Let `delta_b` and `delta_c` be sampled adjustments, `b = 1 + delta_b`, `c = 1 + delta_c`, `mu` the grayscale-luminance mean for RGB or global mean otherwise, and `M` the dtype maximum.

Default (`brightness_by_max=False`):

```text
contrast = clip(c * image + (1 - c) * mu)
output = clip(b * contrast)
```

Legacy/OpenCV (`brightness_by_max=True`):

```text
output = clip(c * image + delta_b * M)
```

The default separates the two sampled effects: brightness scales the mean intensity, while contrast changes deviations around the mean. The retained OpenCV mode remains available for additive black-level or sensor-offset augmentation.

## Compatibility

This intentionally changes the default output. Code that needs the 2.3.7 default can preserve it explicitly:

```python
A.RandomBrightnessContrast(
    brightness_range=(-0.2, 0.2),
    contrast_range=(-0.2, 0.2),
    brightness_by_max=True,
)
```

Existing `brightness_by_max=False` code also changes meaning: it now uses torchvision multiplicative brightness and mean-centered contrast instead of a mean-scaled additive offset.

This matches the torchvision brightness and contrast operations in a fixed contrast-then-brightness order. `ColorJitter` still randomizes operation order.

## Validation

- `uv run pytest -q -m "not slow"` — 12,663 passed, 42 skipped, 9 xfailed.
- `uv run python -m tools.quality_gate fast` — passed.
- Direct output comparison with torchvision differs by at most one `uint8` level.
- Regression coverage includes `uint8`, `float32`, RGB, arbitrary channels, image batches, volumes, safe output, invalid factors, serialization, and the preserved OpenCV formula.
- ASV parameter-sensitivity coverage now tracks both photometric models.

Closes #372.

## Summary by Sourcery

Align RandomBrightnessContrast with torchvision brightness/contrast semantics while preserving an explicit OpenCV-style mode and updating validation, docs, and benchmarks accordingly.

New Features:
- Introduce a torchvision-compatible brightness and mean-centered contrast mode as the default behavior for RandomBrightnessContrast.
- Expose the legacy OpenCV-style affine brightness/contrast model via brightness_by_max=True as an alternative photometric mode.

Bug Fixes:
- Correct the RandomBrightnessContrast contract to match documented and torchvision semantics, including proper handling of image batches and volumes.

Enhancements:
- Update RandomBrightnessContrast parameter validation to reject adjustment ranges that would yield negative multiplicative factors in torchvision mode.
- Refine ensure_safe_output behavior to operate on combined affine coefficients in the torchvision-compatible mode.
- Clarify RandomBrightnessContrast documentation with explicit formulas, RGB/volume mean definitions, usage examples, and references to torchvision and OpenCV implementations.
- Slightly simplify grayscale mean computation in the internal torchvision brightness/contrast helper for non-RGB inputs.
- Add ASV parameter-sensitivity specs for both torchvision and OpenCV RandomBrightnessContrast modes and adjust benchmark coverage expectations.

Tests:
- Add focused tests that verify RandomBrightnessContrast matches the expected torchvision formulas for both uint8 and float32 images, including safe-output behavior.
- Add tests for per-image batch means, per-slice volume means, OpenCV-mode formula preservation, default semantics, and invalid factor rejection.
- Add a cross-library test that compares RandomBrightnessContrast output against torchvision adjust_brightness and adjust_contrast.

Chores:
- Extend transform case helpers to cover RandomBrightnessContrast safe-output and OpenCV-max scenarios for broader regression and benchmark coverage.