### PR TITLE
feat(pixel): add HEStain residual modes and optimize float32 paths

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,7 +91,7 @@ jobs:
         numpy==2.2.6
         scipy==1.15.3
         pydantic==2.12.4
-        albucore==0.2.5
+        albucore==0.2.9
         opencv-python-headless==5.0.0.93
         hypothesis
         pytest

--- a/albumentations/augmentations/geometric/_functional_distortion.py
+++ b/albumentations/augmentations/geometric/_functional_distortion.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import Literal, cast
 
+from albucore import pairwise_distances_squared
+
 from ._functional_shared import (
     cv2,
-    math,
     np,
-    reduce_sum,
 )
 
 
@@ -369,33 +369,9 @@ def create_piecewise_affine_maps(
     return map_x, map_y
 
 
-def compute_pairwise_distances(
-    points1: np.ndarray,
-    points2: np.ndarray,
-) -> np.ndarray:
-    """Compute pairwise Euclidean squared distances between points1 (N, 2) and points2 (M, 2).
-    Returns (N, M) matrix. For TPS and nearest-neighbor. Uses cv2.gemm.
-
-    Args:
-        points1 (np.ndarray): First set of points with shape (N, 2)
-        points2 (np.ndarray): Second set of points with shape (M, 2)
-
-    Returns:
-        np.ndarray: Matrix of pairwise distances with shape (N, M)
-
-    """
-    points1 = np.ascontiguousarray(points1, dtype=np.float32)
-    points2 = np.ascontiguousarray(points2, dtype=np.float32)
-
-    # Compute squared terms
-    p1_squared = reduce_sum(cv2.multiply(points1, points1), axis=1, keepdims=True)
-    p2_squared = np.asarray(reduce_sum(cv2.multiply(points2, points2), axis=1))[None, :]
-
-    # Compute dot product
-    empty_matrix = np.empty((0,), dtype=np.float32)
-    dot_product = cast("np.ndarray", cv2.gemm(points1, points2.T, 1.0, empty_matrix, 0.0))
-
-    return p1_squared + p2_squared - 2 * dot_product
+def _compute_tps_kernel(distances: np.ndarray) -> np.ndarray:
+    log_distances = cv2.log(distances + np.float32(1e-6))
+    return np.multiply(distances, log_distances, out=log_distances)
 
 
 def compute_tps_weights(
@@ -424,13 +400,8 @@ def compute_tps_weights(
     num_points = src_points.shape[0]
 
     # Compute pairwise distances
-    distances = compute_pairwise_distances(src_points, src_points)
-
-    kernel_matrix = np.where(
-        distances > 0,
-        distances * distances * cv2.log(distances + 1e-6),
-        0,
-    ).astype(np.float32)
+    distances = pairwise_distances_squared(src_points, src_points)
+    kernel_matrix = _compute_tps_kernel(distances)
 
     # Build system matrix efficiently
     affine_terms = np.empty((num_points, 3), dtype=np.float32)
@@ -467,14 +438,8 @@ def tps_transform(
     nonlinear_weights = np.ascontiguousarray(nonlinear_weights, dtype=np.float32)
     affine_weights = np.ascontiguousarray(affine_weights, dtype=np.float32)
 
-    distances = compute_pairwise_distances(target_points, control_points)
-
-    # Ensure kernel matrix is float32
-    kernel_matrix = np.where(
-        distances > 0,
-        distances * cv2.log(distances + 1e-6),
-        0,
-    ).astype(np.float32)
+    distances = pairwise_distances_squared(target_points, control_points)
+    kernel_matrix = _compute_tps_kernel(distances)
 
     # Prepare affine terms
     num_points = len(target_points)
@@ -544,26 +509,16 @@ def get_fisheye_distortion_maps(
     height, width = image_shape[:2]
 
     center_x, center_y = width / 2, height / 2
-    # Create coordinate grid
-    y, x = np.mgrid[:height, :width].astype(np.float32)
+    x = np.arange(width, dtype=np.float32)[np.newaxis, :] - center_x
+    y = np.arange(height, dtype=np.float32)[:, np.newaxis] - center_y
 
-    x = x - center_x
-    y = y - center_y
+    max_radius_squared = max(center_x, width - center_x) ** 2 + max(center_y, height - center_y) ** 2
+    distortion_scale = x * x + y * y
+    distortion_scale *= np.float32(k / max_radius_squared)
+    distortion_scale += 1
 
-    # Calculate polar coordinates
-    r = np.sqrt(x * x + y * y)
-    theta = np.arctan2(y, x)
-
-    # Normalize radius by the maximum possible radius to keep distortion in check
-    max_radius = math.sqrt(max(center_x, width - center_x) ** 2 + max(center_y, height - center_y) ** 2)
-    r_norm = r / max_radius
-
-    # Apply fisheye distortion to normalized radius
-    r_dist = r * (1 + k * r_norm * r_norm)
-
-    # Convert back to cartesian coordinates
-    map_x = r_dist * np.cos(theta) + center_x
-    map_y = r_dist * np.sin(theta) + center_y
+    map_x = x * distortion_scale + center_x
+    map_y = y * distortion_scale + center_y
 
     return map_x, map_y
 
@@ -599,7 +554,6 @@ def generate_control_points(num_control_points: int) -> np.ndarray:
 
 
 __all__ = [
-    "compute_pairwise_distances",
     "compute_tps_weights",
     "create_piecewise_affine_maps",
     "generate_control_points",

--- a/albumentations/augmentations/geometric/_functional_keypoints.py
+++ b/albumentations/augmentations/geometric/_functional_keypoints.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Literal, cast
 
+from albucore import sqrt as albucore_sqrt
+
 from ._functional_distortion import (
     generate_inverse_distortion_map,
 )
@@ -294,16 +296,19 @@ def to_distance_maps(
         return np.zeros((height, width, 0), dtype=np.float32)
 
     # Convert keypoints to numpy array
-    keypoints_array = np.array(keypoints)
+    keypoints_array = np.asarray(keypoints, dtype=np.float32)
     if len(keypoints_array) > CV2_DISTANCE_MAP_MAX_KEYPOINTS:
-        yy, xx = np.mgrid[:height, :width]
-        distances = np.sqrt(
-            (xx[..., np.newaxis] - keypoints_array[:, 0]) ** 2 + (yy[..., np.newaxis] - keypoints_array[:, 1]) ** 2,
-        )
+        x_distances = np.arange(width, dtype=np.float32)[np.newaxis, :, np.newaxis] - keypoints_array[:, 0]
+        y_distances = np.arange(height, dtype=np.float32)[:, np.newaxis, np.newaxis] - keypoints_array[:, 1]
+        np.square(x_distances, out=x_distances)
+        np.square(y_distances, out=y_distances)
+        distances = x_distances + y_distances
+        distances = albucore_sqrt(distances, inplace=True)
 
         if inverted:
-            return (1 / (distances + 1)).astype(np.float32)
-        return distances.astype(np.float32)
+            np.add(distances, 1, out=distances)
+            np.reciprocal(distances, out=distances)
+        return distances
 
     # Create coordinate grids
     yy, xx = np.mgrid[:height, :width]
@@ -323,7 +328,8 @@ def to_distance_maps(
         distances[..., keypoint_idx] = magnitude
 
     if inverted:
-        return (1 / (distances + 1)).astype(np.float32)
+        np.add(distances, 1, out=distances)
+        np.reciprocal(distances, out=distances)
     return distances
 
 
@@ -548,11 +554,11 @@ def remap_keypoints_via_mask(
 
     # Remap the mask
     transformed_kp_mask = remap(
-        kp_mask,
+        kp_mask[..., np.newaxis],
         map_x.astype(np.float32),
         map_y.astype(np.float32),
         interpolation=cv2.INTER_NEAREST,
-    )
+    )[..., 0]
 
     # Extract transformed keypoints
     new_points = []

--- a/albumentations/augmentations/mixing/domain_adaptation_functional.py
+++ b/albumentations/augmentations/mixing/domain_adaptation_functional.py
@@ -120,8 +120,8 @@ class MinMaxScaler(BaseScaler):
             When data_min equals data_max for a feature, the range is set to 1 to avoid division by zero.
 
         """
-        self.data_min = np.min(x, axis=0)
-        self.data_max = np.max(x, axis=0)
+        self.data_min = np.asarray(np.min(x, axis=0), dtype=np.float32)
+        self.data_max = np.asarray(np.max(x, axis=0), dtype=np.float32)
         self.data_range = self.data_max - self.data_min
         # Handle case where data_min equals data_max
         self.data_range[self.data_range == 0] = 1
@@ -146,10 +146,10 @@ class MinMaxScaler(BaseScaler):
                 "Call 'fit' with appropriate arguments before using this estimator.",
             )
 
-        x_std = np.subtract(x, self.data_min).astype(float)
+        x_std = np.subtract(x, self.data_min, dtype=np.float32)
         np.divide(x_std, self.data_range, out=x_std)
-        np.multiply(x_std, (self.max - self.min), out=x_std)
-        np.add(x_std, self.min, out=x_std)
+        np.multiply(x_std, np.float32(self.max - self.min), out=x_std)
+        np.add(x_std, np.float32(self.min), out=x_std)
 
         return x_std
 
@@ -172,8 +172,11 @@ class MinMaxScaler(BaseScaler):
                 "This MinMaxScaler instance is not fitted yet. "
                 "Call 'fit' with appropriate arguments before using this estimator.",
             )
-        x_std = ((x - self.min) / (self.max - self.min)).astype(float)
-        return x_std * self.data_range + self.data_min
+        x_std = np.subtract(x, np.float32(self.min), dtype=np.float32)
+        np.divide(x_std, np.float32(self.max - self.min), out=x_std)
+        np.multiply(x_std, self.data_range, out=x_std)
+        np.add(x_std, self.data_min, out=x_std)
+        return x_std
 
 
 class StandardScaler(BaseScaler):
@@ -192,8 +195,8 @@ class StandardScaler(BaseScaler):
 
         """
         mean, scale = mean_std(x, axis=0, eps=0)
-        self.mean = np.asarray(mean)
-        self.scale = np.asarray(scale)
+        self.mean = np.asarray(mean, dtype=np.float32)
+        self.scale = np.asarray(scale, dtype=np.float32)
         # Handle case where std is zero
         self.scale[self.scale == 0] = 1
 
@@ -216,7 +219,9 @@ class StandardScaler(BaseScaler):
                 "This StandardScaler instance is not fitted yet. "
                 "Call 'fit' with appropriate arguments before using this estimator.",
             )
-        return (x - self.mean) / self.scale
+        result = np.subtract(x, self.mean, dtype=np.float32)
+        np.divide(result, self.scale, out=result)
+        return result
 
     def inverse_transform(self, x: np.ndarray) -> np.ndarray:
         """Reverse standardization: x = z * std + mean using fitted mean and scale. Raises
@@ -237,7 +242,9 @@ class StandardScaler(BaseScaler):
                 "This StandardScaler instance is not fitted yet. "
                 "Call 'fit' with appropriate arguments before using this estimator.",
             )
-        return (x * self.scale) + self.mean
+        result = np.multiply(x, self.scale, dtype=np.float32)
+        np.add(result, self.mean, out=result)
+        return result
 
 
 class TransformerInterface(Protocol):
@@ -351,13 +358,11 @@ class DomainAdapter:
             width (int): The width of the output image.
 
         Returns:
-            np.ndarray: The reconstructed image with shape (height, width) for grayscale
-                or (height, width, n_channels) for color images.
+            np.ndarray: The reconstructed image with shape (height, width, n_channels), including
+                an explicit singleton channel dimension for grayscale images.
 
         """
         pixels = clip(pixels, np.dtype(np.uint8), inplace=True)
-        if self.num_channels == 1:
-            return self.from_colorspace(pixels.reshape(height, width))
         return self.from_colorspace(pixels.reshape(height, width, self.num_channels))
 
     @staticmethod
@@ -418,10 +423,6 @@ def adapt_pixel_distribution(
     if img_num_channels != ref_num_channels:
         raise ValueError("Input image and reference image must have the same number of channels.")
 
-    if img_num_channels == 1:
-        img = cast("ImageType", np.squeeze(img))
-        ref = cast("ImageType", np.squeeze(ref))
-
     if img.shape != ref.shape:
         ref = fgeometric.resize(ref, cast("tuple[int, int]", img.shape[:2]), cv2.INTER_AREA)
 
@@ -429,13 +430,13 @@ def adapt_pixel_distribution(
 
     if original_dtype == np.float32:
         img = from_float(cast("np.ndarray", img), np.dtype(np.uint8))
-        ref = from_float(cast("np.ndarray", ref), np.dtype(np.uint8))
+        ref = from_float(ref, np.dtype(np.uint8))
 
     transformer = {"pca": PCA, "standard": StandardScaler, "minmax": MinMaxScaler}[transform_type]()
     adapter = DomainAdapter(transformer=transformer, ref_img=ref)
     transformed = adapter(img).astype(np.float32)
 
-    result = img.astype(np.float32) * (1 - weight) + transformed * weight
+    result = add_weighted(img.astype(np.float32), 1 - weight, transformed, weight)
 
     return result if original_dtype == np.uint8 else to_float(result)
 

--- a/albumentations/augmentations/mixing/functional.py
+++ b/albumentations/augmentations/mixing/functional.py
@@ -113,7 +113,12 @@ def blend_images_using_alpha(
         return result
 
     alpha_3d = alpha[..., np.newaxis].astype(np.float32)
-    blended = donor_image.astype(np.float32) * alpha_3d + base_image.astype(np.float32) * (1.0 - alpha_3d)
+    if img_dtype == np.float32:
+        blended = np.subtract(donor_image, base_image, dtype=np.float32)
+        np.multiply(blended, alpha_3d, out=blended)
+        np.add(blended, base_image, out=blended)
+    else:
+        blended = donor_image.astype(np.float32) * alpha_3d + base_image.astype(np.float32) * (1.0 - alpha_3d)
     clip_high = _soft_blend_clip_high(base_image, donor_image)
     return np.clip(blended, 0, clip_high).astype(img_dtype)
 

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -32,6 +32,7 @@ from ._functional_shared import (
     non_rgb_error,
     normalize_per_image,
     np,
+    power,
     preserve_channel_dim,
     reduce_sum,
     reshape_ndhwc_channel,
@@ -803,7 +804,7 @@ def gamma_transform(img: ImageType, gamma: float) -> ImageType:
         table = (np.arange(0, 256.0 / 255, 1.0 / 255) ** gamma) * 255
         return sz_lut(img, table.astype(np.uint8), inplace=False)
 
-    return np.power(img, gamma)
+    return power(img, gamma)
 
 
 @float32_io
@@ -1202,7 +1203,7 @@ def to_gray_pca(img: ImageType) -> ImageType:
     pixels = img.reshape(-1, img.shape[-1])
 
     # Perform PCA
-    pca = PCA(n_components=1)
+    pca = PCA(n_components=1, dtype=np.float32)
     pca_result = pca.fit_transform(pixels)
 
     # Reshape back to image dimensions and scale to 0-255

--- a/albumentations/augmentations/pixel/_functional_histology.py
+++ b/albumentations/augmentations/pixel/_functional_histology.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Literal, cast
 
+from albucore import exp as albucore_exp
+
 from ._functional_shared import (
     MAX_VALUES_BY_DTYPE,
     ImageType,
@@ -443,10 +445,9 @@ def _build_stain_affine_matrix(
 
 
 def _apply_stain_affine(optical_density: np.ndarray, affine_matrix: np.ndarray) -> np.ndarray:
-    result = cv2.transform(optical_density.reshape(-1, 1, 3), affine_matrix).reshape(-1, 3)
+    result = cv2.transform(optical_density.reshape(-1, 1, 3), affine_matrix)
     result *= -1.0
-    cv2.exp(result, dst=result)
-    return result
+    return albucore_exp(result, inplace=True).reshape(-1, 3)
 
 
 def _validate_stain_augmentation_inputs(

--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -6,6 +6,8 @@ from collections.abc import Sequence
 from typing import Any, Literal, cast
 
 import numkong as nk
+from albucore import exp as albucore_exp
+from albucore import sqrt as albucore_sqrt
 
 from ._functional_noise import (
     DIAMOND_KERNEL,
@@ -300,7 +302,7 @@ def create_corner_illumination_gradient(
     x = np.arange(width, dtype=np.float32)[np.newaxis, :] - corner_x
 
     pattern = x * x + y * y
-    cv2.sqrt(pattern, dst=pattern)
+    pattern = albucore_sqrt(pattern, inplace=True)
     _multiply_scalar_inplace(pattern, -intensity / math.sqrt(height * height + width * width))
     _add_scalar_inplace(pattern, 1.0)
     return pattern
@@ -345,7 +347,7 @@ def create_illumination_gradient(
     cv2.multiply(y, y, dst=y)
     x = x + y
     _multiply_scalar_inplace(x, -1 / sigma2)
-    cv2.exp(x, dst=x)
+    x = albucore_exp(x, inplace=True)
     _multiply_scalar_inplace(x, intensity)
     _add_scalar_inplace(x, 1.0)
     return x
@@ -458,7 +460,7 @@ def apply_gaussian_illumination(
 
     # Calculate gaussian directly into x array
     _multiply_scalar_inplace(x, -1 / sigma2)
-    cv2.exp(x, dst=x)
+    x = albucore_exp(x, inplace=True)
 
     # Scale by intensity
     _multiply_scalar_inplace(x, intensity)
@@ -994,7 +996,8 @@ def apply_film_grain(
 
     modulated = (grain * inv_lum * intensity * max_val).astype(np.float32)
 
-    return add_array(img, modulated[..., np.newaxis])
+    result = add_array(img, modulated[..., np.newaxis])
+    return clip(result, img.dtype, inplace=True) if img.dtype == np.float32 else result
 
 
 @uint8_io

--- a/albumentations/augmentations/pixel/_functional_noise.py
+++ b/albumentations/augmentations/pixel/_functional_noise.py
@@ -41,8 +41,16 @@ def add_noise(img: ImageType, noise: np.ndarray) -> ImageType:
     if img.ndim == 3 and noise.ndim == 1:
         return add_vector(img, noise, inplace=False)
 
-    n_tiles = np.prod(img.shape) // np.prod(noise.shape)
-    noise = np.tile(noise, (n_tiles,) + (1,) * noise.ndim).reshape(img.shape)
+    if noise.shape != img.shape:
+        try:
+            noise = np.broadcast_to(noise, img.shape)
+        except ValueError:
+            n_tiles = np.prod(img.shape) // np.prod(noise.shape)
+            noise = np.tile(noise, (n_tiles,) + (1,) * noise.ndim).reshape(img.shape)
+    elif img.dtype == np.uint8:
+        # Shared spatial noise is a zero-stride broadcast view. NumKong's dense uint8 route
+        # requires contiguous input and is faster than letting it materialize that view internally.
+        noise = np.ascontiguousarray(noise)
 
     return add_array(img, noise)
 
@@ -311,15 +319,18 @@ def sample_noise(
 
     """
     if noise_type == "uniform":
-        return sample_uniform(size, params, random_generator) * max_value
-    if noise_type == "gaussian":
-        return sample_gaussian(size, params, random_generator) * max_value
-    if noise_type == "laplace":
-        return sample_laplace(size, params, random_generator) * max_value
-    if noise_type == "beta":
-        return sample_beta(size, params, random_generator) * max_value
+        samples = sample_uniform(size, params, random_generator)
+    elif noise_type == "gaussian":
+        samples = sample_gaussian(size, params, random_generator)
+    elif noise_type == "laplace":
+        samples = sample_laplace(size, params, random_generator)
+    elif noise_type == "beta":
+        samples = sample_beta(size, params, random_generator)
+    else:
+        raise ValueError(f"Unknown noise type: {noise_type}")
 
-    raise ValueError(f"Unknown noise type: {noise_type}")
+    np.multiply(samples, max_value, out=samples)
+    return samples.astype(np.float32, copy=False)
 
 
 def sample_uniform(

--- a/albumentations/augmentations/pixel/_functional_noise.py
+++ b/albumentations/augmentations/pixel/_functional_noise.py
@@ -47,9 +47,9 @@ def add_noise(img: ImageType, noise: np.ndarray) -> ImageType:
         except ValueError:
             n_tiles = np.prod(img.shape) // np.prod(noise.shape)
             noise = np.tile(noise, (n_tiles,) + (1,) * noise.ndim).reshape(img.shape)
-    elif img.dtype == np.uint8:
-        # Shared spatial noise is a zero-stride broadcast view. NumKong's dense uint8 route
-        # requires contiguous input and is faster than letting it materialize that view internally.
+
+    if img.dtype == np.uint8 and not noise.flags.c_contiguous:
+        # NumKong's dense uint8 route is faster with a dense array than with a zero-stride broadcast view.
         noise = np.ascontiguousarray(noise)
 
     return add_array(img, noise)

--- a/albumentations/augmentations/pixel/_functional_sharpness.py
+++ b/albumentations/augmentations/pixel/_functional_sharpness.py
@@ -338,16 +338,20 @@ def planckian_jitter(
     img = img.copy()
     red_multiplier, blue_multiplier = _get_planckian_coeffs(mode, temperature)
 
-    img[..., 0] = multiply_by_constant(
-        img[..., 0],
-        red_multiplier,
-        inplace=True,
-    )
-    img[..., 2] = multiply_by_constant(
-        img[..., 2],
-        blue_multiplier,
-        inplace=True,
-    )
+    if img.dtype == np.float32:
+        np.multiply(img[..., 0], red_multiplier, out=img[..., 0])
+        np.multiply(img[..., 2], blue_multiplier, out=img[..., 2])
+    else:
+        img[..., 0] = multiply_by_constant(
+            img[..., 0],
+            red_multiplier,
+            inplace=True,
+        )
+        img[..., 2] = multiply_by_constant(
+            img[..., 2],
+            blue_multiplier,
+            inplace=True,
+        )
 
     return img
 

--- a/albumentations/augmentations/pixel/_functional_torchvision.py
+++ b/albumentations/augmentations/pixel/_functional_torchvision.py
@@ -32,37 +32,65 @@ from ._functional_shared import (
 )
 
 
+def _initialize_slic_centers(height: int, width: int, grid_step: int) -> np.ndarray:
+    x_range = np.arange(grid_step // 2, width, grid_step, dtype=np.float32)
+    y_range = np.arange(grid_step // 2, height, grid_step, dtype=np.float32)
+    centers = np.empty((x_range.size * y_range.size, 2), dtype=np.float32)
+    centers[:, 0] = np.tile(x_range, y_range.size)
+    centers[:, 1] = np.repeat(y_range, x_range.size)
+    return centers
+
+
+def _update_slic_centers(
+    labels: np.ndarray,
+    centers: np.ndarray,
+    x_coordinates: np.ndarray,
+    y_coordinates: np.ndarray,
+) -> None:
+    labels_flat = labels.reshape(-1)
+    counts = np.bincount(labels_flat, minlength=len(centers))
+    nonempty = counts > 0
+    x_sums = np.bincount(labels_flat, weights=x_coordinates, minlength=len(centers))
+    y_sums = np.bincount(labels_flat, weights=y_coordinates, minlength=len(centers))
+    np.divide(x_sums, counts, out=centers[:, 0], where=nonempty)
+    np.divide(y_sums, counts, out=centers[:, 1], where=nonempty)
+
+
 def _replace_segments_with_mean(
     image: np.ndarray,
     segments: np.ndarray,
     replace_samples: Sequence[bool],
 ) -> np.ndarray:
-    unique_labels, inverse_labels = np.unique(segments, return_inverse=True)
-    inverse_labels = inverse_labels.reshape(-1)
+    unique_labels = np.unique(segments)
     replace_start = 1 if unique_labels[0] == 0 else 0
     num_replaceable = len(unique_labels) - replace_start
     if num_replaceable == 0:
         return image.copy()
 
-    replace_by_label = np.zeros(len(unique_labels), dtype=bool)
-    replace_by_label[replace_start:] = np.resize(
+    num_labels = int(unique_labels[-1]) + 1
+    replace_by_label = np.zeros(num_labels, dtype=bool)
+    replace_by_label[unique_labels[replace_start:]] = np.resize(
         np.asarray(replace_samples, dtype=bool),
         num_replaceable,
     )
-    replace_mask = replace_by_label[inverse_labels]
+    labels_flat = segments.reshape(-1)
+    replace_mask = replace_by_label[labels_flat]
+    replace_labels = labels_flat[replace_mask]
 
     result = image.copy()
     result_flat = result.reshape(-1, result.shape[-1])
-    counts = np.bincount(inverse_labels, minlength=len(unique_labels))
+    counts = np.bincount(labels_flat, minlength=num_labels)
+    nonempty = counts > 0
+    segment_means = np.empty(num_labels, dtype=np.uint8)
 
     for channel_index in range(result.shape[-1]):
         sums = np.bincount(
-            inverse_labels,
+            labels_flat,
             weights=result_flat[:, channel_index],
-            minlength=len(unique_labels),
+            minlength=num_labels,
         )
-        segment_means = np.rint(sums / counts).astype(np.uint8)
-        result_flat[replace_mask, channel_index] = segment_means[inverse_labels[replace_mask]]
+        segment_means[nonempty] = np.rint(sums[nonempty] / counts[nonempty]).astype(np.uint8)
+        result_flat[replace_mask, channel_index] = segment_means[replace_labels]
 
     return result
 
@@ -401,77 +429,88 @@ def slic(
 
     """
     height, width = image.shape[:2]
-    num_pixels = height * width
+    grid_step = max(1, int((height * width / n_segments) ** 0.5))
 
     # Normalize image to [0, 1] range
-    max_val = np.float32(image.max())
-    image_normalized = image.astype(np.float32) / (max_val + np.float32(1e-6))
+    max_value = np.float32(image.max())
+    image_normalized = image.astype(np.float32)
+    np.divide(image_normalized, max_value + np.float32(1e-6), out=image_normalized)
     single_channel = image_normalized.shape[-1] == 1
 
-    # Initialize cluster centers via meshgrid
-    grid_step = int((num_pixels / n_segments) ** 0.5)
-    x_range = np.arange(grid_step // 2, width, grid_step)
-    y_range = np.arange(grid_step // 2, height, grid_step)
-    xx_grid, yy_grid = np.meshgrid(x_range, y_range)
-    centers = np.column_stack([xx_grid.ravel(), yy_grid.ravel()]).astype(np.float32)
-    y_coordinates, x_coordinates = np.indices((height, width), dtype=np.float64)
-    x_coordinates_flat = x_coordinates.reshape(-1)
-    y_coordinates_flat = y_coordinates.reshape(-1)
+    # Initialize cluster centers on a regular grid.
+    centers = _initialize_slic_centers(height, width, grid_step)
 
     # Initialize labels and distances
     labels = np.full((height, width), -1, dtype=np.int32)
-    if len(centers) == 0:
+    if len(centers) == 0 or max_iterations <= 0:
         return labels
 
-    distances = np.full((height, width), np.inf, dtype=np.float32)
+    x_coordinates_flat = np.tile(np.arange(width, dtype=np.float32), height)
+    y_coordinates_flat = np.repeat(np.arange(height, dtype=np.float32), width)
+    distances = np.empty((height, width), dtype=np.float32)
 
-    inv_grid_step_sq = np.float32(1.0 / (grid_step * grid_step))
+    max_window_height = min(height, 2 * grid_step + 1)
+    max_window_width = min(width, 2 * grid_step + 1)
+    color_diff_buffer = (
+        np.empty(0, dtype=np.float32)
+        if single_channel
+        else np.empty((max_window_height, max_window_width, image.shape[-1]), dtype=np.float32)
+    )
+    distance_buffer = np.empty((max_window_height, max_window_width), dtype=np.float32)
+    update_mask_buffer = np.empty((max_window_height, max_window_width), dtype=bool)
 
-    for _ in range(max_iterations):
-        for i, center in enumerate(centers):
-            y, x = int(center[1]), int(center[0])
+    offsets_squared = np.arange(-grid_step, grid_step + 1, dtype=np.float32)
+    np.square(offsets_squared, out=offsets_squared)
+    spatial_distances = np.add.outer(offsets_squared, offsets_squared)
+    spatial_distances *= np.float32(compactness / (grid_step * grid_step))
 
-            y_low, y_high = max(0, y - grid_step), min(height, y + grid_step + 1)
-            x_low, x_high = max(0, x - grid_step), min(width, x + grid_step + 1)
+    for iteration in range(max_iterations):
+        # Compare pixels only with the cluster centers from the current k-means iteration.
+        distances.fill(np.inf)
+        for center_index, center in enumerate(centers):
+            center_y, center_x = int(center[1]), int(center[0])
+
+            y_low, y_high = max(0, center_y - grid_step), min(height, center_y + grid_step + 1)
+            x_low, x_high = max(0, center_x - grid_step), min(width, center_x + grid_step + 1)
+            window_height = y_high - y_low
+            window_width = x_high - x_low
 
             crop = image_normalized[y_low:y_high, x_low:x_high]
-            color_diff = crop - image_normalized[y, x]
+            distance = distance_buffer[:window_height, :window_width]
             if single_channel:
-                color_distance = color_diff[..., 0] ** 2
+                np.subtract(crop[..., 0], image_normalized[center_y, center_x, 0], out=distance)
+                np.square(distance, out=distance)
             else:
-                color_distance = np.einsum(
+                color_diff = color_diff_buffer[:window_height, :window_width]
+                np.subtract(crop, image_normalized[center_y, center_x], out=color_diff)
+                np.einsum(
                     "...c,...c->...",
                     color_diff,
                     color_diff,
                     dtype=np.float32,
                     optimize=False,
+                    out=distance,
                 )
 
-            yy, xx = np.ogrid[y_low:y_high, x_low:x_high]
-            spatial_distance = ((yy - y) ** 2 + (xx - x) ** 2) * inv_grid_step_sq
+            offset_y_low = y_low - center_y + grid_step
+            offset_x_low = x_low - center_x + grid_step
+            spatial_distance = spatial_distances[
+                offset_y_low : offset_y_low + window_height,
+                offset_x_low : offset_x_low + window_width,
+            ]
+            np.add(distance, spatial_distance, out=distance)
 
-            distance = color_distance + compactness * spatial_distance
+            distance_slice = distances[y_low:y_high, x_low:x_high]
+            update_mask = update_mask_buffer[:window_height, :window_width]
+            np.less(distance, distance_slice, out=update_mask)
+            np.minimum(distance, distance_slice, out=distance_slice)
+            label_slice = labels[y_low:y_high, x_low:x_high]
+            label_slice[update_mask] = center_index
 
-            dist_slice = distances[y_low:y_high, x_low:x_high]
-            mask = distance < dist_slice
-            dist_slice[mask] = distance[mask]
-            labels[y_low:y_high, x_low:x_high][mask] = i
+        if iteration == max_iterations - 1:
+            break
 
-        labels_flat = labels.reshape(-1)
-        counts = np.bincount(labels_flat, minlength=len(centers))
-        nonempty = counts > 0
-        x_sums = np.bincount(
-            labels_flat,
-            weights=x_coordinates_flat,
-            minlength=len(centers),
-        )
-        y_sums = np.bincount(
-            labels_flat,
-            weights=y_coordinates_flat,
-            minlength=len(centers),
-        )
-        centers[nonempty, 0] = x_sums[nonempty] / counts[nonempty]
-        centers[nonempty, 1] = y_sums[nonempty] / counts[nonempty]
+        _update_slic_centers(labels, centers, x_coordinates_flat, y_coordinates_flat)
 
     return labels
 

--- a/albumentations/augmentations/pixel/_functional_torchvision.py
+++ b/albumentations/augmentations/pixel/_functional_torchvision.py
@@ -35,10 +35,24 @@ from ._functional_shared import (
 def _initialize_slic_centers(height: int, width: int, grid_step: int) -> np.ndarray:
     x_range = np.arange(grid_step // 2, width, grid_step, dtype=np.float32)
     y_range = np.arange(grid_step // 2, height, grid_step, dtype=np.float32)
+    if x_range.size == 0:
+        x_range = np.array([width // 2], dtype=np.float32)
+    if y_range.size == 0:
+        y_range = np.array([height // 2], dtype=np.float32)
+
     centers = np.empty((x_range.size * y_range.size, 2), dtype=np.float32)
     centers[:, 0] = np.tile(x_range, y_range.size)
     centers[:, 1] = np.repeat(y_range, x_range.size)
     return centers
+
+
+def _validate_slic_params(n_segments: int, max_iterations: int) -> None:
+    if n_segments <= 0:
+        msg = "n_segments must be positive"
+        raise ValueError(msg)
+    if max_iterations <= 0:
+        msg = "max_iterations must be positive"
+        raise ValueError(msg)
 
 
 def _update_slic_centers(
@@ -427,7 +441,12 @@ def slic(
     Returns:
         np.ndarray: Segmentation mask where each superpixel has a unique label.
 
+    Raises:
+        ValueError: If n_segments or max_iterations is not positive.
+
     """
+    _validate_slic_params(n_segments, max_iterations)
+
     height, width = image.shape[:2]
     grid_step = max(1, int((height * width / n_segments) ** 0.5))
 
@@ -442,8 +461,6 @@ def slic(
 
     # Initialize labels and distances
     labels = np.full((height, width), -1, dtype=np.int32)
-    if len(centers) == 0 or max_iterations <= 0:
-        return labels
 
     x_coordinates_flat = np.tile(np.arange(width, dtype=np.float32), height)
     y_coordinates_flat = np.repeat(np.arange(height, dtype=np.float32), width)

--- a/albumentations/augmentations/pixel/_functional_weather.py
+++ b/albumentations/augmentations/pixel/_functional_weather.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from albucore import exp as albucore_exp
+from albucore import sqrt as albucore_sqrt
+
 from ._functional_color import (
     equalize,
 )
@@ -126,7 +129,7 @@ def generate_snow_textures(
 
     """
     # Generate base snow texture
-    snow_texture = random_generator.normal(size=img_shape[:2], loc=0.5, scale=0.3)
+    snow_texture = random_generator.normal(size=img_shape[:2], loc=0.5, scale=0.3).astype(np.float32)
     snow_texture = cv2.GaussianBlur(snow_texture, (0, 0), sigmaX=1, sigmaY=1)
 
     # Generate sparkle mask
@@ -211,7 +214,7 @@ def add_snow_texture(
     # This simulates natural snow distribution on surfaces
     # The effect is achieved using a linear gradient from 1 (full snow) to 0.2 (less snow)
     rows = img.shape[0]
-    depth_effect = np.linspace(1, 0.2, rows)[:, np.newaxis]
+    depth_effect = np.linspace(1, 0.2, rows, dtype=np.float32)[:, np.newaxis]
     snow_texture *= depth_effect
 
     # Apply snow texture
@@ -589,13 +592,16 @@ def add_sun_flare_physics_based(
     flare_layer = cv2.GaussianBlur(flare_layer, (0, 0), sigmaX=15, sigmaY=15)
 
     # Create a radial gradient mask
-    y, x = np.ogrid[:height, :width]
-    mask = np.sqrt((x - flare_center[0]) ** 2 + (y - flare_center[1]) ** 2)
-    mask = 1 - np.clip(mask / (max(width, height) * 0.7), 0, 1)
-    mask = np.dstack([mask] * 3)
+    y = np.arange(height, dtype=np.float32)[:, np.newaxis] - flare_center[1]
+    x = np.arange(width, dtype=np.float32)[np.newaxis, :] - flare_center[0]
+    mask = x * x + y * y
+    mask = albucore_sqrt(mask, inplace=True)
+    mask *= np.float32(1 / (max(width, height) * 0.7))
+    np.clip(mask, 0, 1, out=mask)
+    np.subtract(1, mask, out=mask)
 
     # Apply the mask to the flare layer
-    flare_layer *= mask
+    flare_layer *= mask[..., np.newaxis]
 
     # Add chromatic aberration
     channels = list(cv2.split(flare_layer))
@@ -614,7 +620,7 @@ def add_sun_flare_physics_based(
     flare_layer = cv2.merge(channels)
 
     # Blend the flare with the original image using screen blending
-    return 255 - ((255 - output) * (255 - flare_layer) / 255)
+    return cast("ImageType", 255 - ((255 - output) * (255 - flare_layer) / 255))
 
 
 @uint8_io
@@ -848,7 +854,7 @@ def get_rain_params(
         m = np.zeros_like(m)
 
     # Apply color with adjusted intensity for more natural look
-    drops = m[:, :, None] * color * (intensity * 0.9)  # Slightly reduced intensity
+    drops = m[:, :, None] * color.astype(np.float32, copy=False) * np.float32(intensity * 0.9)
 
     return {
         "drops": drops,
@@ -956,14 +962,20 @@ def apply_atmospheric_fog(
 
     """
     num_channels = img.shape[-1]
-    transmission = np.exp(-density * depth_map).astype(np.float32)[:, :, np.newaxis]
+    transmission = np.multiply(depth_map, np.float32(-density), dtype=np.float32)
+    transmission = albucore_exp(transmission, inplace=True)[:, :, np.newaxis]
 
     fog_array = np.array(fog_color, dtype=np.float32)
     if len(fog_array) < num_channels:
         fog_array = np.pad(fog_array, (0, num_channels - len(fog_array)), mode="edge")
     fog_array = fog_array[:num_channels].reshape(1, 1, -1)
 
-    result = img.astype(np.float32) * transmission + fog_array * (1.0 - transmission)
+    if img.dtype == np.float32:
+        result = np.multiply(img, transmission, dtype=np.float32)
+        np.subtract(np.float32(1.0), transmission, out=transmission)
+        np.add(result, fog_array * transmission, out=result)
+    else:
+        result = img.astype(np.float32) * transmission + fog_array * (1.0 - transmission)
 
     return clip(result, img.dtype)
 

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -963,7 +963,8 @@ class ExposureMatching(ImageOnlyTransform):
         self.gain_range = gain_range
 
     def apply(self, img: ImageType, gain: float, **params: Any) -> ImageType:
-        return albucore.multiply(img, gain, inplace=False)
+        result = albucore.multiply(img, gain, inplace=False)
+        return fpixel.clip(result, img.dtype, inplace=True) if img.dtype == np.float32 else result
 
     def apply_to_images(self, images: ImageType, image_gains: list[float], **params: Any) -> ImageType:
         return fpixel.exposure_match_batch(images, np.asarray(image_gains, dtype=np.float32))

--- a/albumentations/augmentations/pixel/dithering_functional.py
+++ b/albumentations/augmentations/pixel/dithering_functional.py
@@ -350,8 +350,8 @@ def random_dither(
 
     """
     # Add random noise
-    noise = random_generator.uniform(noise_range[0], noise_range[1], size=img.shape)
-    noisy = img + noise
+    noisy = random_generator.uniform(noise_range[0], noise_range[1], size=img.shape)
+    np.add(noisy, img, out=noisy)
     np.clip(noisy, 0, 1, out=noisy)
 
     # Quantize using vectorized numpy operations
@@ -359,9 +359,10 @@ def random_dither(
         return (noisy >= 0.5).astype(np.float32)
 
     # Vectorized quantization for float32
-    scaled = noisy * (n_colors - 1)
-    quantized = np.round(scaled) / (n_colors - 1)
-    return quantized.astype(np.float32)
+    np.multiply(noisy, n_colors - 1, out=noisy)
+    np.round(noisy, out=noisy)
+    np.divide(noisy, n_colors - 1, out=noisy)
+    return noisy.astype(np.float32)
 
 
 def _floyd_steinberg_binary_uint8(img: ImageUInt8) -> ImageUInt8:

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -11,6 +11,7 @@ import cv2
 import numpy as np
 from albucore import (
     MAX_VALUES_BY_DTYPE,
+    clip,
     multiply,
 )
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -353,7 +354,8 @@ class MultiplicativeNoise(ImageOnlyTransform):
         multiplier: float | np.ndarray,
         **kwargs: Any,
     ) -> ImageType:
-        return multiply(img, multiplier)
+        result = multiply(img, multiplier)
+        return clip(result, img.dtype, inplace=True) if img.dtype == np.float32 else result
 
     def apply_to_images(self, images: ImageType, multiplier: float | np.ndarray, **kwargs: Any) -> ImageType:
         return self.apply(images, multiplier, **kwargs)

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -1390,13 +1390,15 @@ class Spatter(ImageOnlyTransform):
         sigma = self.py_random.uniform(*self.gauss_sigma_range)
         mode = self.mode
         intensity = self.py_random.uniform(*self.intensity_range)
-        color = np.array(self.color) / 255.0
+        color = np.asarray(self.color, dtype=np.float32) / np.float32(255)
 
         liquid_layer = self.random_generator.normal(
             size=(height, width),
             loc=mean,
             scale=std,
         )
+        if mode == "rain":
+            liquid_layer = liquid_layer.astype(np.float32)
         # Convert sigma to kernel size (must be odd)
         ksize = 2 * round(3 * sigma) + 1  # 3 sigma rule, rounded to nearest odd
         cv2.GaussianBlur(
@@ -1545,11 +1547,11 @@ class AtmosphericFog(ImageOnlyTransform):
             depth_map = (y[:, np.newaxis] + x[np.newaxis, :]) / 2.0
         else:
             cy, cx = height / 2.0, width / 2.0
-            y = np.arange(height, dtype=np.float32)
-            x = np.arange(width, dtype=np.float32)
-            dist = np.sqrt((y[:, np.newaxis] - cy) ** 2 + (x[np.newaxis, :] - cx) ** 2)
-            max_dist = np.sqrt(cy**2 + cx**2)
-            depth_map = (dist / max_dist).astype(np.float32)
+            y = np.arange(height, dtype=np.float32)[:, np.newaxis] - cy
+            x = np.arange(width, dtype=np.float32)[np.newaxis, :] - cx
+            depth_map = x * x + y * y
+            depth_map = albucore.sqrt(depth_map, inplace=True)
+            depth_map *= np.float32(1 / math.hypot(cy, cx))
 
         max_val = albucore.MAX_VALUES_BY_DTYPE[np.uint8]
         image_data = self.get_image_data(data)

--- a/albumentations/augmentations/utils.py
+++ b/albumentations/augmentations/utils.py
@@ -138,6 +138,8 @@ class PCA:
             - If None: Keep all components (min of n_samples and n_features)
             - If int: Keep the specified number of components
             Must be greater than 0 if specified.
+        dtype (np.dtype | type[np.generic]): Computation dtype. OpenCV PCA supports
+            np.float32 and np.float64. Default: np.float64.
 
     Raises:
         ValueError: If n_components is specified and is less than or equal to 0.
@@ -161,9 +163,16 @@ class PCA:
 
     """
 
-    def __init__(self, n_components: int | None = None) -> None:
+    def __init__(
+        self,
+        n_components: int | None = None,
+        dtype: np.dtype | type[np.generic] = np.float64,
+    ) -> None:
         if n_components is not None and n_components <= 0:
             raise ValueError("Number of components must be greater than zero.")
+        self.dtype = np.dtype(dtype)
+        if self.dtype not in {np.dtype(np.float32), np.dtype(np.float64)}:
+            raise ValueError("PCA dtype must be np.float32 or np.float64.")
         self.n_components = n_components
         self.mean: np.ndarray | None = None
         self.components_: np.ndarray | None = None
@@ -187,7 +196,7 @@ class PCA:
 
         Args:
             x (np.ndarray): Training data of shape (n_samples, n_features).
-                Data will be automatically converted to float64 for computation.
+                Data will be converted to the configured computation dtype.
 
         Note:
             - The data is automatically centered (mean-subtracted) during fitting
@@ -203,15 +212,15 @@ class PCA:
             >>> print(pca.components_.shape)  # (3, 10)
 
         """
-        x = x.astype(np.float64, copy=False)  # avoid unnecessary copy if already float64
-        n_samples, n_features = x.shape
+        x_float = cast("np.ndarray[Any, np.dtype[np.floating[Any]]]", x.astype(self.dtype, copy=False))
+        n_samples, n_features = x_float.shape
 
         # Determine the number of components if not set
         if self.n_components is None:
             self.n_components = min(n_samples, n_features)
 
-        mean = np.empty((0,), dtype=np.float64)
-        computed_mean, eigenvectors, eigenvalues = cv2.PCACompute2(x, mean=mean, maxComponents=self.n_components)
+        mean = cast("np.ndarray[Any, np.dtype[np.floating[Any]]]", np.empty((0,), dtype=self.dtype))
+        computed_mean, eigenvectors, eigenvalues = cv2.PCACompute2(x_float, mean=mean, maxComponents=self.n_components)
         self.mean = cast("np.ndarray", computed_mean)
         self.components_ = cast("np.ndarray", eigenvectors)
         self.explained_variance_ = cast("np.ndarray", eigenvalues).flatten()
@@ -226,7 +235,7 @@ class PCA:
         Args:
             x (np.ndarray): Data to transform of shape (n_samples, n_features).
                 Must have the same number of features as the data used for fitting.
-                Data will be automatically converted to float64 for computation.
+                Data will be converted to the fitted PCA dtype.
 
         Returns:
             np.ndarray: Transformed data of shape (n_samples, n_components).
@@ -249,7 +258,7 @@ class PCA:
 
         """
         mean, components = self._require_fitted()
-        x = x.astype(np.float64, copy=False)  # avoid unnecessary copy if already float64
+        x = x.astype(mean.dtype, copy=False)
         return cast("np.ndarray", cv2.PCAProject(x, mean, components))
 
     def fit_transform(self, x: np.ndarray) -> np.ndarray:
@@ -262,7 +271,7 @@ class PCA:
 
         Args:
             x (np.ndarray): Data to fit and transform of shape (n_samples, n_features).
-                Data will be automatically converted to float64 for computation.
+                Data will be converted to the configured computation dtype.
 
         Returns:
             np.ndarray: Transformed data of shape (n_samples, n_components).
@@ -318,7 +327,7 @@ class PCA:
 
         """
         mean, components = self._require_fitted()
-        return cast("np.ndarray", cv2.PCABackProject(x, mean, components))
+        return cast("np.ndarray", cv2.PCABackProject(x.astype(mean.dtype, copy=False), mean, components))
 
     def explained_variance_ratio(self) -> np.ndarray:
         """Return fraction of total variance explained by each component (shape (n_components,),

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=5.0.0.93
-    - albucore==0.2.5
+    - albucore==0.2.9
     - numkong!=7.7.1
 
 suggests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "albucore==0.2.5",
+  "albucore==0.2.9",
   "numkong!=7.7.1",
   "numpy>=2.2.6",
   "pydantic>=2.12.4",

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1174,6 +1174,34 @@ def test_slic_handles_more_segments_than_pixels(channels):
     assert np.all(labels >= 0)
 
 
+@pytest.mark.parametrize("n_segments", [0, -1])
+def test_slic_rejects_nonpositive_segment_count(n_segments):
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="n_segments must be positive"):
+        fpixel.slic(image, n_segments=n_segments)
+
+
+@pytest.mark.parametrize("shape", [(1, 32, 1), (24, 4, 3), (4, 24, 5)])
+def test_slic_assigns_labels_for_narrow_images(shape):
+    image = np.random.default_rng(137).integers(0, 256, shape, dtype=np.uint8)
+
+    labels = fpixel.slic(image, n_segments=1)
+    result = fpixel.superpixels(
+        image,
+        n_segments=1,
+        replace_samples=[True],
+        max_size=None,
+        interpolation=cv2.INTER_NEAREST,
+    )
+
+    assert labels.shape == image.shape[:2]
+    assert labels.dtype == np.int32
+    assert np.all(labels >= 0)
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype
+
+
 @pytest.mark.parametrize("channels", [1, 3, 5])
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 def test_superpixels_segment_mean_replacement(monkeypatch, channels, dtype):

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1150,9 +1150,9 @@ def test_fancy_pca_zero_alpha(shape, dtype):
 @pytest.mark.parametrize(
     ("channels", "expected_hash"),
     [
-        (1, "3f7d5fd9af229099078be43a5119cc70a1ffb3487e0fb933e89db31ac667a1a0"),
-        (3, "f1e44bb1c912d89a4393343f0caec246d12707511a3099d450591f9e24b1879c"),
-        (5, "3b074bf63f9fe72f4c5839ab24b0e15fc49fe091697ab1cec2299117a8db63f4"),
+        (1, "782589b0420c6c4c3da9edb8aa262c23bb6083be3cc8f2daa41a464518f69bd0"),
+        (3, "a686ba8aa835095757718232e7b343a9bd2926aa13b0f85cc5f136b6d925cef8"),
+        (5, "2bb1fa123dfe7a1d2e33f2436b9a5b303a4783a80891a6c4213fb1a4c8dee3e3"),
     ],
 )
 def test_slic_output_regression(channels, expected_hash):
@@ -1164,14 +1164,25 @@ def test_slic_output_regression(channels, expected_hash):
 
 
 @pytest.mark.parametrize("channels", [1, 3, 5])
+def test_slic_handles_more_segments_than_pixels(channels):
+    image = np.random.default_rng(137).integers(0, 256, (4, 4, channels), dtype=np.uint8)
+
+    labels = fpixel.slic(image, n_segments=17)
+
+    assert labels.shape == image.shape[:2]
+    assert labels.dtype == np.int32
+    assert np.all(labels >= 0)
+
+
+@pytest.mark.parametrize("channels", [1, 3, 5])
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 def test_superpixels_segment_mean_replacement(monkeypatch, channels, dtype):
     image_uint8 = np.arange(2 * 4 * channels, dtype=np.uint8).reshape(2, 4, channels)
     image = image_uint8 if dtype == np.uint8 else image_uint8.astype(np.float32) / 255
     segments = np.array(
         [
-            [0, 0, 1, 1],
-            [2, 2, 3, 3],
+            [0, 0, 2, 2],
+            [5, 5, 9, 9],
         ],
         dtype=np.int32,
     )
@@ -1186,7 +1197,7 @@ def test_superpixels_segment_mean_replacement(monkeypatch, channels, dtype):
     )
 
     expected_uint8 = image_uint8.copy()
-    for segment_label in (1, 3):
+    for segment_label in (2, 9):
         segment_mask = segments == segment_label
         expected_uint8[segment_mask] = np.rint(image_uint8[segment_mask].mean(axis=0)).astype(np.uint8)
     expected = expected_uint8 if dtype == np.uint8 else expected_uint8.astype(np.float32) / 255
@@ -2760,7 +2771,7 @@ def test_rain_params_different_inputs(liquid_layer):
     result = fpixel.get_rain_params(liquid_layer, color, intensity)
 
     assert isinstance(result["drops"], np.ndarray)
-    assert result["drops"].dtype in [np.float32, np.float64]
+    assert result["drops"].dtype == np.float32
 
 
 def test_rain_params_deterministic():

--- a/tests/functional/test_geometric.py
+++ b/tests/functional/test_geometric.py
@@ -100,7 +100,7 @@ def test_from_distance_maps(
 )
 def test_to_distance_maps_extra_columns(image_shape, keypoints, inverted):
     keypoints_with_extra = [(x, y, 0, 1) for x, y in keypoints]
-    distance_maps = to_distance_maps(keypoints, image_shape, inverted)
+    distance_maps = to_distance_maps(keypoints_with_extra, image_shape, inverted)
 
     assert distance_maps.shape == (*image_shape, len(keypoints))
     assert distance_maps.dtype == np.float32
@@ -110,6 +110,104 @@ def test_to_distance_maps_extra_columns(image_shape, keypoints, inverted):
             assert np.isclose(distance_maps[int(y), int(x), i], 1.0)
         else:
             assert np.isclose(distance_maps[int(y), int(x), i], 0.0)
+
+
+@pytest.mark.parametrize("inverted", [False, True])
+def test_to_distance_maps_many_keypoints_matches_float32_reference(inverted: bool) -> None:
+    height, width = 24, 32
+    keypoints = (
+        np.random.default_rng(137)
+        .uniform(
+            [0, 0, 0, 0],
+            [width - 1, height - 1, 2 * np.pi, 1],
+            size=(33, 4),
+        )
+        .astype(np.float32)
+    )
+
+    distance_maps = to_distance_maps(keypoints, (height, width), inverted)
+
+    y_coordinates, x_coordinates = np.mgrid[:height, :width]
+    expected = np.sqrt(
+        (x_coordinates[..., np.newaxis] - keypoints[:, 0]) ** 2
+        + (y_coordinates[..., np.newaxis] - keypoints[:, 1]) ** 2,
+    ).astype(np.float32)
+    if inverted:
+        expected = (1 / (expected + 1)).astype(np.float32)
+
+    assert distance_maps.shape == (height, width, len(keypoints))
+    assert distance_maps.dtype == np.float32
+    np.testing.assert_allclose(distance_maps, expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(("image_shape", "k"), [((24, 32), -0.2), ((33, 25), 0.3)])
+def test_fisheye_distortion_maps_match_radial_model(image_shape: tuple[int, int], k: float) -> None:
+    height, width = image_shape
+    center_x, center_y = width / 2, height / 2
+    y_coordinates, x_coordinates = np.mgrid[:height, :width].astype(np.float32)
+    x_coordinates -= center_x
+    y_coordinates -= center_y
+    radius = np.sqrt(x_coordinates * x_coordinates + y_coordinates * y_coordinates)
+    max_radius = np.hypot(
+        max(center_x, width - center_x),
+        max(center_y, height - center_y),
+    )
+    distorted_radius = radius * (1 + k * (radius / max_radius) ** 2)
+    angle = np.arctan2(y_coordinates, x_coordinates)
+    expected_x = distorted_radius * np.cos(angle) + center_x
+    expected_y = distorted_radius * np.sin(angle) + center_y
+
+    map_x, map_y = fgeometric.get_fisheye_distortion_maps(image_shape, k)
+
+    assert map_x.dtype == np.float32
+    assert map_y.dtype == np.float32
+    np.testing.assert_allclose(map_x, expected_x, rtol=1e-6, atol=1e-5)
+    np.testing.assert_allclose(map_y, expected_y, rtol=1e-6, atol=1e-5)
+
+
+@pytest.mark.parametrize("num_control_points", [2, 3, 4, 5])
+def test_tps_interpolates_control_points(num_control_points: int) -> None:
+    src_points = fgeometric.generate_control_points(num_control_points)
+    dst_points = src_points + np.random.default_rng(137).uniform(
+        -0.08,
+        0.08,
+        size=src_points.shape,
+    ).astype(np.float32)
+
+    nonlinear_weights, affine_weights = fgeometric.compute_tps_weights(src_points, dst_points)
+    transformed_points = fgeometric.tps_transform(
+        src_points,
+        src_points,
+        nonlinear_weights,
+        affine_weights,
+    )
+
+    assert transformed_points.dtype == np.float32
+    np.testing.assert_allclose(transformed_points, dst_points, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.filterwarnings("error::RuntimeWarning")
+def test_tps_transform_dense_map_emits_no_runtime_warnings() -> None:
+    src_points = fgeometric.generate_control_points(4)
+    dst_points = src_points + np.random.default_rng(137).uniform(
+        -0.08,
+        0.08,
+        size=src_points.shape,
+    ).astype(np.float32)
+    nonlinear_weights, affine_weights = fgeometric.compute_tps_weights(src_points, dst_points)
+    axis = np.linspace(0, 1, 64, dtype=np.float32)
+    target_points = np.stack(np.meshgrid(axis, axis), axis=-1).reshape(-1, 2)
+
+    transformed_points = fgeometric.tps_transform(
+        target_points,
+        src_points,
+        nonlinear_weights,
+        affine_weights,
+    )
+
+    assert transformed_points.shape == target_points.shape
+    assert transformed_points.dtype == np.float32
+    assert np.isfinite(transformed_points).all()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_domain_adaptation.py
+++ b/tests/test_domain_adaptation.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from albucore import to_float
 from skimage.exposure import match_histograms as skimage_match_histograms
 from skimage.metrics import structural_similarity as ssim
 
@@ -89,7 +90,20 @@ def test_standard_inverse_transform(data, data_scaled, expected):
     scaler = StandardScaler()
     scaler.fit(data)
     result = scaler.inverse_transform(data_scaled)
-    np.testing.assert_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize("scaler_cls", [MinMaxScaler, StandardScaler])
+def test_scalers_use_float32_working_arrays(scaler_cls):
+    data = np.array([[1, 2], [3, 4], [5, 6]], dtype=np.uint8)
+    scaler = scaler_cls()
+
+    transformed = scaler.fit_transform(data)
+    reconstructed = scaler.inverse_transform(transformed)
+
+    assert transformed.dtype == np.float32
+    assert reconstructed.dtype == np.float32
+    np.testing.assert_allclose(reconstructed, data)
 
 
 @pytest.mark.parametrize(
@@ -138,6 +152,20 @@ def test_pca_transform(n_components, data, expected_shape):
     transformed = pca.fit_transform(data)
     assert transformed.shape == expected_shape
     assert np.all(np.isfinite(transformed)), "Transformed data contains non-finite values"
+
+
+def test_pca_configurable_computation_dtype():
+    data = np.random.default_rng(137).random((32, 3), dtype=np.float32)
+
+    default_pca = PCA(n_components=2)
+    default_result = default_pca.fit_transform(data)
+    float32_pca = PCA(n_components=2, dtype=np.float32)
+    float32_result = float32_pca.fit_transform(data)
+
+    assert default_result.dtype == np.float64
+    assert float32_result.dtype == np.float32
+    assert float32_pca.mean is not None and float32_pca.mean.dtype == np.float32
+    assert float32_pca.components_ is not None and float32_pca.components_.dtype == np.float32
 
 
 @pytest.mark.parametrize(
@@ -465,6 +493,32 @@ def test_adapt_pixel_distribution_5plus_channels(num_channels, transform_type):
     result = adapt_pixel_distribution(img, ref, transform_type=transform_type, weight=0.5)
     assert result.shape == img.shape
     assert result.dtype == img.dtype
+
+
+@pytest.mark.parametrize("transform_type", ["pca", "standard", "minmax"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_pixel_distribution_adaptation_single_channel(transform_type, dtype):
+    rng = np.random.default_rng(137)
+    image_uint8 = rng.integers(0, 256, (17, 23, 1), dtype=np.uint8)
+    reference_uint8 = rng.integers(0, 256, (13, 19, 1), dtype=np.uint8)
+    image = image_uint8 if dtype == np.uint8 else to_float(image_uint8)
+    reference = reference_uint8 if dtype == np.uint8 else to_float(reference_uint8)
+    transform = A.Compose(
+        [
+            A.PixelDistributionAdaptation(
+                blend_ratio=(0.5, 0.5),
+                transform_type=transform_type,
+                metadata_key="pda_metadata",
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    result = transform(image=image, pda_metadata=[reference])["image"]
+
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype
 
 
 @pytest.mark.parametrize("num_channels", [5, 6])

--- a/tests/test_new_transforms.py
+++ b/tests/test_new_transforms.py
@@ -4,6 +4,7 @@ Halftone, GridMask, LensFlare, WaterRefraction, AtmosphericFog.
 
 import numpy as np
 import pytest
+from albucore import clip
 
 import albumentations as A
 import albumentations.augmentations.pixel.functional as fpixel
@@ -547,6 +548,24 @@ class TestAtmosphericFog:
         depth = np.broadcast_to(depth, (100, 100)).copy()
         result = fpixel.apply_atmospheric_fog(img, density=0.0, fog_color=(200.0, 200.0, 200.0), depth_map=depth)
         np.testing.assert_array_equal(result, img)
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+    def test_matches_numpy_exponential_reference(self, dtype: type[np.generic]) -> None:
+        img = _make_image(shape=(24, 32, 3), dtype=dtype, seed=137)
+        depth = np.random.default_rng(138).random((24, 32), dtype=np.float32)
+        density = 1.7
+        fog_color = (200.0, 210.0, 220.0) if dtype == np.uint8 else (0.7, 0.8, 0.9)
+        transmission = np.exp(-density * depth).astype(np.float32)[..., np.newaxis]
+        fog_array = np.asarray(fog_color, dtype=np.float32).reshape(1, 1, -1)
+        expected = clip(
+            img.astype(np.float32) * transmission + fog_array * (1.0 - transmission),
+            img.dtype,
+        )
+
+        result = fpixel.apply_atmospheric_fog(img, density, fog_color, depth)
+
+        tolerance = 1 if dtype == np.uint8 else 1e-6
+        np.testing.assert_allclose(result, expected, rtol=1e-5, atol=tolerance)
 
     def test_linear_mode_top_foggier(self):
         img = np.full((200, 200, 3), 50, dtype=np.uint8)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1910,6 +1910,33 @@ def test_gauss_noise(mean, image):
 
 
 @pytest.mark.parametrize(
+    ("noise_type", "noise_params"),
+    [
+        ("uniform", {"ranges": [(-0.2, 0.2)]}),
+        ("gaussian", {"mean_range": (0.0, 0.0), "std_range": (0.1, 0.1)}),
+        ("laplace", {"mean_range": (0.0, 0.0), "scale_range": (0.1, 0.1)}),
+        ("beta", {"alpha_range": (0.5, 1.5), "beta_range": (0.5, 1.5), "scale_range": (0.1, 0.3)}),
+    ],
+)
+@pytest.mark.parametrize("spatial_mode", ["per_pixel", "shared"])
+def test_additive_noise_spatial_map_is_float32(noise_type, noise_params, spatial_mode):
+    image = np.full((32, 48, 3), 128, dtype=np.uint8)
+    aug = A.AdditiveNoise(
+        noise_type=noise_type,
+        spatial_mode=spatial_mode,
+        noise_params=noise_params,
+        p=1,
+    )
+
+    apply_params = aug.get_params_dependent_on_data(
+        params={"shape": image.shape},
+        data={"image": image},
+    )
+
+    assert apply_params["noise_map"].dtype == np.float32
+
+
+@pytest.mark.parametrize(
     "params",
     [
         ({"flare_roi": (1.2, 0.2, 0.8, 0.9)}),  # Invalid flare_roi -> x_min out of bounds

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -11,6 +11,7 @@ from albucore import MAX_VALUES_BY_DTYPE, clip, to_float
 import albumentations as A
 import albumentations.augmentations.geometric.functional as fgeometric
 import albumentations.augmentations.pixel.functional as fpixel
+from albumentations.augmentations.pixel import _functional_noise as fnoise
 from albumentations.core.transforms_interface import BasicTransform
 from tests.conftest import (
     IMAGES,
@@ -1934,6 +1935,23 @@ def test_additive_noise_spatial_map_is_float32(noise_type, noise_params, spatial
     )
 
     assert apply_params["noise_map"].dtype == np.float32
+
+
+def test_add_noise_materializes_broadcast_uint8_noise(monkeypatch):
+    image = np.full((4, 6, 3), 128, dtype=np.uint8)
+    noise = np.ones((4, 6, 1), dtype=np.float32)
+    captured_noise: list[np.ndarray] = []
+
+    def capture_add_array(image: np.ndarray, noise: np.ndarray) -> np.ndarray:
+        captured_noise.append(noise)
+        return image
+
+    monkeypatch.setattr(fnoise, "add_array", capture_add_array)
+    fnoise.add_noise(image, noise)
+
+    assert len(captured_noise) == 1
+    assert captured_noise[0].shape == image.shape
+    assert captured_noise[0].flags.c_contiguous
 
 
 @pytest.mark.parametrize(

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -71,7 +71,7 @@ LOWER_BOUND_REQUIREMENTS = (
     "numpy==2.2.6",
     "scipy==1.15.3",
     "pydantic==2.12.4",
-    "albucore==0.2.5",
+    "albucore==0.2.9",
     "opencv-python-headless==5.0.0.93",
 )
 CI_DEPENDENCY_GROUPS = {

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "albucore"
-version = "0.2.5"
+version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numkong" },
@@ -35,9 +35,9 @@ dependencies = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "stringzilla" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/69/c5846a4e520935a8125c5a83be11326eae838a1dfb280c7b38fa1b9c5f33/albucore-0.2.5.tar.gz", hash = "sha256:6653da52223987af3bcf264ff4c1672595ed8c13b6f66ffd28c5a353a68cb43f", size = 153595, upload-time = "2026-07-22T13:55:02.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/d2/cfcbe0778e60e091d0594c87269a8fe37ef83f5cf5d11c7db04e27230545/albucore-0.2.9.tar.gz", hash = "sha256:c7d94e902371a533237cf4894b42881229b64e3afb8780d0de4ba254ace445a3", size = 170347, upload-time = "2026-07-31T13:46:17.704Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/ef/dd7fddfc3ce4d25d51923eb68a09e9a29e23740f731d1b9116d99c338f8a/albucore-0.2.5-py3-none-any.whl", hash = "sha256:946a28bbe1c6078a72ef9220955239db7d4b4fec4ba90b552c25e3daa5d2f2ae", size = 42535, upload-time = "2026-07-22T13:55:00.939Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ea/83fca154d58f695adf07540c79817af4dd2e51b2ae6e59aafd3d34892b83/albucore-0.2.9-py3-none-any.whl", hash = "sha256:5180bcc0cb2643a6916fda8bd8334eea018071795ec71654b4062ecc6e747365", size = 46851, upload-time = "2026-07-31T13:46:16.398Z" },
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "albucore", specifier = "==0.2.5" },
+    { name = "albucore", specifier = "==0.2.9" },
     { name = "huggingface-hub", marker = "extra == 'hub'" },
     { name = "numkong", specifier = "!=7.7.1" },
     { name = "numpy", specifier = ">=2.2.6" },


### PR DESCRIPTION
## Summary

- add residual-channel modes to HEStain and harden residual stain augmentation
- correct ThinPlateSpline interpolation kernel and move image-sized geometry, illumination, weather, histology, noise, and SLIC paths to validated float32/Albucore operations
- preserve clipping semantics for float32 ExposureMatching, FilmGrain, and MultiplicativeNoise
- make PCA computation dtype-aware and update Albucore 0.2.9 integration

## Validation

- `PYTHONPATH="$PWD" .venv/bin/python -m pytest -n auto -q`
  - 12,921 passed, 42 skipped, 9 xfailed, 3 xpassed
- `uv run pre-commit run --all-files`
- targeted performance comparisons for TPS, SLIC, fisheye/distance maps, weather, and float32 paths; only retained changes with measured wins or correctness fixes

## Notes

- The local Git hook points to a stale global Python environment with an older Albucore. The two import-dependent hooks were run successfully through the project venv before commit.

## Summary by Sourcery

Introduce residual-channel modes to HE stain augmentation and optimize multiple pixel and geometric operations for validated float32 behavior and Albucore 0.2.9 integration.

New Features:
- Add configurable HEStain residual modes (project, preserve, augment) with support across image targets and JSON serialization.
- Extend pixel distribution adaptation to handle single-channel images while preserving dtype and shape semantics.

Bug Fixes:
- Correct Thin Plate Spline kernel computation and fisheye distortion maps to match their intended radial models.
- Ensure atmospheric fog, film grain, multiplicative noise, rain, snow, and dithering operations preserve clipping and numerical behavior for float32 inputs.
- Fix distance-map generation for many keypoints and keypoint remapping via masks to avoid warnings and maintain accuracy.
- Resolve SLIC segmentation edge cases, including more segments than pixels, and adjust superpixel replacement to use stable label handling.

Enhancements:
- Refine HE stain augmentation internals with residual fallbacks, stricter input validation, and tissue-mask-aware behavior.
- Standardize domain adaptation scalers and PCA to use configurable float32/float64 working dtypes and Albucore primitives.
- Optimize various pixel, color, mixing, illumination, and weather paths to use Albucore math, vectorized NumPy operations, and explicit float32 buffers.
- Tighten additive noise sampling so spatial noise maps are consistently generated as float32 with robust broadcasting.

Build:
- Update Albucore dependency to version 0.2.9 across packaging, CI matrix, and nightly workflow.

Tests:
- Add comprehensive tests for HEStain residual modes, TPS interpolation and maps, fisheye distortion, distance maps, atmospheric fog, domain adaptation scalers and PCA dtype behavior, SLIC regression and edge cases, additive noise maps, rain parameters, and keypoint distance maps and remapping.