### PR TITLE
Add HEStain residual channel modes

### DIFF
--- a/albumentations/augmentations/pixel/_functional_histology.py
+++ b/albumentations/augmentations/pixel/_functional_histology.py
@@ -16,6 +16,7 @@ from ._functional_shared import (
 )
 
 _Cv2InPlaceOp = Callable[..., np.ndarray]
+_SPARSE_TISSUE_MAX_FRACTION = 0.4
 
 
 def rgb_to_optical_density(img: ImageType, eps: float = 1e-6) -> np.ndarray:
@@ -443,9 +444,121 @@ def _build_stain_affine_matrix(
 
 def _apply_stain_affine(optical_density: np.ndarray, affine_matrix: np.ndarray) -> np.ndarray:
     result = cv2.transform(optical_density.reshape(-1, 1, 3), affine_matrix).reshape(-1, 3)
-    multiply = cast("_Cv2InPlaceOp", cv2.multiply)
-    multiply(result, -1.0, dst=result)
+    result *= -1.0
     cv2.exp(result, dst=result)
+    return result
+
+
+def _validate_stain_augmentation_inputs(
+    stain_matrix: np.ndarray,
+    scale_factors: np.ndarray,
+    shift_values: np.ndarray,
+    residual_mode: Literal["project", "preserve", "augment"],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    stain_matrix = np.ascontiguousarray(stain_matrix, dtype=np.float32)
+    if stain_matrix.shape != (2, 3):
+        raise ValueError(f"stain_matrix must have shape (2, 3), got {stain_matrix.shape}")
+    if not np.isfinite(stain_matrix).all():
+        raise ValueError("stain_matrix must contain only finite values")
+    if residual_mode not in {"project", "preserve", "augment"}:
+        raise ValueError(f"Invalid residual_mode: {residual_mode}")
+
+    component_count = 2 if residual_mode == "project" else 3
+    scale_factors = np.asarray(scale_factors)
+    shift_values = np.asarray(shift_values)
+    if scale_factors.shape != (component_count,):
+        raise ValueError(f"scale_factors must have shape ({component_count},), got {scale_factors.shape}")
+    if shift_values.shape != (component_count,):
+        raise ValueError(f"shift_values must have shape ({component_count},), got {shift_values.shape}")
+    return stain_matrix, scale_factors, shift_values
+
+
+def _build_residual_stain_matrix(stain_matrix: np.ndarray, tolerance: float) -> np.ndarray | None:
+    residual_vector = np.cross(stain_matrix[0], stain_matrix[1])
+    residual_norm = np.linalg.norm(residual_vector)
+    stain_norm_product = np.linalg.norm(stain_matrix[0]) * np.linalg.norm(stain_matrix[1])
+    if (
+        not np.isfinite(residual_norm)
+        or not np.isfinite(stain_norm_product)
+        or residual_norm <= tolerance * stain_norm_product
+    ):
+        return None
+
+    residual_vector /= residual_norm
+    reconstruction_matrix = np.empty((3, 3), dtype=np.float32)
+    reconstruction_matrix[:2] = stain_matrix
+    reconstruction_matrix[2] = residual_vector
+    return reconstruction_matrix
+
+
+def _apply_project_stain_affine(
+    img: ImageType,
+    optical_density: np.ndarray,
+    stain_matrix: np.ndarray,
+    scale_factors: np.ndarray,
+    shift_values: np.ndarray,
+    augment_background: bool,
+    regularization: float,
+) -> np.ndarray:
+    stain_correlation = stain_matrix @ stain_matrix.T + regularization * np.eye(2)
+    deconvolution_matrix = np.linalg.solve(stain_correlation, stain_matrix)
+    augmented_affine = _build_stain_affine_matrix(
+        stain_matrix,
+        deconvolution_matrix,
+        scale_factors,
+        shift_values,
+    )
+    if augment_background:
+        return _apply_stain_affine(optical_density, augmented_affine)
+
+    tissue_mask = get_tissue_mask(img)
+    if np.all(tissue_mask):
+        return _apply_stain_affine(optical_density, augmented_affine)
+
+    base_affine = _build_stain_affine_matrix(
+        stain_matrix,
+        deconvolution_matrix,
+        np.ones_like(scale_factors),
+        np.zeros_like(shift_values),
+    )
+    result = _apply_stain_affine(optical_density, base_affine)
+    if np.any(tissue_mask):
+        result[tissue_mask] = _apply_stain_affine(optical_density[tissue_mask], augmented_affine)
+    return result
+
+
+def _apply_residual_stain_affine(
+    img: ImageType,
+    optical_density: np.ndarray,
+    reconstruction_matrix: np.ndarray,
+    scale_factors: np.ndarray,
+    shift_values: np.ndarray,
+    augment_background: bool,
+) -> np.ndarray:
+    deconvolution_matrix = np.linalg.inv(reconstruction_matrix).T
+    augmented_affine = _build_stain_affine_matrix(
+        reconstruction_matrix,
+        deconvolution_matrix,
+        scale_factors,
+        shift_values,
+    )
+    if augment_background:
+        return _apply_stain_affine(optical_density, augmented_affine)
+
+    tissue_mask = get_tissue_mask(img)
+    tissue_count = np.count_nonzero(tissue_mask)
+    image_matrix = img.reshape(-1, 3)
+    if tissue_count == tissue_mask.size:
+        return _apply_stain_affine(optical_density, augmented_affine)
+    if tissue_count <= tissue_mask.size * _SPARSE_TISSUE_MAX_FRACTION:
+        result = image_matrix.copy()
+        if tissue_count:
+            result[tissue_mask] = _apply_stain_affine(optical_density[tissue_mask], augmented_affine)
+        return result
+
+    result = _apply_stain_affine(optical_density, augmented_affine)
+    background_mask = ~tissue_mask
+    result[background_mask] = image_matrix[background_mask]
     return result
 
 
@@ -478,9 +591,13 @@ def apply_he_stain_augmentation(
     Returns:
         ImageType: RGB image with the input shape and dtype.
 
+    Raises:
+        ValueError: If the stain matrix, residual mode, or adjustment-vector shapes are invalid.
+
     Note:
         - `"project"` solves the regularized two-stain model used by earlier releases.
         - The residual modes use `R = normalize(cross(H, E))` and solve the full H&E+R basis.
+        - If H and E are nearly collinear, residual modes fall back to the regularized `"project"` model.
 
     Examples:
         >>> import numpy as np
@@ -497,64 +614,40 @@ def apply_he_stain_augmentation(
         ... )
 
     """
-    # Step 1: Convert RGB to optical density space
-    optical_density = rgb_to_optical_density(img)
-
-    # Step 2: Calculate stain concentrations using regularized pseudo-inverse
-    stain_matrix = np.ascontiguousarray(stain_matrix, dtype=np.float32)
-
-    # Add small regularization term for numerical stability.
+    stain_matrix, scale_factors, shift_values = _validate_stain_augmentation_inputs(
+        stain_matrix,
+        scale_factors,
+        shift_values,
+        residual_mode,
+    )
     regularization = 1e-6
+    reconstruction_matrix = (
+        None if residual_mode == "project" else _build_residual_stain_matrix(stain_matrix, regularization)
+    )
+    optical_density = rgb_to_optical_density(img)
 
     # Suppress numerical warnings for edge cases with extreme optical densities
     with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
-        if residual_mode == "project":
-            stain_correlation = stain_matrix @ stain_matrix.T + regularization * np.eye(2)
-            deconvolution_matrix = np.linalg.solve(stain_correlation, stain_matrix)
-            augmented_affine = _build_stain_affine_matrix(
+        if reconstruction_matrix is None:
+            component_slice = slice(None) if residual_mode == "project" else slice(2)
+            rgb_result = _apply_project_stain_affine(
+                img,
+                optical_density,
                 stain_matrix,
-                deconvolution_matrix,
-                scale_factors,
-                shift_values,
+                scale_factors[component_slice],
+                shift_values[component_slice],
+                augment_background,
+                regularization,
             )
-            if augment_background:
-                rgb_result = _apply_stain_affine(optical_density, augmented_affine)
-            else:
-                tissue_mask = get_tissue_mask(img)
-                if np.all(tissue_mask):
-                    rgb_result = _apply_stain_affine(optical_density, augmented_affine)
-                else:
-                    base_affine = _build_stain_affine_matrix(
-                        stain_matrix,
-                        deconvolution_matrix,
-                        np.ones_like(scale_factors),
-                        np.zeros_like(shift_values),
-                    )
-                    rgb_result = _apply_stain_affine(optical_density, base_affine)
-                    if np.any(tissue_mask):
-                        rgb_result[tissue_mask] = _apply_stain_affine(
-                            optical_density[tissue_mask],
-                            augmented_affine,
-                        )
         else:
-            residual_vector = np.cross(stain_matrix[0], stain_matrix[1])
-            residual_vector /= np.linalg.norm(residual_vector)
-            reconstruction_matrix = np.empty((3, 3), dtype=np.float32)
-            reconstruction_matrix[:2] = stain_matrix
-            reconstruction_matrix[2] = residual_vector
-            deconvolution_matrix = np.linalg.inv(reconstruction_matrix).T
-            augmented_affine = _build_stain_affine_matrix(
+            rgb_result = _apply_residual_stain_affine(
+                img,
+                optical_density,
                 reconstruction_matrix,
-                deconvolution_matrix,
                 scale_factors,
                 shift_values,
+                augment_background,
             )
-            rgb_result = _apply_stain_affine(optical_density, augmented_affine)
-            if not augment_background:
-                background_mask = ~get_tissue_mask(img)
-                if np.any(background_mask):
-                    image_matrix = img.reshape(-1, 3)
-                    rgb_result[background_mask] = image_matrix[background_mask]
 
     return rgb_result.reshape(img.shape)
 

--- a/albumentations/augmentations/pixel/_functional_histology.py
+++ b/albumentations/augmentations/pixel/_functional_histology.py
@@ -429,6 +429,26 @@ def get_tissue_mask(img: ImageType, threshold: float = 0.85) -> np.ndarray:
     return mask.reshape(-1)
 
 
+def _build_stain_affine_matrix(
+    stain_matrix: np.ndarray,
+    deconvolution_matrix: np.ndarray,
+    scale_factors: np.ndarray,
+    shift_values: np.ndarray,
+) -> np.ndarray:
+    affine_matrix = np.empty((3, 4), dtype=np.float32)
+    affine_matrix[:, :3] = stain_matrix.T @ (scale_factors[:, None] * deconvolution_matrix)
+    affine_matrix[:, 3] = stain_matrix.T @ shift_values
+    return affine_matrix
+
+
+def _apply_stain_affine(optical_density: np.ndarray, affine_matrix: np.ndarray) -> np.ndarray:
+    result = cv2.transform(optical_density.reshape(-1, 1, 3), affine_matrix).reshape(-1, 3)
+    multiply = cast("_Cv2InPlaceOp", cv2.multiply)
+    multiply(result, -1.0, dst=result)
+    cv2.exp(result, dst=result)
+    return result
+
+
 @clipped
 @float32_io
 def apply_he_stain_augmentation(
@@ -437,21 +457,44 @@ def apply_he_stain_augmentation(
     scale_factors: np.ndarray,
     shift_values: np.ndarray,
     augment_background: bool,
+    residual_mode: Literal["project", "preserve", "augment"] = "project",
 ) -> ImageType:
-    """Apply HE (hematoxylin-eosin) stain augmentation. Shifts stain concentrations;
-    params control strength. Used for histology augmentation. Returns RGB image.
+    """Perturb H&E concentrations in optical-density space, with an optional residual channel
+    for stain-variation augmentation in histology pipelines.
 
-    This function applies HE stain augmentation to an image.
+    The two-row stain matrix always defines hematoxylin and eosin. Residual modes derive a normalized third vector
+    from their cross product, so callers do not need to provide a redundant three-row matrix.
 
     Args:
-        img (ImageType): Input image.
-        stain_matrix (np.ndarray): Stain matrix.
-        scale_factors (np.ndarray): Scale factors.
-        shift_values (np.ndarray): Shift values.
-        augment_background (bool): Whether to augment the background.
+        img (ImageType): RGB image with values in the dtype's standard range.
+        stain_matrix (np.ndarray): H&E optical-density basis with shape `(2, 3)`.
+        scale_factors (np.ndarray): Per-component multiplicative factors. Supply two values for `"project"` and
+            three values for the residual modes.
+        shift_values (np.ndarray): Per-component additive shifts, with the same length as `scale_factors`.
+        augment_background (bool): Whether to adjust concentrations outside the tissue mask.
+        residual_mode (Literal['project', 'preserve', 'augment']): Residual-channel policy. `"project"` reconstructs
+            from H&E only; `"preserve"` keeps the residual unchanged; `"augment"` adjusts all three components.
 
     Returns:
-        ImageType: Augmented image.
+        ImageType: RGB image with the input shape and dtype.
+
+    Note:
+        - `"project"` solves the regularized two-stain model used by earlier releases.
+        - The residual modes use `R = normalize(cross(H, E))` and solve the full H&E+R basis.
+
+    Examples:
+        >>> import numpy as np
+        >>> from albumentations.augmentations.pixel import functional as fpixel
+        >>> image = np.full((8, 8, 3), 0.5, dtype=np.float32)
+        >>> stain_matrix = np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32)
+        >>> result = fpixel.apply_he_stain_augmentation(
+        ...     image,
+        ...     stain_matrix,
+        ...     scale_factors=np.array([1.05, 0.95, 1.02]),
+        ...     shift_values=np.array([0.02, -0.01, 0.01]),
+        ...     augment_background=True,
+        ...     residual_mode="augment",
+        ... )
 
     """
     # Step 1: Convert RGB to optical density space
@@ -460,37 +503,58 @@ def apply_he_stain_augmentation(
     # Step 2: Calculate stain concentrations using regularized pseudo-inverse
     stain_matrix = np.ascontiguousarray(stain_matrix, dtype=np.float32)
 
-    # Add small regularization term for numerical stability
+    # Add small regularization term for numerical stability.
     regularization = 1e-6
 
     # Suppress numerical warnings for edge cases with extreme optical densities
     with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
-        stain_correlation = stain_matrix @ stain_matrix.T + regularization * np.eye(2)
-        density_projection = stain_matrix @ optical_density.T
-
-        try:
-            # Solve for stain concentrations
-            stain_concentrations = np.linalg.solve(stain_correlation, density_projection).T
-        except np.linalg.LinAlgError:
-            # Fallback to pseudo-inverse if direct solve fails
-            stain_concentrations = np.linalg.lstsq(
-                stain_matrix.T,
-                optical_density,
-                rcond=regularization,
-            )[0].T
-
-        # Step 3: Apply concentration adjustments
-        if not augment_background:
-            # Only modify tissue regions
-            tissue_mask = get_tissue_mask(img).reshape(-1)
-            stain_concentrations[tissue_mask] = stain_concentrations[tissue_mask] * scale_factors + shift_values
+        if residual_mode == "project":
+            stain_correlation = stain_matrix @ stain_matrix.T + regularization * np.eye(2)
+            deconvolution_matrix = np.linalg.solve(stain_correlation, stain_matrix)
+            augmented_affine = _build_stain_affine_matrix(
+                stain_matrix,
+                deconvolution_matrix,
+                scale_factors,
+                shift_values,
+            )
+            if augment_background:
+                rgb_result = _apply_stain_affine(optical_density, augmented_affine)
+            else:
+                tissue_mask = get_tissue_mask(img)
+                if np.all(tissue_mask):
+                    rgb_result = _apply_stain_affine(optical_density, augmented_affine)
+                else:
+                    base_affine = _build_stain_affine_matrix(
+                        stain_matrix,
+                        deconvolution_matrix,
+                        np.ones_like(scale_factors),
+                        np.zeros_like(shift_values),
+                    )
+                    rgb_result = _apply_stain_affine(optical_density, base_affine)
+                    if np.any(tissue_mask):
+                        rgb_result[tissue_mask] = _apply_stain_affine(
+                            optical_density[tissue_mask],
+                            augmented_affine,
+                        )
         else:
-            # Modify all pixels
-            stain_concentrations = stain_concentrations * scale_factors + shift_values
-
-        # Step 4: Reconstruct RGB image
-        optical_density_result = stain_concentrations @ stain_matrix
-        rgb_result = np.exp(-optical_density_result)
+            residual_vector = np.cross(stain_matrix[0], stain_matrix[1])
+            residual_vector /= np.linalg.norm(residual_vector)
+            reconstruction_matrix = np.empty((3, 3), dtype=np.float32)
+            reconstruction_matrix[:2] = stain_matrix
+            reconstruction_matrix[2] = residual_vector
+            deconvolution_matrix = np.linalg.inv(reconstruction_matrix).T
+            augmented_affine = _build_stain_affine_matrix(
+                reconstruction_matrix,
+                deconvolution_matrix,
+                scale_factors,
+                shift_values,
+            )
+            rgb_result = _apply_stain_affine(optical_density, augmented_affine)
+            if not augment_background:
+                background_mask = ~get_tissue_mask(img)
+                if np.any(background_mask):
+                    image_matrix = img.reshape(-1, 3)
+                    rgb_result[background_mask] = image_matrix[background_mask]
 
     return rgb_result.reshape(img.shape)
 

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -769,6 +769,12 @@ class HEStain(ImageOnlyTransform):
             sampled independently for hematoxylin and eosin. Default: (-0.2, 0.2).
 
         augment_background (bool): Whether to perturb background pixels along with tissue pixels. Default: False.
+        residual_mode (Literal["project", "preserve", "augment"]): Controls the optical-density component orthogonal
+            to the H&E plane:
+            - `"project"`: Reconstruct from H&E only, retaining the two-stain model from earlier releases.
+            - `"preserve"`: Derive the residual basis vector and keep its concentration unchanged.
+            - `"augment"`: Independently perturb the derived residual along with H&E.
+            Default: `"project"`.
         p (float): Probability of applying the transform. Default: 0.5.
         stain_matrix (np.ndarray | None): Fixed H&E stain basis used when `method="custom"`. The matrix must have
             shape `(2, 3)`: row 0 is the hematoxylin RGB optical-density vector and row 1 is the eosin vector. Both
@@ -785,9 +791,10 @@ class HEStain(ImageOnlyTransform):
         uint8, float32
 
     Note:
-        - Let `M` be the `(2, 3)` stain matrix and `C` the per-pixel stain concentrations. The transform solves
-          `OD ~= C @ M`, samples `scale` and `shift` for each stain, then reconstructs
-          `RGB = exp(-(C * scale + shift) @ M)`.
+        - Let `M` be the `(2, 3)` H&E matrix and `C` the per-pixel concentrations. `"project"` solves
+          `OD ~= C @ M`, perturbs H&E, and reconstructs `RGB = exp(-(C * scale + shift) @ M)`.
+        - `"preserve"` and `"augment"` derive `R = normalize(cross(H, E))`, solve the full H&E+R basis, and either
+          retain or perturb the residual concentration.
         - A custom matrix is fixed for the lifetime of the transform. Per-image callable extraction is not supported.
 
     References:
@@ -795,6 +802,8 @@ class HEStain(ImageOnlyTransform):
             cytology and histology, 2001.
         - M. Macenko et al., "A method for normalizing histology slides for: 2009 IEEE International Symposium on
             quantitative analysis," 2009 IEEE International Symposium on Biomedical Imaging, 2009.
+        - D. Tellez et al., "H&E stain augmentation improves generalization of convolutional networks for
+            histopathological mitosis detection": Medical Imaging, 2018.
 
     Examples:
         >>> import numpy as np
@@ -818,6 +827,7 @@ class HEStain(ImageOnlyTransform):
         >>> transform = A.HEStain(
         ...     method="custom",
         ...     stain_matrix=stain_matrix,
+        ...     residual_mode="augment",
         ...     intensity_scale_range=(0.8, 1.2),
         ...     intensity_shift_range=(-0.1, 0.1),
         ...     p=1.0,
@@ -897,6 +907,7 @@ class HEStain(ImageOnlyTransform):
             AfterValidator(check_range_bounds(-1, 1)),
         ]
         augment_background: bool
+        residual_mode: Literal["project", "preserve", "augment"]
 
         @field_validator("stain_matrix", mode="before")
         @classmethod
@@ -948,6 +959,7 @@ class HEStain(ImageOnlyTransform):
         augment_background: bool = False,
         p: float = 0.5,
         *,
+        residual_mode: Literal["project", "preserve", "augment"] = "project",
         stain_matrix: np.ndarray | None = None,
     ):
         super().__init__(p=p)
@@ -956,6 +968,7 @@ class HEStain(ImageOnlyTransform):
         self.intensity_scale_range = intensity_scale_range
         self.intensity_shift_range = intensity_shift_range
         self.augment_background = augment_background
+        self.residual_mode = residual_mode
         self.stain_matrix = stain_matrix
 
         # Initialize stain extractor here if needed
@@ -1012,6 +1025,7 @@ class HEStain(ImageOnlyTransform):
             scale_factors=scale_factors,
             shift_values=shift_values,
             augment_background=self.augment_background,
+            residual_mode=self.residual_mode,
         )
 
     @batch_transform("channel")
@@ -1043,12 +1057,29 @@ class HEStain(ImageOnlyTransform):
         shift_h = self.py_random.uniform(*self.intensity_shift_range)
         shift_e = self.py_random.uniform(*self.intensity_shift_range)
 
-        scale_factors = np.array([scale_h, scale_e])
-        shift_values = np.array([shift_h, shift_e])
+        sampled_scales: tuple[float, ...]
+        sampled_shifts: tuple[float, ...]
+        if self.residual_mode == "preserve":
+            scale_factors = np.array([scale_h, scale_e, 1.0], dtype=np.float32)
+            shift_values = np.array([shift_h, shift_e, 0.0], dtype=np.float32)
+            sampled_scales = (scale_h, scale_e)
+            sampled_shifts = (shift_h, shift_e)
+        elif self.residual_mode == "augment":
+            scale_residual = self.py_random.uniform(*self.intensity_scale_range)
+            shift_residual = self.py_random.uniform(*self.intensity_shift_range)
+            scale_factors = np.array([scale_h, scale_e, scale_residual], dtype=np.float32)
+            shift_values = np.array([shift_h, shift_e, shift_residual], dtype=np.float32)
+            sampled_scales = (scale_h, scale_e, scale_residual)
+            sampled_shifts = (shift_h, shift_e, shift_residual)
+        else:
+            scale_factors = np.array([scale_h, scale_e])
+            shift_values = np.array([shift_h, shift_e])
+            sampled_scales = (scale_h, scale_e)
+            sampled_shifts = (shift_h, shift_e)
 
         self.applied_config = {
-            "intensity_scale_range": (min(scale_h, scale_e), max(scale_h, scale_e)),
-            "intensity_shift_range": (min(shift_h, shift_e), max(shift_h, shift_e)),
+            "intensity_scale_range": (min(sampled_scales), max(sampled_scales)),
+            "intensity_shift_range": (min(sampled_shifts), max(sampled_shifts)),
         }
 
         return {

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -857,6 +857,26 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
             "stain_matrix": np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32),
         },
     ),
+    (
+        "preserve-residual",
+        A.HEStain,
+        {
+            "method": "custom",
+            "stain_matrix": np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32),
+            "residual_mode": "preserve",
+            "augment_background": True,
+        },
+    ),
+    (
+        "augment-residual",
+        A.HEStain,
+        {
+            "method": "custom",
+            "stain_matrix": np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32),
+            "residual_mode": "augment",
+            "augment_background": True,
+        },
+    ),
     ("custom-reference", A.HistogramMatching, {"blend_ratio": (0.2, 0.4), "metadata_key": "references"}),
     (
         "gaussian-darken",

--- a/tests/test_hestain.py
+++ b/tests/test_hestain.py
@@ -133,6 +133,74 @@ def test_hestain_default_project_mode_preserves_seeded_parameter_sequence() -> N
     np.testing.assert_array_equal(result, explicit_project)
 
 
+@pytest.mark.parametrize("residual_mode", ["preserve", "augment"])
+def test_hestain_degenerate_extracted_residual_basis_falls_back_to_project(residual_mode: str) -> None:
+    image = np.full((32, 32, 3), 32, dtype=np.uint8)
+    project = A.Compose(
+        [A.HEStain(method="macenko", residual_mode="project", p=1.0)],
+        seed=137,
+        strict=True,
+    )(image=image)["image"]
+    residual = A.Compose(
+        [A.HEStain(method="macenko", residual_mode=residual_mode, p=1.0)],
+        seed=137,
+        strict=True,
+    )(image=image)["image"]
+
+    np.testing.assert_array_equal(residual, project)
+
+
+def test_apply_he_stain_augmentation_nearly_collinear_residual_basis_falls_back_to_project() -> None:
+    image = np.random.default_rng(137).uniform(0.05, 1.0, size=(12, 10, 3)).astype(np.float32)
+    nearly_collinear_matrix = np.array([[1.0, 0.0, 0.0], [1.0, 5e-7, 0.0]], dtype=np.float32)
+    scale_factors = np.array([1.2, 0.8, 1.5], dtype=np.float32)
+    shift_values = np.array([0.1, -0.05, 0.2], dtype=np.float32)
+
+    residual = fpixel.apply_he_stain_augmentation(
+        image,
+        nearly_collinear_matrix,
+        scale_factors,
+        shift_values,
+        augment_background=True,
+        residual_mode="augment",
+    )
+    project = fpixel.apply_he_stain_augmentation(
+        image,
+        nearly_collinear_matrix,
+        scale_factors[:2],
+        shift_values[:2],
+        augment_background=True,
+        residual_mode="project",
+    )
+
+    np.testing.assert_array_equal(residual, project)
+
+
+@pytest.mark.parametrize(
+    ("scale_factors", "shift_values", "invalid_parameter"),
+    [
+        (np.ones(2, dtype=np.float32), np.zeros(3, dtype=np.float32), "scale_factors"),
+        (np.ones(3, dtype=np.float32), np.zeros(2, dtype=np.float32), "shift_values"),
+    ],
+)
+def test_apply_he_stain_augmentation_rejects_mismatched_residual_parameters(
+    scale_factors: np.ndarray,
+    shift_values: np.ndarray,
+    invalid_parameter: str,
+) -> None:
+    image = np.full((8, 8, 3), 0.5, dtype=np.float32)
+
+    with pytest.raises(ValueError, match=rf"{invalid_parameter} must have shape \(3,\)"):
+        fpixel.apply_he_stain_augmentation(
+            image,
+            CUSTOM_STAIN_MATRIX,
+            scale_factors,
+            shift_values,
+            augment_background=True,
+            residual_mode="augment",
+        )
+
+
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 @pytest.mark.parametrize("augment_background", [False, True])
 def test_hestain_project_mode_stays_within_accepted_legacy_tolerance(
@@ -203,9 +271,14 @@ def test_hestain_augment_residual_replay_reuses_all_sampled_parameters(
 
 
 @pytest.mark.parametrize("residual_mode", ["preserve", "augment"])
-def test_hestain_residual_modes_respect_tissue_mask(residual_mode: str) -> None:
-    image = np.ones((12, 10, 3), dtype=np.float32)
-    image[3:9, 2:8] = np.array([0.2, 0.3, 0.4], dtype=np.float32)
+@pytest.mark.parametrize("dense_tissue", [False, True])
+def test_hestain_residual_modes_respect_tissue_mask(residual_mode: str, dense_tissue: bool) -> None:
+    if dense_tissue:
+        image = np.full((12, 10, 3), np.array([0.2, 0.3, 0.4]), dtype=np.float32)
+        image[:2] = 1.0
+    else:
+        image = np.ones((12, 10, 3), dtype=np.float32)
+        image[3:9, 2:8] = np.array([0.2, 0.3, 0.4], dtype=np.float32)
     transform = A.HEStain(
         method="custom",
         stain_matrix=CUSTOM_STAIN_MATRIX,
@@ -217,9 +290,10 @@ def test_hestain_residual_modes_respect_tissue_mask(residual_mode: str) -> None:
     )
 
     result = transform(image=image)["image"]
+    tissue_mask = fpixel.get_tissue_mask(image).reshape(image.shape[:2])
 
-    np.testing.assert_allclose(result[:3], image[:3], rtol=1e-5, atol=1e-6)
-    assert not np.allclose(result[3:9, 2:8], image[3:9, 2:8])
+    np.testing.assert_array_equal(result[~tissue_mask], image[~tissue_mask])
+    assert not np.allclose(result[tissue_mask], image[tissue_mask])
 
 
 def test_hestain_uses_custom_stain_matrix() -> None:

--- a/tests/test_hestain.py
+++ b/tests/test_hestain.py
@@ -10,6 +10,218 @@ from tests.helpers import TestDataFactory
 CUSTOM_STAIN_MATRIX = np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32)
 
 
+def _apply_he_residual_reference(
+    image: np.ndarray,
+    stain_matrix: np.ndarray,
+    scale_factors: np.ndarray,
+    shift_values: np.ndarray,
+) -> np.ndarray:
+    max_value = 255.0 if image.dtype == np.uint8 else 1.0
+    pixel_matrix = image.reshape(-1, 3).astype(np.float32) / max_value
+    pixel_matrix = np.maximum(pixel_matrix, np.float32(1e-6))
+    optical_density = -np.log(pixel_matrix)
+    residual_vector = np.cross(stain_matrix[0], stain_matrix[1])
+    residual_vector /= np.linalg.norm(residual_vector)
+    full_stain_matrix = np.vstack([stain_matrix, residual_vector]).astype(np.float32)
+    stain_concentrations = np.linalg.solve(full_stain_matrix.T, optical_density.T).T
+    augmented_concentrations = stain_concentrations * scale_factors + shift_values
+    result = np.clip(np.exp(-(augmented_concentrations @ full_stain_matrix)), 0, 1).reshape(image.shape)
+    if image.dtype == np.uint8:
+        return np.rint(result * 255).astype(np.uint8)
+    return result
+
+
+def _apply_he_project_legacy_reference(
+    image: np.ndarray,
+    stain_matrix: np.ndarray,
+    scale_factors: np.ndarray,
+    shift_values: np.ndarray,
+    augment_background: bool,
+) -> np.ndarray:
+    max_value = 255.0 if image.dtype == np.uint8 else 1.0
+    image_float = image.astype(np.float32) / max_value
+    pixel_matrix = np.maximum(image_float.reshape(-1, 3), np.float32(1e-6))
+    optical_density = -np.log(pixel_matrix)
+    regularization = 1e-6
+    stain_correlation = stain_matrix @ stain_matrix.T + regularization * np.eye(2)
+    density_projection = stain_matrix @ optical_density.T
+    stain_concentrations = np.linalg.solve(stain_correlation, density_projection).T
+    if augment_background:
+        stain_concentrations = stain_concentrations * scale_factors + shift_values
+    else:
+        luminosity = image_float @ np.array([0.299, 0.587, 0.114], dtype=np.float32)
+        tissue_mask = luminosity.reshape(-1) < 0.85
+        stain_concentrations[tissue_mask] = stain_concentrations[tissue_mask] * scale_factors + shift_values
+    result = np.clip(np.exp(-(stain_concentrations @ stain_matrix)), 0, 1).reshape(image.shape)
+    if image.dtype == np.uint8:
+        return np.rint(result * 255).astype(np.uint8)
+    return result.astype(np.float32)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_hestain_augment_residual_matches_full_basis_reference(dtype: type[np.generic]) -> None:
+    rng = np.random.default_rng(137)
+    if dtype == np.uint8:
+        image = rng.integers(13, 256, size=(12, 10, 3), dtype=np.uint8)
+    else:
+        image = rng.uniform(0.05, 1.0, size=(12, 10, 3)).astype(np.float32)
+    transform = A.HEStain(
+        method="custom",
+        stain_matrix=CUSTOM_STAIN_MATRIX,
+        residual_mode="augment",
+        intensity_scale_range=(0.8, 1.2),
+        intensity_shift_range=(-0.1, 0.1),
+        augment_background=True,
+        p=1.0,
+    )
+
+    result = transform(image=image)["image"]
+    params = transform.get_applied_params()
+
+    assert params["scale_factors"].shape == (3,)
+    assert params["shift_values"].shape == (3,)
+    expected = _apply_he_residual_reference(
+        image,
+        CUSTOM_STAIN_MATRIX,
+        params["scale_factors"],
+        params["shift_values"],
+    )
+    tolerance = 1 if dtype == np.uint8 else 1e-6
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=tolerance)
+
+
+def test_hestain_preserve_residual_reconstructs_identity() -> None:
+    image = np.random.default_rng(137).uniform(0.05, 1.0, size=(12, 10, 3)).astype(np.float32)
+    transform = A.HEStain(
+        method="custom",
+        stain_matrix=CUSTOM_STAIN_MATRIX,
+        residual_mode="preserve",
+        intensity_scale_range=(1.0, 1.0),
+        intensity_shift_range=(0.0, 0.0),
+        augment_background=True,
+        p=1.0,
+    )
+
+    result = transform(image=image)["image"]
+    params = transform.get_applied_params()
+
+    np.testing.assert_array_equal(params["scale_factors"], np.array([1.0, 1.0, 1.0]))
+    np.testing.assert_array_equal(params["shift_values"], np.array([0.0, 0.0, 0.0]))
+    np.testing.assert_allclose(result, image, rtol=1e-5, atol=1e-6)
+
+
+def test_hestain_default_project_mode_preserves_seeded_parameter_sequence() -> None:
+    image = np.random.default_rng(137).integers(0, 256, size=(8, 7, 3), dtype=np.uint8)
+    transform = A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, p=1.0)
+
+    result = A.Compose([transform], seed=137, strict=True)(image=image)["image"]
+    params = transform.get_applied_params()
+    explicit_project = A.Compose(
+        [A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, residual_mode="project", p=1.0)],
+        seed=137,
+        strict=True,
+    )(image=image)["image"]
+
+    np.testing.assert_array_equal(
+        params["scale_factors"],
+        np.array([0.9460570722474746, 1.2941528299113085]),
+    )
+    np.testing.assert_array_equal(
+        params["shift_values"],
+        np.array([-0.10763109776870272, -0.06048900184007305]),
+    )
+    np.testing.assert_array_equal(result, explicit_project)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("augment_background", [False, True])
+def test_hestain_project_mode_stays_within_accepted_legacy_tolerance(
+    dtype: type[np.generic],
+    augment_background: bool,
+) -> None:
+    data = TestDataFactory.create_image((24, 20, 3), dtype=dtype, seed=137)
+    transform = A.HEStain(
+        method="custom",
+        stain_matrix=CUSTOM_STAIN_MATRIX,
+        residual_mode="project",
+        intensity_scale_range=(0.8, 1.2),
+        intensity_shift_range=(-0.1, 0.1),
+        augment_background=augment_background,
+        p=1.0,
+    )
+
+    result = transform(image=data)["image"]
+    params = transform.get_applied_params()
+    expected = _apply_he_project_legacy_reference(
+        data,
+        CUSTOM_STAIN_MATRIX,
+        params["scale_factors"],
+        params["shift_values"],
+        augment_background,
+    )
+
+    tolerance = 1 if dtype == np.uint8 else 1.5e-6
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=tolerance)
+
+
+@pytest.mark.parametrize(
+    ("target", "shape"),
+    [
+        ("image", (12, 10, 3)),
+        ("images", (2, 12, 10, 3)),
+        ("volume", (2, 12, 10, 3)),
+        ("volumes", (2, 2, 12, 10, 3)),
+    ],
+)
+def test_hestain_augment_residual_replay_reuses_all_sampled_parameters(
+    target: str,
+    shape: tuple[int, ...],
+) -> None:
+    data = TestDataFactory.create_image(shape, dtype=np.uint8, seed=137)
+    pipeline = A.ReplayCompose(
+        [
+            A.HEStain(
+                method="custom",
+                stain_matrix=CUSTOM_STAIN_MATRIX,
+                residual_mode="augment",
+                augment_background=True,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    result = pipeline(**{target: data})
+    replay_params = result["replay"]["transforms"][0]["params"]
+    replayed = A.ReplayCompose.replay(result["replay"], **{target: data})
+
+    assert len(replay_params["scale_factors"]) == 3
+    assert len(replay_params["shift_values"]) == 3
+    assert replay_params["scale_factors"][2] != 1.0
+    assert replay_params["shift_values"][2] != 0.0
+    np.testing.assert_array_equal(replayed[target], result[target])
+
+
+@pytest.mark.parametrize("residual_mode", ["preserve", "augment"])
+def test_hestain_residual_modes_respect_tissue_mask(residual_mode: str) -> None:
+    image = np.ones((12, 10, 3), dtype=np.float32)
+    image[3:9, 2:8] = np.array([0.2, 0.3, 0.4], dtype=np.float32)
+    transform = A.HEStain(
+        method="custom",
+        stain_matrix=CUSTOM_STAIN_MATRIX,
+        residual_mode=residual_mode,
+        intensity_scale_range=(1.2, 1.2),
+        intensity_shift_range=(0.1, 0.1),
+        augment_background=False,
+        p=1.0,
+    )
+
+    result = transform(image=image)["image"]
+
+    np.testing.assert_allclose(result[:3], image[:3], rtol=1e-5, atol=1e-6)
+    assert not np.allclose(result[3:9, 2:8], image[3:9, 2:8])
+
+
 def test_hestain_uses_custom_stain_matrix() -> None:
     image = TestDataFactory.create_image((32, 24, 3), dtype=np.uint8, seed=137)
     transform = A.HEStain(
@@ -94,7 +306,36 @@ def test_hestain_custom_stain_matrix_survives_json_serialization() -> None:
     np.testing.assert_array_equal(restored_transform.stain_matrix, CUSTOM_STAIN_MATRIX)
 
 
+@pytest.mark.parametrize("residual_mode", ["preserve", "augment"])
+def test_hestain_residual_mode_survives_json_serialization(residual_mode: str) -> None:
+    pipeline = A.Compose(
+        [
+            A.HEStain(
+                method="custom",
+                stain_matrix=CUSTOM_STAIN_MATRIX,
+                residual_mode=residual_mode,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+        strict=True,
+    )
+
+    serialized = json.loads(json.dumps(A.to_dict(pipeline), allow_nan=False))
+    restored = A.from_dict(serialized)
+
+    restored_transform = restored.transforms[0]
+    assert isinstance(restored_transform, A.HEStain)
+    assert restored_transform.residual_mode == residual_mode
+
+
+def test_hestain_rejects_invalid_residual_mode() -> None:
+    with pytest.raises(ValueError, match="residual_mode"):
+        A.HEStain(residual_mode="invalid")
+
+
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("residual_mode", ["project", "preserve", "augment"])
 @pytest.mark.parametrize(
     ("target", "shape"),
     [
@@ -108,6 +349,7 @@ def test_hestain_custom_matrix_supports_all_image_targets(
     target: str,
     shape: tuple[int, ...],
     dtype: type[np.generic],
+    residual_mode: str,
 ) -> None:
     data = TestDataFactory.create_image(shape, dtype=dtype, seed=137)
     transform = A.Compose(
@@ -115,6 +357,7 @@ def test_hestain_custom_matrix_supports_all_image_targets(
             A.HEStain(
                 method="custom",
                 stain_matrix=CUSTOM_STAIN_MATRIX,
+                residual_mode=residual_mode,
                 intensity_scale_range=(1.1, 1.1),
                 intensity_shift_range=(0.05, 0.05),
                 augment_background=True,


### PR DESCRIPTION
## Summary

- add `residual_mode="project" | "preserve" | "augment"` to `HEStain`
- derive the third optical-density basis vector from `cross(H, E)`
- preserve or independently augment the residual concentration
- fuse stain deconvolution, perturbation, and reconstruction into one OpenCV affine transform
- cover the new modes across image, batch, and volumetric targets, replay, serialization, and tissue masking

## Motivation

The two-stain projection discards the optical-density component outside the H&E plane. Preserving or augmenting that residual supports the stain variation described in #371 without requiring callers to provide a redundant three-row stain matrix.

Closes #371.

## Compatibility and performance

`project` remains the default and preserves the existing H/E random-parameter sequence. The fused implementation improves measured runtime by 3.5–5.7x for RGB images from 256×256 to 1024×1024, for both `uint8` and `float32`, directly and through `Compose`.

The optimized `project` path can differ from the earlier implementation by at most one `uint8` level or about `1.43e-6` for `float32` in the benchmarked cases.

## Validation

- full non-slow suite: 12,845 passed, 42 skipped, 38 deselected, 9 xfailed, 3 xpassed
- contract suite: 1,338 passed
- quality gate
- repository-wide pre-commit
- ruff, mypy, Pyrefly, docstring, regression-vector, and legal-integrity checks

## Summary by Sourcery

Add residual-channel modes to HE stain augmentation, deriving a third basis vector and optimizing the HEStain pipeline while preserving existing project-mode behavior.

New Features:
- Introduce a residual_mode option for HEStain with 'project', 'preserve', and 'augment' policies for the optical-density component orthogonal to the H&E plane.
- Support residual-channel augmentation and preservation across image, batch, and volumetric targets, including replay pipelines and JSON serialization.
- Allow HEStain parameter sampling to include an independently perturbed residual component when requested.

Enhancements:
- Refactor HE stain augmentation into a single OpenCV-based affine transform that fuses deconvolution, perturbation, and reconstruction for improved efficiency.
- Derive a normalized residual optical-density basis vector from the cross product of the hematoxylin and eosin vectors to avoid requiring a three-row stain matrix.
- Ensure the default project mode preserves seeded parameter sequences and remains numerically consistent with the legacy implementation within a tight tolerance.
- Clarify HEStain documentation with residual-mode semantics, mathematical notes, references, and usage examples.

Documentation:
- Extend HEStain docstrings to document residual modes, basis construction, parameter requirements, and provide illustrative examples and literature references.

Tests:
- Add reference and property tests for residual_mode='preserve' and 'augment', including identity reconstruction and tissue-mask behavior.
- Add compatibility tests to verify that the optimized project mode stays within accepted tolerances of the legacy implementation.
- Extend HEStain tests to cover residual modes across different dtypes, image and volume targets, replay/serialization workflows, and invalid-configuration handling.
- Register new HEStain residual-mode cases in shared transform test fixtures to integrate with the broader test suite.