### PR TITLE
Add continuous float32 path to RandomToneCurve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,19 @@ Project-specific skills live in `.codex/skills`. Use the matching skill whenever
 Use `performance-optimization` whenever implementing, reviewing, profiling, or optimizing runtime code. The skill
 loads Albucore's canonical performance workflow, including delete-first review, vectorization, grouped reductions,
 LUT and random-generator selection, backend comparison, Albucore extraction, and safe in-place operations.
+
+## PR Review Guardrails
+
+- Keep `apply`, `apply_to_images`, and `apply_to_volumes` limited to validation, policy, and dispatch. Put reusable
+  pixel arithmetic in the functional layer or Albucore.
+- Reuse Albucore dtype, conversion, and arithmetic helpers when they provide the required semantics. Do not recreate
+  conversions such as uint8 normalization locally without a documented reason.
+- Record the exact validation commands and results in the PR or task report. Do not claim a broader quality gate than
+  was run; include both mypy and Pyrefly when a change relies on type narrowing.
+- For runtime-sensitive changes, publish every before/after benchmark cell, not only ranges or aggregates. Cover the
+  affected direct and Compose paths, including direct batch methods and public image/volume batch routes, and include
+  all relevant modes, fallbacks, and specializations. State and justify any intentionally bounded axis.
+- Rework or explicitly justify regressions above 5%, following `.codex/rules/benchmarking.md`; do not hide a common
+  route's regression inside an overall average.
+- Check `git status --short` before handoff. Because `pre-commit run --all-files` omits untracked files, run
+  `pre-commit` with `--files` for each new file until it is tracked or staged.

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -423,7 +423,8 @@ def _move_tone_curve_float32(
 
     result = np.empty_like(img)
     if coefficient_1.shape == (3,) and img.shape[-1] == 3:
-        # Avoid slow last-axis coefficient broadcasting for the common per-channel RGB path.
+        # The loop wins at the measured 256/512/1024 single-image C=3 sizes but loses at
+        # the measured 1x1-32x32 sizes; the single-machine crossover does not establish a stable cutoff.
         for channel_idx in range(3):
             image_channel = img[..., channel_idx]
             result_channel = result[..., channel_idx]

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -13,6 +13,7 @@ from ._functional_shared import (
     NUM_MULTI_CHANNEL_DIMENSIONS,
     NUM_RGB_CHANNELS,
     PCA,
+    ImageFloat32,
     ImageType,
     ImageUInt8,
     add_array,
@@ -388,13 +389,12 @@ def evaluate_bez(
     low_y: float | np.ndarray,
     high_y: float | np.ndarray,
 ) -> np.ndarray:
-    """Evaluate the Bezier curve at the given t values. Used for tone-curve control points;
-    returns y coordinates for input t in [0, 1].
+    """Build a 256-entry cubic Bezier tone curve from shared or per-channel control points for fast lookup-table
+    evaluation of uint8 images.
 
     Args:
-        t (np.ndarray): The t values to evaluate the Bezier curve at.
-        low_y (float | np.ndarray): The low y values to evaluate the Bezier curve at.
-        high_y (float | np.ndarray): The high y values to evaluate the Bezier curve at.
+        low_y (float | np.ndarray): The first inner control ordinate of the Bezier curve.
+        high_y (float | np.ndarray): The second inner control ordinate of the Bezier curve.
 
     Returns:
         np.ndarray: The Bezier curve values.
@@ -406,15 +406,43 @@ def evaluate_bez(
     return (3 * one_minus_t**2 * t * low_y + 3 * one_minus_t * t**2 * high_y + t**3) * 255
 
 
-@uint8_io
+def _move_tone_curve_float32(
+    img: ImageFloat32,
+    low_y: float | np.ndarray,
+    high_y: float | np.ndarray,
+) -> ImageFloat32:
+    """Evaluate a cubic Bezier tone curve continuously in float32 while reusing one image-sized output buffer for
+    memory-efficient processing.
+    """
+    low_y_float32 = np.asarray(low_y, dtype=np.float32)
+    high_y_float32 = np.asarray(high_y, dtype=np.float32)
+
+    coefficient_1 = np.float32(3) * low_y_float32
+    coefficient_2 = np.float32(3) * high_y_float32 - np.float32(6) * low_y_float32
+    coefficient_3 = np.float32(3) * low_y_float32 - np.float32(3) * high_y_float32 + np.float32(1)
+
+    result = np.empty_like(img)
+    np.multiply(img, coefficient_3, out=result)
+    np.add(result, coefficient_2, out=result)
+    np.multiply(result, img, out=result)
+    np.add(result, coefficient_1, out=result)
+    np.multiply(result, img, out=result)
+    np.clip(result, np.float32(0), np.float32(1), out=result)
+    # Float32 coefficient rounding can undershoot the cubic curve's exact t=1 endpoint.
+    result[img == np.float32(1)] = np.float32(1)
+    return result
+
+
 def move_tone_curve(
     img: ImageType,
     low_y: float | np.ndarray,
     high_y: float | np.ndarray,
     num_channels: int,
 ) -> ImageType:
-    """Rescale bright/dark via Bezier tone curve. low_y, high_y (per-channel or scalar), num_channels
-    for per-channel curves. uint8 I/O.
+    """Apply a cubic Bezier tone curve with scalar or per-channel controls, dispatching to continuous float32
+    arithmetic or a uint8 lookup table.
+
+    Float32 images are evaluated continuously. Uint8 images retain the rounded 256-entry LUT path.
 
     Args:
         img (ImageType): Any number of channels
@@ -431,6 +459,12 @@ def move_tone_curve(
     if np.isscalar(low_y) and np.isscalar(high_y):
         low_y_scalar = cast("Any", low_y)
         high_y_scalar = cast("Any", high_y)
+        if img.dtype == np.float32:
+            return _move_tone_curve_float32(
+                cast("ImageFloat32", img),
+                float(low_y_scalar),
+                float(high_y_scalar),
+            )
         lut = cast(
             "ImageUInt8",
             clip(np.rint(evaluate_bez(float(low_y_scalar), float(high_y_scalar))), np.dtype(np.uint8), inplace=False),
@@ -438,6 +472,8 @@ def move_tone_curve(
         return sz_lut(cast("ImageUInt8", img), lut, inplace=False)
 
     if isinstance(low_y, np.ndarray) and isinstance(high_y, np.ndarray):
+        if img.dtype == np.float32:
+            return _move_tone_curve_float32(cast("ImageFloat32", img), low_y, high_y)
         luts = cast(
             "ImageUInt8",
             clip(

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -422,11 +422,22 @@ def _move_tone_curve_float32(
     coefficient_3 = np.float32(3) * low_y_float32 - np.float32(3) * high_y_float32 + np.float32(1)
 
     result = np.empty_like(img)
-    np.multiply(img, coefficient_3, out=result)
-    np.add(result, coefficient_2, out=result)
-    np.multiply(result, img, out=result)
-    np.add(result, coefficient_1, out=result)
-    np.multiply(result, img, out=result)
+    if coefficient_1.shape == (3,) and img.shape[-1] == 3:
+        # Avoid slow last-axis coefficient broadcasting for the common per-channel RGB path.
+        for channel_idx in range(3):
+            image_channel = img[..., channel_idx]
+            result_channel = result[..., channel_idx]
+            np.multiply(image_channel, coefficient_3[channel_idx], out=result_channel)
+            np.add(result_channel, coefficient_2[channel_idx], out=result_channel)
+            np.multiply(result_channel, image_channel, out=result_channel)
+            np.add(result_channel, coefficient_1[channel_idx], out=result_channel)
+            np.multiply(result_channel, image_channel, out=result_channel)
+    else:
+        np.multiply(img, coefficient_3, out=result)
+        np.add(result, coefficient_2, out=result)
+        np.multiply(result, img, out=result)
+        np.add(result, coefficient_1, out=result)
+        np.multiply(result, img, out=result)
     np.clip(result, np.float32(0), np.float32(1), out=result)
     # Float32 coefficient rounding can undershoot the cubic curve's exact t=1 endpoint.
     result[img == np.float32(1)] = np.float32(1)

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -29,15 +29,15 @@ from ._color_shared import (
 
 
 class RandomToneCurve(ImageOnlyTransform):
-    """Randomly warp the tone curve to change contrast and tonal distribution. scale and
-    scale_upper control strength. Good for exposure variation.
+    """Randomly warp image tone curves to create natural nonlinear changes in contrast, brightness, and tonal
+    distribution for realistic exposure variation.
 
     This transform applies a random S-curve to the image's tone curve, adjusting the brightness and contrast
     in a non-linear manner. It can be applied to the entire image or to each channel separately.
 
     Args:
-        scale (float): Standard deviation of the normal distribution used to sample random distances
-            to move two control points that modify the image's curve. Values should be in range [0, 1].
+        scale (float): Standard deviation of the normal distributions used to sample the two inner control
+            ordinates that modify the image's curve. Values should be in range [0, 1].
             Higher values will result in more dramatic changes to the image. Default: 0.1
         per_channel (bool): If True, the tone curve will be applied to each channel of the input image separately,
             which can lead to color distortion. If False, the same curve is applied to all channels,
@@ -55,7 +55,8 @@ class RandomToneCurve(ImageOnlyTransform):
 
     Note:
         - This transform modifies the image's histogram by applying a smooth, S-shaped curve to it.
-        - The S-curve is defined by moving two control points of a quadratic Bézier curve.
+        - The S-curve is defined by sampling the two inner control ordinates of a cubic Bézier curve.
+        - Float32 images use continuous curve evaluation, while uint8 images use a 256-entry lookup table.
         - When per_channel is False, the same curve is applied to all channels, maintaining color balance.
         - When per_channel is True, different curves are applied to each channel, which can create color shifts.
         - This transform can be used to adjust image contrast and brightness in a more natural way than linear
@@ -63,11 +64,12 @@ class RandomToneCurve(ImageOnlyTransform):
         - The effect can range from subtle contrast adjustments to more dramatic "vintage" or "faded" looks.
 
     Mathematical Formulation:
-        1. Two control points are randomly moved from their default positions (0.25, 0.25) and (0.75, 0.75).
-        2. The new positions are sampled from a normal distribution: N(μ, σ²), where μ is the original position
-        and alpha is the scale parameter.
-        3. These points, along with fixed points at (0, 0) and (1, 1), define a quadratic Bézier curve.
-        4. The curve is applied as a lookup table to the image intensities:
+        1. The two inner control ordinates start at 0.25 and 0.75.
+        2. Their values are sampled independently from normal distributions centered at 0.25 and 0.75, with
+           standard deviation given by `scale`, then clipped to [0, 1].
+        3. Together with fixed endpoint ordinates 0 and 1, they define the scalar cubic Bézier function `y(t)`;
+           the normalized input intensity is used directly as `t`.
+        4. The function is evaluated continuously for float32 images and through a lookup table for uint8 images:
            new_intensity = curve(original_intensity)
 
     Examples:
@@ -86,7 +88,7 @@ class RandomToneCurve(ImageOnlyTransform):
     References:
         - "What Else Can Fool Deep Learning? Addressing Color Constancy Errors on Deep Neural Network Performance":
           https://arxiv.org/abs/1912.06960
-        - Bézier curve: https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Quadratic_B%C3%A9zier_curves
+        - Bézier curve: https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Cubic_B%C3%A9zier_curves
         - Tone mapping: https://en.wikipedia.org/wiki/Tone_mapping
 
     """

--- a/benchmark/benchmarks/test_batch_matrix.py
+++ b/benchmark/benchmarks/test_batch_matrix.py
@@ -25,6 +25,8 @@ BATCH_SIZES = (4, 8)
 VOLUME_BATCH_SIZES = (2, 4)
 SPATTER_BATCH_SIZES = (2, 4, 8, 16)
 SPATTER_SIZES = ("small", "medium", "large")
+RANDOM_TONE_CURVE_NAMES = ("random_tone_curve", "random_tone_curve_per_channel")
+RANDOM_TONE_CURVE_CASE_PREFIXES = tuple(f"{name}|" for name in RANDOM_TONE_CURVE_NAMES)
 
 
 @dataclass(frozen=True)
@@ -49,6 +51,10 @@ IMAGE_BATCH_TRANSFORMS: Mapping[str, BatchSpec] = {
     "horizontal_flip": BatchSpec(lambda: albumentations.HorizontalFlip(p=1.0)),
     "normalize": BatchSpec(lambda: albumentations.Normalize(p=1.0)),
     "random_brightness_contrast": BatchSpec(lambda: albumentations.RandomBrightnessContrast(p=1.0)),
+    "random_tone_curve": BatchSpec(lambda: albumentations.RandomToneCurve(p=1.0)),
+    "random_tone_curve_per_channel": BatchSpec(
+        lambda: albumentations.RandomToneCurve(per_channel=True, p=1.0),
+    ),
     "resize": BatchSpec(lambda: albumentations.Resize(height=128, width=128, p=1.0)),
     "spatter_mud": BatchSpec(
         lambda: albumentations.Spatter(mode="mud", p=1.0),
@@ -89,6 +95,16 @@ VOLUME_BATCH_TRANSFORMS: Mapping[str, BatchSpec] = {
         sizes=tuple(VOLUME_SIZES),
         batch_sizes=VOLUME_BATCH_SIZES,
     ),
+    "random_tone_curve": BatchSpec(
+        lambda: albumentations.RandomToneCurve(p=1.0),
+        sizes=tuple(VOLUME_SIZES),
+        batch_sizes=VOLUME_BATCH_SIZES,
+    ),
+    "random_tone_curve_per_channel": BatchSpec(
+        lambda: albumentations.RandomToneCurve(per_channel=True, p=1.0),
+        sizes=tuple(VOLUME_SIZES),
+        batch_sizes=VOLUME_BATCH_SIZES,
+    ),
     "transpose": BatchSpec(
         lambda: albumentations.Transpose(p=1.0),
         channels=(1, 3),
@@ -116,6 +132,11 @@ def _cases(transforms: Mapping[str, BatchSpec], target_route: str) -> tuple[str,
 
 
 IMAGE_BATCH_CASES = _cases(IMAGE_BATCH_TRANSFORMS, "images")
+RANDOM_TONE_CURVE_DIRECT_IMAGE_CASES = tuple(
+    case_id.replace("|images|", "|direct_images|", 1)
+    for case_id in IMAGE_BATCH_CASES
+    if case_id.startswith(RANDOM_TONE_CURVE_CASE_PREFIXES)
+)
 SPATTER_DIRECT_CASES = tuple(
     case_id.replace("|images|", "|direct_images|", 1)
     for case_id in IMAGE_BATCH_CASES
@@ -123,6 +144,11 @@ SPATTER_DIRECT_CASES = tuple(
 )
 MASK_BATCH_CASES = _cases(MASK_BATCH_TRANSFORMS, "images_and_masks")
 VOLUME_BATCH_CASES = _cases(VOLUME_BATCH_TRANSFORMS, "volumes_and_masks3d")
+RANDOM_TONE_CURVE_DIRECT_VOLUME_CASES = tuple(
+    case_id.replace("|volumes_and_masks3d|", "|direct_volumes|", 1)
+    for case_id in VOLUME_BATCH_CASES
+    if case_id.startswith(RANDOM_TONE_CURVE_CASE_PREFIXES)
+)
 
 
 def _parse_batch_case(case_id: str) -> tuple[str, str, str, int, str, int]:
@@ -184,6 +210,48 @@ class TimeSpatterDirectBatchMatrix:
 
     def time_apply_to_images(self, case_id: str) -> None:
         self.transform.apply_to_images(self.images, **self.params)
+
+
+class TimeRandomToneCurveDirectImageBatchMatrix:
+    """Benchmark RandomToneCurve's direct `apply_to_images` route for shared and per-channel curves."""
+
+    params = (RANDOM_TONE_CURVE_DIRECT_IMAGE_CASES,)
+    param_names = ("case_id",)
+
+    def setup(self, case_id: str) -> None:
+        name, _, size_name, channels, dtype_name, batch_size = _parse_batch_case(case_id)
+        self.transform = albumentations.RandomToneCurve(
+            per_channel=name == "random_tone_curve_per_channel",
+            p=1.0,
+        )
+        self.transform.set_random_seed(137)
+        self.images = _make_image_batch(size_name, channels, dtype_from_name(dtype_name), batch_size)
+        self.transform(image=self.images[0])
+        self.applied_params = self.transform.get_applied_params()
+
+    def time_apply_to_images(self, case_id: str) -> None:
+        self.transform.apply_to_images(self.images, **self.applied_params)
+
+
+class TimeRandomToneCurveDirectVolumeBatchMatrix:
+    """Benchmark RandomToneCurve's direct `apply_to_volumes` route for shared and per-channel curves."""
+
+    params = (RANDOM_TONE_CURVE_DIRECT_VOLUME_CASES,)
+    param_names = ("case_id",)
+
+    def setup(self, case_id: str) -> None:
+        name, _, size_name, channels, dtype_name, batch_size = _parse_batch_case(case_id)
+        self.transform = albumentations.RandomToneCurve(
+            per_channel=name == "random_tone_curve_per_channel",
+            p=1.0,
+        )
+        self.transform.set_random_seed(137)
+        self.volumes = _make_volume_batch(size_name, channels, dtype_from_name(dtype_name), batch_size)
+        self.transform(volume=self.volumes[0])
+        self.applied_params = self.transform.get_applied_params()
+
+    def time_apply_to_volumes(self, case_id: str) -> None:
+        self.transform.apply_to_volumes(self.volumes, **self.applied_params)
 
 
 class PeakMemorySpatterBatchMatrix:

--- a/benchmark/benchmarks/test_family_matrix.py
+++ b/benchmark/benchmarks/test_family_matrix.py
@@ -154,6 +154,9 @@ PIXEL_TRANSFORMS: Mapping[str, PixelSpec] = {
     "random_snow": PixelSpec(lambda: albumentations.RandomSnow(p=1.0), channels=(3,)),
     "random_sun_flare": PixelSpec(lambda: albumentations.RandomSunFlare(p=1.0), channels=(3,)),
     "random_tone_curve": PixelSpec(lambda: albumentations.RandomToneCurve(p=1.0)),
+    "random_tone_curve_per_channel": PixelSpec(
+        lambda: albumentations.RandomToneCurve(per_channel=True, p=1.0),
+    ),
     "ringing_overshoot": PixelSpec(lambda: albumentations.RingingOvershoot(p=1.0)),
     "salt_and_pepper": PixelSpec(lambda: albumentations.SaltAndPepper(p=1.0)),
     "sharpen": PixelSpec(lambda: albumentations.Sharpen(p=1.0)),

--- a/benchmark/benchmarks/test_functional_kernels.py
+++ b/benchmark/benchmarks/test_functional_kernels.py
@@ -83,6 +83,8 @@ FUNCTIONAL_PIXEL_KERNELS: Mapping[str, KernelSupport] = {
     "pixel_dropout": KernelSupport(),
     "channel_shuffle": KernelSupport(channels=(3, 5)),
     "image_compression": KernelSupport(dtypes=("uint8",)),
+    "move_tone_curve_shared": KernelSupport(),
+    "move_tone_curve_per_channel": KernelSupport(),
     "solarize": KernelSupport(),
     "posterize": KernelSupport(),
 }
@@ -326,6 +328,19 @@ def _call_image_compression(benchmark: Any) -> np.ndarray:
     return fpixel.image_compression(benchmark.image, 90, ".jpg")
 
 
+def _call_move_tone_curve_shared(benchmark: Any) -> np.ndarray:
+    return fpixel.move_tone_curve(benchmark.image, 0.17, 0.83, benchmark.image.shape[-1])
+
+
+def _call_move_tone_curve_per_channel(benchmark: Any) -> np.ndarray:
+    return fpixel.move_tone_curve(
+        benchmark.image,
+        benchmark.tone_curve_low_y,
+        benchmark.tone_curve_high_y,
+        benchmark.image.shape[-1],
+    )
+
+
 def _call_solarize(benchmark: Any) -> np.ndarray:
     return fpixel.solarize(benchmark.image, benchmark.solarize_threshold)
 
@@ -348,6 +363,8 @@ PIXEL_CALLS: Mapping[str, ImageKernelCall] = {
     "pixel_dropout": _call_pixel_dropout,
     "channel_shuffle": _call_channel_shuffle,
     "image_compression": _call_image_compression,
+    "move_tone_curve_shared": _call_move_tone_curve_shared,
+    "move_tone_curve_per_channel": _call_move_tone_curve_per_channel,
     "solarize": _call_solarize,
     "posterize": _call_posterize,
 }
@@ -488,6 +505,8 @@ class TimeFunctionalPixelKernels:
         self.drop_values = np.zeros((channels,), dtype=self.image.dtype)
         self.channels_shuffled = list(reversed(range(channels)))
         self.solarize_threshold = 128 if self.image.dtype == np.uint8 else 0.5
+        self.tone_curve_low_y = np.linspace(0.11, 0.31, channels, dtype=np.float64)
+        self.tone_curve_high_y = np.linspace(0.69, 0.89, channels, dtype=np.float64)
 
     def time_kernel(self, case_id: str) -> None:
         PIXEL_CALLS[self.name](self)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -919,7 +919,7 @@ def test_random_tone_curve(image, num_channels):
         num_channels,
     )
 
-    np.testing.assert_allclose(result_float_value, result_array_value)
+    np.testing.assert_array_equal(result_float_value, result_array_value)
 
     assert result_float_value.dtype == image.dtype
     assert result_float_value.shape == image.shape

--- a/tests/test_benchmark_coverage.py
+++ b/tests/test_benchmark_coverage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from collections import Counter
 from typing import Any
 
 import pytest
@@ -25,7 +26,7 @@ def test_benchmark_coverage_details_account_for_every_public_transform() -> None
     )
     assert details["summary"]["contract_failures"] == 0
     assert details["contract_failures"] == []
-    assert details["summary"]["performance_contract_status_counts"]["batch"]["covered"] == 13
+    assert details["summary"]["performance_contract_status_counts"]["batch"]["covered"] == 14
     assert details["summary"]["performance_contract_status_counts"]["parameter_sensitivity"]["covered"] == 8
 
 
@@ -160,6 +161,55 @@ def test_benchmark_coverage_details_map_expanded_pixel_matrix_to_public_transfor
 
     assert random_rain["smoke_only"] is False
     assert "family_matrix" in random_rain["layers"]
+
+
+def test_benchmark_coverage_details_map_both_random_tone_curve_modes() -> None:
+    random_tone_curve = _coverage_for("RandomToneCurve")
+    family_case_ids = {case["case_id"] for case in random_tone_curve["asv_cases"] if case["layer"] == "family_matrix"}
+    direct_case_ids = {case["case_id"] for case in random_tone_curve["asv_cases"] if case["layer"] == "direct_kernel"}
+    batch_cases = [case for case in random_tone_curve["asv_cases"] if case["layer"] == "batch_matrix"]
+    batch_case_ids = {case["case_id"] for case in batch_cases}
+
+    assert {case_id.split("|", maxsplit=1)[0] for case_id in family_case_ids} == {
+        "random_tone_curve",
+        "random_tone_curve_per_channel",
+    }
+    assert {case_id.split("|", maxsplit=1)[0] for case_id in direct_case_ids} == {
+        "move_tone_curve_shared",
+        "move_tone_curve_per_channel",
+    }
+    assert len(family_case_ids) == 36
+    assert len(direct_case_ids) == 36
+    assert {case_id.split("|", maxsplit=1)[0] for case_id in batch_case_ids} == {
+        "random_tone_curve",
+        "random_tone_curve_per_channel",
+    }
+    assert len(batch_cases) == len(batch_case_ids) == 192
+    assert Counter(case_id.split("|")[1] for case_id in batch_case_ids) == {
+        "direct_images": 48,
+        "direct_volumes": 48,
+        "images": 48,
+        "volumes_and_masks3d": 48,
+    }
+    assert {
+        "random_tone_curve|images|small|1|uint8|4",
+        "random_tone_curve|direct_images|medium|5|float32|8",
+        "random_tone_curve_per_channel|volumes_and_masks3d|small|3|uint8|2",
+        "random_tone_curve_per_channel|direct_volumes|medium|5|float32|4",
+    }.issubset(batch_case_ids)
+    assert random_tone_curve["performance_contract"]["batch"]["status"] == "covered"
+    assert {"compose_batch", "direct_batch"}.issubset(random_tone_curve["scenario_contract"]["scopes"])
+    assert {"images", "masks3d", "volumes"}.issubset(random_tone_curve["scenario_contract"]["targets"])
+    assert random_tone_curve["scenario_axis_contracts"]["batch_matrix"] == {
+        "covered": {
+            "channels": [1, 3, 5],
+            "dtypes": ["uint8", "float32"],
+            "sizes": ["small", "medium"],
+            "volume_sizes": ["small", "medium"],
+        },
+        "skip_reason": "batch matrix omits large image batches to keep CI evidence stable and affordable",
+        "skipped": {"sizes": ["large"]},
+    }
 
 
 def test_benchmark_coverage_details_require_family_matrix_for_image_transforms() -> None:

--- a/tests/test_random_tone_curve.py
+++ b/tests/test_random_tone_curve.py
@@ -33,6 +33,28 @@ def _cubic_tone_curve(
     return np.clip(result, np.float32(0), np.float32(1))
 
 
+def _broadcast_horner_tone_curve(
+    image: np.ndarray,
+    low_y: np.ndarray,
+    high_y: np.ndarray,
+) -> np.ndarray:
+    low_y_float32 = np.asarray(low_y, dtype=np.float32)
+    high_y_float32 = np.asarray(high_y, dtype=np.float32)
+    coefficient_1 = np.float32(3) * low_y_float32
+    coefficient_2 = np.float32(3) * high_y_float32 - np.float32(6) * low_y_float32
+    coefficient_3 = np.float32(3) * low_y_float32 - np.float32(3) * high_y_float32 + np.float32(1)
+
+    result = np.empty_like(image)
+    np.multiply(image, coefficient_3, out=result)
+    np.add(result, coefficient_2, out=result)
+    np.multiply(result, image, out=result)
+    np.add(result, coefficient_1, out=result)
+    np.multiply(result, image, out=result)
+    np.clip(result, np.float32(0), np.float32(1), out=result)
+    result[image == np.float32(1)] = np.float32(1)
+    return result
+
+
 @pytest.mark.parametrize(("rank_name", "shape_prefix"), FLOAT_SHAPE_PREFIXES.items())
 @pytest.mark.parametrize("num_channels", [1, 3, 5])
 @pytest.mark.parametrize("per_channel", [False, True])
@@ -63,6 +85,26 @@ def test_move_tone_curve_float32_matches_cubic_formula(
     assert result.dtype == np.float32
     assert result.shape == image.shape
     assert np.all((result >= 0) & (result <= 1)), rank_name
+
+
+@pytest.mark.parametrize(("rank_name", "shape_prefix"), FLOAT_SHAPE_PREFIXES.items())
+def test_move_tone_curve_float32_rgb_channel_loop_matches_broadcast(
+    rank_name: str,
+    shape_prefix: tuple[int, ...],
+) -> None:
+    expanded_shape = (*shape_prefix[:-1], shape_prefix[-1] * 2, 3)
+    image = _make_float_input(expanded_shape)[..., ::2, :]
+    original = image.copy()
+    low_y = np.array([0.08, 0.25, 0.42], dtype=np.float64)
+    high_y = np.array([0.53, 0.72, 0.91], dtype=np.float64)
+
+    assert not image.flags.c_contiguous, rank_name
+    result = fpixel.move_tone_curve(image, low_y, high_y, 3)
+    expected = _broadcast_horner_tone_curve(image, low_y, high_y)
+
+    np.testing.assert_array_equal(result, expected)
+    np.testing.assert_array_equal(image, original)
+    assert not np.shares_memory(result, image)
 
 
 def test_move_tone_curve_uint8_shared_golden_vector() -> None:

--- a/tests/test_random_tone_curve.py
+++ b/tests/test_random_tone_curve.py
@@ -1,0 +1,166 @@
+import numpy as np
+import pytest
+
+import albumentations as A
+from albumentations.augmentations.pixel import functional as fpixel
+
+FLOAT_SHAPE_PREFIXES = {
+    "image": (2, 3),
+    "images": (2, 2, 3),
+    "volume": (3, 2, 3),
+    "volumes": (2, 3, 2, 3),
+}
+
+
+def _make_float_input(shape: tuple[int, ...]) -> np.ndarray:
+    values = np.array([0.0, 0.123456, 0.50123, 0.876543, 1.0], dtype=np.float32)
+    return np.resize(values, int(np.prod(shape))).reshape(shape)
+
+
+def _cubic_tone_curve(
+    image: np.ndarray,
+    low_y: float | np.ndarray,
+    high_y: float | np.ndarray,
+) -> np.ndarray:
+    low_y_float32 = np.asarray(low_y, dtype=np.float32)
+    high_y_float32 = np.asarray(high_y, dtype=np.float32)
+    one_minus_image = np.float32(1) - image
+    result = (
+        np.float32(3) * one_minus_image**2 * image * low_y_float32
+        + np.float32(3) * one_minus_image * image**2 * high_y_float32
+        + image**3
+    )
+    return np.clip(result, np.float32(0), np.float32(1))
+
+
+@pytest.mark.parametrize(("rank_name", "shape_prefix"), FLOAT_SHAPE_PREFIXES.items())
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
+@pytest.mark.parametrize("per_channel", [False, True])
+def test_move_tone_curve_float32_matches_cubic_formula(
+    rank_name: str,
+    shape_prefix: tuple[int, ...],
+    num_channels: int,
+    per_channel: bool,
+) -> None:
+    image = _make_float_input((*shape_prefix, num_channels))
+    original = image.copy()
+
+    if per_channel:
+        low_y: float | np.ndarray = np.linspace(0.08, 0.42, num_channels, dtype=np.float64)
+        high_y: float | np.ndarray = np.linspace(0.53, 0.91, num_channels, dtype=np.float64)
+    else:
+        low_y = 0.173
+        high_y = 0.731
+
+    result = fpixel.move_tone_curve(image, low_y, high_y, num_channels)
+    expected = _cubic_tone_curve(image, low_y, high_y)
+
+    np.testing.assert_allclose(result, expected, rtol=2e-6, atol=1e-7)
+    np.testing.assert_array_equal(result[image == 0], np.float32(0))
+    np.testing.assert_array_equal(result[image == 1], np.float32(1))
+    np.testing.assert_array_equal(image, original)
+    assert not np.shares_memory(result, image)
+    assert result.dtype == np.float32
+    assert result.shape == image.shape
+    assert np.all((result >= 0) & (result <= 1)), rank_name
+
+
+def test_move_tone_curve_uint8_shared_golden_vector() -> None:
+    image = np.array([0, 1, 2, 17, 64, 127, 128, 191, 254, 255], dtype=np.uint8).reshape(2, 5, 1)
+    expected = np.array([0, 0, 1, 7, 47, 127, 128, 208, 255, 255], dtype=np.uint8).reshape(image.shape)
+
+    result = fpixel.move_tone_curve(image, 0.1, 0.9, 1)
+
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("low_y", "high_y"),
+    [
+        (0.80094105, 0.27785528),
+        (
+            np.array([0.80094105, 0.173, 0.091], dtype=np.float64),
+            np.array([0.27785528, 0.731, 0.643], dtype=np.float64),
+        ),
+    ],
+)
+def test_move_tone_curve_float32_exact_asymmetric_endpoints(
+    low_y: float | np.ndarray,
+    high_y: float | np.ndarray,
+) -> None:
+    num_channels = low_y.size if isinstance(low_y, np.ndarray) else 1
+    image = np.array([0, 1], dtype=np.float32).reshape(2, 1, 1)
+    image = np.broadcast_to(image, (2, 1, num_channels)).copy()
+
+    result = fpixel.move_tone_curve(image, low_y, high_y, num_channels)
+
+    np.testing.assert_array_equal(result[0], np.float32(0))
+    np.testing.assert_array_equal(result[1], np.float32(1))
+
+
+def test_move_tone_curve_uint8_per_channel_golden_vector() -> None:
+    values = np.array([0, 1, 2, 17, 64, 127, 128, 191, 254, 255], dtype=np.uint8).reshape(2, 5)
+    image = np.stack([values] * 3, axis=-1)
+    low_y = np.array([0.1, 0.25, 0.4], dtype=np.float64)
+    high_y = np.array([0.6, 0.75, 0.9], dtype=np.float64)
+    expected = np.array(
+        [
+            [0, 0, 0],
+            [0, 1, 1],
+            [1, 2, 2],
+            [6, 14, 21],
+            [36, 58, 80],
+            [98, 127, 156],
+            [99, 128, 157],
+            [175, 197, 219],
+            [254, 254, 255],
+            [255, 255, 255],
+        ],
+        dtype=np.uint8,
+    ).reshape(image.shape)
+
+    result = fpixel.move_tone_curve(image, low_y, high_y, 3)
+
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize(
+    ("low_y", "high_y"),
+    [
+        (0.2, np.array([0.8], dtype=np.float32)),
+        (np.array([0.2], dtype=np.float32), 0.8),
+    ],
+)
+def test_move_tone_curve_rejects_mixed_control_types(
+    dtype: type[np.generic],
+    low_y: float | np.ndarray,
+    high_y: float | np.ndarray,
+) -> None:
+    image = np.zeros((2, 3, 1), dtype=dtype)
+
+    with pytest.raises(TypeError, match=r"must both be of type float or np.ndarray"):
+        fpixel.move_tone_curve(image, low_y, high_y, 1)
+
+
+@pytest.mark.parametrize(("target", "shape_prefix"), FLOAT_SHAPE_PREFIXES.items())
+@pytest.mark.parametrize("per_channel", [False, True])
+def test_random_tone_curve_compose_float32_target_routing(
+    target: str,
+    shape_prefix: tuple[int, ...],
+    per_channel: bool,
+) -> None:
+    num_channels = 3
+    image = _make_float_input((*shape_prefix, num_channels))
+    transform = A.Compose(
+        [A.RandomToneCurve(scale=0.0, per_channel=per_channel, p=1.0)],
+        seed=137,
+        strict=True,
+    )
+    low_y: float | np.ndarray = np.full(num_channels, 0.25, dtype=np.float64) if per_channel else 0.25
+    high_y: float | np.ndarray = np.full(num_channels, 0.75, dtype=np.float64) if per_channel else 0.75
+    expected = fpixel.move_tone_curve(image, low_y, high_y, num_channels)
+
+    result = transform(**{target: image})[target]
+
+    np.testing.assert_array_equal(result, expected)

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -35,6 +35,8 @@ from benchmarks.test_batch_matrix import (  # noqa: E402
     IMAGE_BATCH_TRANSFORMS,
     MASK_BATCH_CASES,
     MASK_BATCH_TRANSFORMS,
+    RANDOM_TONE_CURVE_DIRECT_IMAGE_CASES,
+    RANDOM_TONE_CURVE_DIRECT_VOLUME_CASES,
     SPATTER_DIRECT_CASES,
     VOLUME_BATCH_CASES,
     VOLUME_BATCH_TRANSFORMS,
@@ -182,6 +184,7 @@ PIXEL_ALIAS_TO_TRANSFORM = {
     "random_snow": "RandomSnow",
     "random_sun_flare": "RandomSunFlare",
     "random_tone_curve": "RandomToneCurve",
+    "random_tone_curve_per_channel": "RandomToneCurve",
     "rgb_shift": "RGBShift",
     "ringing_overshoot": "RingingOvershoot",
     "salt_and_pepper": "SaltAndPepper",
@@ -247,6 +250,8 @@ BATCH_ALIAS_TO_TRANSFORM = {
     "normalize": "Normalize",
     "random_brightness_contrast": "RandomBrightnessContrast",
     "random_rotate90": "RandomRotate90",
+    "random_tone_curve": "RandomToneCurve",
+    "random_tone_curve_per_channel": "RandomToneCurve",
     "resize": "Resize",
     "spatter_mud": "Spatter",
     "spatter_rain": "Spatter",
@@ -283,6 +288,7 @@ DIRECT_KERNEL_TRANSFORMS = frozenset(
         "PixelDropout",
         "Posterize",
         "RandomGamma",
+        "RandomToneCurve",
         "Resize",
         "Solarize",
         "ToGray",
@@ -346,6 +352,7 @@ DIRECT_KERNEL_CASE_PREFIXES_BY_TRANSFORM = {
     "PixelDropout": ("pixel_dropout",),
     "Posterize": ("posterize",),
     "RandomGamma": ("gamma_transform",),
+    "RandomToneCurve": ("move_tone_curve_shared", "move_tone_curve_per_channel"),
     "Resize": ("resize", "resize_bboxes"),
     "Solarize": ("solarize",),
     "ToGray": ("to_gray",),
@@ -371,6 +378,12 @@ ASV_BENCHMARKS = {
     "annotation_scaling": "benchmarks.test_family_matrix.TimeAnnotationTargets.time_transform",
     "batch_image": "benchmarks.test_batch_matrix.TimeImageBatchMatrix.time_transform",
     "batch_mask": "benchmarks.test_batch_matrix.TimeMaskBatchMatrix.time_transform",
+    "batch_random_tone_curve_direct_image": (
+        "benchmarks.test_batch_matrix.TimeRandomToneCurveDirectImageBatchMatrix.time_apply_to_images"
+    ),
+    "batch_random_tone_curve_direct_volume": (
+        "benchmarks.test_batch_matrix.TimeRandomToneCurveDirectVolumeBatchMatrix.time_apply_to_volumes"
+    ),
     "batch_spatter_direct": "benchmarks.test_batch_matrix.TimeSpatterDirectBatchMatrix.time_apply_to_images",
     "batch_volume": "benchmarks.test_batch_matrix.TimeVolumeBatchMatrix.time_transform",
     "catalog_smoke": "benchmarks.test_catalog_smoke.TimeCatalogTransformSmoke.time_transform_compose",
@@ -451,7 +464,12 @@ AXIS_ORDERS: Mapping[str, tuple[Any, ...]] = {
 
 LAYER_AXIS_REFERENCES: Mapping[str, Mapping[str, tuple[Any, ...]]] = {
     "annotation_scaling": {"annotation_counts": ANNOTATION_COUNT_ORDER},
-    "batch_matrix": {"channels": CHANNEL_ORDER, "dtypes": DTYPE_ORDER, "sizes": SIZE_ORDER},
+    "batch_matrix": {
+        "channels": CHANNEL_ORDER,
+        "dtypes": DTYPE_ORDER,
+        "sizes": SIZE_ORDER,
+        "volume_sizes": VOLUME_SIZE_ORDER,
+    },
     "direct_kernel": {
         "annotation_counts": ANNOTATION_COUNT_ORDER,
         "channels": CHANNEL_ORDER,
@@ -687,6 +705,7 @@ def _parse_batch_case(case_id: str) -> dict[str, Any]:
     name, target_route, size_name, channels, dtype_name, batch_size = case_id.split("|")
     targets = {
         "direct_images": ["images"],
+        "direct_volumes": ["volumes"],
         "images": ["images"],
         "images_and_masks": ["images", "masks"],
         "volumes_and_masks3d": ["masks3d", "volumes"],
@@ -699,7 +718,7 @@ def _parse_batch_case(case_id: str) -> dict[str, Any]:
         "target_route": target_route,
         "targets": targets,
     }
-    if target_route == "volumes_and_masks3d":
+    if target_route in {"direct_volumes", "volumes_and_masks3d"}:
         scenario["volume_size"] = size_name
     else:
         scenario["size"] = size_name
@@ -745,7 +764,7 @@ def _target_matrix_scenario(case: Mapping[str, str], route: str, transform_name:
 def _batch_matrix_scenario(case: Mapping[str, str], route: str, transform_name: str) -> dict[str, Any]:
     """Return scenario metadata for a batch matrix case."""
     scenario = _parse_batch_case(case["case_id"])
-    scope = "direct_batch" if scenario["target_route"] == "direct_images" else "compose_batch"
+    scope = "direct_batch" if scenario["target_route"].startswith("direct_") else "compose_batch"
     return {**scenario, "scope": scope}
 
 
@@ -1068,6 +1087,20 @@ def _benchmark_case_index() -> dict[str, list[dict[str, str]]]:
         cases,
         benchmark=ASV_BENCHMARKS["batch_mask"],
         case_ids=MASK_BATCH_CASES,
+        layer="batch_matrix",
+        name_map=BATCH_ALIAS_TO_TRANSFORM,
+    )
+    _add_matrix_cases(
+        cases,
+        benchmark=ASV_BENCHMARKS["batch_random_tone_curve_direct_image"],
+        case_ids=RANDOM_TONE_CURVE_DIRECT_IMAGE_CASES,
+        layer="batch_matrix",
+        name_map=BATCH_ALIAS_TO_TRANSFORM,
+    )
+    _add_matrix_cases(
+        cases,
+        benchmark=ASV_BENCHMARKS["batch_random_tone_curve_direct_volume"],
+        case_ids=RANDOM_TONE_CURVE_DIRECT_VOLUME_CASES,
         layer="batch_matrix",
         name_map=BATCH_ALIAS_TO_TRANSFORM,
     )


### PR DESCRIPTION
#161

## Summary by Sourcery

Add continuous float32 tone-curve evaluation for RandomToneCurve and extend benchmarks, coverage, and tests to fully exercise shared and per-channel modes across image and volume routes.

New Features:
- Support continuous float32 tone-curve evaluation for RandomToneCurve alongside the existing uint8 lookup-table path.
- Add functional kernel and batch-matrix benchmarks for RandomToneCurve shared and per-channel tone-curve operations on images and volumes.

Enhancements:
- Refine RandomToneCurve documentation to describe the cubic Bézier formulation, float32 vs uint8 behavior, and usage more clearly.
- Extend benchmark coverage tooling to track RandomToneCurve scenarios across direct and Compose batch routes, including volume-specific axes.
- Document PR review guardrails for performance-sensitive and validation-related changes in AGENTS.md.

Tests:
- Add dedicated tests validating move_tone_curve behavior for float32 and uint8 images, including shared and per-channel control points, endpoint correctness, and type validation.
- Add tests ensuring benchmark coverage correctly maps RandomToneCurve to family, direct-kernel, and batch-matrix cases with expected scopes and axes.
- Tighten functional tests for RandomToneCurve to enforce exact equality between scalar and per-channel control representations.