### PR TITLE
feat(torch): add CPU Tensor Compose foundation

### DIFF
--- a/.codex/rules/albumentations-rules.md
+++ b/.codex/rules/albumentations-rules.md
@@ -31,6 +31,18 @@ always_apply: true
 - For performance work, benchmark before choosing `cv2`, `sz_lut`, or NumPy. Direct bitwise operations can beat
   LUTs for true bit masks, scalar NumPy bitwise can beat OpenCV, and tiny transforms may be dominated by dispatch
   overhead rather than pixel kernels.
+- For Torch backend work, follow `docs/design/torch-cpu-backend-migration.md`. Extend the existing `Compose`,
+  `apply_*`, and functional layers; do not add a second Tensor composition API. CPU Tensor targets use `C,H,W` for
+  `image`, `C,L,H,W` for `images`, and `C,D,H,W` for `volume`. The central planner may route NumPy input through
+  Torch segments and Tensor input through NumPy/OpenCV/NumKong segments, but only when the full path including every
+  bridge, layout conversion, and return conversion has evidence of no repeatable regression. Helpers must not perform
+  ad hoc representation conversion. Backend routing preserves the input representation; existing explicit terminal
+  `ToTensorV2` and `ToTensor3D` behavior remains unchanged for NumPy input, and Tensor-input pipelines reject those
+  unnecessary terminal transforms. Do not add device, CUDA, MPS, stream, or autograd support in the CPU stage. Every
+  accepted Tensor route must be no slower than the equivalent NumPy `Compose` in a direct pre-created-input benchmark,
+  and must also pass the NumPy-Compose-plus-terminal-conversion versus Tensor-Compose model-ready-output benchmark.
+  Run `DataLoader`/collation benchmarks for shared Compose, bridge, planner, batching, and milestone changes; do not
+  require them in every isolated transform-family pull request.
 - After Python or quality-gate config edits, run `uv run python tools/quality_gate.py fast` before marking work
   complete when the environment can support it.
 

--- a/.github/workflows/pytorch-performance.yml
+++ b/.github/workflows/pytorch-performance.yml
@@ -28,7 +28,7 @@ jobs:
       run: >
         python tools/collect_test_environment.py
         --output pytorch-benchmark-evidence/environment-pytorch-benchmark.json
-        --command "asv run optional PyTorch tensor benchmark evidence"
+        --command "asv run dedicated PyTorch Tensor benchmark evidence"
     - name: Register PyTorch ASV machine profile
       working-directory: benchmark
       run: asv --config asv-pytorch.conf.json machine --yes

--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -20,12 +20,8 @@ except ImportError as e:
     )
     raise ImportError(msg) from e
 
-from contextlib import suppress
-
 from .augmentations import *
 from .core.composition import *
 from .core.serialization import *
 from .core.transforms_interface import *
-
-with suppress(ImportError):
-    from .pytorch import *
+from .pytorch import *

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Any, Literal, cast
 
 import numpy as np
+import torch
 from albucore import hflip, vflip
 
 from albumentations.core.transforms_interface import (
@@ -317,8 +318,13 @@ class Transpose(DualTransform):
 
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
+    _supports_cpu_tensor = True
+    _cpu_tensor_targets = frozenset({"image", "mask", "masks", "mask3d"})
+    _cpu_tensor_channels = frozenset({1, 3})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
+        if isinstance(img, torch.Tensor):
+            return cast("ImageType", img.mT)
         return fgeometric.transpose(img)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
@@ -329,6 +335,8 @@ class Transpose(DualTransform):
         return fgeometric.keypoints_transpose(keypoints)
 
     def apply_to_mask(self, mask: ImageType, **params: Any) -> ImageType:
+        if isinstance(mask, torch.Tensor):
+            return cast("ImageType", mask.mT)
         if mask.size == 0:
             # Transpose swaps H and W
             # Assume mask shape is (H, W, C) -> (W, H, C)
@@ -336,6 +344,8 @@ class Transpose(DualTransform):
         return self.apply(mask, **params)
 
     def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
+        if isinstance(masks, torch.Tensor):
+            return cast("StackedMasks4D", masks.transpose(-1, -2))
         if masks.size == 0:
             return StackedMasks4D(
                 np.empty((0, masks.shape[2], masks.shape[1], masks.shape[3]), dtype=masks.dtype),
@@ -346,6 +356,8 @@ class Transpose(DualTransform):
         return fgeometric.transpose_images(images)
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
+        if isinstance(mask3d, torch.Tensor):
+            return cast("VolumeType", mask3d.transpose(-1, -2))
         if mask3d.size == 0:
             # Transpose swaps H and W
             # Assume mask3d shape is (D, H, W, C) -> (D, W, H, C)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -18,6 +18,7 @@ from typing import Any, ClassVar, Union, cast
 
 import cv2
 import numpy as np
+import torch
 from numpy.typing import NDArray
 from pydantic import PydanticSchemaGenerationError, PydanticUserError, TypeAdapter, ValidationError
 
@@ -43,9 +44,16 @@ from .serialization import (
     instantiate_nonserializable,
     register_additional_transforms,
 )
+from .tensor import (
+    TENSOR_ANNOTATION_TARGETS,
+    TENSOR_SPATIAL_TARGETS,
+    numpy_to_tensor_annotation,
+    tensor_to_numpy_annotation,
+    validate_tensor_input,
+)
 from .transforms_interface import BasicTransform
 from .type_definitions import StackedMasks4D
-from .utils import DataProcessor, _is_torch_tensor, format_args, get_shape
+from .utils import DataProcessor, format_args, get_shape
 
 __all__ = [
     "BaseCompose",
@@ -257,6 +265,15 @@ class BaseCompose(Serializable):
     _transforms_dict: dict[int, BasicTransform] | None = None
     check_each_transform: tuple[DataProcessor[Any], ...] | None = None
     main_compose: bool = True
+    _tensor_capability_is_transparent: bool = True
+    _tensor_annotation_targets: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def tensor_capability_is_transparent(self) -> bool:
+        """Return whether this composition only delegates accepted CPU Tensor work to child
+        transforms and therefore introduces no representation boundary of its own.
+        """
+        return self._tensor_capability_is_transparent
 
     def __init__(
         self,
@@ -677,11 +694,7 @@ class BaseCompose(Serializable):
         """
         if "masks" in binding:
             masks_pre = data.get("masks")
-            if (
-                masks_pre is not None
-                and (isinstance(masks_pre, np.ndarray) or _is_torch_tensor(masks_pre))
-                and len(masks_pre) > n_pre
-            ):
+            if masks_pre is not None and isinstance(masks_pre, (np.ndarray, torch.Tensor)) and len(masks_pre) > n_pre:
                 valid = pre_bbox_ids[(pre_bbox_ids >= 0) & (pre_bbox_ids < len(masks_pre))]
                 data["masks"] = self._index_axis(masks_pre, valid, 0)
         elif "mask" in binding:
@@ -739,7 +752,7 @@ class BaseCompose(Serializable):
         """
         if "masks" in binding:
             masks = data.get("masks")
-            if masks is not None and (isinstance(masks, np.ndarray) or _is_torch_tensor(masks)) and len(masks) == n_pre:
+            if masks is not None and isinstance(masks, (np.ndarray, torch.Tensor)) and len(masks) == n_pre:
                 data["masks"] = self._index_axis(masks, keep_mask, 0)
         elif "mask" in binding:
             mask = data.get("mask")
@@ -832,11 +845,7 @@ class BaseCompose(Serializable):
         """
         if "masks" in binding:
             masks = data.get("masks")
-            if (
-                masks is not None
-                and (isinstance(masks, np.ndarray) or _is_torch_tensor(masks))
-                and len(masks) == instance_count
-            ):
+            if masks is not None and isinstance(masks, (np.ndarray, torch.Tensor)) and len(masks) == instance_count:
                 return masks, 0
         elif "mask" in binding:
             mask = data.get("mask")
@@ -849,7 +858,7 @@ class BaseCompose(Serializable):
         """Identify whether a packed instance mask stores instances on the trailing NumPy axis or the leading axis
         produced by transposed tensor output.
         """
-        if not (isinstance(mask, np.ndarray) or _is_torch_tensor(mask)) or mask.ndim < 3:
+        if not isinstance(mask, (np.ndarray, torch.Tensor)) or mask.ndim < 3:
             return None
         if isinstance(mask, np.ndarray):
             return -1
@@ -892,7 +901,7 @@ class BaseCompose(Serializable):
         """Select instance rows or channels along one axis while preserving the input array type and using safe index
         tensors for PyTorch values.
         """
-        if _is_torch_tensor(array) and isinstance(index, np.ndarray):
+        if isinstance(array, torch.Tensor) and isinstance(index, np.ndarray):
             if np.issubdtype(index.dtype, np.bool_):
                 index = np.flatnonzero(index)
             index_tensor = array.new_tensor(index.tolist()).long()
@@ -1455,6 +1464,8 @@ class Compose(BaseCompose, HubMixin):
             msg = "You have to pass data to augmentations as named arguments, for example: aug(image=image)"
             raise KeyError(msg)
 
+        self._validate_tensor_inputs(data)
+
         # Initialize applied_transforms only in top-level Compose if requested
         if self.save_applied_params and self.main_compose:
             data["applied_transforms"] = []
@@ -1473,17 +1484,108 @@ class Compose(BaseCompose, HubMixin):
                 if resync is not None:
                     resync(data)
 
-            return self.postprocess(data)
+            result = self.postprocess(data)
+            self._restore_tensor_annotations(result)
+            return result
         finally:
             # Clear per-call unpack/repack flags if preprocess or a transform raised mid-call.
             if self.main_compose and self._instance_binding:
                 self._clear_instance_binding_call_state_if_pending()
+            self._tensor_annotation_targets = ()
 
     def _clear_instance_binding_call_state_if_pending(self) -> None:
         if getattr(self, "_repack_after_processors", False):
             del self._repack_after_processors
         if hasattr(self, "_instance_count"):
             delattr(self, "_instance_count")
+
+    def _validate_tensor_inputs(self, data: dict[str, Any]) -> None:
+        """Validate Tensor boundary contracts before Compose samples probability or parameters,
+        ensuring each spatial target uses a single representation.
+
+        Tensor execution is opt-in at the capability level. This prevents a NumPy-only
+        helper from receiving a Tensor and performing an ad hoc representation bridge.
+        """
+        tensor_targets: list[tuple[str, str, torch.Tensor]] = []
+        spatial_representations: set[str] = set()
+        annotation_targets: list[tuple[str, str]] = []
+        self._tensor_annotation_targets = ()
+
+        for data_name, value in data.items():
+            canonical_name = self._additional_targets.get(data_name, data_name)
+            if isinstance(value, torch.Tensor):
+                if canonical_name in TENSOR_SPATIAL_TARGETS:
+                    tensor_targets.append((data_name, canonical_name, value))
+                    spatial_representations.add("tensor")
+                    if canonical_name in TENSOR_ANNOTATION_TARGETS:
+                        annotation_targets.append((data_name, canonical_name))
+            elif (
+                canonical_name in TENSOR_SPATIAL_TARGETS
+                and value is not None
+                and (self.main_compose or canonical_name not in TENSOR_ANNOTATION_TARGETS)
+            ):
+                spatial_representations.add("numpy")
+
+        if not tensor_targets:
+            return
+
+        for data_name, canonical_name, value in tensor_targets:
+            validate_tensor_input(value, data_name, canonical_name)
+
+        if len(spatial_representations) != 1:
+            raise TypeError(
+                "NumPy arrays or sequences and torch.Tensors cannot be mixed across spatial targets; "
+                "when Compose receives a Tensor image, masks, bboxes, and keypoints must also be Tensors",
+            )
+
+        self._tensor_annotation_targets = tuple(annotation_targets)
+
+        tensor_image_inputs = tuple(
+            (canonical_name, value)
+            for _, canonical_name, value in tensor_targets
+            if canonical_name not in TENSOR_ANNOTATION_TARGETS
+        )
+        self._validate_tensor_pipeline(self.transforms, tensor_image_inputs)
+
+    def _validate_tensor_pipeline(
+        self,
+        transforms: TransformsSeqType,
+        tensor_inputs: tuple[tuple[str, torch.Tensor], ...],
+    ) -> None:
+        """Require every selectable transform branch to declare CPU Tensor capability before a
+        caller-provided Tensor can reach any helper or fallback implementation.
+        """
+        for transform in transforms:
+            if isinstance(transform, BaseCompose):
+                if not transform.tensor_capability_is_transparent:
+                    raise TypeError(f"{transform.__class__.__name__} does not support CPU Tensor input")
+                self._validate_tensor_pipeline(transform.transforms, tensor_inputs)
+                continue
+            if getattr(transform, "_is_tensor_terminal", False):
+                raise TypeError(
+                    "Tensor input is already model-ready; remove ToTensorV2 or ToTensor3D from this Compose pipeline",
+                )
+            if not transform.supports_cpu_tensor_inputs(tensor_inputs):
+                supported_targets = transform.cpu_tensor_targets
+                supported_channels = transform.cpu_tensor_channels
+                tensor_targets = frozenset(target for target, _ in tensor_inputs)
+                target_note = (
+                    ""
+                    if supported_targets is None
+                    else f" for Tensor target(s) {', '.join(sorted(tensor_targets))}; accepted targets are "
+                    f"{', '.join(sorted(supported_targets))}"
+                )
+                channel_note = (
+                    ""
+                    if supported_channels is None
+                    else "; accepted channel counts are "
+                    + ", ".join(str(channel) for channel in sorted(supported_channels))
+                )
+                raise TypeError(
+                    f"{transform.__class__.__name__} does not yet declare CPU Tensor capability"
+                    f"{target_note}{channel_note}; "
+                    "use a NumPy input until its Tensor route is accepted",
+                )
 
     @staticmethod
     def from_applied_transforms(
@@ -1551,7 +1653,17 @@ class Compose(BaseCompose, HubMixin):
 
         # Add channel dimensions first, before processors run
         self._preprocess_arrays(data)
+        self._bridge_tensor_annotations_to_numpy(data)
         self._preprocess_processors(data)
+
+    def _bridge_tensor_annotations_to_numpy(self, data: dict[str, Any]) -> None:
+        """Convert accepted Tensor bbox and keypoint matrices once for existing NumPy-only
+        processors, keeping all public annotations Tensor at Compose entry and exit.
+        """
+        for data_name, canonical_name in self._tensor_annotation_targets:
+            value = data.get(data_name)
+            if isinstance(value, torch.Tensor):
+                data[data_name] = tensor_to_numpy_annotation(value, canonical_name)
 
     def _gather_shapes_from_data(self, data: dict[str, Any]) -> tuple[list[tuple[int, ...]], list[tuple[int, ...]]]:
         """Gather shapes from data for validation. Collects (H,W) or (D,H,W) from
@@ -1578,11 +1690,13 @@ class Compose(BaseCompose, HubMixin):
                 continue
 
             # Skip empty data
-            if data_value is None or not isinstance(data_value, np.ndarray):
+            if data_value is None or not isinstance(data_value, (np.ndarray, torch.Tensor)):
                 continue
 
             # Skip arrays with size 0 (empty arrays)
-            if data_value.size == 0:
+            if (isinstance(data_value, np.ndarray) and data_value.size == 0) or (
+                isinstance(data_value, torch.Tensor) and data_value.numel() == 0
+            ):
                 continue
 
             self._process_data_shape(canonical, data_value, shapes, volume_shapes)
@@ -1592,13 +1706,17 @@ class Compose(BaseCompose, HubMixin):
     def _process_data_shape(
         self,
         data_name: str,
-        data_value: np.ndarray,
+        data_value: np.ndarray | torch.Tensor,
         shapes: list[tuple[int, ...]],
         volume_shapes: list[tuple[int, ...]],
     ) -> None:
         """Process shape of a single data item. Appends (H,W) or (D,H,W) to shapes or
         volume_shapes depending on data_name (image, mask, images, volume, etc.).
         """
+        if isinstance(data_value, torch.Tensor):
+            self._process_tensor_data_shape(data_name, data_value, shapes, volume_shapes)
+            return
+
         # Handle 2D single data
         if data_name in {"image", "mask"}:
             shapes.append(data_value.shape[:2])  # H,W
@@ -1615,6 +1733,31 @@ class Compose(BaseCompose, HubMixin):
                 raise TypeError(f"{data_name} must be 3D or 4D array")
             shapes.append(data_value.shape[1:3])  # H,W
             volume_shapes.append(data_value.shape[:3])  # D,H,W
+
+    @staticmethod
+    def _process_tensor_data_shape(
+        data_name: str,
+        data_value: torch.Tensor,
+        shapes: list[tuple[int, ...]],
+        volume_shapes: list[tuple[int, ...]],
+    ) -> None:
+        """Append shape metadata for a validated Tensor target without converting its public
+        channel-first image or channel-free mask layout to a NumPy representation.
+        """
+        if data_name == "image":
+            shapes.append((data_value.shape[1], data_value.shape[2]))
+        elif data_name == "images":
+            shapes.append((data_value.shape[2], data_value.shape[3]))
+        elif data_name == "volume":
+            shapes.append((data_value.shape[2], data_value.shape[3]))
+            volume_shapes.append((data_value.shape[1], data_value.shape[2], data_value.shape[3]))
+        elif data_name == "mask":
+            shapes.append(data_value.shape[:2])
+        elif data_name == "masks":
+            shapes.append(data_value.shape[1:3])
+        elif data_name == "mask3d":
+            shapes.append(data_value.shape[1:3])
+            volume_shapes.append(data_value.shape[:3])
 
     def _validate_data(self, data: dict[str, Any]) -> None:
         """Validate input data keys and arguments. When strict, checks every key is in
@@ -1728,6 +1871,15 @@ class Compose(BaseCompose, HubMixin):
 
         return data
 
+    def _restore_tensor_annotations(self, data: dict[str, Any]) -> None:
+        """Restore Tensor bbox and keypoint matrices after NumPy processing so all spatial
+        targets in the public Compose result remain Tensors.
+        """
+        for data_name, canonical_name in self._tensor_annotation_targets:
+            value = data.get(data_name)
+            if isinstance(value, np.ndarray):
+                data[data_name] = numpy_to_tensor_annotation(value, canonical_name)
+
     def _filter_bound_bboxes_before_postprocess(self, data: dict[str, Any]) -> None:
         """Filter bound bboxes at the final boundary and mirror their keep mask before postprocessing removes internal
         instance ids required to align masks and keypoints.
@@ -1746,12 +1898,8 @@ class Compose(BaseCompose, HubMixin):
         self._resync_instance_ids(data)
 
     def _remove_grayscale_channels(self, data: dict[str, Any]) -> None:
-        """Strip the trailing channel dimension that `_add_grayscale_channels` added,
-        for both numpy arrays and torch tensors, using the bookkeeping from preprocess.
-
-        Uses `_added_channel_dim` to squeeze only where we added a dim, and
-        `_added_channel_canonical` to dispatch torch logic by canonical role so aliased
-        keys are handled the same as their canonical counterparts.
+        """Strip a trailing grayscale channel added by NumPy preprocessing while leaving Tensor
+        masks in their public H,W or N,H,W layout unchanged.
         """
         if not hasattr(self, "_added_channel_dim"):
             return
@@ -1763,25 +1911,16 @@ class Compose(BaseCompose, HubMixin):
                 value = data[key]
                 canonical = canonical_map.get(key, key)
 
-                # Handle numpy arrays
                 if isinstance(value, np.ndarray):
                     if value.shape[-1] == 1:
                         data[key] = np.squeeze(value, axis=-1)
-
-                # Handle torch tensors
-                elif hasattr(value, "__module__") and "torch" in value.__module__:
-                    # Import torch only if we have a torch tensor
-                    import torch
-
-                    if isinstance(value, torch.Tensor):
-                        # For torch tensors, we need to handle different cases
-                        # ToTensorV2 transposes image tensors but not mask tensors
-                        if canonical in {"image", "images"} and len(value.shape) >= 3 and value.shape[0] == 1:
-                            # Image tensor with shape (1, H, W) -> (H, W) is not typical, skip
-                            pass
-                        elif canonical in {"mask", "masks", "mask3d"} and value.shape[-1] == 1:
-                            # Mask tensor with shape (..., H, W, 1) -> (..., H, W)
-                            data[key] = torch.squeeze(value, dim=-1)
+                elif (
+                    isinstance(value, torch.Tensor)
+                    and canonical in {"mask", "masks", "mask3d"}
+                    and value.shape[-1] == 1
+                ):
+                    # Legacy terminal ToTensorV2/ToTensor3D transforms keep mask axis behavior unchanged.
+                    data[key] = torch.squeeze(value, dim=-1)
 
     def _get_user_bbox_label_fields(self) -> list[str]:
         return list(self._bbox_label_map.values())
@@ -1908,11 +2047,7 @@ class Compose(BaseCompose, HubMixin):
         """
         if "masks" in binding:
             masks = data.get("masks")
-            if (
-                masks is not None
-                and (isinstance(masks, np.ndarray) or _is_torch_tensor(masks))
-                and len(masks) != bboxes_len
-            ):
+            if masks is not None and isinstance(masks, (np.ndarray, torch.Tensor)) and len(masks) != bboxes_len:
                 self._raise_or_warn_invariant_violation(len(masks), bboxes_len)
         elif "mask" in binding:
             mask = data.get("mask")
@@ -2449,11 +2584,11 @@ class Compose(BaseCompose, HubMixin):
         if internal_name not in shape_check_targets:
             return
 
-        if not isinstance(data, np.ndarray):
-            raise TypeError(f"{data_name} must be numpy array type")
+        if not isinstance(data, (np.ndarray, torch.Tensor)):
+            raise TypeError(f"{data_name} must be a NumPy array or torch.Tensor")
 
         # Skip arrays with size 0 (empty arrays)
-        if data.size == 0:
+        if (isinstance(data, np.ndarray) and data.size == 0) or (isinstance(data, torch.Tensor) and data.numel() == 0):
             return
 
         # Process the shape based on data type
@@ -2829,6 +2964,8 @@ class SelectiveChannelTransform(BaseCompose):
         - Only the transform list is modified while maintaining the same channel selection behavior.
 
     """
+
+    _tensor_capability_is_transparent = False
 
     def __init__(
         self,

--- a/albumentations/core/tensor.py
+++ b/albumentations/core/tensor.py
@@ -1,0 +1,95 @@
+"""CPU Tensor input contract and annotation bridge shared by Compose."""
+
+from typing import Final
+
+import numpy as np
+import torch
+from numpy.typing import NDArray
+
+TENSOR_TARGET_RANKS: Final[dict[str, int]] = {
+    "image": 3,
+    "images": 4,
+    "volume": 4,
+    "mask": 2,
+    "masks": 3,
+    "mask3d": 3,
+    "bboxes": 2,
+    "keypoints": 2,
+}
+TENSOR_ANNOTATION_TARGETS: Final[frozenset[str]] = frozenset({"bboxes", "keypoints"})
+TENSOR_SPATIAL_TARGETS: Final[frozenset[str]] = frozenset(
+    {"image", "images", "volume", "mask", "masks", "mask3d", "bboxes", "keypoints"},
+)
+TENSOR_IMAGE_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.uint8, torch.float32})
+TENSOR_MASK_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.uint8, torch.int64, torch.float32, torch.bool})
+TENSOR_ANNOTATION_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.float32})
+TENSOR_TARGET_DTYPES: Final[dict[str, frozenset[torch.dtype]]] = {
+    "image": TENSOR_IMAGE_DTYPES,
+    "images": TENSOR_IMAGE_DTYPES,
+    "volume": TENSOR_IMAGE_DTYPES,
+    "mask": TENSOR_MASK_DTYPES,
+    "masks": TENSOR_MASK_DTYPES,
+    "mask3d": TENSOR_MASK_DTYPES,
+    **dict.fromkeys(TENSOR_ANNOTATION_TARGETS, TENSOR_ANNOTATION_DTYPES),
+}
+
+
+def validate_tensor_input(value: torch.Tensor, data_name: str, canonical_name: str) -> None:
+    """Validate a CPU Tensor against target-specific Compose shape, dtype, device, layout,
+    and autograd boundary rules before it reaches a transform helper.
+
+    The CPU stage accepts explicit-channel image targets, spatial mask targets,
+    and float32 annotation matrices. It preserves non-contiguous strides because
+    each accepted capability later decides whether a contiguous copy is justified
+    by its full-path benchmark.
+    """
+    expected_rank = TENSOR_TARGET_RANKS.get(canonical_name)
+    if expected_rank is None:
+        raise TypeError(
+            f"{data_name} is a torch.Tensor, but Tensor input is currently supported only for "
+            "image, images, volume, mask, masks, mask3d, bboxes, and keypoints targets",
+        )
+    if value.device.type != "cpu":
+        raise ValueError(f"{data_name} must be a CPU torch.Tensor, got device {value.device}")
+    if value.requires_grad:
+        raise ValueError(f"{data_name} must have requires_grad=False")
+    if value.layout is not torch.strided:
+        raise TypeError(f"{data_name} must use torch.strided layout, got {value.layout}")
+    supported_dtypes = TENSOR_TARGET_DTYPES[canonical_name]
+    if value.dtype not in supported_dtypes:
+        supported = ", ".join(str(dtype).removeprefix("torch.") for dtype in sorted(supported_dtypes, key=str))
+        raise TypeError(f"{data_name} must have dtype one of {supported}, got {value.dtype}")
+    if value.ndim != expected_rank:
+        expected_shape = {
+            "image": "(C, H, W)",
+            "images": "(C, L, H, W)",
+            "volume": "(C, D, H, W)",
+            "mask": "(H, W)",
+            "masks": "(N, H, W)",
+            "mask3d": "(D, H, W)",
+            "bboxes": "(N, K)",
+            "keypoints": "(N, K)",
+        }[canonical_name]
+        raise TypeError(f"{data_name} must have shape {expected_shape}, got {tuple(value.shape)}")
+
+
+def tensor_to_numpy_annotation(value: torch.Tensor, target: str) -> NDArray[np.generic]:
+    """Return a NumPy view of a validated Tensor bbox or keypoint matrix through the shared
+    annotation bridge used by the existing geometry processors.
+    """
+    validate_tensor_input(value, target, target)
+    return value.numpy()
+
+
+def numpy_to_tensor_annotation(value: NDArray[np.generic], target: str) -> torch.Tensor:
+    """Return a Tensor bbox or keypoint matrix from a processor result, materializing only
+    negative-stride NumPy storage that PyTorch cannot safely share.
+    """
+    expected_rank = TENSOR_TARGET_RANKS[target]
+    if value.ndim != expected_rank:
+        raise TypeError(f"{target} bridge expected a {expected_rank}D NumPy array, got {value.ndim}D")
+    if value.dtype != np.float32:
+        value = value.astype(np.float32, copy=False)
+    if any(stride < 0 for stride in value.strides):
+        value = np.ascontiguousarray(value)
+    return torch.from_numpy(value)

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -16,6 +16,7 @@ from warnings import warn
 
 import cv2
 import numpy as np
+import torch
 from albucore import batch_transform
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -107,6 +108,61 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
     InitSchema: ClassVar[type[BaseTransformInitSchema]] = _BasicTransformInitSchema
     _valid_applied_config_keys_cache: ClassVar[frozenset[str] | None] = None
     _applied_replay_class: ClassVar[type["BasicTransform"] | None] = None
+    _supports_cpu_tensor: ClassVar[bool] = False
+    _cpu_tensor_targets: ClassVar[frozenset[str] | None] = None
+    _cpu_tensor_channels: ClassVar[frozenset[int] | None] = None
+
+    @property
+    def supports_cpu_tensor(self) -> bool:
+        """Return whether this transform exposes an accepted CPU Tensor capability
+        route rather than relying on an unsupported implicit representation conversion.
+        """
+        return self._supports_cpu_tensor
+
+    @property
+    def cpu_tensor_targets(self) -> frozenset[str] | None:
+        """Return canonical Compose targets covered by this Tensor capability so callers can
+        reject unsupported target combinations before sampling transform parameters.
+        """
+        return self._cpu_tensor_targets
+
+    @property
+    def cpu_tensor_channels(self) -> frozenset[int] | None:
+        """Return image channel counts covered by this Tensor capability, or `None` when
+        the accepted Tensor route is independent of the channel count.
+        """
+        return self._cpu_tensor_channels
+
+    def supports_cpu_tensor_targets(self, targets: frozenset[str]) -> bool:
+        """Return whether accepted Tensor capability routes cover every caller-provided
+        canonical target before Compose samples parameters or enters transform dispatch.
+
+        `None` means that this transform's accepted Tensor route is target
+        agnostic. Transforms with a narrower first capability declare the
+        canonical target names explicitly, so Compose rejects unsupported Tensor
+        targets before sampling parameters.
+        """
+        return self.supports_cpu_tensor and (
+            self._cpu_tensor_targets is None or targets.issubset(self._cpu_tensor_targets)
+        )
+
+    def supports_cpu_tensor_inputs(self, tensor_inputs: tuple[tuple[str, Any], ...]) -> bool:
+        """Return whether the accepted Tensor route covers every supplied target and image
+        channel count before Compose samples parameters or calls transform helpers.
+
+        Compose calls this before transform parameter sampling. Capability records
+        may be deliberately narrow while a route is being introduced; callers get
+        a boundary error instead of an unsupported helper receiving a Tensor.
+        """
+        targets = frozenset(target for target, _ in tensor_inputs)
+        if not self.supports_cpu_tensor_targets(targets):
+            return False
+        if self._cpu_tensor_channels is None:
+            return True
+        return all(
+            target not in {"image", "images", "volume"} or value.shape[0] in self._cpu_tensor_channels
+            for target, value in tensor_inputs
+        )
 
     def __init__(self, p: float = 0.5):
         self.p = p
@@ -692,7 +748,13 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             chosen = resolved.get(target)
             if chosen is None:
                 continue
-            return extractor(data[chosen])
+            value = data[chosen]
+            if isinstance(value, torch.Tensor):
+                if target == "image":
+                    return value.shape[1], value.shape[2], value.shape[0]
+                if target in {"images", "volume"}:
+                    return value.shape[2], value.shape[3], value.shape[0]
+            return extractor(value)
         return None
 
     def get_image_data(self, data: dict[str, Any]) -> dict[str, Any]:
@@ -1311,6 +1373,24 @@ class NoOp(DualTransform):
 
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})  # NoOp passes all bbox types
+    _supports_cpu_tensor = True
+
+    @property
+    def targets(self) -> dict[str, Callable[..., Any]]:
+        """Return identity handlers that preserve every Tensor target without the NumPy batch
+        dispatch inherited by `DualTransform` for the volume route.
+        """
+        return {
+            "image": self.apply,
+            "images": self.apply_to_images,
+            "mask": self.apply_to_mask,
+            "masks": self.apply_to_masks,
+            "mask3d": self.apply_to_mask3d,
+            "bboxes": self.apply_to_bboxes,
+            "keypoints": self.apply_to_keypoints,
+            "volume": self.apply_to_volume,
+            "user_data": self.apply_to_user_data,
+        }
 
     def apply_to_keypoints(self, keypoints: np.ndarray, **params: Any) -> np.ndarray:
         return keypoints
@@ -1321,8 +1401,14 @@ class NoOp(DualTransform):
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
 
+    def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
+        return images
+
     def apply_to_mask(self, mask: ImageType, **params: Any) -> ImageType:
         return mask
+
+    def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
+        return masks
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
         return volume

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from typing import Any, Generic, Literal, TypeVar
 
 import numpy as np
+import torch
 
 from albumentations.core.label_manager import LabelManager
 
@@ -113,15 +114,23 @@ def get_image_data(
             continue
         arr = data[key]
         shape = arr.shape
-        if target == "image":
+        if isinstance(arr, torch.Tensor):
+            if target == "image":
+                height, width = shape[1], shape[2]
+            else:
+                height, width = shape[2], shape[3]
+            num_channels = int(shape[0])
+        elif target == "image":
             height, width = shape[0], shape[1]
+            num_channels = shape[-1]
         else:
             height, width = shape[1], shape[2]
+            num_channels = shape[-1]
         return {
             "dtype": arr.dtype,
             "height": height,
             "width": width,
-            "num_channels": shape[-1],
+            "num_channels": num_channels,
         }
     raise ValueError("No valid image/volume data found in data dict")
 
@@ -148,11 +157,8 @@ def _volume_shape_from_array(vol: Any) -> tuple[int, int, int]:
     """Return (D, H, W) from a single volume array, handling both torch CDHW/DHW layouts
     and numpy DHWC/DHW layouts. Private helper for `get_volume_shape`.
     """
-    if _is_torch_tensor(vol):
-        if len(vol.shape) == 4:  # (C, D, H, W)
-            return int(vol.shape[1]), int(vol.shape[2]), int(vol.shape[3])
-        if len(vol.shape) == 3:  # (D, H, W)
-            return int(vol.shape[0]), int(vol.shape[1]), int(vol.shape[2])
+    if isinstance(vol, torch.Tensor):
+        return vol.shape[1], vol.shape[2], vol.shape[3]
     return vol.shape[0], vol.shape[1], vol.shape[2]
 
 
@@ -184,39 +190,22 @@ def get_volume_shape(
     return None
 
 
-def _is_torch_tensor(obj: Any) -> bool:
-    """Return True if obj is a PyTorch tensor (by __module__). Private helper for get_shape and
-    get_volume_shape when resolving layout.
-    """
-    return hasattr(obj, "__module__") and "torch" in obj.__module__
-
-
 def _get_shape_from_image(img: np.ndarray) -> tuple[int, int]:
     """Extract (height, width) from a single image. Handles numpy HWC or PyTorch CHW. Private
     helper for get_shape when data has 'image' key.
     """
-    # Check if it's a torch tensor that has been transposed to CHW format
-    if _is_torch_tensor(img):
-        # PyTorch tensor in CHW format
-        if len(img.shape) == 3:  # (C, H, W)
-            return int(img.shape[1]), int(img.shape[2])
-        if len(img.shape) == 2:  # (H, W) - grayscale without channel
-            return int(img.shape[0]), int(img.shape[1])
+    if isinstance(img, torch.Tensor):
+        return img.shape[1], img.shape[2]
     # Regular numpy array in HWC format
     return img.shape[0], img.shape[1]
 
 
 def _get_shape_from_images(imgs: np.ndarray) -> tuple[int, int]:
-    """Extract (height, width) from batch of images. Uses first image. NHWC or NCHW. Private
-    helper for get_shape when data has 'images' key.
+    """Extract height and width from either a NumPy NHWC batch or a CPU Tensor C,L,H,W
+    sequence while retaining the public layout contract of each representation.
     """
-    # Check if it's a torch tensor batch
-    if _is_torch_tensor(imgs):
-        # PyTorch tensor batch in NCHW format
-        if len(imgs.shape) == 4:  # (N, C, H, W)
-            return int(imgs.shape[2]), int(imgs.shape[3])
-        if len(imgs.shape) == 3:  # (N, H, W) - grayscale batch without channel
-            return int(imgs.shape[1]), int(imgs.shape[2])
+    if isinstance(imgs, torch.Tensor):
+        return imgs.shape[2], imgs.shape[3]
     # Regular numpy array batch in NHWC format - take first image
     return imgs[0].shape[0], imgs[0].shape[1]
 
@@ -225,13 +214,8 @@ def _get_shape_from_volume(vol: np.ndarray) -> tuple[int, int]:
     """Extract (height, width) from a single volume (D,H,W or D,H,W,C). Private helper for
     get_shape when data has 'volume' key.
     """
-    # Check if it's a torch tensor
-    if _is_torch_tensor(vol):
-        # PyTorch 3D tensor in CDHW format
-        if len(vol.shape) == 4:  # (C, D, H, W)
-            return int(vol.shape[2]), int(vol.shape[3])
-        if len(vol.shape) == 3:  # (D, H, W) - grayscale volume without channel
-            return int(vol.shape[1]), int(vol.shape[2])
+    if isinstance(vol, torch.Tensor):
+        return vol.shape[2], vol.shape[3]
     # Regular numpy array in DHWC format
     return vol.shape[1], vol.shape[2]
 

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -30,6 +30,8 @@ class _TensorTransform(BasicTransform):
     the core array-return contract.
     """
 
+    _is_tensor_terminal = True
+
     def apply(self, img: ImageType, *args: Any, **params: Any) -> Any:
         raise NotImplementedError
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,8 +23,9 @@ uv tool run --from asv asv --config asv.conf.json continuous \
   <candidate-ref>
 ```
 
-Optional PyTorch tensor transforms are benchmarked with a separate ASV config so
-the default headless suite stays importable without torch:
+PyTorch Tensor routes are benchmarked with a separate ASV config so terminal
+conversion and accepted Tensor-native capability matrices remain independently
+reviewable:
 
 ```bash
 cd benchmark
@@ -103,7 +104,7 @@ The detail artifact is intended for review, not only for automation. Each
 record includes the public class module/qualname, catalog benchmark route,
 constructor parameters, family labels, required coverage contract, and exact
 ASV case IDs for the transform's smoke, family-matrix, direct-kernel, memory,
-reference-data, volumetric, target, or optional PyTorch evidence.
+reference-data, volumetric, target, or dedicated PyTorch Tensor evidence.
 Each ASV case also includes parsed scenario metadata, and each transform record
 includes a `scenario_contract` summary of covered sizes, channels, dtypes,
 annotation counts, batch sizes, targets, memory cases, direct-kernel groups,
@@ -116,7 +117,7 @@ Each transform also has a `performance_contract` section for batch,
 annotation, direct-kernel, parameter-sensitivity, and memory expectations. This
 section records required benchmark layers, directly declared implementation
 methods, and the reason a dedicated layer is covered, advisory, tracked for
-audit, optional, or not required.
+audit, or not required.
 The diff artifact is intended for PR and release review. It reports added or
 removed public transforms and coverage changes such as layer, ASV case, or
 axis-contract, performance-contract, or benchmark-policy drift.
@@ -145,11 +146,10 @@ The check fails when a public transform is missing from coverage accounting,
 when a configured transform no longer exists, when a benchmark transform cannot
 be constructed, or when the representative smoke route no longer runs. The ASV
 suite includes `TimeCatalogTransformSmoke`, which executes one valid
-`Compose` path for every runnable public transform. Optional PyTorch tensor
+`Compose` path for every runnable public transform. Explicit terminal Tensor
 transforms are accounted separately and benchmarked by the dedicated
-`asv-pytorch.conf.json` lane because the default performance environment
-installs only headless package extras. The detail artifact records the expected
-coverage contract and actual coverage layers for each public transform.
+`asv-pytorch.conf.json` lane. The detail artifact records the expected coverage
+contract and actual coverage layers for each public transform.
 
 Catalog smoke coverage is not the whole performance policy. It proves that
 every transform has at least one measured route. Hot families still need richer
@@ -159,8 +159,8 @@ memory checks.
 
 The current ASV suite includes these production coverage layers:
 
-- Catalog smoke: one runnable `Compose` path for every public transform that
-  does not require optional PyTorch.
+- Catalog smoke: one runnable `Compose` path for every public transform except
+  explicit terminal Tensor transforms, which have a dedicated matrix.
 - Full-matrix geometry: representative crop, resize, pad, symmetry, rotate,
   affine, perspective, distortion, spline, and refraction transforms across
   size, channel, and dtype matrices.
@@ -177,8 +177,10 @@ The current ASV suite includes these production coverage layers:
 - Volumetric paths: all public 3D transforms over size and dtype variants.
 - Alias coverage: warning aliases mapped to their canonical benchmarked
   implementation while catalog smoke still validates public construction.
-- Optional PyTorch tensor paths: `ToTensorV2` and `ToTensor3D` in a separate
-  ASV environment with torch installed.
+- Dedicated PyTorch Tensor paths: `ToTensorV2`, `ToTensor3D`, and accepted
+  Tensor-native capabilities such as `Transpose(image=...)` in a separate ASV
+  environment. The Tensor-native `Transpose` matrix currently covers C=1 and
+  C=3 image Tensors only.
 - Core pipeline: single-transform Compose, multi-transform Compose,
   ReplayCompose, `p=0` skip dispatch, `additional_targets`, image batches,
   Compose setup, and bbox/keypoint processor overhead.

--- a/benchmark/asv-pytorch.conf.json
+++ b/benchmark/asv-pytorch.conf.json
@@ -4,7 +4,7 @@
   "project_url": "https://github.com/albumentations-team/AlbumentationsX",
   "repo": "..",
   "environment_type": "virtualenv",
-  "install_command": "python -m pip install {build_dir}[headless,pytorch]",
+  "install_command": "python -m pip install {build_dir}[headless]",
   "benchmark_dir": "pytorch_benchmarks",
   "env_dir": ".asv/pytorch-env",
   "results_dir": ".asv/pytorch-results",

--- a/benchmark/benchmarks/catalog.py
+++ b/benchmark/benchmarks/catalog.py
@@ -7,7 +7,6 @@ staying small enough for scheduled CI.
 
 from __future__ import annotations
 
-import importlib.util
 import inspect
 import warnings
 from collections.abc import Callable, Mapping
@@ -33,13 +32,9 @@ ABSTRACT_TRANSFORM_NAMES = frozenset(
     },
 )
 
-OPTIONAL_BENCHMARK_TRANSFORMS = {
-    "ToTensor3D": "requires optional PyTorch dependency; covered by the dedicated PyTorch ASV lane",
-    "ToTensorV2": "requires optional PyTorch dependency; covered by the dedicated PyTorch ASV lane",
-}
-OPTIONAL_BENCHMARK_DEPENDENCIES = {
-    "ToTensor3D": "torch",
-    "ToTensorV2": "torch",
+DEDICATED_TENSOR_BENCHMARK_TRANSFORMS = {
+    "ToTensor3D": "covered by the dedicated PyTorch Tensor ASV lane",
+    "ToTensorV2": "covered by the dedicated PyTorch Tensor ASV lane",
 }
 
 EXPECTED_INIT_WARNINGS = (
@@ -156,18 +151,9 @@ def public_transform_names() -> tuple[str, ...]:
     return tuple(_public_transform_classes())
 
 
-def unavailable_optional_transform_names() -> set[str]:
-    """Return optional transforms whose runtime dependency is not installed."""
-    return {
-        name
-        for name, dependency in OPTIONAL_BENCHMARK_DEPENDENCIES.items()
-        if importlib.util.find_spec(dependency) is None
-    }
-
-
 def _route_for_transform(name: str, transform_cls: type[BasicTransform]) -> str:
-    if name in OPTIONAL_BENCHMARK_TRANSFORMS:
-        return "optional"
+    if name in DEDICATED_TENSOR_BENCHMARK_TRANSFORMS:
+        return "dedicated_tensor"
     if issubclass(transform_cls, Transform3D):
         return "volume"
     if name in BBOX_ROUTE_TRANSFORMS:
@@ -190,14 +176,14 @@ def benchmark_specs() -> dict[str, TransformBenchmarkSpec]:
     specs: dict[str, TransformBenchmarkSpec] = {}
     for name, transform_cls in _public_transform_classes().items():
         route = _route_for_transform(name, transform_cls)
-        benchmark = route != "optional"
+        benchmark = route != "dedicated_tensor"
         specs[name] = TransformBenchmarkSpec(
             name=name,
             route=route,
             params=PARAM_OVERRIDES.get(name, {}),
             channels=CHANNEL_OVERRIDES.get(name, 3),
             benchmark=benchmark,
-            reason=OPTIONAL_BENCHMARK_TRANSFORMS.get(name, ""),
+            reason=DEDICATED_TENSOR_BENCHMARK_TRANSFORMS.get(name, ""),
         )
     return specs
 

--- a/benchmark/pytorch_benchmarks/__init__.py
+++ b/benchmark/pytorch_benchmarks/__init__.py
@@ -1,1 +1,1 @@
-"""Optional PyTorch ASV benchmarks."""
+"""Dedicated PyTorch Tensor ASV benchmarks."""

--- a/benchmark/pytorch_benchmarks/test_tensor.py
+++ b/benchmark/pytorch_benchmarks/test_tensor.py
@@ -1,8 +1,7 @@
 """PyTorch tensor transform benchmarks.
 
-These benchmarks live outside the default ASV benchmark directory so the
-headless benchmark suite remains importable without the optional PyTorch
-dependency.
+These benchmarks live outside the default ASV benchmark directory so Tensor
+conversion evidence remains separately reviewable from the general catalog.
 """
 
 from __future__ import annotations
@@ -10,6 +9,9 @@ from __future__ import annotations
 import importlib
 import sys
 from pathlib import Path
+
+import numpy as np
+import torch
 
 import albumentations
 
@@ -35,6 +37,9 @@ IMAGE_CASES = tuple(
 )
 VOLUME_CASES = tuple(
     f"{size_name}|{channels}|{dtype_name}" for size_name in VOLUME_SIZES for channels in (1, 3) for dtype_name in DTYPES
+)
+TENSOR_NATIVE_IMAGE_CASES = tuple(
+    f"{size_name}|{channels}|{dtype_name}" for size_name in SIZES for channels in (1, 3) for dtype_name in DTYPES
 )
 
 
@@ -98,3 +103,37 @@ class TimeToTensor3D:
 
     def peakmem_volume(self, case_id: str) -> None:
         self.transform(volume=self.volume)
+
+
+class TimeTensorNativeTranspose:
+    """Benchmark the accepted Tensor `Transpose(image=...)` capability.
+
+    The route is intentionally bounded to the accepted C=1 and C=3 image
+    contract. `images` and `volume` Tensor targets remain unsupported.
+    """
+
+    params = (TENSOR_NATIVE_IMAGE_CASES,)
+    param_names = ("case_id",)
+
+    def setup(self, case_id: str) -> None:
+        size_name, channels, dtype_name = _parse_image_case(case_id)
+        self.image = make_image(size_name, channels, dtype_from_name(dtype_name))
+        self.tensor = torch.from_numpy(np.ascontiguousarray(self.image.transpose(2, 0, 1)))
+        self.numpy_direct = albumentations.Compose([albumentations.Transpose(p=1.0)], strict=True)
+        self.numpy_model_ready = albumentations.Compose(
+            [albumentations.Transpose(p=1.0), albumentations.ToTensorV2(p=1.0)],
+            strict=True,
+        )
+        self.tensor_direct = albumentations.Compose([albumentations.Transpose(p=1.0)], strict=True)
+
+    def time_numpy_direct(self, case_id: str) -> None:
+        self.numpy_direct(image=self.image)
+
+    def time_numpy_model_ready(self, case_id: str) -> None:
+        self.numpy_model_ready(image=self.image)
+
+    def time_tensor_direct(self, case_id: str) -> None:
+        self.tensor_direct(image=self.tensor)
+
+    def peakmem_tensor_direct(self, case_id: str) -> None:
+        self.tensor_direct(image=self.tensor)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy>=2.2.6
     - scipy
     - pydantic>=2.9
-    - pytorch
+    - pytorch>=2.13.0
     - typing_extensions
     - opencv-python-headless
 
@@ -36,9 +36,9 @@ requirements:
     - opencv-python-headless>=5.0.0.93
     - albucore==0.2.9
     - numkong!=7.7.1
+    - pytorch>=2.13.0
 
 suggests:
-  - pytorch
   - huggingface-hub
   - pillow
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -45,6 +45,15 @@ parameter.
 **Status**: Implemented
 **Phase**: Complete
 
+### [Torch CPU Backend and Tensor-Native Compose](torch-cpu-backend-migration.md)
+
+Plan for making Torch a required dependency and routing compatible NumPy/OpenCV/NumKong and Torch segments through
+the existing `Compose`. The route planner can cross the representation boundary in either direction when the complete
+measured path does not regress.
+
+**Status**: Proposed
+**Phase**: Planning
+
 ## Creating New Design Documents
 
 When creating a new design document:

--- a/docs/design/torch-cpu-backend-migration.md
+++ b/docs/design/torch-cpu-backend-migration.md
@@ -1,0 +1,407 @@
+# Torch CPU Backend and Tensor-Native Compose Plan
+
+**Status:** In progress
+
+**Decision:** `torch` becomes a required dependency. The existing `Compose` accepts both NumPy arrays and CPU
+`torch.Tensor` values. One execution engine routes each compatible *segment* to NumPy/OpenCV/NumKong or Torch based on
+full-path benchmark evidence. A Tensor input may use a faster NumPy segment and return to Tensor form. A NumPy input
+may use a faster Torch segment and return to NumPy form, unless an existing explicit terminal `ToTensorV2` or
+`ToTensor3D` transform requests Tensor output.
+
+**Primary workload:** a PyTorch training process in which Torch is already imported. Steady-state `DataLoader`
+throughput is a milestone integration gate. Individual transform pull requests use direct and `Compose` benchmarks
+without rebuilding and timing a complete loader for every matrix cell.
+
+## Current implementation status
+
+The repository is in the foundation stage. `torch` is now a required dependency. `Compose` accepts CPU Tensor image,
+mask, bbox, and keypoint targets, preserves their public representation through the existing dispatch flow, and rejects
+accelerators, autograd inputs, mixed spatial representations, and legacy terminal Tensor transforms. Bbox and keypoint
+processors still use one centralized NumPy bridge internally and restore their `float32` Tensor output at the public
+boundary. A private probe and a `DataLoader` collation test cover this plumbing.
+
+`NoOp` accepts every supported Tensor target. The measured `Transpose` capability accepts C=1 and C=3 Tensor images,
+plus `mask`, `masks`, and `mask3d`; it keeps Tensor bbox and keypoint entry and exit through the central processor
+bridge. Its Tensor `images` and `volume` routes remain unsupported. Every accepted Tensor-image pipeline requires each
+supplied spatial target to be a Tensor; the prior image-Tensor plus NumPy-target combination is no longer accepted.
+
+The repository also contains `python -m tools.tensor_compose_benchmark`. It records raw model-ready `Compose` and
+optional steady-state `DataLoader` measurements as JSON. Run it after a change to Compose, a bridge, batching, or
+collation. Do not run it for every individual transform capability.
+
+The first pilot, `HorizontalFlip`, was rejected on the current macOS ARM development host. A contiguous `C,H,W` RGB
+Tensor must become a strided `H,W,C` view before it reaches the existing OpenCV helper. Across the 256, 512, and 1024
+matrix, that route was much slower than the NumPy baseline. `torch.flip` also lost on the required 1- and 3-channel
+cells. Torch won on some contiguous 5-channel cells, but a partial win cannot accept a route that regresses common
+RGB inputs. No PyTorch primitive is missing, so this is a retained-backend decision rather than an upstream request.
+
+`VerticalFlip` was also rejected: `torch.flip` loses on the required 256-pixel C=1 and C=3 cells, even though it wins
+selected larger cells. The route therefore remains NumPy/Albucore rather than creating a partial Tensor capability.
+
+The first 3D investigation rejected `CenterCrop3D`, `RandomCrop3D`, and `CubicSymmetry` as native CPU Tensor routes.
+For no-padding crops, direct `Compose(volume=Tensor)` was 1.40x to 1.67x the NumPy route over the small and medium
+volume matrix (C=1, C=3, C=5; `uint8` and `float32`). Reusing the NumPy crop helper through the shared bridge was
+slower still. A correctness-equivalent `CubicSymmetry` prototype reduced all 48 symmetries to one Tensor permutation
+and at most one flip or clone, but it still lost on required common cells; only the medium C=5 `float32` subset won.
+`Pad3D` with `torch.nn.functional.pad` likewise lost by 1.10x to 3.43x outside the one medium C=5 `float32` win. The
+needed Torch operations exist, so no upstream feature request is open. These transforms remain explicitly rejected
+until a future CPU release or a different full-path implementation passes every required cell.
+
+The initial integration run measured workers 0 and 2 successfully. The 8-worker run did not finish on this macOS ARM
+host and produced no artifact. Repeat the 0, 2, and 8 worker suite on the stable Linux x86-64 benchmark host before
+marking Phase 1 complete. The route result must include the generated JSON, not only a summary.
+
+## Problem and goal
+
+Today, a caller that trains a PyTorch model normally augments a NumPy array and converts it to Tensor at the end. This
+adds representation boundaries and may copy data. Some Torch CPU kernels can replace NumPy, OpenCV, or NumKong work.
+Others cannot match their speed or semantics. A global replacement would regress part of the matrix.
+
+The goal is to remove only the boundaries and helpers that full measurements prove safe. The result preserves the
+current NumPy contracts and adds a direct Tensor input form for training pipelines. It does not require all work to use
+one backend.
+
+## Decisions
+
+### One Compose and two representations
+
+There is one public `Compose`, one transform hierarchy, and one parameter-sampling and replay flow. `apply`,
+`apply_to_images`, and `apply_to_volume` decide target policy and dispatch. Reusable pixel arithmetic remains in the
+functional layer or Albucore.
+
+The planner may choose either representation for any compatible contiguous segment:
+
+```mermaid
+flowchart LR
+    NI["NumPy input"] --> NS1["NumPy / OpenCV / NumKong segment"]
+    NS1 --> NT["Measured bridge"]
+    NT --> TS["Torch segment"]
+    TS --> NO["NumPy output"]
+
+    TI["Tensor input"] --> TS1["Torch segment"]
+    TS1 --> TN["Measured bridge"]
+    TN --> NS["NumPy / OpenCV / NumKong segment"]
+    NS --> TO["Tensor output"]
+```
+
+The diagram shows possible boundaries, not a required alternation. The planner groups adjacent helpers with the same
+backend. It must not convert around every helper: a Tensor → NumPy → Tensor crossing is paid once per accepted NumPy
+segment, and a NumPy → Tensor → NumPy crossing is paid once per accepted Torch segment.
+
+The first segment may use either backend. No helper may add an ad hoc `.numpy()`, `torch.from_numpy()`, or layout
+conversion. The central bridge and capability registry own every crossing. The registry records why a route is
+eligible, rejected, or blocked.
+
+### Tensor boundary contract
+
+The public CPU Tensor contract is channel first:
+
+| Compose target | Tensor shape | Meaning |
+|---|---|---|
+| `image` | `C, H, W` | One 2D image |
+| `images` | `C, L, H, W` | Sequence of images; `L=N` for an image sequence and `L=T` for video frames |
+| `volume` | `C, D, H, W` | One medical or scientific volume |
+
+`images` and `volume` deliberately share the four-axis pattern `C, L, H, W`. The target key gives the second axis its
+meaning. `images` selects framewise image semantics; `volume` selects volume and 3D-transform semantics. No `video`
+or `videos` target is introduced by this work.
+
+Normal `DataLoader` collation adds the outer batch axis. A 3D video model receives `B, C, T, H, W`; a volume model
+receives `B, C, D, H, W`. This matches the input convention of `torch.nn.Conv3d` and common PyTorch video models.
+
+The logical axes are fixed. There is no public `data_format`, `channel_first`, or `channel_last` parameter.
+`torch.channels_last` and `torch.channels_last_3d` are physical-memory-format candidates only at valid batched model
+boundaries. They do not alter the public Tensor axis contract.
+
+NumPy callers retain the current explicit-channel, channel-last contracts: `H,W,C`, `N,H,W,C`, and `D,H,W,C`.
+
+### Annotation Tensor boundary
+
+When the caller supplies an image Tensor, every supplied spatial target also uses Tensor form. This removes the
+last public representation boundary before `DataLoader` collation. Annotation axes follow PyTorch training
+conventions rather than the image channel convention:
+
+| Compose target | Tensor shape | Dtype | Meaning |
+|---|---|---|---|
+| `mask` | `H,W` | `uint8`, `int64`, `float32`, or `bool` | One semantic, regression, or binary mask |
+| `masks` | `N,H,W` | `uint8`, `int64`, `float32`, or `bool` | `N` instance masks |
+| `mask3d` | `D,H,W` | `uint8`, `int64`, `float32`, or `bool` | One volumetric mask |
+| `bboxes` | `N,K` | `float32` | `N` boxes in the configured current coordinate format; the existing processor defines columns after coordinates |
+| `keypoints` | `N,K` | `float32` | `N` keypoints in the configured current coordinate format; the existing processor defines extra columns |
+
+`mask` has no channel axis because a training mask usually stores one label or value per pixel. `masks` adds an
+instance axis, not an image-channel axis. If a model needs a channel-first target, the dataset or collate function
+creates that model-specific form after `Compose`.
+
+The implementation keeps one transform hierarchy. A route may bridge Tensor annotations to the current NumPy
+processor or helper when that full route is faster, then return Tensor. The bridge owns conversion, layout, and
+ownership checks. No transform-specific helper may convert an annotation silently.
+
+### CPU-only boundary
+
+The first stage accepts CPU tensors with `requires_grad=False`.
+
+- `Compose` exposes no `device` parameter and never calls `.to(device)`.
+- CUDA, MPS, XPU, and other accelerator tensors are rejected during capability validation.
+- The pipeline does not construct an autograd graph, manage streams, set global Torch thread settings, or change the
+  caller's grad mode, RNG state, deterministic-algorithm setting, or default dtype.
+- `DataLoader(pin_memory=True)` and host-to-device transfer remain training-code responsibilities after `Compose`.
+
+Existing `ToTensorV2` and `ToTensor3D` remain explicit NumPy-to-Tensor terminal transforms. The CPU routing work does
+not change their legacy NumPy behavior. A Tensor-native pipeline does not contain either transform because its input is
+already Tensor. Tensor capability validation reports a clear error when a Tensor-input pipeline still contains one and
+asks the caller to remove it.
+
+Accelerator support is a later project phase. It reuses the Tensor and capability contracts only after the CPU routes
+have passed their performance gate.
+
+## Bidirectional segment planner
+
+### Capability declaration
+
+Each transform family and reusable functional helper receives a private capability record. It declares:
+
+- supported targets, dtypes, ranks, channel counts, layouts, strides, and parameter modes;
+- exact output shape, dtype, range, mutation, aliasing, RNG, replay, and annotation behavior;
+- available implementations: current backend, Torch, or both;
+- valid entry and exit bridges, including all required layout views and copies;
+- supported predecessor and successor capability IDs; and
+- benchmark cells and status: `accepted`, `partial_route`, `existing_backend`, `rejected`, or `blocked_upstream`.
+
+`Compose` builds the route from the ordered transforms and their target set. Nested `OneOf`, `SomeOf`, and `Sequential`
+branches must all have a valid plan before execution. A plan must not change probabilities, parameter sampling, replay,
+or transform order.
+
+### Bridges are operations, not bookkeeping
+
+On a supported CPU array/Tensor, `torch.from_numpy(array)` and `tensor.numpy()` can share storage. That does not make a
+route free. Torch dispatch, reference lifetime, unsupported strides, read-only storage, layout views, and a required
+contiguous copy all affect wall time and ownership.
+
+A Tensor NumPy segment commonly needs these steps:
+
+```text
+C,L,H,W Tensor → layout view for the NumPy helper → NumPy helper → output layout view → Tensor
+```
+
+Any `.contiguous()`, `np.ascontiguousarray()`, dtype cast, or allocation is O(n). The benchmark includes it. If the
+NumPy helper only accepts a layout requiring a copy, the planner uses that route only when the entire segment remains
+at least as fast as its baseline and preserves the stated ownership contract.
+
+The analogous rule applies to NumPy callers entering Torch. A fast Torch kernel does not qualify if its bridge,
+layout conversion, and return conversion make the whole route slower.
+
+### Backend decision rule
+
+For every matrix cell:
+
+1. Keep the current backend when it is faster or is the only implementation with the required semantics.
+2. Route a compatible segment through Torch when the full route is faster or tied within calibrated noise and every
+   other contract is equal.
+3. At a measured tie, prefer Torch when it removes a boundary or extends a proven adjacent Torch segment.
+4. Route a Tensor segment through NumPy/OpenCV/NumKong when that complete Tensor → NumPy → Tensor route is faster
+   and the enclosing Tensor `Compose` route passes its direct performance gate.
+5. Split a segment when a required operation loses. A later win cannot compensate for a repeatable regression.
+
+The input representation does not force the backend. It determines only the input and output representation seen by
+the caller.
+
+## Performance invariant and evidence
+
+### Acceptance condition
+
+> No accepted route may show a repeatable CPU slowdown in any required benchmark cell.
+
+Torch is imported before both baseline and candidate timing. Cold import time, wheel size, and install time are tracked
+as dependency diagnostics; they do not decide a hot training-path route.
+
+For NumPy input, the baseline is the current public NumPy `Compose` or functional call. Each transform capability has
+two blocking comparisons that do not construct a `DataLoader`:
+
+1. **Direct Compose gate:** run the same transform chain and sampled parameters with pre-created, logically identical
+   NumPy and CPU Tensor inputs. Input construction and output normalization for value comparison stay outside the timed
+   block. `Compose(image=tensor)` must be no slower than `Compose(image=array)` in every accepted cell. Measure both a
+   shared-storage channel-first Tensor view and a native contiguous channel-first Tensor where either is supported.
+2. **Model-ready output gate:** compare NumPy `Compose` plus the existing explicit terminal `ToTensorV2` or
+   `ToTensor3D` conversion with direct Tensor `Compose`. This is a controlled `Compose` benchmark with pre-created
+   inputs; it does not include collation or `DataLoader` workers.
+
+The direct gate detects Tensor-dispatch or planner overhead. The model-ready output gate measures the cost to produce
+the Tensor that the model consumes. A candidate includes every bridge and layout operation that occurs inside its
+timed path.
+
+A transform PR reports every direct helper, segment, direct-Compose, and model-ready-output cell. The output report
+records raw before/after measurements rather than aggregates alone.
+
+### Benchmark cadence
+
+`DataLoader` and collation measure shared integration behavior. Repeating them for every transform would multiply the
+runtime without isolating that transform's kernel or dispatch cost. Use this cadence:
+
+| Change | Required benchmark |
+|---|---|
+| `Compose`, preprocessing, postprocessing, shape handling, common bridge, or planner | Direct microbenchmarks, `Compose`, and representative `DataLoader`/collation cases |
+| One transform or functional family gains Tensor capability | Direct functional, ordered segment, direct `Compose`, and model-ready output; no `DataLoader` |
+| Several accepted capabilities form a new mixed-backend segment | Ordered segment and `Compose`; add one representative `DataLoader` case only when a shared boundary or batch behavior changed |
+| Milestone, release candidate, or scheduled performance run | Full representative `DataLoader` suite for NumPy, Tensor, and mixed routes |
+
+This keeps per-transform feedback short while preserving an integration gate for changes that can affect the whole
+training input pipeline.
+
+### Required matrix
+
+Every affected 2D route covers the repository matrix where supported:
+
+| Resolution | Channels | Typical workload |
+|---|---:|---|
+| 256 × 256 | 1, 3, 5 | Classification and RGBD/multispectral training |
+| 512 × 512 | 1, 3, 5 | Detection and segmentation |
+| 1024 × 1024 | 1, 3, 5 | High-resolution, medical, and satellite workloads |
+
+Run `uint8` and `float32` whenever the public function supports them. Also cover positive and negative strides,
+read-only storage, non-contiguous Tensor inputs, image sequences, video-through-`images`, masks and target
+annotations where applicable, and the selected parameter axes.
+
+When the integration suite runs, it holds batch size, workers, persistent workers, prefetching, pinning, collation, and
+output consumption constant. It compares decoded NumPy samples, Tensor samples, mixed backend segments, and 0, 2, and
+8 workers where the workload is relevant.
+
+### Correctness and ownership gates
+
+An accepted route preserves:
+
+- target alignment for image, mask, bbox, OBB, keypoint, volume, and metadata;
+- shape, axis meaning, dtype, value range, exact integer behavior, and documented floating tolerance;
+- seeded RNG behavior, replay records, transform probability, and constructor serialization;
+- caller-visible mutation and aliasing behavior; and
+- output representation: backend routing returns the input representation. Existing explicit terminal `ToTensorV2`
+  and `ToTensor3D` transforms retain their documented NumPy-to-Tensor behavior.
+
+A Tensor route may use a NumPy segment internally. This boundary is planner-controlled and reported in the route
+artifact. It is not an implicit fallback hidden inside a helper.
+
+## Implementation phases
+
+### Phase 0 — dependency and baselines
+
+1. Add the validated Torch floor to runtime dependencies. Keep TorchVision optional.
+2. Update lockfile, CI, platform/Python support checks, SBOM/security inputs, and environment reporting.
+3. Measure baseline variance on a stable Linux x86-64 machine. Calibrate a repeatability threshold no larger than 1%.
+4. Add the route-result JSON schema: environment, input representation, helper/segment IDs, every bridge, raw samples,
+   correctness result, memory result, and decision.
+
+Exit: a default install includes Torch, and the benchmark runner can distinguish a real regression from noise.
+
+### Phase 1 — prove the complete Compose Tensor lifecycle once
+
+The first runtime pull request changes the framework plumbing. It does not add Tensor implementations to every public
+transform.
+
+1. Define Array-or-Tensor internal types and the fixed Tensor target contracts.
+2. Extend `Compose` input checks, shape extraction, preprocessing, target routing, postprocessing, and output repair for
+   CPU Tensor input.
+3. Pass Tensor values through `BasicTransform.__call__`, `apply_with_params`, and the existing `apply_*` dispatch.
+4. Use a minimal private probe transform to prove that the Tensor arriving at `apply` or `apply_to_images` also leaves
+   `Compose` as Tensor. Test empty pipelines, `p=0`, nested compositions, additional targets, masks, annotations,
+   replay, and failure before parameter sampling.
+5. Reject accelerator tensors, `requires_grad=True`, and Tensor-input pipelines containing `ToTensorV2` or
+   `ToTensor3D` with actionable errors.
+6. Preserve every NumPy test and benchmark result.
+7. Run the representative `DataLoader` and collation suite once for this shared lifecycle change.
+
+Exit: the full `Compose` wrapper carries supported CPU Tensor targets from input to a transform and from its result to
+the caller. No public transform is considered Tensor-capable until its own capability PR lands.
+
+### Phase 2 — add the central bridge and the first two capabilities
+
+1. Build one bridge API for Tensor/NumPy conversion, axis adapters, ownership checks, and route diagnostics.
+2. Add the capability record and single-transform routing needed by the first pilots. Do not build a global optimizer
+   before real capabilities exist.
+3. Prove one Tensor input that uses a faster NumPy/OpenCV helper and returns Tensor.
+4. Prove one NumPy input that uses a faster or tied Torch helper and returns NumPy.
+5. Run direct, `Compose`, model-ready-output, and one representative `DataLoader` benchmark for each bridge direction.
+
+Exit: both bridge directions preserve correctness and pass their full-path performance gates. Adjacent accepted
+capabilities can then be grouped into longer segments without changing transform order.
+
+### Phase 3 — add Tensor support one transform family at a time
+
+Each transform-family pull request follows the same bounded workflow:
+
+1. Freeze the current NumPy contract and save reference outputs for every target, dtype, channel count, and parameter
+   mode in scope.
+2. Identify the best Tensor route. It may call a Torch helper or cross once into an existing NumPy/OpenCV/NumKong
+   helper and return to Tensor.
+3. Add the Tensor implementation to the existing functional and `apply_*` flow. Keep reusable arithmetic in the
+   functional layer or Albucore; do not add a parallel transform class.
+4. Add correctness tests for Tensor input and confirm that NumPy input remains unchanged.
+5. Run direct functional, ordered-segment, direct `Compose`, and model-ready-output benchmarks for NumPy and Tensor.
+   Do not run `DataLoader` for this transform PR unless it changes shared bridge, planner, batching, or collation code.
+6. Accept, narrow, reject, or mark the capability `blocked_upstream`.
+7. After the Tensor path is accepted, test whether the same Torch helper should serve NumPy input. Route NumPy through
+   Torch only when the full NumPy → Torch → NumPy path is no slower.
+
+Land one operation family, capability record, tests, benchmark artifact, and routing change per pull request.
+
+### Phase 4 — consolidate segments and run milestones
+
+As accepted capabilities accumulate, group adjacent compatible operations so each NumPy/Tensor boundary is paid once
+per segment. A segment change runs its ordered-chain and `Compose` benchmarks. Add a representative `DataLoader` case
+only when the segment changes shared boundaries or batch behavior.
+
+Run the complete `DataLoader` suite on scheduled milestones and before release. It covers NumPy input, Tensor input,
+mixed backend segments, video-through-`images`, volume, and the supported worker matrix.
+
+### Phase 5 — audit retained backends and prepare accelerators
+
+After the CPU registry is complete, publish the retained NumPy, OpenCV, NumKong, Albucore, and Torch routes with their
+evidence. Removing a dependency requires a separate audit showing no remaining required or faster route.
+
+Accelerator work later adds device and stream capability, transfer planning, synchronization-aware benchmarks, and
+RNG/autograd policy. It does not change the public Tensor axis contract or create another composition API.
+
+## Missing Torch operations
+
+An unavailable primitive, missing dtype/stride support, incorrect semantics, or unavoidable losing copy blocks only its
+candidate. Open the request where the missing capability belongs:
+
+- PyTorch for a general Tensor operator, CPU dispatch, dtype, stride, correctness, or performance gap;
+- Albucore for a reusable image-processing helper or shared bridge contract;
+- TorchVision for a vision-specific operator that does not belong in core Torch; or
+- AlbumentationsX for transform semantics and local routing.
+
+The issue or pull request includes:
+
+- a minimal input and expected result;
+- dtype, shape, stride, layout, and device;
+- a correctness reproducer;
+- a self-contained benchmark; and
+- the affected capability IDs and fallback decision.
+
+The registry marks that candidate `blocked_upstream` and the next candidate proceeds. A missing operation never blocks
+unrelated migration work.
+
+## Completion criteria
+
+The CPU program is complete when:
+
+- Torch is a required dependency on supported platforms;
+- `Compose` accepts the declared CPU Tensor forms and returns Tensor output for Tensor input;
+- the route planner can use accepted NumPy and Torch segments in either input representation;
+- every accepted route has permanent correctness tests and full per-cell performance evidence;
+- every accepted Tensor route passes both the direct Tensor-Compose and model-ready-output performance gates;
+- Compose/planner milestones and release candidates pass the representative `DataLoader` suite;
+- no accepted route has a repeatable CPU regression;
+- all missing primitives have an upstream artifact or explicit retained-backend decision; and
+- the audit explains every retained backend and leaves a reusable capability contract for future accelerator work.
+
+## References
+
+- [PyTorch `Conv2d`](https://docs.pytorch.org/docs/2.13/generated/torch.nn.Conv2d.html)
+- [PyTorch `Conv3d`](https://docs.pytorch.org/docs/2.13/generated/torch.nn.Conv3d.html)
+- [PyTorch tensor memory formats](https://docs.pytorch.org/docs/2.13/tensor_attributes.html)
+- [TorchVision Tensor conventions](https://docs.pytorch.org/vision/stable/transforms.html)
+- [PyTorchVideo data convention](https://pytorchvideo.readthedocs.io/en/latest/data.html)
+- [Kornia `VideoSequential`](https://kornia.readthedocs.io/en/v0.6.3/_modules/kornia/augmentation/container/video.html)
+- [MONAI transform conventions](https://docs.monai.io/en/0.9.1/transforms.html)
+- [TorchIO transform input](https://docs.torchio.org/latest/transforms/)

--- a/docs/maintaining/ci-greenfield-plan.md
+++ b/docs/maintaining/ci-greenfield-plan.md
@@ -225,7 +225,7 @@ runtime code and documentation gets both sets of checks.
 | `docs` | `**/*.md`, documentation assets | Broken prose, links, examples, or package-description rendering |
 | `runtime` | `albumentations/**/*.py` except dedicated PyTorch paths | Product behavior, API, serialization, typing |
 | `tests` | `tests/**` | Test validity; shared fixtures can affect the whole suite |
-| `pytorch` | `albumentations/pytorch/**` and related tests | Optional heavy dependency and tensor behavior |
+| `pytorch` | `albumentations/pytorch/**` and related tests | Dedicated heavyweight Tensor and TorchVision behavior |
 | `dependencies` | `pyproject.toml`, `uv.lock`, requirements/conda metadata | Resolution, installability, vulnerabilities, cross-platform wheels |
 | `packaging` | build backend configuration, package manifests, release build code | Wheel/sdist contents and metadata |
 | `workflows` | `.github/workflows/**`, local actions | Actions syntax, permissions, supply-chain hardening |

--- a/docs/maintaining/correctness-and-compatibility-report.md
+++ b/docs/maintaining/correctness-and-compatibility-report.md
@@ -18,7 +18,7 @@ which limitations are known.
 5. Known limitations: dependency-sensitive exactness, advisory optional-extra
    coverage, and platform caveats.
 6. Performance summary: benchmark status, coverage-contract status,
-   performance-budget status, optional PyTorch tensor benchmark evidence, ASV
+   performance-budget status, dedicated PyTorch Tensor benchmark evidence, ASV
    comparison triage where available, and memory observations.
 7. Security posture: runtime audit, workflow audit, OpenSSF Scorecard, CodeQL
    status, SBOM, checksums, and PyPI provenance.

--- a/docs/maintaining/performance-coverage.md
+++ b/docs/maintaining/performance-coverage.md
@@ -16,8 +16,8 @@ included in CI or release evidence.
 - Discover public concrete `BasicTransform` subclasses exported by
   `albumentations`.
 - Require every public transform to have benchmark accounting.
-- Record optional transforms explicitly with a reason instead of silently
-  skipping them.
+- Record transforms covered in a dedicated benchmark lane explicitly with a
+  reason instead of silently skipping them.
 - Record each transform's expected coverage contract and fail validation when
   required layers are missing.
 
@@ -50,7 +50,7 @@ each public transform it records:
 - benchmark route and constructor parameters used by the catalog smoke path
 - coverage layers and required coverage contract
 - family labels such as geometry, pixel, reference-data, volumetric, direct
-  kernel, memory, alias, or optional PyTorch
+  kernel, memory, alias, or dedicated PyTorch Tensor
 - exact ASV benchmark class, config, and case IDs that measure the transform
 - parsed scenario metadata for each ASV case
 - a compact `scenario_contract` summary of covered sizes, channels, dtypes,
@@ -76,8 +76,8 @@ uv run python -m tools.performance_budget check
 - Run one valid `Compose` path for every runnable public transform.
 - Use deterministic inputs and explicit parameter overrides for transforms that
   need non-default constructor arguments or auxiliary metadata.
-- Keep optional PyTorch tensor transforms accounted separately unless the
-  benchmark environment installs the optional dependency.
+- Keep explicit terminal Tensor transforms accounted separately in their
+  dedicated benchmark lane.
 
 This layer catches public catalog drift and verifies that every runnable
 transform has at least one measured user-facing route.
@@ -90,8 +90,10 @@ verifies that the public alias constructs and executes.
 `ToTensorV2` and `ToTensor3D` are not part of the default headless ASV suite.
 They are covered by the dedicated PyTorch ASV config,
 `benchmark/asv-pytorch.conf.json`, and appear in coverage details under the
-`pytorch_tensor` layer. They must not be treated as uncovered simply because
-the default ASV environment avoids torch.
+`pytorch_tensor` layer. The same lane also measures accepted Tensor-native
+capabilities beside their normal NumPy coverage. `Transpose(image=...)` is the
+first such route, bounded to C=1 and C=3 CPU Tensor images. It does not imply
+that its `images` or `volume` targets accept Tensor input.
 
 ### L2: Family Matrices
 
@@ -122,8 +124,8 @@ The current family matrix covers:
 - reference data: mixing, domain adaptation, overlay, copy-paste, mosaic, and
   text metadata transforms
 - volumetric data: public 3D transforms over volume size and dtype variants
-- optional tensor data: PyTorch tensor conversion paths for 2D and 3D terminal
-  transforms in the optional PyTorch ASV lane
+- tensor data: PyTorch terminal conversion paths and accepted Tensor-native
+  `Compose` paths in the dedicated PyTorch Tensor ASV lane
 - batch data: selected image, mask, volume, and mask3d batch routes over
   size, channel, dtype, and batch-size variants
 
@@ -295,9 +297,8 @@ Pull requests:
   triage items, and release-blocking regressions
 - the default performance workflow evaluates the core budget with `--core-only`;
   it does not report the separately owned `pytorch_tensor` layer as missing
-- optional PyTorch ASV is not run on every pull request because installing
-  torch can dominate feedback time; it is run by the separate scheduled/manual
-  PyTorch Tensor Performance workflow
+- dedicated PyTorch Tensor ASV is not run on every pull request; it is run by
+  the separate scheduled/manual PyTorch Tensor Performance workflow
 - when the PR router selects the CPU-only PyTorch correctness job, that job
   validates the complete benchmark catalog and performance policy with Torch
   installed
@@ -305,7 +306,7 @@ Pull requests:
 Nightly and scheduled runs:
 
 - full ASV evidence from the default-branch scheduled workflow
-- optional PyTorch tensor ASV evidence from the PyTorch Tensor Performance
+- dedicated PyTorch Tensor ASV evidence from the PyTorch Tensor Performance
   workflow
 - environment JSON
 - benchmark coverage JSON
@@ -336,7 +337,7 @@ uv run asv --config asv.conf.json continuous \
 Manual workflow runs may pass `bench_filter` to scope a comparison or leave it
 empty to compare the full suite.
 
-Optional PyTorch tensor benchmarks can be run locally with:
+Dedicated PyTorch Tensor benchmarks can be run locally with:
 
 ```bash
 cd benchmark
@@ -390,7 +391,7 @@ following are true:
   evidence instead of relying only on default constructor parameters.
 - Core pipeline evidence includes dispatch, setup, `additional_targets`,
   image batch routing, and bbox/keypoint processor overhead.
-- Optional PyTorch tensor paths are included in scheduled or release-adjacent
+- Dedicated PyTorch Tensor paths are included in scheduled or release-adjacent
   benchmark evidence.
 - Performance-budget evidence is published and has no coverage-contract
   failures.

--- a/docs/maintaining/release-process.md
+++ b/docs/maintaining/release-process.md
@@ -47,10 +47,10 @@ environment. It performs the release-specific work:
 9. Generates the CycloneDX SBOM and Correctness & Compatibility Report.
 10. Creates checksums and an immutable release manifest.
 
-The core performance profile passes `--core-only` because `ci-release` does not
-install Torch. The dedicated PyTorch PR job validates the optional tensor layer
-with CPU Torch installed. The stable `Correctness` and `Security and policy`
-gates require both selected paths to succeed.
+The core performance profile passes `--core-only` because it does not run the
+dedicated Tensor benchmark matrix. The dedicated PyTorch PR job validates that
+Tensor lane with CPU Torch installed. The stable `Correctness` and `Security
+and policy` gates require both selected paths to succeed.
 
 ## The PR Produces the Final Bundle
 

--- a/docs/maintaining/support-policy.md
+++ b/docs/maintaining/support-policy.md
@@ -40,7 +40,7 @@ requires an update to this document and the matrix validator.
 | --- | --- | --- |
 | `locked-latest` | Tests the repository lockfile and normal contributor environment. | Selected PR gates and full nightly/release |
 | `declared-minimum` | Tests the declared lower runtime bounds on Ubuntu and Python 3.10. | Nightly and release gate |
-| `optional-extras` | Smoke-tests extras such as `pillow`, `pytorch`, `text`, `hub`, and OpenCV variants. | Advisory until stable |
+| `optional-extras` | Smoke-tests extras such as `pillow`, `text`, `hub`, and OpenCV variants. | Advisory until stable |
 | `pre-release-probe` | Probes future Python or dependency releases when wheels are available. | Scheduled advisory |
 
 Lower-bound failures block a release unless the support policy, dependency
@@ -57,9 +57,10 @@ are outside normal Linux CI unless a workflow has a real GUI reason.
 ## Optional Extras
 
 The `headless` extra is the default runtime path. The `contrib-headless`,
-`pillow`, `pytorch`, `text`, and `hub` extras get targeted import or small
-functional smoke tests. The `pyvips` extra is scheduled-only when binary
-availability is stable.
+`pillow`, `text`, and `hub` extras get targeted import or small functional
+smoke tests. Torch is a required runtime dependency; TorchVision-specific
+coverage remains in the dedicated PyTorch CI lane. The `pyvips` extra is
+scheduled-only when binary availability is stable.
 
 ## Retiring Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ dependencies = [
   "pydantic>=2.12.4",
   "pyyaml",
   "scipy>=1.15.3",
+  "torch>=2.13.0",
   "typing-extensions>=4.9.0",
 ]
 
@@ -142,7 +143,6 @@ gui = ["opencv-python>=5.0.0.93"]
 headless = ["opencv-python-headless>=5.0.0.93"]
 hub = ["huggingface-hub"]
 pillow = ["pillow"]
-pytorch = ["torch"]
 pyvips = ["pyvips[binary]"]
 text = ["pillow"]
 

--- a/tests/test_benchmark_coverage.py
+++ b/tests/test_benchmark_coverage.py
@@ -4,8 +4,6 @@ import copy
 from collections import Counter
 from typing import Any
 
-import pytest
-
 from tools import benchmark_coverage
 from tools.benchmark_coverage import coverage_details, coverage_diff
 
@@ -19,10 +17,11 @@ def _coverage_for(transform_name: str) -> dict[str, Any]:
 def test_benchmark_coverage_details_account_for_every_public_transform() -> None:
     details = coverage_details()
 
-    assert details["schema_version"] == 5
+    assert details["schema_version"] == 6
     assert details["public_transforms"] == len(details["transforms"])
     assert (
-        details["layer_counts"]["catalog_smoke"] + details["layer_counts"]["optional"] == details["public_transforms"]
+        details["layer_counts"]["catalog_smoke"] + details["summary"]["dedicated_tensor_transforms"]
+        == details["public_transforms"]
     )
     assert details["summary"]["contract_failures"] == 0
     assert details["contract_failures"] == []
@@ -261,8 +260,7 @@ def test_benchmark_coverage_details_explain_warning_aliases() -> None:
     assert shift_scale_rotate["performance_contract"]["direct_kernel"]["status"] == "not_required"
 
 
-@pytest.mark.pytorch
-def test_benchmark_coverage_details_keep_optional_transforms_explicit() -> None:
+def test_benchmark_coverage_details_keep_dedicated_tensor_transforms_explicit() -> None:
     to_tensor = _coverage_for("ToTensorV2")
 
     assert to_tensor["benchmark"] is False
@@ -271,12 +269,13 @@ def test_benchmark_coverage_details_keep_optional_transforms_explicit() -> None:
         "public_api": "albumentations.ToTensorV2",
         "qualname": "ToTensorV2",
     }
-    assert to_tensor["layers"] == ["optional", "pytorch_tensor"]
+    assert to_tensor["benchmark_spec"]["route"] == "dedicated_tensor"
+    assert to_tensor["layers"] == ["pytorch_tensor"]
     assert to_tensor["families"] == ["pytorch_tensor"]
     assert to_tensor["coverage_contract"]["status"] == "ok"
-    assert to_tensor["coverage_contract"]["required_layers"] == ["optional", "pytorch_tensor"]
-    assert to_tensor["performance_contract"]["batch"]["status"] == "covered_optional"
-    assert "PyTorch" in str(to_tensor["optional_reason"])
+    assert to_tensor["coverage_contract"]["required_layers"] == ["pytorch_tensor"]
+    assert to_tensor["performance_contract"]["batch"]["status"] == "covered_dedicated_tensor"
+    assert "PyTorch" in str(to_tensor["benchmark_reason"])
     assert {
         ("pytorch", "pytorch_tensor", "small|1|uint8"),
         ("pytorch", "pytorch_tensor", "large|5|float32"),
@@ -286,22 +285,40 @@ def test_benchmark_coverage_details_keep_optional_transforms_explicit() -> None:
     assert to_tensor["scenario_contract"]["targets"] == ["image", "images", "mask", "masks"]
 
 
-def test_registry_allows_optional_transforms_only_when_their_dependency_is_unavailable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    optional = set(benchmark_coverage.OPTIONAL_BENCHMARK_TRANSFORMS)
-    spec_names = set(benchmark_coverage.benchmark_specs()) - optional
-    public_names = set(benchmark_coverage.public_transform_names()) - optional
+def test_benchmark_coverage_details_keep_native_tensor_capabilities_beside_numpy_coverage() -> None:
+    transpose = _coverage_for("Transpose")
 
-    monkeypatch.setattr(benchmark_coverage, "unavailable_optional_transform_names", lambda: optional)
-    assert benchmark_coverage._validate_public_registry(public_names, spec_names) == []
-    assert benchmark_coverage._validate_coverage_layers(spec_names) == []
+    assert transpose["benchmark"] is True
+    assert {"catalog_smoke", "family_matrix", "pytorch_tensor"}.issubset(transpose["layers"])
+    assert transpose["coverage_contract"]["required_layers"] == ["catalog_smoke", "family_matrix", "pytorch_tensor"]
+    tensor_cases = [case for case in transpose["asv_cases"] if case["layer"] == "pytorch_tensor"]
+    assert {case["case_id"] for case in tensor_cases} == {
+        "small|1|uint8",
+        "small|1|float32",
+        "small|3|uint8",
+        "small|3|float32",
+        "medium|1|uint8",
+        "medium|1|float32",
+        "medium|3|uint8",
+        "medium|3|float32",
+        "large|1|uint8",
+        "large|1|float32",
+        "large|3|uint8",
+        "large|3|float32",
+    }
+    assert all(case["scenario"]["scope"] == "tensor_native_compose" for case in tensor_cases)
+    assert all(case["scenario"]["targets"] == ["image"] for case in tensor_cases)
 
-    monkeypatch.setattr(benchmark_coverage, "unavailable_optional_transform_names", set)
+
+def test_registry_requires_dedicated_tensor_transforms_as_runtime_public_apis() -> None:
+    dedicated = set(benchmark_coverage.DEDICATED_TENSOR_BENCHMARK_TRANSFORMS)
+    spec_names = set(benchmark_coverage.benchmark_specs()) - dedicated
+    public_names = set(benchmark_coverage.public_transform_names())
+
     registry_errors = benchmark_coverage._validate_public_registry(public_names, spec_names)
     layer_errors = benchmark_coverage._validate_coverage_layers(spec_names)
 
-    assert registry_errors == ["Optional benchmark transform is not public: ToTensor3D, ToTensorV2"]
+    assert registry_errors == ["Missing benchmark specs: ToTensor3D, ToTensorV2"]
     assert layer_errors == ["Benchmark coverage layers reference unknown transforms: ToTensor3D, ToTensorV2"]
 
 
@@ -312,7 +329,7 @@ def test_benchmark_coverage_details_include_reviewable_case_metadata_for_all_lay
         assert transform["class"]["module"].startswith("albumentations.")
         assert transform["class"]["public_api"] == f"albumentations.{transform['name']}"
         assert transform["benchmark_spec"]["route"] == transform["route"]
-        assert transform["asv_cases"] or transform["layers"] == ["optional"]
+        assert transform["asv_cases"]
         assert transform["scenario_contract"]["case_count"] == len(transform["asv_cases"])
         assert set(transform["scenario_contract"]["layers"]).issubset(transform["layers"])
         assert set(transform["scenario_axis_contracts"]).issubset(transform["layers"])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -292,27 +292,31 @@ def test_named_args():
 @pytest.mark.parametrize(
     ["targets", "additional_targets", "err_message"],
     [
-        [{"image": None}, None, "image must be numpy array type"],
-        [{"image": np.empty([100, 100, 3], np.uint8), "mask": None}, None, "mask must be numpy array type"],
+        [{"image": None}, None, "image must be a NumPy array or torch.Tensor"],
+        [
+            {"image": np.empty([100, 100, 3], np.uint8), "mask": None},
+            None,
+            "mask must be a NumPy array or torch.Tensor",
+        ],
         [
             {"images": [np.empty([100, 100, 3], np.uint8)]},
             None,
-            "images must be numpy array type",
+            "images must be a NumPy array or torch.Tensor",
         ],
         [
             {"masks": [np.empty([100, 100], np.uint8)]},
             None,
-            "masks must be numpy array type",
+            "masks must be a NumPy array or torch.Tensor",
         ],
         [
             {"image": np.empty([100, 100, 3], np.uint8), "image1": None},
             {"image1": "image"},
-            "image1 must be numpy array type",
+            "image1 must be a NumPy array or torch.Tensor",
         ],
         [
             {"image": np.empty([100, 100, 3], np.uint8), "mask1": None},
             {"mask1": "mask"},
-            "mask1 must be numpy array type",
+            "mask1 must be a NumPy array or torch.Tensor",
         ],
     ],
 )

--- a/tests/test_correctness_report.py
+++ b/tests/test_correctness_report.py
@@ -52,7 +52,7 @@ def test_generate_report_accepts_required_release_evidence(tmp_path) -> None:
             "summary": {
                 "contract_failures": 0,
                 "deep_coverage_transforms": 1,
-                "optional_transforms": 0,
+                "dedicated_tensor_transforms": 0,
                 "performance_contract_status_counts": {
                     "batch": {"covered": 1, "tracked_without_dedicated_matrix": 2},
                     "memory": {"covered_advisory": 1},
@@ -150,7 +150,7 @@ def test_generate_report_rejects_incomplete_or_failing_pytest_evidence(tmp_path,
         {
             "kind": "benchmark-coverage-detail",
             "layer_counts": {},
-            "summary": {"contract_failures": 0, "deep_coverage_transforms": 1, "optional_transforms": 0},
+            "summary": {"contract_failures": 0, "deep_coverage_transforms": 1, "dedicated_tensor_transforms": 0},
         },
     )
     _write_json(

--- a/tests/test_performance_budget.py
+++ b/tests/test_performance_budget.py
@@ -36,8 +36,8 @@ def _coverage_detail() -> dict:
         "public_transforms": 136,
         "summary": {
             "contract_failures": 0,
-            "deep_coverage_transforms": 134,
-            "optional_transforms": 2,
+            "deep_coverage_transforms": 136,
+            "dedicated_tensor_transforms": 2,
             "smoke_only_transforms": 0,
         },
     }
@@ -47,8 +47,8 @@ def _coverage_summary() -> dict:
     return {
         "coverage_depth": {
             "contract_failures": 0,
-            "deep_coverage_transforms": 134,
-            "optional_transforms": 2,
+            "deep_coverage_transforms": 136,
+            "dedicated_tensor_transforms": 2,
             "smoke_only_transforms": 0,
         },
         "memory_benchmarks": 7,
@@ -144,17 +144,17 @@ def test_build_budget_rejects_missing_required_coverage_layers() -> None:
     assert any("family_matrix" in issue for issue in budget["issues"])
 
 
-def test_build_budget_allows_optional_layer_only_in_core_mode() -> None:
+def test_build_budget_allows_dedicated_tensor_lane_only_in_core_mode() -> None:
     coverage_detail = _coverage_detail()
     coverage_detail["layer_counts"] = {**coverage_detail["layer_counts"], "pytorch_tensor": 0}
     coverage_detail["public_transforms"] = 134
-    coverage_detail["summary"] = {**coverage_detail["summary"], "optional_transforms": 0}
+    coverage_detail["summary"] = {**coverage_detail["summary"], "dedicated_tensor_transforms": 0}
     coverage_summary = _coverage_summary()
     coverage_summary["public_transforms"] = 134
     coverage_summary["pytorch_tensor_benchmark_cases"] = 0
 
-    assert build_budget(coverage_summary, coverage_detail, require_optional=False)["status"] == "ok"
-    assert build_budget(coverage_summary, coverage_detail, require_optional=True)["status"] == "release_blocked"
+    assert build_budget(coverage_summary, coverage_detail, require_tensor=False)["status"] == "ok"
+    assert build_budget(coverage_summary, coverage_detail, require_tensor=True)["status"] == "release_blocked"
 
 
 def test_summarize_prints_concrete_release_blockers(

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -94,7 +94,7 @@ def test_only_pypi_job_receives_oidc_permission() -> None:
     assert jobs["publish_to_pypi"]["permissions"]["id-token"] == "write"
 
 
-def test_release_candidate_core_profiles_do_not_require_optional_pytorch_coverage() -> None:
+def test_release_candidate_core_profiles_do_not_require_dedicated_tensor_coverage() -> None:
     text = RELEASE_CANDIDATE_PATH.read_text(encoding="utf-8")
 
     assert text.count("python -m tools.performance_budget summarize") == 2

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -1,0 +1,389 @@
+"""CPU Tensor boundary tests for the Tensor-native Compose foundation."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+
+import albumentations as A
+from albumentations.core.transforms_interface import ImageOnlyTransform
+from albumentations.core.utils import get_image_data, get_shape, get_volume_shape
+
+
+class _TensorProbe(ImageOnlyTransform):
+    """Private test transform that proves Compose carries Tensor values to dispatch."""
+
+    _supports_cpu_tensor = True
+
+    def __init__(self) -> None:
+        super().__init__(p=1.0)
+        self.seen_shapes: list[tuple[int, ...]] = []
+
+    def apply(self, image: torch.Tensor, **params: Any) -> torch.Tensor:
+        self.seen_shapes.append(params["shape"])
+        return image + 1
+
+    def apply_to_images(self, images: torch.Tensor, **params: Any) -> torch.Tensor:
+        self.seen_shapes.append(params["shape"])
+        return images + 1
+
+    def apply_to_volume(self, volume: torch.Tensor, **params: Any) -> torch.Tensor:
+        self.seen_shapes.append(params["shape"])
+        return volume + 1
+
+
+class _NumpyOnlyProbe(_TensorProbe):
+    """Private probe whose parameter sampling must not run for Tensor input."""
+
+    _supports_cpu_tensor = False
+
+    def get_params(self) -> dict[str, Any]:
+        pytest.fail("Compose must reject an unsupported Tensor transform before parameter sampling")
+
+
+@pytest.mark.parametrize(
+    ("target", "shape", "expected_shape"),
+    [
+        ("image", (3, 11, 13), (11, 13, 3)),
+        ("images", (3, 5, 11, 13), (11, 13, 3)),
+        ("volume", (3, 7, 11, 13), (11, 13, 3)),
+    ],
+)
+def test_compose_preserves_cpu_tensor_representation_and_logical_shape(
+    target: str,
+    shape: tuple[int, ...],
+    expected_shape: tuple[int, ...],
+) -> None:
+    probe = _TensorProbe()
+    tensor = torch.zeros(shape, dtype=torch.uint8)
+
+    result = A.Compose([probe], strict=True)(**{target: tensor})
+
+    assert isinstance(result[target], torch.Tensor)
+    assert result[target].shape == tensor.shape
+    assert result[target].dtype == tensor.dtype
+    torch.testing.assert_close(result[target], tensor + 1)
+    assert probe.seen_shapes == [expected_shape]
+
+
+def test_empty_compose_preserves_cpu_tensor_identity() -> None:
+    tensor = torch.zeros((3, 11, 13), dtype=torch.float32)
+
+    result = A.Compose([])(image=tensor)
+
+    assert result["image"] is tensor
+
+
+def test_noop_preserves_non_contiguous_cpu_tensor_without_copy() -> None:
+    tensor = torch.arange(3 * 11 * 13, dtype=torch.float32).reshape(3, 11, 13)[:, :, ::2]
+    assert not tensor.is_contiguous()
+
+    result = A.Compose([A.NoOp(p=1.0)], strict=True)(image=tensor)
+
+    assert result["image"] is tensor
+    assert not result["image"].is_contiguous()
+
+
+def test_tensor_additional_target_uses_channel_first_shape_contract() -> None:
+    probe = _TensorProbe()
+    image = torch.zeros((3, 11, 13), dtype=torch.uint8)
+    image2 = torch.full((3, 11, 13), 7, dtype=torch.uint8)
+    compose = A.Compose([probe], additional_targets={"image2": "image"}, strict=True)
+
+    result = compose(image=image, image2=image2)
+
+    torch.testing.assert_close(result["image"], image + 1)
+    torch.testing.assert_close(result["image2"], image2 + 1)
+    assert probe.seen_shapes == [(11, 13, 3), (11, 13, 3)]
+
+
+def test_tensor_nested_compose_uses_declared_child_capability() -> None:
+    tensor = torch.zeros((3, 11, 13), dtype=torch.float32)
+    compose = A.Compose([A.Sequential([_TensorProbe()], p=1.0)], strict=True)
+
+    result = compose(image=tensor)
+
+    torch.testing.assert_close(result["image"], tensor + 1)
+
+
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
+@pytest.mark.parametrize("channels", [1, 3])
+def test_noop_preserves_tensor_image_sequences(dtype: torch.dtype, channels: int) -> None:
+    images = torch.zeros((channels, 5, 11, 13), dtype=dtype)
+
+    result = A.Compose([A.NoOp(p=1.0)], strict=True)(images=images)["images"]
+
+    assert isinstance(result, torch.Tensor)
+    assert result.data_ptr() == images.data_ptr()
+    assert result.shape == images.shape
+    assert result.dtype == images.dtype
+
+
+@pytest.mark.parametrize(
+    ("target", "value"),
+    [
+        ("images", np.zeros((2, 11, 13, 3), dtype=np.uint8)),
+        ("masks", np.zeros((2, 11, 13, 3), dtype=np.uint8)),
+        ("volume", np.zeros((2, 11, 13, 3), dtype=np.uint8)),
+    ],
+)
+def test_noop_preserves_numpy_batch_target_without_copy(target: str, value: np.ndarray) -> None:
+    result = A.Compose([A.NoOp(p=1.0)], strict=True)(**{target: value})[target]
+
+    assert result is value
+
+
+def test_nested_compose_preserves_tensor_annotations() -> None:
+    image = torch.zeros((3, 11, 13), dtype=torch.uint8)
+    bboxes = torch.tensor([[1, 1, 5, 4]], dtype=torch.float32)
+    keypoints = torch.tensor([[2, 3]], dtype=torch.float32)
+    compose = A.Compose(
+        [A.Compose([A.NoOp(p=1.0)], strict=True)],
+        bbox_params=A.BboxParams(coord_format="pascal_voc"),
+        keypoint_params=A.KeypointParams(coord_format="xy"),
+        strict=True,
+    )
+
+    result = compose(image=image, bboxes=bboxes, keypoints=keypoints)
+
+    for target, expected in (("image", image), ("bboxes", bboxes), ("keypoints", keypoints)):
+        assert isinstance(result[target], torch.Tensor)
+        torch.testing.assert_close(result[target], expected)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        A.HorizontalFlip(p=1.0),
+        A.VerticalFlip(p=1.0),
+        _NumpyOnlyProbe(),
+    ],
+)
+def test_tensor_rejects_unsupported_transform_before_parameter_sampling(transform: A.BasicTransform) -> None:
+    with pytest.raises(TypeError, match="does not yet declare CPU Tensor capability"):
+        A.Compose([transform], p=0.0)(image=torch.zeros((3, 11, 13), dtype=torch.uint8))
+
+
+@pytest.mark.parametrize("terminal", [A.ToTensorV2(p=1.0), A.ToTensor3D(p=1.0)])
+def test_tensor_rejects_legacy_terminal_transforms(terminal: A.BasicTransform) -> None:
+    with pytest.raises(TypeError, match="remove ToTensorV2 or ToTensor3D"):
+        A.Compose([terminal])(image=torch.zeros((3, 11, 13), dtype=torch.uint8))
+
+
+@pytest.mark.parametrize(
+    ("tensor", "message"),
+    [
+        (torch.zeros((11, 13), dtype=torch.uint8), "must have shape"),
+        (torch.zeros((3, 11, 13), dtype=torch.int64), "dtype one of"),
+        (torch.zeros((3, 11, 13), dtype=torch.float32, requires_grad=True), "requires_grad=False"),
+    ],
+)
+def test_tensor_boundary_rejects_invalid_image_contract(tensor: torch.Tensor, message: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        A.Compose([])(image=tensor)
+
+
+@pytest.mark.parametrize(
+    ("target", "tensor", "message"),
+    [
+        ("mask", torch.zeros((1, 11, 13), dtype=torch.uint8), "must have shape"),
+        ("masks", torch.zeros((11, 13), dtype=torch.uint8), "must have shape"),
+        ("mask3d", torch.zeros((1, 11, 13), dtype=torch.int32), "dtype one of"),
+        ("bboxes", torch.zeros((1, 4), dtype=torch.int64), "dtype one of"),
+        ("keypoints", torch.zeros((1, 2, 1), dtype=torch.float32), "must have shape"),
+    ],
+)
+def test_tensor_boundary_rejects_invalid_annotation_contract(
+    target: str,
+    tensor: torch.Tensor,
+    message: str,
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        A.Compose([])(
+            image=torch.zeros((3, 11, 13), dtype=torch.uint8),
+            **{target: tensor},
+        )
+
+
+def test_noop_preserves_tensor_spatial_targets_at_compose_boundary() -> None:
+    image = torch.arange(3 * 5 * 7, dtype=torch.float32).reshape(3, 5, 7)
+    mask = torch.arange(5 * 7, dtype=torch.int64).reshape(5, 7)
+    masks = torch.arange(2 * 5 * 7, dtype=torch.uint8).reshape(2, 5, 7)
+    bboxes = torch.tensor([[1.0, 1.0, 5.0, 4.0]], dtype=torch.float32)
+    keypoints = torch.tensor([[2.0, 3.0]], dtype=torch.float32)
+    compose = A.Compose(
+        [A.NoOp(p=1.0)],
+        bbox_params=A.BboxParams(coord_format="pascal_voc"),
+        keypoint_params=A.KeypointParams(coord_format="xy"),
+        strict=True,
+    )
+
+    result = compose(image=image, mask=mask, masks=masks, bboxes=bboxes, keypoints=keypoints)
+
+    for target, expected in {
+        "image": image,
+        "mask": mask,
+        "masks": masks,
+        "bboxes": bboxes,
+        "keypoints": keypoints,
+    }.items():
+        assert isinstance(result[target], torch.Tensor)
+        torch.testing.assert_close(result[target], expected)
+
+
+def test_noop_preserves_tensor_volume_and_mask3d_without_numpy_batch_dispatch() -> None:
+    volume = torch.arange(3 * 5 * 7 * 9, dtype=torch.float32).reshape(3, 5, 7, 9)
+    mask3d = torch.arange(5 * 7 * 9, dtype=torch.int64).reshape(5, 7, 9)
+
+    result = A.Compose([A.NoOp(p=1.0)], strict=True)(volume=volume, mask3d=mask3d)
+
+    assert result["volume"] is volume
+    assert result["mask3d"] is mask3d
+
+
+@pytest.mark.parametrize(
+    ("image", "mask"),
+    [
+        (torch.zeros((3, 11, 13), dtype=torch.uint8), np.zeros((11, 13), dtype=np.uint8)),
+        (np.zeros((11, 13, 3), dtype=np.uint8), torch.zeros((11, 13), dtype=torch.uint8)),
+    ],
+)
+def test_tensor_boundary_rejects_mixed_spatial_representations(image: Any, mask: Any) -> None:
+    with pytest.raises(TypeError, match="cannot be mixed across spatial targets"):
+        A.Compose([])(image=image, mask=mask)
+
+
+def test_tensor_boundary_rejects_numpy_bbox_with_tensor_image() -> None:
+    with pytest.raises(TypeError, match="must also be Tensors"):
+        A.Compose([])(
+            image=torch.zeros((3, 11, 13), dtype=torch.uint8),
+            bboxes=[[1.0, 1.0, 5.0, 4.0]],
+        )
+
+
+def test_tensor_shape_helpers_follow_channel_first_images_sequence_and_volume_contracts() -> None:
+    image = torch.zeros((3, 11, 13), dtype=torch.uint8)
+    images = torch.zeros((3, 5, 11, 13), dtype=torch.uint8)
+    volume = torch.zeros((3, 7, 11, 13), dtype=torch.uint8)
+
+    assert get_shape({"image": image}) == (11, 13)
+    assert get_shape({"images": images}) == (11, 13)
+    assert get_shape({"volume": volume}) == (11, 13)
+    assert get_volume_shape({"volume": volume}) == (7, 11, 13)
+    assert get_image_data({"image": image}) == {
+        "dtype": torch.uint8,
+        "height": 11,
+        "width": 13,
+        "num_channels": 3,
+    }
+    assert get_image_data({"images": images}) == {
+        "dtype": torch.uint8,
+        "height": 11,
+        "width": 13,
+        "num_channels": 3,
+    }
+    assert get_image_data({"volume": volume}) == {
+        "dtype": torch.uint8,
+        "height": 11,
+        "width": 13,
+        "num_channels": 3,
+    }
+
+
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
+@pytest.mark.parametrize("channels", [1, 3])
+def test_transpose_preserves_accepted_tensor_image_view_contract(dtype: torch.dtype, channels: int) -> None:
+    image = torch.arange(channels * 5 * 7, dtype=torch.int64).reshape(channels, 5, 7).to(dtype)
+
+    result = A.Compose([A.Transpose(p=1.0)], strict=True)(image=image)["image"]
+
+    assert isinstance(result, torch.Tensor)
+    assert result.shape == (channels, 7, 5)
+    assert result.dtype == image.dtype
+    assert result.data_ptr() == image.data_ptr()
+    assert not result.is_contiguous()
+    torch.testing.assert_close(result, image.mT)
+
+
+def test_transpose_keeps_tensor_masks_bboxes_and_keypoints_aligned_with_tensor_image() -> None:
+    image = torch.arange(3 * 5 * 7, dtype=torch.uint8).reshape(3, 5, 7)
+    numpy_image = image.permute(1, 2, 0).numpy().copy()
+    mask = np.arange(5 * 7, dtype=np.uint8).reshape(5, 7)
+    masks = np.arange(2 * 5 * 7, dtype=np.int64).reshape(2, 5, 7)
+    mask3d = np.arange(3 * 5 * 7, dtype=np.uint8).reshape(3, 5, 7)
+    bboxes = np.array([[1, 1, 5, 4]], dtype=np.float32)
+    keypoints = np.array([[2, 3]], dtype=np.float32)
+    bbox_params = A.BboxParams(coord_format="pascal_voc")
+    keypoint_params = A.KeypointParams(coord_format="xy")
+
+    tensor_result = A.Compose(
+        [A.Transpose(p=1.0)],
+        bbox_params=bbox_params,
+        keypoint_params=keypoint_params,
+        strict=True,
+    )(
+        image=image,
+        mask=torch.from_numpy(mask.copy()),
+        masks=torch.from_numpy(masks.copy()),
+        mask3d=torch.from_numpy(mask3d.copy()),
+        bboxes=torch.from_numpy(bboxes.copy()),
+        keypoints=torch.from_numpy(keypoints.copy()),
+    )
+    numpy_result = A.Compose(
+        [A.Transpose(p=1.0)],
+        bbox_params=bbox_params,
+        keypoint_params=keypoint_params,
+        strict=True,
+    )(
+        image=numpy_image,
+        mask=mask,
+        masks=masks,
+        mask3d=mask3d,
+        bboxes=bboxes,
+        keypoints=keypoints,
+    )
+
+    torch.testing.assert_close(
+        tensor_result["image"],
+        torch.from_numpy(numpy_result["image"]).permute(2, 0, 1),
+    )
+    for target in ("mask", "masks", "mask3d", "bboxes", "keypoints"):
+        assert isinstance(tensor_result[target], torch.Tensor)
+        expected = torch.from_numpy(numpy_result[target]).to(dtype=tensor_result[target].dtype)
+        torch.testing.assert_close(tensor_result[target], expected)
+
+
+@pytest.mark.parametrize(
+    ("target", "tensor", "message"),
+    [
+        ("image", torch.zeros((5, 5, 7), dtype=torch.uint8), "accepted channel counts are 1, 3"),
+        ("images", torch.zeros((3, 2, 5, 7), dtype=torch.uint8), "accepted targets are image"),
+        ("volume", torch.zeros((3, 2, 5, 7), dtype=torch.uint8), "accepted targets are image"),
+    ],
+)
+def test_transpose_rejects_tensor_routes_outside_accepted_capability(
+    target: str,
+    tensor: torch.Tensor,
+    message: str,
+) -> None:
+    with pytest.raises(TypeError, match=message):
+        A.Compose([A.Transpose(p=1.0)], strict=True)(**{target: tensor})
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        A.CenterCrop3D(size=(3, 5, 7), pad_if_needed=False, p=1.0),
+        A.RandomCrop3D(size=(3, 5, 7), pad_if_needed=False, p=1.0),
+        A.CubicSymmetry(p=1.0),
+        A.Pad3D(padding=(1, 2, 2), p=1.0),
+    ],
+)
+def test_3d_transforms_remain_rejected_until_their_tensor_routes_pass_the_performance_gate(
+    transform: A.BasicTransform,
+) -> None:
+    with pytest.raises(TypeError, match="does not yet declare CPU Tensor capability"):
+        A.Compose([transform], strict=True)(
+            volume=torch.zeros((3, 5, 7, 9), dtype=torch.uint8),
+        )

--- a/tests/test_tensor_dataloader.py
+++ b/tests/test_tensor_dataloader.py
@@ -1,0 +1,34 @@
+"""Integration coverage for Tensor-native Compose and PyTorch collation."""
+
+from __future__ import annotations
+
+import torch
+
+import albumentations as A
+
+
+class _TensorComposeDataset(torch.utils.data.Dataset[dict[str, torch.Tensor]]):
+    """Small picklable dataset that applies the supported Tensor Compose path."""
+
+    def __init__(self) -> None:
+        self.images = torch.arange(12 * 3 * 11 * 13, dtype=torch.float32).reshape(12, 3, 11, 13)
+        self.transform = A.Compose([A.NoOp(p=1.0)], strict=True)
+
+    def __len__(self) -> int:
+        return len(self.images)
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        return self.transform(image=self.images[index])
+
+
+def test_tensor_compose_output_collates_into_model_ready_nchw() -> None:
+    loader = torch.utils.data.DataLoader(
+        _TensorComposeDataset(),
+        batch_size=4,
+        num_workers=0,
+    )
+
+    batches = list(loader)
+
+    assert [batch["image"].shape for batch in batches] == [(4, 3, 11, 13)] * 3
+    assert all(batch["image"].dtype == torch.float32 for batch in batches)

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -18,16 +18,13 @@ BENCHMARK_ROOT = REPO_ROOT / "benchmark"
 sys.path.insert(0, str(BENCHMARK_ROOT))
 
 from benchmarks.catalog import (  # noqa: E402
-    OPTIONAL_BENCHMARK_TRANSFORMS,
+    DEDICATED_TENSOR_BENCHMARK_TRANSFORMS,
     asv_case_ids,
     benchmark_specs,
     instantiate_transform,
     make_compose,
     make_data,
     public_transform_names,
-)
-from benchmarks.catalog import (  # noqa: E402
-    unavailable_optional_transform_names as _unavailable_optional_transform_names,
 )
 from benchmarks.common import CHANNELS, DTYPES, SIZES, VOLUME_SIZES  # noqa: E402
 from benchmarks.test_batch_matrix import (  # noqa: E402
@@ -66,12 +63,6 @@ from benchmarks.test_parameter_sensitivity import (  # noqa: E402
     PARAMETER_SENSITIVITY_TRANSFORMS,
 )
 from pytorch_benchmarks import test_tensor as pytorch_tensor_benchmarks  # noqa: E402
-
-
-def unavailable_optional_transform_names() -> set[str]:
-    """Return optional transforms unavailable in the current environment."""
-    return _unavailable_optional_transform_names()
-
 
 BATCH_METHOD_NAMES = (
     "apply_to_images",
@@ -319,9 +310,12 @@ MEMORY_COVERED_TRANSFORMS = frozenset(
     },
 )
 
-PYTORCH_TENSOR_TRANSFORMS = frozenset({"ToTensor3D", "ToTensorV2"})
+PYTORCH_TERMINAL_TENSOR_TRANSFORMS = frozenset({"ToTensor3D", "ToTensorV2"})
+PYTORCH_NATIVE_TENSOR_TRANSFORMS = frozenset({"Transpose"})
+PYTORCH_TENSOR_TRANSFORMS = PYTORCH_TERMINAL_TENSOR_TRANSFORMS | PYTORCH_NATIVE_TENSOR_TRANSFORMS
 PYTORCH_IMAGE_CASES = pytorch_tensor_benchmarks.IMAGE_CASES
 PYTORCH_VOLUME_CASES = pytorch_tensor_benchmarks.VOLUME_CASES
+PYTORCH_NATIVE_IMAGE_CASES = pytorch_tensor_benchmarks.TENSOR_NATIVE_IMAGE_CASES
 
 DIRECT_KERNEL_CASE_PREFIXES_BY_TRANSFORM = {
     "Affine": ("bboxes_affine", "keypoints_affine"),
@@ -392,6 +386,7 @@ ASV_BENCHMARKS = {
     "parameter_sensitivity": "benchmarks.test_parameter_sensitivity.TimeParameterSensitivity.time_transform",
     "pytorch_tensor_2d": "pytorch_benchmarks.test_tensor.TimeToTensorV2",
     "pytorch_tensor_3d": "pytorch_benchmarks.test_tensor.TimeToTensor3D",
+    "pytorch_tensor_native": "pytorch_benchmarks.test_tensor.TimeTensorNativeTranspose",
     "reference_data": "benchmarks.test_family_matrix.TimeReferenceDataFullMatrix.time_transform",
     "target_matrix": "benchmarks.test_family_matrix.TimeSpecialTargetMatrix.time_transform",
     "volumetric_matrix": "benchmarks.test_family_matrix.TimeVolumetricFullMatrix.time_transform",
@@ -482,7 +477,7 @@ LAYER_SKIP_REASONS: Mapping[str, str] = {
     "direct_kernel": "direct-kernel cases cover the axes exercised by each shared functional hot path",
     "family_matrix": "family matrix uses the transform's supported or representative size/channel/dtype axes",
     "parameter_sensitivity": "parameter stress cases are bounded to representative axes for scheduled evidence",
-    "pytorch_tensor": "optional PyTorch tensor benchmarks follow supported tensor conversion axes",
+    "pytorch_tensor": "dedicated PyTorch Tensor benchmarks follow supported tensor conversion axes",
     "reference_data": "reference-data benchmarks are bounded to small/medium metadata-heavy cases",
     "target_matrix": "target matrix uses the standard image axes for target-specialized transforms",
     "volumetric_matrix": "volumetric matrix uses the supported volume size and dtype axes",
@@ -525,10 +520,15 @@ def _coverage_layer_sets() -> dict[str, set[str]]:
 
 def _coverage_expectation(name: str, route: str) -> CoverageExpectation:
     """Return the expected benchmark coverage layers for a public transform."""
-    if name in PYTORCH_TENSOR_TRANSFORMS:
+    if name in PYTORCH_TERMINAL_TENSOR_TRANSFORMS:
         return CoverageExpectation(
-            required_layers=frozenset({"optional", "pytorch_tensor"}),
-            reason="optional PyTorch tensor transforms are benchmarked in the dedicated PyTorch ASV lane",
+            required_layers=frozenset({"pytorch_tensor"}),
+            reason="PyTorch Tensor transforms are benchmarked in the dedicated Tensor ASV lane",
+        )
+    if name in PYTORCH_NATIVE_TENSOR_TRANSFORMS:
+        return CoverageExpectation(
+            required_layers=frozenset({"catalog_smoke", "family_matrix", "pytorch_tensor"}),
+            reason="the retained NumPy route and accepted CPU Tensor route both have dedicated Compose evidence",
         )
     if name in ALIAS_COVERAGE_TRANSFORMS:
         return CoverageExpectation(
@@ -681,7 +681,7 @@ def _parse_volume_case(case_id: str) -> dict[str, Any]:
 
 
 def _parse_pytorch_case(case_id: str) -> dict[str, Any]:
-    """Parse an optional PyTorch tensor benchmark case id."""
+    """Parse a dedicated PyTorch Tensor benchmark case id."""
     size_name, channels, dtype_name = case_id.split("|")
     return {
         "channels": int(channels),
@@ -781,12 +781,18 @@ def _memory_scenario(case: Mapping[str, str], route: str, transform_name: str) -
 
 
 def _pytorch_tensor_scenario(case: Mapping[str, str], route: str, transform_name: str) -> dict[str, Any]:
-    """Return scenario metadata for an optional PyTorch tensor case."""
+    """Return scenario metadata for a dedicated PyTorch Tensor case."""
+    if transform_name in PYTORCH_NATIVE_TENSOR_TRANSFORMS:
+        return {
+            **_parse_pytorch_case(case["case_id"]),
+            "scope": "tensor_native_compose",
+            "targets": ["image"],
+        }
     targets = ["mask3d", "volume"] if transform_name == "ToTensor3D" else ["image", "images", "mask", "masks"]
     return {
         **_parse_pytorch_case(case["case_id"]),
         "batch_size": 8,
-        "scope": "optional_pytorch",
+        "scope": "pytorch_tensor",
         "targets": targets,
     }
 
@@ -1133,6 +1139,15 @@ def _benchmark_case_index() -> dict[str, list[dict[str, str]]]:
             config="pytorch",
             layer="pytorch_tensor",
         )
+    for case_id in PYTORCH_NATIVE_IMAGE_CASES:
+        _add_asv_case(
+            cases,
+            "Transpose",
+            benchmark=ASV_BENCHMARKS["pytorch_tensor_native"],
+            case_id=case_id,
+            config="pytorch",
+            layer="pytorch_tensor",
+        )
     return {
         name: sorted(items, key=lambda item: (item["layer"], item["benchmark"], item["case_id"]))
         for name, items in cases.items()
@@ -1140,7 +1155,7 @@ def _benchmark_case_index() -> dict[str, list[dict[str, str]]]:
 
 
 def _family_labels(name: str, layers: Iterable[str]) -> list[str]:
-    families = set(layers) - {"catalog_smoke", "optional"}
+    families = set(layers) - {"catalog_smoke"}
     if name in _mapped_names(GEOMETRY_ALIAS_TO_TRANSFORM, GEOMETRY_TRANSFORMS):
         families.add("geometry")
     if name in _mapped_names(PIXEL_ALIAS_TO_TRANSFORM, PIXEL_TRANSFORMS):
@@ -1193,12 +1208,12 @@ def _performance_contract_entry(
 def _batch_performance_contract(name: str, layers: set[str]) -> dict[str, Any]:
     """Return batch-route performance expectations for one transform."""
     methods = _declared_transform_methods(name, BATCH_METHOD_NAMES)
-    if name in PYTORCH_TENSOR_TRANSFORMS:
+    if name in PYTORCH_TERMINAL_TENSOR_TRANSFORMS:
         return _performance_contract_entry(
             implementation_methods=methods,
-            reason="optional tensor batch routes are measured in the dedicated PyTorch benchmark lane",
+            reason="Tensor batch routes are measured in the dedicated PyTorch benchmark lane",
             required_layers=("pytorch_tensor",),
-            status="covered_optional",
+            status="covered_dedicated_tensor",
         )
     if "batch_matrix" in layers:
         return _performance_contract_entry(
@@ -1355,7 +1370,7 @@ def coverage_details() -> dict[str, Any]:
     transforms: list[dict[str, Any]] = []
 
     for name, spec in specs.items():
-        layers = ["optional"] if not spec.benchmark else ["catalog_smoke"]
+        layers = [] if not spec.benchmark else ["catalog_smoke"]
         for layer_name, transform_names in layer_sets.items():
             if name in transform_names:
                 layers.append(layer_name)
@@ -1386,7 +1401,7 @@ def coverage_details() -> dict[str, Any]:
                 "families": _family_labels(name, layers),
                 "layers": layers,
                 "name": name,
-                "optional_reason": spec.reason,
+                "benchmark_reason": spec.reason,
                 "performance_contract": performance_contract,
                 "route": spec.route,
                 "scenario_axis_contracts": _scenario_axis_contracts(transform_cases),
@@ -1412,7 +1427,6 @@ def coverage_details() -> dict[str, Any]:
                 "memory",
                 "parameter_sensitivity",
                 "pytorch_tensor",
-                "optional",
             )
         },
     )
@@ -1423,12 +1437,12 @@ def coverage_details() -> dict[str, Any]:
         "kind": "benchmark-coverage-detail",
         "layer_counts": dict(sorted(layer_counts.items())),
         "public_transforms": len(transforms),
-        "schema_version": 5,
+        "schema_version": 6,
         "smoke_only_transforms": smoke_only,
         "summary": {
             "contract_failures": len(contract_failures),
-            "deep_coverage_transforms": len(transforms) - len(smoke_only) - layer_counts["optional"],
-            "optional_transforms": layer_counts["optional"],
+            "deep_coverage_transforms": len(transforms) - len(smoke_only),
+            "dedicated_tensor_transforms": len(PYTORCH_TERMINAL_TENSOR_TRANSFORMS),
             "performance_contract_status_counts": _performance_contract_status_counts(transforms),
             "smoke_only_transforms": len(smoke_only),
         },
@@ -1440,7 +1454,7 @@ def _spec_summary() -> dict[str, Any]:
     specs = benchmark_specs()
     route_counts = Counter(spec.route for spec in specs.values())
     runnable = [spec.name for spec in specs.values() if spec.benchmark]
-    optional = {spec.name: spec.reason for spec in specs.values() if not spec.benchmark}
+    dedicated = {spec.name: spec.reason for spec in specs.values() if not spec.benchmark}
     details = coverage_details()
     return {
         "annotation_matrix_cases": len(ANNOTATION_CASES),
@@ -1469,7 +1483,7 @@ def _spec_summary() -> dict[str, Any]:
         "pytorch_tensor_benchmark_cases": len(PYTORCH_TENSOR_TRANSFORMS),
         "registered_specs": len(specs),
         "asv_cases": len(asv_case_ids()),
-        "optional_cases": optional,
+        "dedicated_tensor_cases": dedicated,
         "performance_contract_status_counts": details["summary"]["performance_contract_status_counts"],
         "route_counts": dict(sorted(route_counts.items())),
         "runnable_transforms": runnable,
@@ -1484,18 +1498,16 @@ def _validate_public_registry(public_names: set[str], spec_names: set[str]) -> l
         errors.append("Missing benchmark specs: " + ", ".join(missing))
     if unexpected:
         errors.append("Benchmark specs reference unknown transforms: " + ", ".join(unexpected))
-    unknown_optional = sorted(
-        set(OPTIONAL_BENCHMARK_TRANSFORMS) - public_names - unavailable_optional_transform_names(),
-    )
-    if unknown_optional:
-        errors.append("Optional benchmark transform is not public: " + ", ".join(unknown_optional))
+    unknown_dedicated = sorted(set(DEDICATED_TENSOR_BENCHMARK_TRANSFORMS) - public_names)
+    if unknown_dedicated:
+        errors.append("Dedicated Tensor benchmark transform is not public: " + ", ".join(unknown_dedicated))
     return errors
 
 
 def _validate_transform_construction(specs: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     for spec in specs.values():
-        if spec.route == "optional":
+        if spec.route == "dedicated_tensor":
             continue
         try:
             instantiate_transform(spec)
@@ -1515,7 +1527,7 @@ def _validate_case_groups(groups: Mapping[str, tuple[str, ...]], message: str) -
 def _validate_coverage_layers(spec_names: set[str]) -> list[str]:
     layer_sets = _coverage_layer_sets()
     referenced = set().union(*layer_sets.values())
-    unknown = sorted(referenced - spec_names - unavailable_optional_transform_names())
+    unknown = sorted(referenced - spec_names)
     if unknown:
         return ["Benchmark coverage layers reference unknown transforms: " + ", ".join(unknown)]
     return []
@@ -1632,7 +1644,7 @@ def check(*, run_smoke: bool, output: Path | None) -> int:
     print(
         "Benchmark coverage ok: "
         f"{summary['asv_cases']} ASV cases, "
-        f"{len(summary['optional_cases'])} optional cases, "
+        f"{len(summary['dedicated_tensor_cases'])} dedicated Tensor cases, "
         f"{summary['public_transforms']} public transforms accounted.",
     )
     return 0

--- a/tools/check_conda_dependencies.py
+++ b/tools/check_conda_dependencies.py
@@ -29,6 +29,7 @@ def normalize_package_name(name: str) -> str:
     # Common package name mappings between pip and conda
     mappings = {
         "opencv-python-headless": "opencv-python-headless",
+        "torch": "pytorch",
         "typing-extensions": "typing_extensions",
     }
     return mappings.get(name, name)

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -107,7 +107,7 @@ SUPPORT_POLICY_TABLE_ROWS = (
         "Nightly and release gate |"
     ),
     (
-        "| `optional-extras` | Smoke-tests extras such as `pillow`, `pytorch`, `text`, `hub`, "
+        "| `optional-extras` | Smoke-tests extras such as `pillow`, `text`, `hub`, "
         "and OpenCV variants. | Advisory until stable |"
     ),
     (

--- a/tools/generate_correctness_report.py
+++ b/tools/generate_correctness_report.py
@@ -160,7 +160,7 @@ def _format_benchmark_summary(summaries: list[dict[str, Any]]) -> str:
                 "- Benchmark coverage detail "
                 f"{index}: {coverage_depth.get('deep_coverage_transforms', 0)} transform(s) with deep coverage, "
                 f"{coverage_depth.get('smoke_only_transforms', 0)} smoke-only transform(s), "
-                f"{coverage_depth.get('optional_transforms', 0)} optional transform(s); "
+                f"{coverage_depth.get('dedicated_tensor_transforms', 0)} dedicated Tensor transform(s); "
                 f"{coverage_depth.get('contract_failures', 0)} coverage contract failure(s); "
                 f"{layer_counts.get('alias_coverage', 0)} alias-covered, "
                 f"{layer_counts.get('family_matrix', 0)} family-matrix, "

--- a/tools/performance_budget.py
+++ b/tools/performance_budget.py
@@ -161,7 +161,7 @@ BENCHMARK_POLICIES = (
         "pytorch_tensor",
         "advisory",
         False,
-        "optional PyTorch tensor transforms are tracked in a separate dependency lane",
+        "PyTorch Tensor transforms are tracked in a dedicated benchmark lane",
     ),
 )
 
@@ -189,7 +189,7 @@ def classify_benchmark(benchmark_name: str) -> BenchmarkPolicy:
 def _coverage_issue_summary(
     coverage_detail: dict[str, Any],
     *,
-    require_optional: bool,
+    require_tensor: bool,
 ) -> tuple[list[str], dict[str, Any]]:
     detail_summary = coverage_detail.get("summary", {})
     layer_counts = coverage_detail.get("layer_counts", {})
@@ -200,7 +200,7 @@ def _coverage_issue_summary(
     if detail_summary.get("smoke_only_transforms", 0) != 0:
         issues.append(f"{detail_summary.get('smoke_only_transforms')} runnable smoke-only transform(s)")
 
-    required_layers = REQUIRED_COVERAGE_LAYERS if require_optional else REQUIRED_COVERAGE_LAYERS[:-1]
+    required_layers = REQUIRED_COVERAGE_LAYERS if require_tensor else REQUIRED_COVERAGE_LAYERS[:-1]
     missing_layers = [layer for layer in required_layers if layer_counts.get(layer, 0) <= 0]
     if missing_layers:
         issues.append("missing required benchmark coverage layer(s): " + ", ".join(missing_layers))
@@ -209,7 +209,7 @@ def _coverage_issue_summary(
         "contract_failures": detail_summary.get("contract_failures", 0),
         "deep_coverage_transforms": detail_summary.get("deep_coverage_transforms", 0),
         "layer_counts": {layer: layer_counts.get(layer, 0) for layer in REQUIRED_COVERAGE_LAYERS},
-        "optional_transforms": detail_summary.get("optional_transforms", 0),
+        "dedicated_tensor_transforms": detail_summary.get("dedicated_tensor_transforms", 0),
         "public_transforms": coverage_detail.get("public_transforms", 0),
         "smoke_only_transforms": detail_summary.get("smoke_only_transforms", 0),
     }
@@ -219,7 +219,7 @@ def _coverage_summary_issues(
     coverage_summary: dict[str, Any],
     coverage_detail: dict[str, Any],
     *,
-    require_optional: bool,
+    require_tensor: bool,
 ) -> list[str]:
     issues: list[str] = []
     summary_public = coverage_summary.get("public_transforms")
@@ -234,8 +234,8 @@ def _coverage_summary_issues(
         issues.append("benchmark coverage summary reports contract failures")
     if coverage_summary.get("memory_benchmarks", 0) <= 0:
         issues.append("benchmark coverage summary reports no memory benchmarks")
-    if require_optional and coverage_summary.get("pytorch_tensor_benchmark_cases", 0) <= 0:
-        issues.append("benchmark coverage summary reports no optional PyTorch tensor benchmark cases")
+    if require_tensor and coverage_summary.get("pytorch_tensor_benchmark_cases", 0) <= 0:
+        issues.append("benchmark coverage summary reports no PyTorch Tensor benchmark cases")
     return issues
 
 
@@ -322,13 +322,13 @@ def build_budget(
     asv_summary: dict[str, Any] | None = None,
     *,
     require_comparison: bool = False,
-    require_optional: bool = True,
+    require_tensor: bool = True,
 ) -> dict[str, Any]:
     """Build machine-readable performance budget evidence."""
-    detail_issues, coverage = _coverage_issue_summary(coverage_detail, require_optional=require_optional)
+    detail_issues, coverage = _coverage_issue_summary(coverage_detail, require_tensor=require_tensor)
     coverage_issues = [
         *detail_issues,
-        *_coverage_summary_issues(coverage_summary, coverage_detail, require_optional=require_optional),
+        *_coverage_summary_issues(coverage_summary, coverage_detail, require_tensor=require_tensor),
     ]
     comparison = _classify_regressions(asv_summary)
     status = _budget_status(coverage_issues, comparison, require_comparison=require_comparison)
@@ -366,7 +366,7 @@ def _summarize(args: argparse.Namespace) -> int:
         _read_json(args.coverage_detail),
         asv_summary,
         require_comparison=args.require_comparison,
-        require_optional=not args.core_only,
+        require_tensor=not args.core_only,
     )
     _write_budget(args.output, budget)
     print(f"Wrote performance budget to {args.output}: {budget['status']}")
@@ -388,7 +388,7 @@ def _check_current() -> int:
     budget = build_budget(
         summary,
         detail,
-        require_optional=not _benchmark_coverage.unavailable_optional_transform_names(),
+        require_tensor=True,
     )
     if budget["status"] != "ok":
         print("Performance budget validation failed:")
@@ -419,7 +419,7 @@ def parse_args() -> argparse.Namespace:
     summarize_parser.add_argument(
         "--core-only",
         action="store_true",
-        help="Validate the core benchmark lane without requiring optional PyTorch evidence.",
+        help="Validate the core benchmark lane without requiring the dedicated PyTorch Tensor evidence.",
     )
     summarize_parser.add_argument(
         "--require-comparison",

--- a/tools/tensor_compose_benchmark.py
+++ b/tools/tensor_compose_benchmark.py
@@ -1,0 +1,203 @@
+"""Measure the shared Tensor-native Compose lifecycle once per infrastructure change.
+
+Per-transform capability work must not run this DataLoader benchmark. It belongs
+to Compose, bridge, batching, collation, and milestone changes; transform routes
+use their direct and model-ready Compose benchmarks instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import torch
+from numpy.typing import NDArray
+
+import albumentations as A  # noqa: N812
+
+InputRepresentation = Literal["numpy", "tensor"]
+NumpyImages = NDArray[np.generic]
+
+
+class _ComposeDataset(torch.utils.data.Dataset[dict[str, torch.Tensor]]):
+    """Picklable, pre-created inputs for steady-state DataLoader measurements."""
+
+    def __init__(self, images: NumpyImages | torch.Tensor, representation: InputRepresentation) -> None:
+        self.images = images
+        self.representation = representation
+        if representation == "numpy":
+            self.transform = A.Compose([A.NoOp(p=1.0), A.ToTensorV2(p=1.0)], strict=True)
+        else:
+            self.transform = A.Compose([A.NoOp(p=1.0)], strict=True)
+
+    def __len__(self) -> int:
+        return len(self.images)
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        return self.transform(image=self.images[index])
+
+
+def _raw_samples(callable_: Callable[[], None], repeats: int) -> list[float]:
+    """Return millisecond samples after the caller has performed warm-up."""
+    samples: list[float] = []
+    for _ in range(repeats):
+        started = time.perf_counter_ns()
+        callable_()
+        samples.append((time.perf_counter_ns() - started) / 1_000_000)
+    return samples
+
+
+def _consume(loader: torch.utils.data.DataLoader[dict[str, torch.Tensor]]) -> None:
+    """Consume every collated batch so timing includes output construction."""
+    for batch in loader:
+        _ = batch["image"].sum().item()
+
+
+def _compose_samples(
+    image: NumpyImages,
+    tensor: torch.Tensor,
+    *,
+    repeats: int,
+    iterations: int,
+) -> dict[str, list[float]]:
+    numpy_transform = A.Compose([A.NoOp(p=1.0), A.ToTensorV2(p=1.0)], strict=True)
+    tensor_transform = A.Compose([A.NoOp(p=1.0)], strict=True)
+
+    numpy_result = numpy_transform(image=image)["image"]
+    tensor_result = tensor_transform(image=tensor)["image"]
+    torch.testing.assert_close(numpy_result, tensor_result)
+
+    def time_transform(transform: A.Compose, value: NumpyImages | torch.Tensor) -> list[float]:
+        for _ in range(16):
+            transform(image=value)
+
+        def run() -> None:
+            for _ in range(iterations):
+                transform(image=value)
+
+        return [sample / iterations for sample in _raw_samples(run, repeats)]
+
+    return {
+        "numpy_with_to_tensor": time_transform(numpy_transform, image),
+        "tensor_direct": time_transform(tensor_transform, tensor),
+    }
+
+
+def _dataloader_samples(
+    images: NumpyImages | torch.Tensor,
+    representation: InputRepresentation,
+    *,
+    batch_size: int,
+    num_workers: int,
+    repeats: int,
+) -> list[float]:
+    loader = torch.utils.data.DataLoader(
+        _ComposeDataset(images, representation),
+        batch_size=batch_size,
+        num_workers=num_workers,
+        persistent_workers=num_workers > 0,
+    )
+    try:
+        _consume(loader)
+        samples = _raw_samples(lambda: _consume(loader), repeats)
+        return [sample / len(images) for sample in samples]
+    finally:
+        iterator = getattr(loader, "_iterator", None)
+        if iterator is not None:
+            iterator._shutdown_workers()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--size", type=int, default=512, choices=(256, 512, 1024))
+    parser.add_argument("--channels", type=int, default=3, choices=(1, 3, 5))
+    parser.add_argument("--dtype", default="uint8", choices=("uint8", "float32"))
+    parser.add_argument("--samples", type=int, default=64)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--workers", default="0,2,8")
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--iterations", type=int, default=128)
+    parser.add_argument("--skip-dataloader", action="store_true")
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the benchmark and write an inspectable route-result JSON artifact."""
+    args = _parse_args()
+    if args.samples <= 0 or args.batch_size <= 0 or args.repeats <= 0 or args.iterations <= 0:
+        raise ValueError("samples, batch-size, repeats, and iterations must be positive")
+    worker_counts = tuple(int(value) for value in args.workers.split(","))
+    if any(value < 0 for value in worker_counts):
+        raise ValueError("worker counts must be non-negative")
+
+    np_dtype = np.dtype(args.dtype)
+    generator = np.random.default_rng(137)
+    images: NumpyImages = generator.integers(
+        0,
+        256,
+        size=(args.samples, args.size, args.size, args.channels),
+        dtype=np.uint8,
+    )
+    if np_dtype == np.dtype("float32"):
+        images = images.astype(np.float32) / np.float32(255)
+    tensors = torch.from_numpy(np.ascontiguousarray(images.transpose(0, 3, 1, 2)))
+
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "environment": {
+            "albumentations": A.__version__,
+            "numpy": np.__version__,
+            "platform": platform.platform(),
+            "python": sys.version,
+            "torch": torch.__version__,
+            "torch_threads": torch.get_num_threads(),
+        },
+        "input": {
+            "channels": args.channels,
+            "dtype": args.dtype,
+            "shape_numpy": list(images.shape[1:]),
+            "shape_tensor": list(tensors.shape[1:]),
+        },
+        "bridges": [],
+        "compose_model_ready_ms": _compose_samples(
+            images[0], tensors[0], repeats=args.repeats, iterations=args.iterations
+        ),
+    }
+    if not args.skip_dataloader:
+        result["dataloader_model_ready_ms_per_sample"] = {
+            str(workers): {
+                "numpy_with_to_tensor": _dataloader_samples(
+                    images,
+                    "numpy",
+                    batch_size=args.batch_size,
+                    num_workers=workers,
+                    repeats=args.repeats,
+                ),
+                "tensor_direct": _dataloader_samples(
+                    tensors,
+                    "tensor",
+                    batch_size=args.batch_size,
+                    num_workers=workers,
+                    repeats=args.repeats,
+                ),
+            }
+            for workers in worker_counts
+        }
+    result["correctness"] = "passed"
+    result["decision"] = "record evidence; accept no route from one machine alone"
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote Tensor Compose benchmark evidence to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,7 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "torch" },
     { name = "typing-extensions" },
 ]
 
@@ -76,9 +77,6 @@ hub = [
 ]
 pillow = [
     { name = "pillow" },
-]
-pytorch = [
-    { name = "torch" },
 ]
 pyvips = [
     { name = "pyvips", extra = ["binary"] },
@@ -247,10 +245,10 @@ requires-dist = [
     { name = "pyvips", extras = ["binary"], marker = "extra == 'pyvips'" },
     { name = "pyyaml" },
     { name = "scipy", specifier = ">=1.15.3" },
-    { name = "torch", marker = "extra == 'pytorch'" },
+    { name = "torch", specifier = ">=2.13.0" },
     { name = "typing-extensions", specifier = ">=4.9.0" },
 ]
-provides-extras = ["contrib", "contrib-headless", "gui", "headless", "hub", "pillow", "pytorch", "pyvips", "text"]
+provides-extras = ["contrib", "contrib-headless", "gui", "headless", "hub", "pillow", "pyvips", "text"]
 
 [package.metadata.requires-dev]
 ci-benchmark = [


### PR DESCRIPTION
## Summary

- make `torch` a required dependency
- add a CPU-only Tensor boundary to `Compose`, with fixed channel-first contracts, validation, capability gating, and central annotation bridges
- add the first accepted Tensor capabilities: `NoOp` and the bounded `Transpose` route
- add benchmark tooling, CI coverage, correctness tests, and the migration plan
- record rejected CPU Tensor candidates, including the first 3D investigation, rather than accepting a performance regression

## Behavior

Tensor input is preserved through the normal Compose flow only when every selected transform declares the required CPU Tensor capability. Unsupported transforms fail before parameter sampling. Accelerator tensors and autograd-enabled tensors are rejected in this phase.

## Validation

- `uv run pytest -q tests/test_tensor_compose.py tests/test_tensor_dataloader.py tests/test_benchmark_coverage.py tests/test_core.py` — 1,414 passed, 17 skipped
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`
- `uv run python -m tools.benchmark_coverage check`
- `uv run python -m tools.performance_budget check`
