### PR TITLE
feat(transforms3d): add RandomRotate90_3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,15 +347,16 @@ Where:
 - Volume: 3D array of shape (D, H, W) or (D, H, W, C) where D is depth, H is height, W is width, and C is number of channels (optional)
 - Mask3D: Binary or multi-class 3D mask of shape (D, H, W) where each slice represents segmentation for the corresponding volume slice
 
-| Transform                                                                       | Volume | Mask3D | Keypoints |
-| ------------------------------------------------------------------------------- | :----: | :----: | :-------: |
-| [CenterCrop3D](https://albumentations.ai/explore/transform/CenterCrop3D/?utm_source=github&utm_medium=referral&utm_campaign=readme)       | ✓      | ✓      | ✓         |
-| [CoarseDropout3D](https://albumentations.ai/explore/transform/CoarseDropout3D/?utm_source=github&utm_medium=referral&utm_campaign=readme) | ✓      | ✓      | ✓         |
-| [CubicSymmetry](https://albumentations.ai/explore/transform/CubicSymmetry/?utm_source=github&utm_medium=referral&utm_campaign=readme)     | ✓      | ✓      | ✓         |
-| [GridShuffle3D](https://albumentations.ai/explore/transform/GridShuffle3D/?utm_source=github&utm_medium=referral&utm_campaign=readme)     | ✓      | ✓      | ✓         |
-| [Pad3D](https://albumentations.ai/explore/transform/Pad3D/?utm_source=github&utm_medium=referral&utm_campaign=readme)                     | ✓      | ✓      | ✓         |
-| [PadIfNeeded3D](https://albumentations.ai/explore/transform/PadIfNeeded3D/?utm_source=github&utm_medium=referral&utm_campaign=readme)     | ✓      | ✓      | ✓         |
-| [RandomCrop3D](https://albumentations.ai/explore/transform/RandomCrop3D/?utm_source=github&utm_medium=referral&utm_campaign=readme)       | ✓      | ✓      | ✓         |
+| Transform                                                                           | Volume | Mask3D | Keypoints |
+| ----------------------------------------------------------------------------------- | :----: | :----: | :-------: |
+| [CenterCrop3D](https://albumentations.ai/explore/transform/CenterCrop3D/)           | ✓      | ✓      | ✓         |
+| [CoarseDropout3D](https://albumentations.ai/explore/transform/CoarseDropout3D/)     | ✓      | ✓      | ✓         |
+| [CubicSymmetry](https://albumentations.ai/explore/transform/CubicSymmetry/)         | ✓      | ✓      | ✓         |
+| [GridShuffle3D](https://albumentations.ai/explore/transform/GridShuffle3D/)         | ✓      | ✓      | ✓         |
+| [Pad3D](https://albumentations.ai/explore/transform/Pad3D/)                         | ✓      | ✓      | ✓         |
+| [PadIfNeeded3D](https://albumentations.ai/explore/transform/PadIfNeeded3D/)         | ✓      | ✓      | ✓         |
+| [RandomCrop3D](https://albumentations.ai/explore/transform/RandomCrop3D/)           | ✓      | ✓      | ✓         |
+| [RandomRotate90_3D](https://albumentations.ai/explore/transform/RandomRotate90_3D/) | ✓      | ✓      | ✓         |
 
 ## A few more examples of **augmentations**
 

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -152,7 +152,11 @@ class Blur(ImageOnlyTransform):
     def apply(self, img: ImageType, kernel: int, **params: Any) -> ImageType:
         return fblur.box_blur(img, kernel)
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         kernel = fblur.sample_odd_from_range(
             self.py_random,
             self.blur_range[0],
@@ -405,7 +409,11 @@ class MotionBlur(Blur):
             return fblur.box_blur(img, kernel)
         return fpixel.convolve(img, kernel=kernel)
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         ksize = fblur.sample_odd_from_range(
             self.py_random,
             self.blur_range[0],
@@ -645,7 +653,11 @@ class ModeFilter(ImageOnlyTransform):
     def apply(self, img: ImageType, kernel_size: int, **params: Any) -> ImageType:
         return fblur.mode_filter(img, kernel_size)
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         kernel_size = fblur.sample_odd_from_range(
             self.py_random,
             self.kernel_range[0],
@@ -1290,7 +1302,11 @@ class AdvancedBlur(ImageOnlyTransform):
     def apply(self, img: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
         return fpixel.convolve(img, kernel=kernel)
 
-    def get_params(self) -> dict[str, np.ndarray]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, np.ndarray]:
         ksize = fblur.sample_odd_from_range(
             self.py_random,
             self.blur_range[0],
@@ -1484,7 +1500,11 @@ class Defocus(ImageOnlyTransform):
         kernel = fblur.create_defocus_kernel(params["radius"], params["alias_blur"])
         return self._apply_to_batch(images, lambda img: fpixel.convolve(img, kernel))
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         radius = self.py_random.randint(*self.radius_range)
         alias_blur = self.py_random.uniform(*self.alias_blur_range)
         self.applied_config = {"radius_range": radius, "alias_blur_range": alias_blur}
@@ -1611,7 +1631,11 @@ class ZoomBlur(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self._apply_to_batch_same_shape(images, lambda image: self.apply(image, **params))
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         step_factor = self.py_random.uniform(*self.step_factor_range)
         max_factor = max(1 + step_factor, self.py_random.uniform(*self.max_factor_range))
         self.applied_config = {"step_factor_range": step_factor, "max_factor_range": max_factor}

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -542,7 +542,11 @@ class D4(DualTransform):
             return mask3d
         return self.apply_to_images(mask3d, group_element)
 
-    def get_params(self) -> dict[str, Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]]:
         if self.group_element is not None:
             group_element = self.group_element
         else:

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -202,7 +202,11 @@ class RandomScale(DualTransform):
         self.mask_interpolation = mask_interpolation
         self.area_for_downscale = area_for_downscale
 
-    def get_params(self) -> dict[str, float]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, float]:
         if isinstance(self.scale_range, dict):
             scale_x = self.py_random.uniform(*self.scale_range["x"]) + 1.0
             scale_y = self.py_random.uniform(*self.scale_range["y"]) + 1.0

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -190,7 +190,11 @@ class RandomRotate90(DualTransform):
     ) -> ImageType:
         return fgeometric.rot90(img, group_element)
 
-    def get_params(self) -> dict[str, Literal["e", "r90", "r180", "r270"]]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Literal["e", "r90", "r180", "r270"]]:
         if self.group_element is not None:
             group_element = self.group_element
         elif self.group_elements is not None:

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1520,7 +1520,11 @@ class Morphological(DualTransform):
     ) -> np.ndarray:
         return keypoints
 
-    def get_params(self) -> dict[str, np.ndarray]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, np.ndarray]:
         return {
             "kernel": cv2.getStructuringElement(cv2.MORPH_ELLIPSE, self.scale),
         }

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -135,7 +135,11 @@ class ColorJitter(ImageOnlyTransform):
         self.saturation_range = saturation_range
         self.hue_range = hue_range
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         brightness = self.py_random.uniform(*self.brightness_range)
         contrast = self.py_random.uniform(*self.contrast_range)
         saturation = self.py_random.uniform(*self.saturation_range)
@@ -315,7 +319,11 @@ class ChromaticAberration(ImageOnlyTransform):
             self.interpolation,
         )
 
-    def get_params(self) -> dict[str, float]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, float]:
         primary_distortion_red = self.py_random.uniform(*self.primary_distortion_range)
         secondary_distortion_red = self.py_random.uniform(
             *self.secondary_distortion_range,
@@ -545,7 +553,11 @@ class PlanckianJitter(ImageOnlyTransform):
         non_rgb_error(images)
         return self.apply(images, temperature, **params)
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         sampling_prob_boundary = PLANKIAN_JITTER_CONST["SAMPLING_TEMP_PROB"]
         sampling_temp_boundary = PLANKIAN_JITTER_CONST["WHITE_TEMP"]
 

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -264,7 +264,11 @@ class HueSaturationValue(ImageOnlyTransform):
     ) -> ImageType:
         return fpixel.shift_hsv_images(images, hue_shift, sat_shift, val_shift)
 
-    def get_params(self) -> dict[str, float]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, float]:
         hue_shift = self.py_random.uniform(*self.hue_shift_range)
         sat_shift = self.py_random.uniform(*self.sat_shift_range)
         val_shift = self.py_random.uniform(*self.val_shift_range)
@@ -374,7 +378,11 @@ class Solarize(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self.apply(images, **params)
 
-    def get_params(self) -> dict[str, float]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, float]:
         threshold = self.py_random.uniform(*self.threshold_range)
 
         self.applied_config = {"threshold_range": threshold}
@@ -487,7 +495,11 @@ class Posterize(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self.apply(images, **params)
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         if isinstance(self.num_bits, list):
             num_bits_list = [self.py_random.randint(*i) for i in self.num_bits]
             self.applied_config = {"num_bits": num_bits_list}
@@ -948,17 +960,13 @@ class ExposureMatching(ImageOnlyTransform):
     def apply_to_volume(self, volume: VolumeType, volume_gains: list[float], **params: Any) -> VolumeType:
         return fpixel.exposure_match_batch(volume, np.asarray(volume_gains, dtype=np.float32))
 
-    def get_params(self) -> dict[str, float]:
-        target_mean = self.py_random.uniform(*self.target_mean_range)
-        self.applied_config = {"target_mean_range": target_mean}
-        return {"target_mean": target_mean}
-
     def get_params_dependent_on_data(
         self,
         params: dict[str, Any],
         data: dict[str, Any],
     ) -> dict[str, float | list[float]]:
-        target_mean = params["target_mean"]
+        target_mean = self.py_random.uniform(*self.target_mean_range)
+        self.applied_config = {"target_mean_range": target_mean}
         gains: dict[str, float | list[float]] = {}
 
         if "image" in data:
@@ -978,7 +986,7 @@ class ExposureMatching(ImageOnlyTransform):
         if not gains:
             raise RuntimeError("Expected image, images, or volume data for exposure matching")
 
-        return gains
+        return {"target_mean": target_mean, **gains}
 
 
 class CLAHE(ImageOnlyTransform):
@@ -1058,7 +1066,11 @@ class CLAHE(ImageOnlyTransform):
 
         return fpixel.clahe(img, clip_limit, self.tile_grid_size)
 
-    def get_params(self) -> dict[str, float]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, float]:
         clip_limit = self.py_random.uniform(*self.clip_range)
 
         self.applied_config = {"clip_range": clip_limit}

--- a/albumentations/augmentations/pixel/color_gray.py
+++ b/albumentations/augmentations/pixel/color_gray.py
@@ -396,7 +396,11 @@ class Colorize(ImageOnlyTransform):
             self.py_random.randint(lo[2], hi[2]),
         )
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         black_color = self._sample_color(self.black_range)
         white_color = self._sample_color(self.white_range)
         mid_color = self._sample_color(self.mid_range) if self.mid_range is not None else None

--- a/albumentations/augmentations/pixel/color_lighting.py
+++ b/albumentations/augmentations/pixel/color_lighting.py
@@ -704,7 +704,11 @@ class Vignetting(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self._apply_to_batch_same_shape(images, lambda image: self.apply(image, **params))
 
-    def get_params(self) -> dict[str, float]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, float]:
         intensity = self.py_random.uniform(*self.intensity_range)
         center_x = self.py_random.uniform(*self.center_range)
         center_y = self.py_random.uniform(*self.center_range)

--- a/albumentations/augmentations/pixel/compression.py
+++ b/albumentations/augmentations/pixel/compression.py
@@ -109,7 +109,11 @@ class ImageCompression(ImageOnlyTransform):
     ) -> ImageType:
         return fpixel.image_compression(img, quality, image_type)
 
-    def get_params(self) -> dict[str, int | str]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, int | str]:
         image_type = ".jpg" if self.compression_type == "jpeg" else ".webp"
 
         quality = self.py_random.randint(*self.quality_range)
@@ -215,7 +219,11 @@ class Downscale(ImageOnlyTransform):
             up_interpolation=self.interpolation_pair["upscale"],
         )
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         scale = self.py_random.uniform(*self.scale_range)
 
         self.applied_config = {"scale_range": scale}

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -461,7 +461,11 @@ class ShotNoise(ImageOnlyTransform):
     ) -> ImageType:
         return fpixel.shot_noise(img, scale, np.random.default_rng(random_seed))
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         scale = self.py_random.uniform(*self.scale_range)
         self.applied_config = {"scale_range": scale}
         return {

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -427,7 +427,11 @@ class Sharpen(ImageOnlyTransform):
 
         return (1 - alpha) * matrix_nochange + alpha * matrix_effect
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         alpha = self.py_random.uniform(*self.alpha_range)
 
         if self.method == "kernel":
@@ -545,7 +549,11 @@ class Emboss(ImageOnlyTransform):
         )
         return (1 - alpha_sample) * matrix_nochange + alpha_sample * matrix_effect
 
-    def get_params(self) -> dict[str, np.ndarray]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, np.ndarray]:
         alpha = self.py_random.uniform(*self.alpha_range)
         strength = self.py_random.uniform(*self.strength_range)
         emboss_matrix = self.__generate_emboss_matrix(
@@ -657,7 +665,11 @@ class Enhance(ImageOnlyTransform):
         self.mode = mode
         self.alpha_range = alpha_range
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         alpha = self.py_random.uniform(*self.alpha_range)
         # Record the resolved scalar (not the range) for replay/debug, per the
         # applied_config contract documented on get_applied_config.
@@ -794,7 +806,11 @@ class Superpixels(ImageOnlyTransform):
         self.max_size = max_size
         self.interpolation = interpolation
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         n_segments = self.py_random.randint(*self.n_segments_range)
         p = self.py_random.uniform(*self.p_replace_range)
         self.applied_config = {"n_segments_range": n_segments, "p_replace_range": p}
@@ -918,7 +934,11 @@ class RingingOvershoot(ImageOnlyTransform):
         self.blur_range = blur_range
         self.cutoff_range = cutoff_range
 
-    def get_params(self) -> dict[str, np.ndarray]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, np.ndarray]:
         ksize = self.py_random.randrange(self.blur_range[0], self.blur_range[1] + 1, 2)
         if ksize % 2 == 0:
             ksize += 1
@@ -1292,7 +1312,11 @@ class Dithering(ImageOnlyTransform):
             random_generator=self.random_generator,
         )
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         # noise_range is used as per-pixel uniform bounds inside apply_dithering — record the
         # bounds in applied_config so consumers can see the parameter that was used.
         self.applied_config["noise_range"] = self.noise_range
@@ -1378,7 +1402,11 @@ class Halftone(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self._apply_to_batch_same_shape(images, lambda image: self.apply(image, **params))
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         dot_size = self.py_random.randint(*self.dot_size_range)
         blend = self.py_random.uniform(*self.blend_range)
         self.applied_config = {"dot_size_range": dot_size, "blend_range": blend}

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -162,7 +162,7 @@ def rotate90_3d(
     """Rotate a 3D or channel-last 4D volume by 90-degree increments along a selected spatial axis pair, preserving
     dtype and channel order.
     """
-    if rot90_count % 4 == 0:
+    if rot90_count == 0:
         return volume
 
     return cast("VolumeType", np.rot90(volume, k=rot90_count, axes=axis_pair))

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -154,6 +154,55 @@ def cutout3d(volume: ImageType, holes: np.ndarray, fill: tuple[float, ...] | flo
     return volume
 
 
+def rotate90_3d(
+    volume: VolumeType,
+    rot90_count: int,
+    axis_pair: tuple[int, int],
+) -> VolumeType:
+    """Rotate a 3D or channel-last 4D volume by 90-degree increments along a selected spatial axis pair, preserving
+    dtype and channel order.
+    """
+    if rot90_count % 4 == 0:
+        return volume
+
+    return cast("VolumeType", np.rot90(volume, k=rot90_count, axes=axis_pair))
+
+
+def keypoints_rotate90_3d(
+    keypoints: np.ndarray,
+    rot90_count: int,
+    axis_pair: tuple[int, int],
+    volume_shape: tuple[int, int, int],
+) -> np.ndarray:
+    """Rotate XYZ keypoints to match `rotate90_3d` on a volume, keeping their additional attributes and mapping the
+    chosen axis pair exactly.
+    """
+    rot90_count %= 4
+    if rot90_count == 0 or len(keypoints) == 0:
+        return keypoints
+
+    result = keypoints.copy()
+    first_axis, second_axis = axis_pair
+    first_coordinate = 2 - first_axis
+    second_coordinate = 2 - second_axis
+    first_coordinate_values = result[:, first_coordinate].copy()
+    second_coordinate_values = result[:, second_coordinate].copy()
+    first_axis_length = volume_shape[first_axis]
+    second_axis_length = volume_shape[second_axis]
+
+    if rot90_count == 1:
+        result[:, first_coordinate] = second_axis_length - 1 - second_coordinate_values
+        result[:, second_coordinate] = first_coordinate_values
+    elif rot90_count == 2:
+        result[:, first_coordinate] = first_axis_length - 1 - first_coordinate_values
+        result[:, second_coordinate] = second_axis_length - 1 - second_coordinate_values
+    else:
+        result[:, first_coordinate] = second_coordinate_values
+        result[:, second_coordinate] = first_axis_length - 1 - first_coordinate_values
+
+    return result
+
+
 def transform_cube(cube: np.ndarray, index: int) -> np.ndarray:
     """Transform cube by index (0-47). One of 48 cubic symmetries; no interpolation. For
     CubicSymmetry; inverse via inverse index.

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -156,7 +156,7 @@ def cutout3d(volume: ImageType, holes: np.ndarray, fill: tuple[float, ...] | flo
 
 def rotate90_3d(
     volume: VolumeType,
-    rot90_count: int,
+    rot90_count: Literal[0, 1, 2, 3],
     axis_pair: tuple[int, int],
 ) -> VolumeType:
     """Rotate a 3D or channel-last 4D volume by 90-degree increments along a selected spatial axis pair, preserving
@@ -170,14 +170,13 @@ def rotate90_3d(
 
 def keypoints_rotate90_3d(
     keypoints: np.ndarray,
-    rot90_count: int,
+    rot90_count: Literal[0, 1, 2, 3],
     axis_pair: tuple[int, int],
     volume_shape: tuple[int, int, int],
 ) -> np.ndarray:
     """Rotate XYZ keypoints to match `rotate90_3d` on a volume, keeping their additional attributes and mapping the
     chosen axis pair exactly.
     """
-    rot90_count %= 4
     if rot90_count == 0 or len(keypoints) == 0:
         return keypoints
 

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -1425,7 +1425,11 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         self.axis_pair = axis_pair
         self.group_element = group_element
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         axis_pair = self.axis_pair if self.axis_pair is not None else self.py_random.choice(self.axis_pairs)
         if self.group_element is not None:
             group_element = self.group_element
@@ -1435,14 +1439,11 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         rotation_count = cast("RotationCount3D", fgeometric.C4_GROUP_ELEMENT_TO_K[group_element])
 
         self.applied_config = {"axis_pair": axis_pair, "group_element": group_element}
-        return {"axis_pair": axis_pair, "rotation_count": rotation_count}
-
-    def get_params_dependent_on_data(
-        self,
-        params: dict[str, Any],
-        data: dict[str, Any],
-    ) -> dict[str, Any]:
-        return {"volume_shape": _get_volume_spatial_shape(data)}
+        return {
+            "axis_pair": axis_pair,
+            "rotation_count": rotation_count,
+            "volume_shape": _get_volume_spatial_shape(data),
+        }
 
     def apply_to_volume(
         self,

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -28,9 +28,13 @@ __all__ = [
     "Pad3D",
     "PadIfNeeded3D",
     "RandomCrop3D",
+    "RandomRotate90_3D",
 ]
 
 NUM_DIMENSIONS = 3
+AxisIndex3D = Literal[0, 1, 2]
+AxisPair3D = tuple[AxisIndex3D, AxisIndex3D]
+DEFAULT_ROTATION_AXIS_PAIRS: tuple[AxisPair3D, ...] = ((0, 1), (0, 2), (1, 2))
 
 
 def _get_volume_shape(data: dict[str, Any]) -> tuple[int, ...]:
@@ -1343,6 +1347,157 @@ class CubicSymmetry(Transform3D):
 
     def apply_to_keypoints(self, keypoints: np.ndarray, index: int, **params: Any) -> np.ndarray:
         return f3d.transform_cube_keypoints(keypoints, index, volume_shape=params["volume_shape"])
+
+
+class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified by issue #388.
+    """Rotate a volume by a random 90-degree multiple across one spatial axis pair, rotating mask3d and XYZ keypoints
+    without reflections.
+
+    Quarter turns swap the selected depth, height, or width lengths while preserving the channel axis.
+
+    Axis indices always use `(depth, height, width)` order: `(0, 1)` rotates depth with height,
+    `(0, 2)` rotates depth with width, and `(1, 2)` rotates height with width. A 90-degree or
+    270-degree turn swaps the two selected lengths, so non-cubic input can change shape.
+    A 180-degree turn and the identity preserve the original shape. The transform does not reflect data.
+
+    Set both `axis_pair` and `rotation_count` for deterministic test-time augmentation. `inverse()`
+    then returns the rotation that restores the original voxel and keypoint coordinates.
+
+    Args:
+        axis_pairs (tuple[tuple[int, int], ...]): Non-empty set of axis pairs sampled in random mode.
+            Each pair must list two distinct axes in ascending `(depth, height, width)` order.
+            Default: `((0, 1), (0, 2), (1, 2))`.
+        axis_pair (tuple[int, int] | None): Fixed axis pair for deterministic use. Set together with
+            `rotation_count`. Default: None.
+        rotation_count (int | None): Fixed number of counterclockwise 90-degree turns for deterministic
+            use. Valid values are 0, 1, 2, and 3. Default: None.
+        p (float): Probability of applying the transform. Default: 1.0.
+
+    Targets:
+        volume, mask3d, keypoints
+
+    Image types:
+        uint8, float32
+
+    Examples:
+        >>> import numpy as np
+        >>> import albumentations as A
+        >>> volume = np.arange(2 * 3 * 5, dtype=np.uint8).reshape(2, 3, 5, 1)
+        >>> transform = A.RandomRotate90_3D(axis_pair=(0, 2), rotation_count=1, p=1.0)
+        >>> result = transform(volume=volume)
+        >>> result["volume"].shape
+        (5, 3, 2, 1)
+
+    """
+
+    _targets = (Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS)
+
+    class InitSchema(BaseTransformInitSchema):
+        axis_pairs: tuple[AxisPair3D, ...]
+        axis_pair: AxisPair3D | None
+        rotation_count: Literal[0, 1, 2, 3] | None
+
+        @model_validator(mode="after")
+        def _validate_rotation_config(self) -> Self:
+            if not self.axis_pairs:
+                raise ValueError("axis_pairs must contain at least one spatial axis pair")
+            if len(self.axis_pairs) != len(set(self.axis_pairs)):
+                raise ValueError("axis_pairs must not contain duplicate axis pairs")
+            if (self.axis_pair is None) != (self.rotation_count is None):
+                raise ValueError("axis_pair and rotation_count must be set together for deterministic rotation")
+
+            pairs_to_validate = (*self.axis_pairs, *((self.axis_pair,) if self.axis_pair is not None else ()))
+            for axis_pair in pairs_to_validate:
+                if axis_pair[0] >= axis_pair[1]:
+                    raise ValueError(
+                        "Each axis pair must contain distinct axes in ascending (depth, height, width) order",
+                    )
+            return self
+
+    def __init__(
+        self,
+        axis_pairs: tuple[AxisPair3D, ...] = DEFAULT_ROTATION_AXIS_PAIRS,
+        axis_pair: AxisPair3D | None = None,
+        rotation_count: Literal[0, 1, 2, 3] | None = None,
+        p: float = 1.0,
+    ):
+        super().__init__(p=p)
+        self.axis_pairs = axis_pairs
+        self.axis_pair = axis_pair
+        self.rotation_count = rotation_count
+
+    @property
+    def targets(self) -> dict[str, Any]:
+        return {
+            "volume": self.apply_to_volume,
+            "mask3d": self.apply_to_mask3d,
+            "keypoints": self.apply_to_keypoints,
+            "user_data": self.apply_to_user_data,
+        }
+
+    def get_params(self) -> dict[str, Any]:
+        if self.axis_pair is not None:
+            axis_pair = self.axis_pair
+            rotation_count = cast("int", self.rotation_count)
+        else:
+            axis_pair = self.py_random.choice(self.axis_pairs)
+            rotation_count = self.py_random.randint(0, 3)
+
+        self.applied_config = {"axis_pair": axis_pair, "rotation_count": rotation_count}
+        return {"axis_pair": axis_pair, "rotation_count": rotation_count}
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {"volume_shape": _get_volume_spatial_shape(data)}
+
+    def apply_to_volume(
+        self,
+        volume: VolumeType,
+        axis_pair: AxisPair3D,
+        rotation_count: int,
+        **params: Any,
+    ) -> VolumeType:
+        return f3d.rotate90_3d(volume, rotation_count, axis_pair)
+
+    def apply_to_mask3d(
+        self,
+        mask3d: VolumeType,
+        axis_pair: AxisPair3D,
+        rotation_count: int,
+        **params: Any,
+    ) -> VolumeType:
+        return f3d.rotate90_3d(mask3d, rotation_count, axis_pair)
+
+    def apply_to_keypoints(
+        self,
+        keypoints: np.ndarray,
+        axis_pair: AxisPair3D,
+        rotation_count: int,
+        volume_shape: tuple[int, int, int],
+        **params: Any,
+    ) -> np.ndarray:
+        return f3d.keypoints_rotate90_3d(keypoints, rotation_count, axis_pair, volume_shape)
+
+    def inverse(self) -> Self:
+        """Return a deterministic transform whose quarter turns undo this rotation. Use after inference in TTA
+        to restore predictions to the original orientation.
+
+        Raises:
+            ValueError: If this transform is configured in random mode.
+
+        """
+        if self.axis_pair is None or self.rotation_count is None:
+            raise ValueError(
+                "Cannot invert RandomRotate90_3D in random mode. Set axis_pair and rotation_count for TTA.",
+            )
+        return type(self)(
+            axis_pair=self.axis_pair,
+            rotation_count=cast("Literal[0, 1, 2, 3]", (-self.rotation_count) % 4),
+            p=1.0,
+        )
 
 
 class GridShuffle3D(Transform3D):

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -1425,15 +1425,6 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         self.axis_pair = axis_pair
         self.group_element = group_element
 
-    @property
-    def targets(self) -> dict[str, Any]:
-        return {
-            "volume": self.apply_to_volume,
-            "mask3d": self.apply_to_mask3d,
-            "keypoints": self.apply_to_keypoints,
-            "user_data": self.apply_to_user_data,
-        }
-
     def get_params(self) -> dict[str, Any]:
         axis_pair = self.axis_pair if self.axis_pair is not None else self.py_random.choice(self.axis_pairs)
         if self.group_element is not None:

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -18,7 +18,7 @@ from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
 from albumentations.core.transforms_interface import BaseTransformInitSchema, Transform3D
-from albumentations.core.type_definitions import Targets, VolumeType
+from albumentations.core.type_definitions import C4_INVERSE, C4GroupElement, Targets, VolumeType, c4_group_elements
 
 __all__ = [
     "CenterCrop3D",
@@ -34,6 +34,7 @@ __all__ = [
 NUM_DIMENSIONS = 3
 AxisIndex3D = Literal[0, 1, 2]
 AxisPair3D = tuple[AxisIndex3D, AxisIndex3D]
+RotationCount3D = Literal[0, 1, 2, 3]
 DEFAULT_ROTATION_AXIS_PAIRS: tuple[AxisPair3D, ...] = ((0, 1), (0, 2), (1, 2))
 
 
@@ -1360,17 +1361,18 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
     270-degree turn swaps the two selected lengths, so non-cubic input can change shape.
     A 180-degree turn and the identity preserve the original shape. The transform does not reflect data.
 
-    Set both `axis_pair` and `rotation_count` for deterministic test-time augmentation. `inverse()`
+    Set both `axis_pair` and `group_element` for deterministic test-time augmentation. `inverse()`
     then returns the rotation that restores the original voxel and keypoint coordinates.
 
     Args:
         axis_pairs (tuple[tuple[int, int], ...]): Non-empty set of axis pairs sampled in random mode.
             Each pair must list two distinct axes in ascending `(depth, height, width)` order.
             Default: `((0, 1), (0, 2), (1, 2))`.
-        axis_pair (tuple[int, int] | None): Fixed axis pair for deterministic use. Set together with
-            `rotation_count`. Default: None.
-        rotation_count (int | None): Fixed number of counterclockwise 90-degree turns for deterministic
-            use. Valid values are 0, 1, 2, and 3. Default: None.
+        axis_pair (tuple[int, int] | None): Fixed spatial axis pair. Set with `group_element` for
+            deterministic TTA. Default: None.
+        group_element (C4GroupElement | None): If set, always apply this C4 group element:
+            `"e"`=identity, `"r90"`=90°, `"r180"`=180°, `"r270"`=270° counterclockwise.
+            Use for TTA. Default: None (random choice).
         p (float): Probability of applying the transform. Default: 1.0.
 
     Targets:
@@ -1383,7 +1385,7 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         >>> import numpy as np
         >>> import albumentations as A
         >>> volume = np.arange(2 * 3 * 5, dtype=np.uint8).reshape(2, 3, 5, 1)
-        >>> transform = A.RandomRotate90_3D(axis_pair=(0, 2), rotation_count=1, p=1.0)
+        >>> transform = A.RandomRotate90_3D(axis_pair=(0, 2), group_element="r90", p=1.0)
         >>> result = transform(volume=volume)
         >>> result["volume"].shape
         (5, 3, 2, 1)
@@ -1395,7 +1397,7 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
     class InitSchema(BaseTransformInitSchema):
         axis_pairs: tuple[AxisPair3D, ...]
         axis_pair: AxisPair3D | None
-        rotation_count: Literal[0, 1, 2, 3] | None
+        group_element: C4GroupElement | None
 
         @model_validator(mode="after")
         def _validate_rotation_config(self) -> Self:
@@ -1403,9 +1405,6 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
                 raise ValueError("axis_pairs must contain at least one spatial axis pair")
             if len(self.axis_pairs) != len(set(self.axis_pairs)):
                 raise ValueError("axis_pairs must not contain duplicate axis pairs")
-            if (self.axis_pair is None) != (self.rotation_count is None):
-                raise ValueError("axis_pair and rotation_count must be set together for deterministic rotation")
-
             pairs_to_validate = (*self.axis_pairs, *((self.axis_pair,) if self.axis_pair is not None else ()))
             for axis_pair in pairs_to_validate:
                 if axis_pair[0] >= axis_pair[1]:
@@ -1418,13 +1417,13 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         self,
         axis_pairs: tuple[AxisPair3D, ...] = DEFAULT_ROTATION_AXIS_PAIRS,
         axis_pair: AxisPair3D | None = None,
-        rotation_count: Literal[0, 1, 2, 3] | None = None,
+        group_element: C4GroupElement | None = None,
         p: float = 1.0,
     ):
         super().__init__(p=p)
         self.axis_pairs = axis_pairs
         self.axis_pair = axis_pair
-        self.rotation_count = rotation_count
+        self.group_element = group_element
 
     @property
     def targets(self) -> dict[str, Any]:
@@ -1436,14 +1435,15 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         }
 
     def get_params(self) -> dict[str, Any]:
-        if self.axis_pair is not None:
-            axis_pair = self.axis_pair
-            rotation_count = cast("int", self.rotation_count)
+        axis_pair = self.axis_pair if self.axis_pair is not None else self.py_random.choice(self.axis_pairs)
+        if self.group_element is not None:
+            group_element = self.group_element
         else:
-            axis_pair = self.py_random.choice(self.axis_pairs)
-            rotation_count = self.py_random.randint(0, 3)
+            group_element = cast("C4GroupElement", self.py_random.choice(c4_group_elements))
 
-        self.applied_config = {"axis_pair": axis_pair, "rotation_count": rotation_count}
+        rotation_count = cast("RotationCount3D", fgeometric.C4_GROUP_ELEMENT_TO_K[group_element])
+
+        self.applied_config = {"axis_pair": axis_pair, "group_element": group_element}
         return {"axis_pair": axis_pair, "rotation_count": rotation_count}
 
     def get_params_dependent_on_data(
@@ -1457,7 +1457,7 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         self,
         volume: VolumeType,
         axis_pair: AxisPair3D,
-        rotation_count: int,
+        rotation_count: RotationCount3D,
         **params: Any,
     ) -> VolumeType:
         return f3d.rotate90_3d(volume, rotation_count, axis_pair)
@@ -1466,7 +1466,7 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         self,
         mask3d: VolumeType,
         axis_pair: AxisPair3D,
-        rotation_count: int,
+        rotation_count: RotationCount3D,
         **params: Any,
     ) -> VolumeType:
         return f3d.rotate90_3d(mask3d, rotation_count, axis_pair)
@@ -1475,7 +1475,7 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         self,
         keypoints: np.ndarray,
         axis_pair: AxisPair3D,
-        rotation_count: int,
+        rotation_count: RotationCount3D,
         volume_shape: tuple[int, int, int],
         **params: Any,
     ) -> np.ndarray:
@@ -1489,13 +1489,13 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
             ValueError: If this transform is configured in random mode.
 
         """
-        if self.axis_pair is None or self.rotation_count is None:
+        if self.axis_pair is None or self.group_element is None:
             raise ValueError(
-                "Cannot invert RandomRotate90_3D in random mode. Set axis_pair and rotation_count for TTA.",
+                "Cannot invert RandomRotate90_3D in random mode. Set axis_pair and group_element for TTA.",
             )
         return type(self)(
             axis_pair=self.axis_pair,
-            rotation_count=cast("Literal[0, 1, 2, 3]", (-self.rotation_count) % 4),
+            group_element=C4_INVERSE[self.group_element],
             p=1.0,
         )
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -403,8 +403,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         self.applied_config = {}
 
         if self.should_apply(force_apply=force_apply):
-            params = self.get_params()
-            params = self.update_transform_params(params=params, data=kwargs)
+            params = self.update_transform_params(params={}, data=kwargs)
 
             if self.targets_as_params:
                 missing_keys = set(self.targets_as_params).difference(kwargs.keys())
@@ -436,7 +435,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         transport and public pipeline reconstruction.
 
         The result is empty when the transform was not applied. Realized values written by
-        get_params or get_params_dependent_on_data replace their source constructor policy,
+        get_params_dependent_on_data replaces its source constructor policy,
         and aliases expose the fields of their canonical replay class. Values are JSON-safe.
         """
         return self.applied_config
@@ -577,7 +576,7 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         return f"{self.__class__.__name__}({format_args(state)})"
 
     def apply(self, img: ImageType, *args: Any, **params: Any) -> ImageType:
-        """Apply transform on image. Override in subclasses; receives params from get_params and
+        """Apply transform on image. Override in subclasses; receives parameters from
         get_params_dependent_on_data. Single image only.
         """
         raise NotImplementedError
@@ -683,15 +682,9 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         """
         return self.apply_to_images(volume, *args, **params)
 
-    def get_params(self) -> dict[str, Any]:
-        """Returns parameters independent of input data. Override in subclasses to add random
-        params (e.g. angle, crop size). Default returns {}.
-        """
-        return {}
-
     def update_transform_params(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
-        """Updates parameters with input shape and transform-specific params (interpolation, fill,
-        fill_mask, bbox_type). Merges get_params output.
+        """Update parameters with input shape and transform-specific settings (interpolation, fill,
+        fill_mask, bbox type) before data-aware parameter sampling.
 
         Args:
             params (dict[str, Any]): Parameters to be updated
@@ -782,10 +775,10 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
             params["fill_mask"] = self.fill_mask
 
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
-        """Returns parameters dependent on input data (e.g. crop coordinates from image shape).
-        Override in subclasses; default returns params unchanged.
+        """Generate all transform parameters, including random values and data-dependent values.
+        Override in subclasses; default returns an empty mapping.
         """
-        return params
+        return {}
 
     @property
     def targets(self) -> dict[str, Callable[..., Any]]:
@@ -1458,7 +1451,7 @@ class CustomTransformsApplyMixin:
 
     Define methods named `apply_to_<key>` in your transform subclass; they are
     discovered at init time and routed through the standard `apply_with_params`
-    pipeline. Custom targets receive the same params from `get_params`, respect
+    pipeline. Custom targets receive the same parameters from `get_params_dependent_on_data`, respect
     the `p=` probability, and compose correctly with Compose and ReplayCompose.
 
     Placement in inheritance list
@@ -1482,7 +1475,7 @@ class CustomTransformsApplyMixin:
         >>> mask = np.random.randint(0, 2, (64, 64), dtype=np.uint8)
         >>>
         >>> class Rotate90WithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
-        ...     def get_params(self):
+        ...     def get_params_dependent_on_data(self, params, data):
         ...         return {"k": 1}
         ...     def apply(self, img, k=0, **p):
         ...         return np.rot90(img, k)

--- a/benchmark/benchmarks/catalog.py
+++ b/benchmark/benchmarks/catalog.py
@@ -61,7 +61,7 @@ PARAM_OVERRIDES: Mapping[str, Mapping[str, Any]] = {
     "PixelDistributionAdaptation": {"transform_type": "standard"},
     "RandomCrop": {"height": 96, "width": 96},
     "RandomCrop3D": {"size": (4, 48, 48)},
-    "RandomRotate90_3D": {"axis_pair": (0, 2), "rotation_count": 1},
+    "RandomRotate90_3D": {"axis_pair": (0, 2), "group_element": "r90"},
     "RandomResizedCrop": {"size": (96, 96), "scale": (0.8, 1.0)},
     "RandomSizedBBoxSafeCrop": {"height": 96, "width": 96},
     "RandomSizedCrop": {"min_max_height": (96, 128), "size": (96, 96)},

--- a/benchmark/benchmarks/catalog.py
+++ b/benchmark/benchmarks/catalog.py
@@ -61,6 +61,7 @@ PARAM_OVERRIDES: Mapping[str, Mapping[str, Any]] = {
     "PixelDistributionAdaptation": {"transform_type": "standard"},
     "RandomCrop": {"height": 96, "width": 96},
     "RandomCrop3D": {"size": (4, 48, 48)},
+    "RandomRotate90_3D": {"axis_pair": (0, 2), "rotation_count": 1},
     "RandomResizedCrop": {"size": (96, 96), "scale": (0.8, 1.0)},
     "RandomSizedBBoxSafeCrop": {"height": 96, "width": 96},
     "RandomSizedCrop": {"min_max_height": (96, 128), "size": (96, 96)},

--- a/benchmark/benchmarks/test_family_matrix.py
+++ b/benchmark/benchmarks/test_family_matrix.py
@@ -258,6 +258,7 @@ VOLUME_TRANSFORMS: Mapping[str, Factory] = {
     "coarse_dropout3d": lambda: albumentations.CoarseDropout3D(p=1.0),
     "grid_shuffle3d": lambda: albumentations.GridShuffle3D(grid_zyx=(2, 2, 2), p=1.0),
     "cubic_symmetry": lambda: albumentations.CubicSymmetry(p=1.0),
+    "random_rotate90_3d": lambda: albumentations.RandomRotate90_3D(axis_pair=(0, 2), rotation_count=1, p=1.0),
 }
 
 REFERENCE_TRANSFORMS = (

--- a/benchmark/benchmarks/test_family_matrix.py
+++ b/benchmark/benchmarks/test_family_matrix.py
@@ -258,7 +258,7 @@ VOLUME_TRANSFORMS: Mapping[str, Factory] = {
     "coarse_dropout3d": lambda: albumentations.CoarseDropout3D(p=1.0),
     "grid_shuffle3d": lambda: albumentations.GridShuffle3D(grid_zyx=(2, 2, 2), p=1.0),
     "cubic_symmetry": lambda: albumentations.CubicSymmetry(p=1.0),
-    "random_rotate90_3d": lambda: albumentations.RandomRotate90_3D(axis_pair=(0, 2), rotation_count=1, p=1.0),
+    "random_rotate90_3d": lambda: albumentations.RandomRotate90_3D(axis_pair=(0, 2), group_element="r90", p=1.0),
 }
 
 REFERENCE_TRANSFORMS = (

--- a/benchmark/benchmarks/test_functional_kernels.py
+++ b/benchmark/benchmarks/test_functional_kernels.py
@@ -55,6 +55,7 @@ FUNCTIONAL_3D_KERNELS = (
     "crop3d",
     "pad_3d_with_params",
     "cutout3d",
+    "rotate90_3d",
     "transform_cube",
     "swap_tiles_on_volume",
 )
@@ -416,6 +417,10 @@ def _call_cutout3d(benchmark: Any) -> np.ndarray:
     return f3d.cutout3d(benchmark.volume, benchmark.holes, 0)
 
 
+def _call_rotate90_3d(benchmark: Any) -> np.ndarray:
+    return f3d.rotate90_3d(benchmark.volume, rot90_count=1, axis_pair=(0, 2))
+
+
 def _call_transform_cube(benchmark: Any) -> np.ndarray:
     return f3d.transform_cube(benchmark.volume, 7)
 
@@ -428,6 +433,7 @@ FUNCTIONAL_3D_CALLS: Mapping[str, ImageKernelCall] = {
     "crop3d": _call_crop3d,
     "pad_3d_with_params": _call_pad_3d_with_params,
     "cutout3d": _call_cutout3d,
+    "rotate90_3d": _call_rotate90_3d,
     "transform_cube": _call_transform_cube,
     "swap_tiles_on_volume": _call_swap_tiles_on_volume,
 }

--- a/tests/contracts/test_contract_harness.py
+++ b/tests/contracts/test_contract_harness.py
@@ -39,7 +39,11 @@ class CrossFieldConflict(ImageOnlyTransform):
         self.choice = choice
         self.choices = choices
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         self.applied_config = {"choice": "a"}
         return {}
 
@@ -48,7 +52,11 @@ class CrossFieldConflict(ImageOnlyTransform):
 
 
 class UnknownEmittedKey(ImageOnlyTransform):
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         self.applied_config = {"unknown_key": 137}
         return {}
 
@@ -64,7 +72,11 @@ class NonJsonValue(ImageOnlyTransform):
         super().__init__(p=p)
         self.payload = payload
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         self.applied_config = {"payload": {1, 2}}
         return {}
 
@@ -80,7 +92,11 @@ class MutatesPreviousRecord(ImageOnlyTransform):
         super().__init__(p=p)
         self.history = [] if history is None else history
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         self.history.append(len(self.history) + 1)
         self.applied_config = {"history": self.history}
         return {}
@@ -97,7 +113,11 @@ class ReconstructsButCannotRun(ImageOnlyTransform):
         super().__init__(p=p)
         self.mode = mode
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         self.applied_config = {"mode": "replay"}
         return {}
 
@@ -115,7 +135,11 @@ class ReconstructsWithDifferentOutput(ImageOnlyTransform):
         super().__init__(p=p)
         self.mode = mode
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         self.applied_config = {"mode": "replay"}
         return {}
 

--- a/tests/files/public_transform_positional_parameters.json
+++ b/tests/files/public_transform_positional_parameters.json
@@ -98,6 +98,7 @@
   "RandomRain": ["slant_range", "drop_length", "drop_width", "drop_color", "blur_value", "brightness_coefficient", "rain_type", "p"],
   "RandomResizedCrop": ["size", "scale", "ratio", "interpolation", "mask_interpolation", "area_for_downscale", "p"],
   "RandomRotate90": ["p", "group_element", "group_elements"],
+  "RandomRotate90_3D": ["axis_pairs", "axis_pair", "rotation_count", "p"],
   "RandomScale": ["scale_range", "interpolation", "mask_interpolation", "area_for_downscale", "p"],
   "RandomShadow": ["shadow_roi", "num_shadows_range", "shadow_dimension", "shadow_intensity_range", "p"],
   "RandomSizedBBoxSafeCrop": ["height", "width", "erosion_rate", "interpolation", "mask_interpolation", "p"],

--- a/tests/files/public_transform_positional_parameters.json
+++ b/tests/files/public_transform_positional_parameters.json
@@ -98,7 +98,7 @@
   "RandomRain": ["slant_range", "drop_length", "drop_width", "drop_color", "blur_value", "brightness_coefficient", "rain_type", "p"],
   "RandomResizedCrop": ["size", "scale", "ratio", "interpolation", "mask_interpolation", "area_for_downscale", "p"],
   "RandomRotate90": ["p", "group_element", "group_elements"],
-  "RandomRotate90_3D": ["axis_pairs", "axis_pair", "rotation_count", "p"],
+  "RandomRotate90_3D": ["axis_pairs", "axis_pair", "group_element", "p"],
   "RandomScale": ["scale_range", "interpolation", "mask_interpolation", "area_for_downscale", "p"],
   "RandomShadow": ["shadow_roi", "num_shadows_range", "shadow_dimension", "shadow_intensity_range", "p"],
   "RandomSizedBBoxSafeCrop": ["height", "width", "erosion_rate", "interpolation", "mask_interpolation", "p"],

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -1031,7 +1031,7 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
     ),
     ("fixed-element", A.RandomRotate90, {"group_element": "r90"}),
     ("subset-elements", A.RandomRotate90, {"group_elements": ("r90", "r270")}),
-    ("fixed-axis-rotation", A.RandomRotate90_3D, {"axis_pair": (0, 2), "rotation_count": 1}),
+    ("fixed-axis-rotation", A.RandomRotate90_3D, {"axis_pair": (0, 2), "group_element": "r90"}),
     ("anisotropic-range", A.RandomScale, {"scale_range": {"x": (-0.2, 0.3), "y": (-0.1, 0.15)}}),
     ("downscale-aware", A.RandomScale, {"mask_interpolation": cv2.INTER_LINEAR, "area_for_downscale": "image_mask"}),
     ("variable-intensity", A.RandomShadow, {"shadow_intensity_range": (0.2, 0.7)}),

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -586,6 +586,7 @@ _BASE_CASE_SPECS: list[list[Any]] = [
         },
     ],
     [A.CubicSymmetry, {}],
+    [A.RandomRotate90_3D, {"axis_pairs": ((0, 2),)}],
     [A.AtLeastOneBBoxRandomCrop, {"height": 80, "width": 80, "erosion_factor": 0.2}],
     [
         A.ConstrainedCoarseDropout,
@@ -1030,6 +1031,7 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
     ),
     ("fixed-element", A.RandomRotate90, {"group_element": "r90"}),
     ("subset-elements", A.RandomRotate90, {"group_elements": ("r90", "r270")}),
+    ("fixed-axis-rotation", A.RandomRotate90_3D, {"axis_pair": (0, 2), "rotation_count": 1}),
     ("anisotropic-range", A.RandomScale, {"scale_range": {"x": (-0.2, 0.3), "y": (-0.1, 0.15)}}),
     ("downscale-aware", A.RandomScale, {"mask_interpolation": cv2.INTER_LINEAR, "area_for_downscale": "image_mask"}),
     ("variable-intensity", A.RandomShadow, {"shadow_intensity_range": (0.2, 0.7)}),
@@ -1198,6 +1200,7 @@ _EXACT_TRANSFORMS = {
     A.NoOp,
     A.Pad,
     A.RandomRotate90,
+    A.RandomRotate90_3D,
     A.Resize,
     A.Transpose,
     A.VerticalFlip,

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1006,7 +1006,7 @@ def test_zoom_blur_apply_to_images(dtype):
     else:
         images = np.random.RandomState(137).random((2, 100, 100, 3)).astype(np.float32)
 
-    # Use fixed parameters so get_params produces deterministic zoom_factors
+    # Use fixed parameters so parameter generation produces deterministic zoom_factors
     transform = A.ZoomBlur(max_factor_range=(1.1, 1.1), step_factor_range=(0.01, 0.01), p=1.0)
 
     transformed = transform(images=images)["images"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -119,7 +119,11 @@ def test_image_only_transform(image):
     mask = image.copy()
     _height, _width = image.shape[:2]
     with mock.patch.object(ImageOnlyTransform, "apply") as mocked_apply:
-        with mock.patch.object(ImageOnlyTransform, "get_params", return_value={"interpolation": cv2.INTER_LINEAR}):
+        with mock.patch.object(
+            ImageOnlyTransform,
+            "get_params_dependent_on_data",
+            return_value={"interpolation": cv2.INTER_LINEAR},
+        ):
             aug = ImageOnlyTransform(p=1)
             data = aug(image=image, mask=mask)
             mocked_apply.assert_called_once_with(
@@ -135,7 +139,7 @@ def test_dual_transform(image):
     mask = image.copy()
 
     with mock.patch.object(DualTransform, "apply") as mocked_apply:
-        with mock.patch.object(DualTransform, "get_params", return_value={}):  # Empty params
+        with mock.patch.object(DualTransform, "get_params_dependent_on_data", return_value={}):
             aug = DualTransform(p=1)
             aug(image=image, mask=mask)
 
@@ -170,7 +174,11 @@ def test_additional_targets(image):
         shape=mask.shape,
     )
     with mock.patch.object(DualTransform, "apply") as mocked_apply:
-        with mock.patch.object(DualTransform, "get_params", return_value={"interpolation": cv2.INTER_LINEAR}):
+        with mock.patch.object(
+            DualTransform,
+            "get_params_dependent_on_data",
+            return_value={"interpolation": cv2.INTER_LINEAR},
+        ):
             aug = DualTransform(p=1)
             aug.add_targets({"image2": "image"})
             aug(image=image, image2=mask)
@@ -2880,7 +2888,7 @@ def test_applied_config_invalid_key_raises():
     """Transforms that set invalid applied_config keys must raise ValueError."""
 
     class BadTransform(A.NoOp):
-        def get_params(self):
+        def get_params_dependent_on_data(self, params, data):
             self.applied_config = {"not_a_real_constructor_param_xyz": 42}
             return {}
 
@@ -2994,7 +3002,7 @@ SINGLE_SAMPLE_RANGE_RESOLUTIONS: list[tuple[type, str, dict[str, Any]]] = [
 def test_applied_config_resolves_range_param_to_scalar(aug_cls, range_param, init_kwargs):
     """Single-sample `_range` params must be recorded as the sampled scalar in applied_config.
 
-    Catches the bug pattern where get_params samples from a range but forgets to record the
+    Catches the bug pattern where parameter generation samples from a range but forgets to record the
     scalar — leaving `applied_config[range]` as the original input tuple, which silently
     breaks replay/debug consumers of get_applied_config().
     """
@@ -3011,7 +3019,7 @@ def test_applied_config_resolves_range_param_to_scalar(aug_cls, range_param, ini
     assert sampled is not None, f"{aug_cls.__name__}.applied_config missing key {range_param!r}"
     assert not isinstance(sampled, (tuple, list)), (
         f"{aug_cls.__name__}.applied_config[{range_param!r}] is still a tuple {sampled!r}; "
-        f"get_params likely sampled but forgot to record the scalar via "
+        f"parameter generation likely sampled but forgot to record the scalar via "
         f"`self.applied_config = {{{range_param!r}: sampled_value, ...}}`"
     )
     assert isinstance(sampled, (int, float, np.integer, np.floating)), (

--- a/tests/test_custom_transform_apply.py
+++ b/tests/test_custom_transform_apply.py
@@ -48,7 +48,11 @@ def mask3d():
 class BrightnessWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
     """ImageOnlyTransform + one custom target: float label."""
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         return {"factor": 0.5}
 
     def apply(self, img: np.ndarray, factor: float = 1.0, **p) -> np.ndarray:
@@ -74,7 +78,11 @@ class FlipWithMetadata(A.CustomTransformsApplyMixin, A.DualTransform):
 class RotateWithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
     """DualTransform + integer rotation label."""
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         return {"factor": 1}  # fixed for deterministic tests
 
     def apply(self, img: np.ndarray, factor: int = 0, **p) -> np.ndarray:
@@ -90,7 +98,11 @@ class RotateWithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
 class MultiTargetDual(A.CustomTransformsApplyMixin, A.DualTransform):
     """DualTransform + two custom targets."""
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         return {"factor": 2}
 
     def apply(self, img: np.ndarray, **p) -> np.ndarray:
@@ -109,7 +121,11 @@ class MultiTargetDual(A.CustomTransformsApplyMixin, A.DualTransform):
 class VolumeWithLabel(A.CustomTransformsApplyMixin, A.Transform3D):
     """Transform3D + integer label."""
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         return {"factor": 1}
 
     def apply(self, img: np.ndarray, **p) -> np.ndarray:
@@ -143,7 +159,7 @@ class TestImageOnlyTransformWithMixin:
         assert "image" in t._key2func
 
     def test_apply_to_label_called_with_correct_params(self, uint8_image):
-        """factor=0.5 is fixed in get_params; label must be halved."""
+        """factor=0.5 is fixed during parameter generation; label must be halved."""
         t = BrightnessWithLabel(p=1.0)
         out = t(image=uint8_image, label=0.8)
         assert abs(out["label"] - 0.4) < 1e-6
@@ -427,12 +443,12 @@ class TestTransform3DWithMixin:
 class TestParamsPassthrough:
     """All apply_* methods — built-in and custom — must receive the same params."""
 
-    def test_custom_apply_receives_get_params_values(self, uint8_image):
-        """Factor from get_params must reach apply_to_label unchanged."""
+    def test_custom_apply_receives_generated_values(self, uint8_image):
+        """Factor from parameter generation must reach apply_to_label unchanged."""
         received = {}
 
         class _Capture(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def get_params(self):
+            def get_params_dependent_on_data(self, params, data):
                 return {"factor": 7}
 
             def apply(self, img, factor=0, **p):
@@ -452,7 +468,7 @@ class TestParamsPassthrough:
         received = {}
 
         class _CaptureMulti(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def get_params(self):
+            def get_params_dependent_on_data(self, params, data):
                 return {"alpha": 3, "beta": 9}
 
             def apply(self, img, **p):
@@ -569,12 +585,13 @@ class TestGetParamsDependentOnData:
         class DataAwareLabelTransform(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             targets_as_params = ("label",)
 
-            def get_params(self) -> dict[str, Any]:
-                return {"base": 10}
-
-            def get_params_dependent_on_data(self, params: dict, data: dict) -> dict:
+            def get_params_dependent_on_data(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+            ) -> dict[str, Any]:
                 label = data.get("label", 0)
-                return {"offset": label * 2}
+                return {"base": 10, "offset": label * 2}
 
             def apply(self, img: np.ndarray, base: int = 0, offset: int = 0, **p) -> np.ndarray:
                 return img
@@ -591,7 +608,11 @@ class TestGetParamsDependentOnData:
         class RequiresLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             targets_as_params = ("label",)
 
-            def get_params(self) -> dict[str, Any]:
+            def get_params_dependent_on_data(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+            ) -> dict[str, Any]:
                 return {}
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
@@ -612,7 +633,11 @@ class TestAddTargetsWithCustomKeys:
 
     def test_add_targets_aliases_custom_key(self, uint8_image):
         class TransformWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def get_params(self) -> dict[str, Any]:
+            def get_params_dependent_on_data(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+            ) -> dict[str, Any]:
                 return {}
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
@@ -632,7 +657,11 @@ class TestAddTargetsWithCustomKeys:
 
     def test_compose_with_additional_targets_custom_key(self, uint8_image):
         class TransformWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def get_params(self) -> dict[str, Any]:
+            def get_params_dependent_on_data(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+            ) -> dict[str, Any]:
                 return {}
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
@@ -715,7 +744,11 @@ class TestAvailableKeysAndComposition:
 
         # First: label += 1. Second: label *= 2. Input 5 -> 6 -> 12.
         class AddOne(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def get_params(self) -> dict[str, Any]:
+            def get_params_dependent_on_data(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+            ) -> dict[str, Any]:
                 return {}
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
@@ -725,7 +758,11 @@ class TestAvailableKeysAndComposition:
                 return label + 1
 
         class MulTwo(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def get_params(self) -> dict[str, Any]:
+            def get_params_dependent_on_data(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+            ) -> dict[str, Any]:
                 return {}
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
@@ -742,7 +779,11 @@ class TestAvailableKeysAndComposition:
         """Subclass can add another apply_to_ method."""
 
         class BaseWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def get_params(self) -> dict[str, Any]:
+            def get_params_dependent_on_data(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+            ) -> dict[str, Any]:
                 return {}
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -378,6 +378,7 @@ def test_transpose_rejects_tensor_routes_outside_accepted_capability(
         A.RandomCrop3D(size=(3, 5, 7), pad_if_needed=False, p=1.0),
         A.CubicSymmetry(p=1.0),
         A.Pad3D(padding=(1, 2, 2), p=1.0),
+        A.RandomRotate90_3D(axis_pair=(0, 2), rotation_count=1, p=1.0),
     ],
 )
 def test_3d_transforms_remain_rejected_until_their_tensor_routes_pass_the_performance_gate(

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -378,7 +378,7 @@ def test_transpose_rejects_tensor_routes_outside_accepted_capability(
         A.RandomCrop3D(size=(3, 5, 7), pad_if_needed=False, p=1.0),
         A.CubicSymmetry(p=1.0),
         A.Pad3D(padding=(1, 2, 2), p=1.0),
-        A.RandomRotate90_3D(axis_pair=(0, 2), rotation_count=1, p=1.0),
+        A.RandomRotate90_3D(axis_pair=(0, 2), group_element="r90", p=1.0),
     ],
 )
 def test_3d_transforms_remain_rejected_until_their_tensor_routes_pass_the_performance_gate(

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -38,7 +38,11 @@ class _NumpyOnlyProbe(_TensorProbe):
 
     _supports_cpu_tensor = False
 
-    def get_params(self) -> dict[str, Any]:
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         pytest.fail("Compose must reject an unsupported Tensor transform before parameter sampling")
 
 

--- a/tests/test_transform_name_conventions.py
+++ b/tests/test_transform_name_conventions.py
@@ -24,6 +24,7 @@ class RandomNewTransform(ImageOnlyTransform):
     [
         ("RandomBrightnessContrast", "ImageOnlyTransform"),
         ("RandomOrder", "BaseCompose"),
+        ("RandomRotate90_3D", "Transform3D"),
     ],
 )
 def test_legacy_random_transform_name_remains_allowed(class_name: str, base_class_name: str) -> None:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -941,8 +941,7 @@ def test_affine_scale_ratio(params):
     image = SQUARE_UINT8_IMAGE
 
     data = {"image": image}
-    call_params = aug.get_params()
-    call_params = aug.update_transform_params(call_params, data)
+    call_params = aug.update_transform_params({}, data)
 
     apply_params = aug.get_params_dependent_on_data(params=call_params, data=data)
 
@@ -978,8 +977,7 @@ def test_affine_default_keep_ratio_behavior():
     transform.set_random_seed(137)
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
-    params = transform.get_params()
-    params = transform.update_transform_params(params, data)
+    params = transform.update_transform_params({}, data)
     apply_params = transform.get_params_dependent_on_data(params=params, data=data)
 
     assert apply_params["scale"]["x"] == apply_params["scale"]["y"], (
@@ -996,8 +994,7 @@ def test_affine_explicit_keep_ratio_false():
     transform.set_random_seed(137)
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
-    params = transform.get_params()
-    params = transform.update_transform_params(params, data)
+    params = transform.update_transform_params({}, data)
     apply_params = transform.get_params_dependent_on_data(params=params, data=data)
 
     # With keep_ratio=False, x and y can be different (not always will be, but can be)
@@ -1005,8 +1002,7 @@ def test_affine_explicit_keep_ratio_false():
     found_different = False
     for seed in range(10):
         transform.set_random_seed(seed)
-        params = transform.get_params()
-        params = transform.update_transform_params(params, data)
+        params = transform.update_transform_params({}, data)
         apply_params = transform.get_params_dependent_on_data(params=params, data=data)
         if apply_params["scale"]["x"] != apply_params["scale"]["y"]:
             found_different = True
@@ -1025,8 +1021,7 @@ def test_affine_with_dict_scale_keep_ratio_true():
     transform.set_random_seed(137)
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
-    params = transform.get_params()
-    params = transform.update_transform_params(params, data)
+    params = transform.update_transform_params({}, data)
     apply_params = transform.get_params_dependent_on_data(params=params, data=data)
 
     assert apply_params["scale"]["x"] == apply_params["scale"]["y"], (
@@ -1047,8 +1042,7 @@ def test_affine_keep_ratio_with_single_scale_value():
     transform.set_random_seed(137)
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
-    params = transform.get_params()
-    params = transform.update_transform_params(params, data)
+    params = transform.update_transform_params({}, data)
     apply_params = transform.get_params_dependent_on_data(params=params, data=data)
 
     # With a single scale value, both x and y should be that value
@@ -1308,7 +1302,7 @@ def test_motion_blur_allow_shifted():
         direction_range=(0, 0),  # Symmetric direction
         blur_range=(7, 7),  # Fixed kernel size
     )
-    kernel = transform.get_params()["kernel"]
+    kernel = transform.get_params_dependent_on_data(params={}, data={})["kernel"]
 
     center = kernel.shape[0] / 2 - 0.5
 
@@ -1344,7 +1338,7 @@ def test_motion_blur_allow_shifted_true():
     # Generate multiple kernels with same transform instance
     kernels = []
     for _ in range(10):
-        kernel = transform.get_params()["kernel"]
+        kernel = transform.get_params_dependent_on_data(params={}, data={})["kernel"]
         kernels.append(kernel)
 
     # Check that not all kernels are identical (shifting should cause variation)

--- a/tests/transforms3d/test_functions.py
+++ b/tests/transforms3d/test_functions.py
@@ -252,3 +252,44 @@ def test_transform_cube_keypoints_matches_transform_cube(index):
         original_extra_cols,
         err_msg=f"Extra columns should remain unchanged after transformation with index={index}",
     )
+
+
+@pytest.mark.parametrize("axis_pair", [(0, 1), (0, 2), (1, 2)])
+@pytest.mark.parametrize("rotation_count", [0, 1, 2, 3])
+def test_rotate90_3d_matches_numpy(axis_pair, rotation_count):
+    volume = np.arange(3 * 4 * 5 * 2, dtype=np.uint8).reshape(3, 4, 5, 2)
+
+    result = f3d.rotate90_3d(
+        volume,
+        rot90_count=rotation_count,
+        axis_pair=axis_pair,
+    )
+
+    np.testing.assert_array_equal(result, np.rot90(volume, k=rotation_count, axes=axis_pair))
+    assert result.dtype == volume.dtype
+
+
+@pytest.mark.parametrize("axis_pair", [(0, 1), (0, 2), (1, 2)])
+@pytest.mark.parametrize("rotation_count", [1, 2, 3])
+def test_keypoints_rotate90_3d_matches_rotated_volume(axis_pair, rotation_count):
+    volume = np.zeros((3, 4, 5), dtype=np.uint8)
+    keypoints = np.array([[1, 1, 0, 7], [3, 2, 1, 9], [4, 3, 2, 11]], dtype=np.float32)
+
+    for value, (x_coordinate, y_coordinate, z_coordinate) in enumerate(keypoints[:, :3], start=1):
+        volume[int(z_coordinate), int(y_coordinate), int(x_coordinate)] = value
+
+    transformed_volume = f3d.rotate90_3d(
+        volume,
+        rot90_count=rotation_count,
+        axis_pair=axis_pair,
+    )
+    transformed_keypoints = f3d.keypoints_rotate90_3d(
+        keypoints,
+        rot90_count=rotation_count,
+        axis_pair=axis_pair,
+        volume_shape=volume.shape,
+    )
+
+    for value, (x_coordinate, y_coordinate, z_coordinate) in enumerate(transformed_keypoints[:, :3], start=1):
+        assert transformed_volume[int(z_coordinate), int(y_coordinate), int(x_coordinate)] == value
+    np.testing.assert_array_equal(transformed_keypoints[:, 3:], keypoints[:, 3:])

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -270,7 +270,7 @@ def test_pad3d_2d_equivalence(pad3d_padding, pad2d_padding):
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
     get_primary_3d_transform_params(
-        custom_arguments={A.RandomRotate90_3D: {"axis_pair": (0, 2), "rotation_count": 1}},
+        custom_arguments={A.RandomRotate90_3D: {"axis_pair": (0, 2), "group_element": "r90"}},
         except_augmentations={},
     ),
 )
@@ -1117,15 +1117,15 @@ def test_grid_shuffle_3d_probability():
 
 
 @pytest.mark.parametrize("axis_pair", [(0, 1), (0, 2), (1, 2)])
-@pytest.mark.parametrize("rotation_count", [0, 1, 2, 3])
-def test_random_rotate90_3d_rotates_volume_mask_and_keypoints(axis_pair, rotation_count):
+@pytest.mark.parametrize("group_element", ["e", "r90", "r180", "r270"])
+def test_random_rotate90_3d_rotates_volume_mask_and_keypoints(axis_pair, group_element):
     volume = np.arange(3 * 4 * 5 * 2, dtype=np.uint8).reshape(3, 4, 5, 2)
     mask3d = (volume[..., 0] % 2).astype(np.uint8)
     keypoints = np.array([[1, 1, 0], [3, 2, 1], [4, 3, 2]], dtype=np.float32)
     keypoint_labels = [7, 9, 11]
     augmentation = A.RandomRotate90_3D(
         axis_pair=axis_pair,
-        rotation_count=rotation_count,
+        group_element=group_element,
         p=1.0,
     )
     compose = A.Compose(
@@ -1141,6 +1141,7 @@ def test_random_rotate90_3d_rotates_volume_mask_and_keypoints(axis_pair, rotatio
         keypoint_labels=keypoint_labels,
     )
 
+    rotation_count = {"e": 0, "r90": 1, "r180": 2, "r270": 3}[group_element]
     np.testing.assert_array_equal(result["volume"], np.rot90(volume, k=rotation_count, axes=axis_pair))
     np.testing.assert_array_equal(result["mask3d"], np.rot90(mask3d, k=rotation_count, axes=axis_pair))
     assert result["volume"].dtype == volume.dtype
@@ -1179,9 +1180,7 @@ def test_random_rotate90_3d_seeded_replay_and_applied_configuration():
         {"axis_pairs": ()},
         {"axis_pairs": ((0, 0),)},
         {"axis_pairs": ((0, 2), (0, 2))},
-        {"axis_pair": (0, 2)},
-        {"rotation_count": 1},
-        {"axis_pair": (0, 2), "rotation_count": 4},
+        {"group_element": "r45"},
     ],
 )
 def test_random_rotate90_3d_rejects_invalid_configuration(kwargs):

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -270,7 +270,7 @@ def test_pad3d_2d_equivalence(pad3d_padding, pad2d_padding):
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
     get_primary_3d_transform_params(
-        custom_arguments={},
+        custom_arguments={A.RandomRotate90_3D: {"axis_pair": (0, 2), "rotation_count": 1}},
         except_augmentations={},
     ),
 )
@@ -1114,3 +1114,81 @@ def test_grid_shuffle_3d_probability():
 
     # Should transform at least once (very high probability)
     assert transform_count > 0
+
+
+@pytest.mark.parametrize("axis_pair", [(0, 1), (0, 2), (1, 2)])
+@pytest.mark.parametrize("rotation_count", [0, 1, 2, 3])
+def test_random_rotate90_3d_rotates_volume_mask_and_keypoints(axis_pair, rotation_count):
+    volume = np.arange(3 * 4 * 5 * 2, dtype=np.uint8).reshape(3, 4, 5, 2)
+    mask3d = (volume[..., 0] % 2).astype(np.uint8)
+    keypoints = np.array([[1, 1, 0], [3, 2, 1], [4, 3, 2]], dtype=np.float32)
+    keypoint_labels = [7, 9, 11]
+    augmentation = A.RandomRotate90_3D(
+        axis_pair=axis_pair,
+        rotation_count=rotation_count,
+        p=1.0,
+    )
+    compose = A.Compose(
+        [augmentation],
+        keypoint_params=A.KeypointParams(coord_format="xyz", label_fields=["keypoint_labels"]),
+        strict=True,
+    )
+
+    result = compose(
+        volume=volume,
+        mask3d=mask3d,
+        keypoints=keypoints,
+        keypoint_labels=keypoint_labels,
+    )
+
+    np.testing.assert_array_equal(result["volume"], np.rot90(volume, k=rotation_count, axes=axis_pair))
+    np.testing.assert_array_equal(result["mask3d"], np.rot90(mask3d, k=rotation_count, axes=axis_pair))
+    assert result["volume"].dtype == volume.dtype
+    assert result["mask3d"].dtype == mask3d.dtype
+    assert result["keypoint_labels"] == keypoint_labels
+
+    restored = A.Compose(
+        [augmentation.inverse()],
+        keypoint_params=A.KeypointParams(coord_format="xyz", label_fields=["keypoint_labels"]),
+        strict=True,
+    )(**result)
+    np.testing.assert_array_equal(restored["volume"], volume)
+    np.testing.assert_array_equal(restored["mask3d"], mask3d)
+    np.testing.assert_array_equal(restored["keypoints"], keypoints)
+
+
+def test_random_rotate90_3d_seeded_replay_and_applied_configuration():
+    volume = np.arange(3 * 4 * 5, dtype=np.uint8).reshape(3, 4, 5, 1)
+    pipeline = A.Compose(
+        [A.RandomRotate90_3D(axis_pairs=((0, 2),), p=1.0)],
+        save_applied_params=True,
+        seed=137,
+        strict=True,
+    )
+
+    result = pipeline(volume=volume)
+    replay = A.Compose.from_applied_transforms(result["applied_transforms"], strict=True)
+    replayed = replay(volume=volume)
+
+    np.testing.assert_array_equal(replayed["volume"], result["volume"])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"axis_pairs": ()},
+        {"axis_pairs": ((0, 0),)},
+        {"axis_pairs": ((0, 2), (0, 2))},
+        {"axis_pair": (0, 2)},
+        {"rotation_count": 1},
+        {"axis_pair": (0, 2), "rotation_count": 4},
+    ],
+)
+def test_random_rotate90_3d_rejects_invalid_configuration(kwargs):
+    with pytest.raises(ValueError):
+        A.RandomRotate90_3D(**kwargs)
+
+
+def test_random_rotate90_3d_random_mode_cannot_be_inverted():
+    with pytest.raises(ValueError, match="random mode"):
+        A.RandomRotate90_3D().inverse()

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -224,6 +224,7 @@ VOLUME_ALIAS_TO_TRANSFORM = {
     "pad3d": "Pad3D",
     "pad_if_needed3d": "PadIfNeeded3D",
     "random_crop3d": "RandomCrop3D",
+    "random_rotate90_3d": "RandomRotate90_3D",
 }
 
 BATCH_ALIAS_TO_TRANSFORM = {

--- a/tools/check_apply_no_defaults.py
+++ b/tools/check_apply_no_defaults.py
@@ -3,7 +3,7 @@
 
 Enforces the coding guideline: "No default arguments in apply_xxx methods."
 Default argument values in apply methods hide bugs where params are not properly
-forwarded from get_params / get_params_dependent_on_data.
+forwarded from get_params_dependent_on_data.
 
 Allowed: self, *args, **kwargs, **params (keyword-only catch-alls)
 Flagged: any named parameter with a default value

--- a/tools/check_method_docstrings.py
+++ b/tools/check_method_docstrings.py
@@ -17,7 +17,6 @@ OPTIONAL_DOCSTRING_METHODS: set[str] = {
     "get_params_dependent_on_data",
     "to_dict_private",
     "targets_as_params",
-    "get_params",
     "get_transform_init_args",
 }
 

--- a/tools/check_transform_names.py
+++ b/tools/check_transform_names.py
@@ -35,6 +35,8 @@ LEGACY_RANDOM_TRANSFORM_NAMES = frozenset(
         "RandomRain",
         "RandomResizedCrop",
         "RandomRotate90",
+        # Public API name required by https://github.com/albumentations-team/AlbumentationsX/issues/388.
+        "RandomRotate90_3D",
         "RandomScale",
         "RandomShadow",
         "RandomSizedBBoxSafeCrop",


### PR DESCRIPTION
## Summary

- Add `RandomRotate90_3D` with true C4 rotations over selectable spatial axis pairs; `r90`/`r270` intentionally swap the corresponding dimensions.
- Use the 2D-compatible `group_element` API (`e`, `r90`, `r180`, `r270`) for deterministic TTA and random C4 sampling by default.
- Remove redundant per-transform 3D target dispatch; it now inherits `Transform3D` dispatch.
- Remove `BasicTransform.get_params`; all built-in parameter sampling now lives in `get_params_dependent_on_data(params, data)`. This is a breaking custom-transform API change.
- Update custom-transform tests and developer tooling for the unified parameter lifecycle.

## Validation

- `uv run python tools/quality_gate.py fast`
- `uv run pytest -n auto -q` — `12937 passed, 42 skipped, 9 xfailed, 3 xpassed`
- Compose benchmark for `RandomRotate90_3D` across 27 `(D, H, W, C)` inputs: no repeatable regression above 5%.
- Verified no Python production/test occurrences of `get_params`, `volumes`, or `masks3d` remain.