### PR TITLE
feat(transforms3d): add Flip3D reflections

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Where:
 | [CenterCrop3D](https://albumentations.ai/explore/transform/CenterCrop3D/)           | ✓      | ✓      | ✓         |
 | [CoarseDropout3D](https://albumentations.ai/explore/transform/CoarseDropout3D/)     | ✓      | ✓      | ✓         |
 | [CubicSymmetry](https://albumentations.ai/explore/transform/CubicSymmetry/)         | ✓      | ✓      | ✓         |
+| [Flip3D](https://albumentations.ai/explore/transform/Flip3D/)                       | ✓      | ✓      | ✓         |
 | [GridShuffle3D](https://albumentations.ai/explore/transform/GridShuffle3D/)         | ✓      | ✓      | ✓         |
 | [Pad3D](https://albumentations.ai/explore/transform/Pad3D/)                         | ✓      | ✓      | ✓         |
 | [PadIfNeeded3D](https://albumentations.ai/explore/transform/PadIfNeeded3D/)         | ✓      | ✓      | ✓         |

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -15,6 +15,22 @@ from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.type_definitions import NUM_VOLUME_DIMENSIONS, ImageType, VolumeType
 
 
+@handle_empty_array("keypoints")
+def keypoints_flip_3d(
+    keypoints: np.ndarray,
+    flip_axes: tuple[Literal[0, 1, 2], ...],
+    volume_shape: tuple[int, int, int],
+) -> np.ndarray:
+    """Reflect XYZ keypoints across selected depth, height, and width voxel-index axes while preserving all extra
+    columns and dtype.
+    """
+    flipped_keypoints = keypoints.copy()
+    for axis in flip_axes:
+        coordinate_index = len(volume_shape) - axis - 1
+        flipped_keypoints[:, coordinate_index] = volume_shape[axis] - 1 - flipped_keypoints[:, coordinate_index]
+    return flipped_keypoints
+
+
 def adjust_padding_by_position3d(
     paddings: list[tuple[int, int]],  # [(front, back), (top, bottom), (left, right)]
     position: Literal["center", "random"],

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -24,6 +24,7 @@ __all__ = [
     "CenterCrop3D",
     "CoarseDropout3D",
     "CubicSymmetry",
+    "Flip3D",
     "GridShuffle3D",
     "Pad3D",
     "PadIfNeeded3D",
@@ -36,6 +37,7 @@ AxisIndex3D = Literal[0, 1, 2]
 AxisPair3D = tuple[AxisIndex3D, AxisIndex3D]
 RotationCount3D = Literal[0, 1, 2, 3]
 DEFAULT_ROTATION_AXIS_PAIRS: tuple[AxisPair3D, ...] = ((0, 1), (0, 2), (1, 2))
+DEFAULT_FLIP_AXES: tuple[AxisIndex3D, ...] = (0, 1, 2)
 
 
 def _get_volume_shape(data: dict[str, Any]) -> tuple[int, ...]:
@@ -1259,6 +1261,121 @@ class CoarseDropout3D(Transform3D):
         if processor is None or not processor.params.remove_invisible:
             return keypoints
         return f3d.filter_keypoints_in_holes3d(keypoints, holes)
+
+
+class Flip3D(Transform3D):
+    """Reflect a volume independently across depth, height, and width voxel-index axes while retaining its shape and
+    channel layout.
+
+    In random mode, each allowed axis is independently reflected. Set `flip_axes` to a fixed subset for reversible
+    test-time augmentation; reflections are self-inverse. This is a voxel-index reflection only: it does not update
+    affine metadata or perform a physical-space reorientation.
+
+    Args:
+        axes (tuple[int, ...]): Non-empty spatial axes that random mode may flip, in `(depth, height, width)` order.
+            Default: `(0, 1, 2)`.
+        flip_axes (tuple[int, ...] | None): Fixed subset of `axes` to reflect for deterministic test-time augmentation.
+            Default: None.
+        p (float): Probability of applying the transform. Default: 1.0.
+
+    Targets:
+        volume, mask3d, keypoints
+
+    Image types:
+        uint8, float32
+
+    Examples:
+        >>> import numpy as np
+        >>> import albumentations as A
+        >>> volume = np.arange(2 * 3 * 5, dtype=np.uint8).reshape(2, 3, 5, 1)
+        >>> transform = A.Flip3D(flip_axes=(0, 2), p=1.0)
+        >>> result = transform(volume=volume)
+        >>> result["volume"].shape
+        (2, 3, 5, 1)
+
+    """
+
+    _targets = (Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS)
+
+    class InitSchema(BaseTransformInitSchema):
+        axes: tuple[AxisIndex3D, ...]
+        flip_axes: tuple[AxisIndex3D, ...] | None
+
+        @model_validator(mode="after")
+        def _validate_flip_config(self) -> Self:
+            if not self.axes:
+                raise ValueError("axes must contain at least one spatial axis")
+            if len(self.axes) != len(set(self.axes)):
+                raise ValueError("axes must not contain duplicate spatial axes")
+            if self.flip_axes is not None:
+                if not self.flip_axes:
+                    raise ValueError("flip_axes must contain at least one spatial axis")
+                if len(self.flip_axes) != len(set(self.flip_axes)):
+                    raise ValueError("flip_axes must not contain duplicate spatial axes")
+                if not set(self.flip_axes).issubset(self.axes):
+                    raise ValueError("flip_axes must be a subset of axes")
+            return self
+
+    def __init__(
+        self,
+        axes: tuple[AxisIndex3D, ...] = DEFAULT_FLIP_AXES,
+        flip_axes: tuple[AxisIndex3D, ...] | None = None,
+        p: float = 1.0,
+    ):
+        super().__init__(p=p)
+        self.axes = axes
+        self.flip_axes = flip_axes
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        flip_axes = self.flip_axes
+        if flip_axes is None:
+            flip_axes = tuple(axis for axis in self.axes if self.py_random.random() < 0.5)
+            if not flip_axes:
+                flip_axes = (self.py_random.choice(self.axes),)
+
+        self.applied_config = {"flip_axes": flip_axes}
+        return {"flip_axes": flip_axes, "volume_shape": _get_volume_spatial_shape(data)}
+
+    def apply_to_volume(
+        self,
+        volume: VolumeType,
+        flip_axes: tuple[AxisIndex3D, ...],
+        **params: Any,
+    ) -> VolumeType:
+        return cast("VolumeType", np.flip(volume, axis=flip_axes))
+
+    def apply_to_mask3d(
+        self,
+        mask3d: VolumeType,
+        flip_axes: tuple[AxisIndex3D, ...],
+        **params: Any,
+    ) -> VolumeType:
+        return cast("VolumeType", np.flip(mask3d, axis=flip_axes))
+
+    def apply_to_keypoints(
+        self,
+        keypoints: np.ndarray,
+        flip_axes: tuple[AxisIndex3D, ...],
+        volume_shape: tuple[int, int, int],
+        **params: Any,
+    ) -> np.ndarray:
+        return f3d.keypoints_flip_3d(keypoints, flip_axes, volume_shape)
+
+    def inverse(self) -> Self:
+        """Return a fixed self-inverse reflection for test-time augmentation when this transform has a deterministic
+        axis subset configured.
+
+        Raises:
+            ValueError: If this transform is configured in random mode.
+
+        """
+        if self.flip_axes is None:
+            raise ValueError("Cannot invert Flip3D in random mode. Set flip_axes for TTA.")
+        return type(self)(axes=self.axes, flip_axes=self.flip_axes, p=1.0)
 
 
 class CubicSymmetry(Transform3D):

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -173,6 +173,7 @@ IMAGE_KEYS = {"image", "images"}
 CHECK_BBOX_PARAM = {"bboxes"}
 CHECK_KEYPOINTS_PARAM = {"keypoints"}
 VOLUME_KEYS = {"volume"}
+_SPATIAL_ADDITIONAL_TARGETS = frozenset((*IMAGE_KEYS, *MASK_KEYS, *VOLUME_KEYS))
 
 _VALID_INSTANCE_BINDING_TARGETS = frozenset({"mask", "masks", "bboxes", "keypoints"})
 # Distinct ferry-key constants used to shuttle per-row instance ids through `data`
@@ -625,7 +626,7 @@ class BaseCompose(Serializable):
         if not self.check_each_transform:
             return data
 
-        shape = get_shape(data, self._additional_targets)
+        shape = get_shape(data)
         binding = getattr(self, "_instance_binding", None)
 
         for proc in self.check_each_transform:
@@ -863,7 +864,7 @@ class BaseCompose(Serializable):
         if isinstance(mask, np.ndarray):
             return -1
 
-        shape = get_shape(data, self._additional_targets)
+        shape = get_shape(data)
         spatial_shape = tuple(shape[:2])
         trailing_layout = tuple(mask.shape[:2]) == spatial_shape
         leading_layout = tuple(mask.shape[-2:]) == spatial_shape
@@ -1126,7 +1127,8 @@ class Compose(BaseCompose, HubMixin):
         keypoint_params (dict[str, Any] | KeypointParams | None): Parameters for keypoint transforms.
             Can be a dict of params or a KeypointParams object. Default is None.
         additional_targets (dict[str, str] | None): A dictionary mapping additional target names
-            to their types. For example, {'image2': 'image'}. Default is None.
+            to their types. For example, {'image2': 'image'}. Passing a spatial alias also
+            requires passing its canonical target (`image` in this example). Default is None.
         p (float): Probability of applying all transforms. Should be in range [0, 1]. Default is 1.0.
         is_check_shapes (bool): If True, checks consistency of shapes for image/mask/masks on each call.
             Disable only if you are sure about your data consistency. Default is True.
@@ -1464,6 +1466,8 @@ class Compose(BaseCompose, HubMixin):
             msg = "You have to pass data to augmentations as named arguments, for example: aug(image=image)"
             raise KeyError(msg)
 
+        if self._additional_targets:
+            self._validate_additional_target_sources(data)
         self._validate_tensor_inputs(data)
 
         # Initialize applied_transforms only in top-level Compose if requested
@@ -1498,6 +1502,15 @@ class Compose(BaseCompose, HubMixin):
             del self._repack_after_processors
         if hasattr(self, "_instance_count"):
             delattr(self, "_instance_count")
+
+    def _validate_additional_target_sources(self, data: dict[str, Any]) -> None:
+        """Validate that every supplied spatial alias has a populated canonical source at the public Compose
+        input boundary for each invocation.
+        """
+        for alias, target in self._additional_targets.items():
+            if target in _SPATIAL_ADDITIONAL_TARGETS and data.get(alias) is not None and data.get(target) is None:
+                msg = f"Additional target '{alias}' requires canonical target '{target}' to be present."
+                raise ValueError(msg)
 
     def _validate_tensor_inputs(self, data: dict[str, Any]) -> None:
         """Validate Tensor boundary contracts before Compose samples probability or parameters,
@@ -1892,7 +1905,7 @@ class Compose(BaseCompose, HubMixin):
         if not isinstance(bbox_processor, BboxProcessor):
             return
 
-        shape = get_shape(data, self._additional_targets)
+        shape = get_shape(data)
         self._bbox_filter_with_mirror(bbox_processor, data, shape, binding)
         self._drop_instances_with_empty_bound_masks(data, binding)
         self._resync_instance_ids(data)

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -708,60 +708,39 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
         return params
 
-    # Maps canonical shape-bearing target name -> callable extracting the raw shape tuple
-    # used by get_params_dependent_on_data implementations. Order encodes lookup priority.
-    _SHAPE_TARGETS_TUPLE: ClassVar[tuple[tuple[str, Callable[[Any], tuple[int, ...]]], ...]] = (
-        ("image", lambda v: v.shape),
-        ("images", lambda v: v.shape[1:]),
-        ("volume", lambda v: v.shape[1:]),
-        ("mask", lambda v: v.shape),
-        ("masks", lambda v: v.shape[1:]),
-        ("mask3d", lambda v: v.shape[1:]),
-    )
-
     def _extract_shape_from_data(self, data: dict[str, Any]) -> tuple[int, ...] | None:
-        """Return the raw .shape tuple of the first image/mask/volume entry in `data`,
-        resolving aliases via `_additional_targets` (priority from `_SHAPE_TARGETS_TUPLE`).
-
-        Returns None if nothing matches. Aliased keys like
-        `{'custom_image_key': 'image'}` resolve to their canonical role.
+        """Return the raw canonical spatial shape using the layout convention expected by every data-aware
+        transform parameter sampler.
         """
-        # Resolve canonical target -> user key, picking canonical when both present
-        # and otherwise the first alias seen.
-        resolved: dict[str, str] = {}
-        target_set = {name for name, _ in self._SHAPE_TARGETS_TUPLE}
-        for data_key, value in data.items():
-            target = self._additional_targets.get(data_key, data_key)
-            if target not in target_set or value is None:
-                continue
-            if target not in resolved or data_key == target:
-                resolved[target] = data_key
-
-        for target, extractor in self._SHAPE_TARGETS_TUPLE:
-            chosen = resolved.get(target)
-            if chosen is None:
-                continue
-            value = data[chosen]
-            if isinstance(value, torch.Tensor):
-                if target == "image":
-                    return value.shape[1], value.shape[2], value.shape[0]
-                if target in {"images", "volume"}:
-                    return value.shape[2], value.shape[3], value.shape[0]
-            return extractor(value)
+        if (image := data.get("image")) is not None:
+            if isinstance(image, torch.Tensor):
+                return image.shape[1], image.shape[2], image.shape[0]
+            return image.shape
+        if (images := data.get("images")) is not None:
+            if isinstance(images, torch.Tensor):
+                return images.shape[2], images.shape[3], images.shape[0]
+            return images.shape[1:]
+        if (volume := data.get("volume")) is not None:
+            if isinstance(volume, torch.Tensor):
+                return volume.shape[2], volume.shape[3], volume.shape[0]
+            return volume.shape[1:]
+        if (mask := data.get("mask")) is not None:
+            return mask.shape
+        if (masks := data.get("masks")) is not None:
+            return masks.shape[1:]
+        if (mask3d := data.get("mask3d")) is not None:
+            return mask3d.shape[1:]
         return None
 
     def get_image_data(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Return image metadata (dtype, height, width, num_channels) for the first match,
-        resolving aliases via `self._additional_targets` (drop-in for albucore helper).
-
-        Mirrors the contract of the previous `albucore.get_image_data` helper but
-        resolves aliased keys (e.g. `add_targets({'custom_image_key': 'image'})`) first.
+        """Return dtype, spatial dimensions, and channel count from the first canonical image, image batch, or
+        volume for parameter sampling.
 
         Raises:
             ValueError: If no valid image/volume data is present in `data`.
 
         """
-        return _get_image_data_impl(data, self._additional_targets)
+        return _get_image_data_impl(data)
 
     def _add_transform_specific_params(self, params: dict[str, Any]) -> None:
         """Add transform-specific parameters to params dict (interpolation, fill, fill_mask).

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -18,38 +18,8 @@ from albumentations.core.label_manager import LabelManager
 
 from .serialization import Serializable
 
-_IMAGE_DATA_PRIORITY: tuple[str, ...] = ("image", "images", "volume")
 
-
-def _resolve_image_data_keys(
-    data: dict[str, Any],
-    additional_targets: dict[str, str] | None,
-) -> dict[str, str]:
-    """Map canonical image targets (image, images, volume) to the user key
-    holding that data, honoring `additional_targets` aliases (private shape helper).
-
-    The canonical key wins over any alias (so passing both `image=...` and `image2=...`
-    where `image2` aliases `image` keeps `image` as the source). Among aliases that map
-    to the same canonical target, the first one encountered in `data` wins.
-    """
-    aliases = additional_targets or {}
-    resolved: dict[str, str] = {}
-    for key, value in data.items():
-        target = aliases.get(key, key)
-        if target not in _IMAGE_DATA_PRIORITY:
-            continue
-        if value is None:
-            continue
-        # Canonical key always wins; otherwise, first alias seen wins.
-        if target not in resolved or key == target:
-            resolved[target] = key
-    return resolved
-
-
-def get_shape(
-    data: dict[str, Any],
-    additional_targets: dict[str, str] | None = None,
-) -> tuple[int, int]:
+def get_shape(data: dict[str, Any]) -> tuple[int, int]:
     """Extract (height, width) from data dict. Keys: image, images, volume.
     Raises if no image/volume present. Call for spatial checks during pipeline.
 
@@ -60,35 +30,23 @@ def get_shape(
             - 'volume': 3D array of shape (D, H, W, C)
             - 'image': 2D array of shape (H, W, C)
             - 'images': Batch of arrays of shape (N, H, W, C)
-        additional_targets (dict[str, str] | None): Mapping of alias key -> canonical
-            target name (e.g. {'custom_image_key': 'image'}). When provided, aliased
-            keys are resolved to their canonical role.
 
     Returns:
         tuple[int, int]: (height, width) dimensions
 
     """
-    resolved = _resolve_image_data_keys(data, additional_targets)
-    if "image" in resolved:
-        return _get_shape_from_image(data[resolved["image"]])
-    if "images" in resolved:
-        return _get_shape_from_images(data[resolved["images"]])
-    if "volume" in resolved:
-        return _get_shape_from_volume(data[resolved["volume"]])
+    if "image" in data:
+        return _get_shape_from_image(data["image"])
+    if "images" in data:
+        return _get_shape_from_images(data["images"])
+    if "volume" in data:
+        return _get_shape_from_volume(data["volume"])
     raise ValueError("No image or volume found in data", data.keys())
 
 
-def get_image_data(
-    data: dict[str, Any],
-    additional_targets: dict[str, str] | None = None,
-) -> dict[str, Any]:
-    """Extract image metadata (dtype, height, width, num_channels) from a data dict,
-    resolving `additional_targets` aliases (priority: image, images, volume).
-
-    Checks for image data under canonical keys in priority order:
-    `'image'` > `'images'` > `'volume'`. When `additional_targets`
-    is provided, keys aliased to one of those canonical targets are also resolved (e.g.
-    `{'custom_image_key': 'image'}` makes `data['custom_image_key']` count as `'image'`).
+def get_image_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract dtype, spatial dimensions, and channel count from the first canonical image, image batch, or
+    volume in core pipelines.
 
     Height and width skip batch/depth dimensions according to the canonical role:
         - 'image':   H, W from shape[0], shape[1]
@@ -97,8 +55,6 @@ def get_image_data(
 
     Args:
         data (dict[str, Any]): Dictionary potentially containing image/volume arrays.
-        additional_targets (dict[str, str] | None): Mapping of alias key -> canonical
-            target name. When None, only canonical keys are checked.
 
     Returns:
         dict[str, Any]: Dictionary with 'dtype', 'height', 'width', 'num_channels' keys.
@@ -107,14 +63,12 @@ def get_image_data(
         ValueError: If no valid image/volume data keys are found in the dictionary.
 
     """
-    resolved = _resolve_image_data_keys(data, additional_targets)
-    for target in _IMAGE_DATA_PRIORITY:
-        key = resolved.get(target)
-        if key is None:
+    for target in ("image", "images", "volume"):
+        array = data.get(target)
+        if array is None:
             continue
-        arr = data[key]
-        shape = arr.shape
-        if isinstance(arr, torch.Tensor):
+        shape = array.shape
+        if isinstance(array, torch.Tensor):
             if target == "image":
                 height, width = shape[1], shape[2]
             else:
@@ -127,30 +81,12 @@ def get_image_data(
             height, width = shape[1], shape[2]
             num_channels = shape[-1]
         return {
-            "dtype": arr.dtype,
+            "dtype": array.dtype,
             "height": height,
             "width": width,
             "num_channels": num_channels,
         }
     raise ValueError("No valid image/volume data found in data dict")
-
-
-def _resolve_volume_key(data: dict[str, Any], aliases: dict[str, str], canonical: str) -> str | None:
-    """Resolve which user key holds volume data, skipping `None` values
-    and preferring the canonical key name over aliases (same rules as image resolution).
-
-    Returns None if no non-`None` entry matches `canonical`.
-    """
-    chosen: str | None = None
-    for key, value in data.items():
-        if value is None:
-            continue
-        target = aliases.get(key, key)
-        if target != canonical:
-            continue
-        if chosen is None or key == canonical:
-            chosen = key
-    return chosen
 
 
 def _volume_shape_from_array(vol: Any) -> tuple[int, int, int]:
@@ -162,30 +98,22 @@ def _volume_shape_from_array(vol: Any) -> tuple[int, int, int]:
     return vol.shape[0], vol.shape[1], vol.shape[2]
 
 
-def get_volume_shape(
-    data: dict[str, Any],
-    additional_targets: dict[str, str] | None = None,
-) -> tuple[int, int, int] | None:
-    """Extract (depth, height, width) from data containing 'volume',
-    honoring `additional_targets` aliases; returns None when no volume data is present.
+def get_volume_shape(data: dict[str, Any]) -> tuple[int, int, int] | None:
+    """Extract depth, height, and width dimensions from canonical volume data when present for spatial annotation
+    processing steps.
 
     Handles PyTorch tensor layouts (CDHW) and numpy layouts (DHWC).
-    Aliased volume keys resolve to their canonical role.
 
     Args:
         data (dict[str, Any]): Dictionary containing volume data
-        additional_targets (dict[str, str] | None): Mapping of alias key -> canonical
-            target name. When None, only canonical keys are checked.
 
     Returns:
         tuple[int, int, int] | None: (depth, height, width) dimensions if volume data exists, None otherwise
 
     """
-    aliases = additional_targets or {}
-
-    volume_key = _resolve_volume_key(data, aliases, "volume")
-    if volume_key is not None:
-        return _volume_shape_from_array(data[volume_key])
+    volume = data.get("volume")
+    if volume is not None:
+        return _volume_shape_from_array(volume)
 
     return None
 
@@ -344,11 +272,11 @@ class DataProcessor(ABC, Generic[ParamsT]):
             dict[str, Any]: Processed data dictionary.
 
         """
-        shape: tuple[int, int] | tuple[int, int, int] = get_shape(data, self._additional_targets)
+        shape: tuple[int, int] | tuple[int, int, int] = get_shape(data)
 
         # For xyz keypoints, get full 3D shape if available
         if hasattr(self.params, "coord_format") and self.params.coord_format == "xyz":
-            volume_shape = get_volume_shape(data, self._additional_targets)
+            volume_shape = get_volume_shape(data)
             if volume_shape is not None:
                 shape = volume_shape
 
@@ -388,7 +316,7 @@ class DataProcessor(ABC, Generic[ParamsT]):
             data (dict[str, Any]): Data dictionary to preprocess.
 
         """
-        shape = get_shape(data, self._additional_targets)
+        shape = get_shape(data)
 
         # Convert all sequences (including empty lists) to numpy arrays with proper shape
         for data_name in set(self.data_fields) & set(data.keys()):

--- a/benchmark/benchmarks/catalog.py
+++ b/benchmark/benchmarks/catalog.py
@@ -52,6 +52,7 @@ PARAM_OVERRIDES: Mapping[str, Mapping[str, Any]] = {
     "Crop": {"x_max": 128, "y_max": 128},
     "CropAndPad": {"px": 8},
     "CropNonEmptyMaskIfExists": {"height": 96, "width": 96},
+    "Flip3D": {"flip_axes": (0, 1, 2)},
     "GridElasticDeform": {"num_grid_xy": (4, 4), "magnitude": 4},
     "LetterBox": {"size": (128, 128)},
     "LongestMaxSize": {"max_size": 160},

--- a/benchmark/benchmarks/test_family_matrix.py
+++ b/benchmark/benchmarks/test_family_matrix.py
@@ -258,6 +258,7 @@ VOLUME_TRANSFORMS: Mapping[str, Factory] = {
     "coarse_dropout3d": lambda: albumentations.CoarseDropout3D(p=1.0),
     "grid_shuffle3d": lambda: albumentations.GridShuffle3D(grid_zyx=(2, 2, 2), p=1.0),
     "cubic_symmetry": lambda: albumentations.CubicSymmetry(p=1.0),
+    "flip3d": lambda: albumentations.Flip3D(flip_axes=(0, 1, 2), p=1.0),
     "random_rotate90_3d": lambda: albumentations.RandomRotate90_3D(axis_pair=(0, 2), group_element="r90", p=1.0),
 }
 

--- a/tests/files/public_transform_positional_parameters.json
+++ b/tests/files/public_transform_positional_parameters.json
@@ -37,6 +37,7 @@
   "ExposureMatching": ["target_mean_range", "gain_range", "p"],
   "FDA": ["beta_range", "metadata_key", "p"],
   "FancyPCA": ["alpha", "p"],
+  "Flip3D": ["axes", "flip_axes", "p"],
   "FilmGrain": ["intensity_range", "grain_size_range", "p"],
   "FrequencyMasking": ["freq_mask_param", "p"],
   "FromFloat": ["dtype", "max_value", "p"],

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -586,6 +586,7 @@ _BASE_CASE_SPECS: list[list[Any]] = [
         },
     ],
     [A.CubicSymmetry, {}],
+    [A.Flip3D, {"axes": (0, 2)}],
     [A.RandomRotate90_3D, {"axis_pairs": ((0, 2),)}],
     [A.AtLeastOneBBoxRandomCrop, {"height": 80, "width": 80, "erosion_factor": 0.2}],
     [
@@ -1032,6 +1033,7 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
     ("fixed-element", A.RandomRotate90, {"group_element": "r90"}),
     ("subset-elements", A.RandomRotate90, {"group_elements": ("r90", "r270")}),
     ("fixed-axis-rotation", A.RandomRotate90_3D, {"axis_pair": (0, 2), "group_element": "r90"}),
+    ("fixed-axes", A.Flip3D, {"flip_axes": (0, 2)}),
     ("anisotropic-range", A.RandomScale, {"scale_range": {"x": (-0.2, 0.3), "y": (-0.1, 0.15)}}),
     ("downscale-aware", A.RandomScale, {"mask_interpolation": cv2.INTER_LINEAR, "area_for_downscale": "image_mask"}),
     ("variable-intensity", A.RandomShadow, {"shadow_intensity_range": (0.2, 0.7)}),
@@ -1196,6 +1198,7 @@ _EXACT_TRANSFORMS = {
     A.Blur,
     A.CropAndPad,
     A.ExposureMatching,
+    A.Flip3D,
     A.HorizontalFlip,
     A.NoOp,
     A.Pad,

--- a/tests/test_additional_targets.py
+++ b/tests/test_additional_targets.py
@@ -1,563 +1,86 @@
-"""Tests for additional_targets alias resolution across shape/metadata helpers and
-end-to-end transform pipelines.
-
-Covers the family of helpers that historically read data by hardcoded keys
-(`image`, `images`, `mask`, ...) and ignored `_additional_targets`:
-
-- `albumentations.core.utils.get_image_data`
-- `albumentations.core.utils.get_shape`
-- `albumentations.core.utils.get_volume_shape`
-- `BasicTransform._extract_shape_from_data`
-- `BasicTransform.get_image_data`
-- `Compose._gather_shapes_from_data`
-- `Compose._add_grayscale_channels` / `_remove_grayscale_channels`
-- `check_data_post_transform` (via `get_shape`)
-
-Plus integration tests reproducing the user-reported bug (KeyError 'shape',
-"No valid image/volume data found in data dict") for every transform that needs
-shape metadata at param-sampling time.
-"""
+"""Tests for Compose additional target source requirements and routing."""
 
 from __future__ import annotations
-
-from typing import Any
 
 import numpy as np
 import pytest
 
 import albumentations as A
-from albumentations.core.transforms_interface import BasicTransform
-from albumentations.core.utils import get_image_data, get_shape, get_volume_shape
-
-# ---------------------------------------------------------------------------
-# get_image_data
-# ---------------------------------------------------------------------------
-
-
-class TestGetImageData:
-    def test_canonical_image(self) -> None:
-        data = {"image": np.zeros((10, 20, 3), dtype=np.uint8)}
-        meta = get_image_data(data)
-        assert meta == {"dtype": np.uint8, "height": 10, "width": 20, "num_channels": 3}
-
-    def test_canonical_images(self) -> None:
-        data = {"images": np.zeros((4, 10, 20, 3), dtype=np.float32)}
-        meta = get_image_data(data)
-        assert meta["height"] == 10
-        assert meta["width"] == 20
-        assert meta["num_channels"] == 3
-        assert meta["dtype"] == np.float32
-
-    def test_canonical_volume(self) -> None:
-        data = {"volume": np.zeros((5, 10, 20, 3), dtype=np.uint16)}
-        meta = get_image_data(data)
-        assert meta["height"] == 10
-        assert meta["width"] == 20
-        assert meta["num_channels"] == 3
-        assert meta["dtype"] == np.uint16
-
-    def test_aliased_image(self) -> None:
-        data = {"custom_image_key": np.zeros((10, 20, 3), dtype=np.uint8)}
-        meta = get_image_data(data, {"custom_image_key": "image"})
-        assert meta == {"dtype": np.uint8, "height": 10, "width": 20, "num_channels": 3}
-
-    def test_aliased_images(self) -> None:
-        data = {"my_imgs": np.zeros((4, 10, 20, 3), dtype=np.uint8)}
-        meta = get_image_data(data, {"my_imgs": "images"})
-        assert meta["height"] == 10 and meta["width"] == 20
-
-    def test_aliased_volume(self) -> None:
-        data = {"my_vol": np.zeros((5, 10, 20, 3), dtype=np.uint8)}
-        meta = get_image_data(data, {"my_vol": "volume"})
-        assert meta["height"] == 10 and meta["width"] == 20
-
-    def test_priority_canonical_wins_over_alias(self) -> None:
-        """When both canonical and alias resolve to 'image', the canonical key is used."""
-        canonical = np.zeros((10, 20, 3), dtype=np.uint8)
-        aliased = np.zeros((50, 60, 1), dtype=np.uint8)
-        data = {"image": canonical, "custom_image_key": aliased}
-        meta = get_image_data(data, {"custom_image_key": "image"})
-        assert meta["height"] == 10 and meta["width"] == 20
-
-    def test_priority_image_over_images(self) -> None:
-        data = {
-            "images": np.zeros((4, 50, 60, 3), dtype=np.uint8),
-            "image": np.zeros((10, 20, 3), dtype=np.uint8),
-        }
-        meta = get_image_data(data)
-        assert meta["height"] == 10 and meta["width"] == 20
-
-    def test_aliased_image_when_canonical_missing(self) -> None:
-        data = {
-            "custom_img": np.zeros((10, 20, 3), dtype=np.uint8),
-            "bboxes": np.array([[0, 0, 1, 1]]),
-            "labels": [1],
-        }
-        meta = get_image_data(data, {"custom_img": "image"})
-        assert meta["height"] == 10
-
-    def test_ignores_non_image_keys(self) -> None:
-        data = {
-            "bboxes": np.array([[0, 0, 1, 1]]),
-            "keypoints": np.array([[0, 0]]),
-            "labels": [1],
-        }
-        with pytest.raises(ValueError, match="No valid image/volume data"):
-            get_image_data(data)
-
-    def test_empty_dict_raises(self) -> None:
-        with pytest.raises(ValueError, match="No valid image/volume data"):
-            get_image_data({})
-
-    def test_none_value_skipped(self) -> None:
-        data = {"image": None, "custom_img": np.zeros((10, 20, 3), dtype=np.uint8)}
-        meta = get_image_data(data, {"custom_img": "image"})
-        assert meta["height"] == 10
-
-    @pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.float32, np.float64])
-    def test_dtype_preserved(self, dtype: type) -> None:
-        data = {"image": np.zeros((4, 5, 3), dtype=dtype)}
-        assert get_image_data(data)["dtype"] == np.dtype(dtype)
-
-    def test_grayscale_after_expand(self) -> None:
-        data = {"image": np.zeros((10, 20, 1), dtype=np.uint8)}
-        meta = get_image_data(data)
-        assert meta["num_channels"] == 1
-
-
-# ---------------------------------------------------------------------------
-# get_shape
-# ---------------------------------------------------------------------------
-
-
-class TestGetShape:
-    @pytest.mark.parametrize(
-        ("data", "expected"),
-        [
-            ({"image": np.zeros((10, 20, 3), dtype=np.uint8)}, (10, 20)),
-            ({"images": np.zeros((4, 10, 20, 3), dtype=np.uint8)}, (10, 20)),
-            ({"volume": np.zeros((5, 10, 20, 3), dtype=np.uint8)}, (10, 20)),
-        ],
-    )
-    def test_canonical_keys(self, data: dict[str, Any], expected: tuple[int, int]) -> None:
-        assert get_shape(data) == expected
-
-    @pytest.mark.parametrize(
-        ("data", "aliases", "expected"),
-        [
-            ({"x_img": np.zeros((10, 20, 3), dtype=np.uint8)}, {"x_img": "image"}, (10, 20)),
-            ({"x_imgs": np.zeros((4, 10, 20, 3), dtype=np.uint8)}, {"x_imgs": "images"}, (10, 20)),
-            ({"x_vol": np.zeros((5, 10, 20, 3), dtype=np.uint8)}, {"x_vol": "volume"}, (10, 20)),
-        ],
-    )
-    def test_aliased_keys(
-        self,
-        data: dict[str, Any],
-        aliases: dict[str, str],
-        expected: tuple[int, int],
-    ) -> None:
-        assert get_shape(data, aliases) == expected
-
-    def test_canonical_wins_over_alias(self) -> None:
-        data = {
-            "image": np.zeros((10, 20, 3), dtype=np.uint8),
-            "x_img": np.zeros((50, 60, 3), dtype=np.uint8),
-        }
-        assert get_shape(data, {"x_img": "image"}) == (10, 20)
-
-    def test_no_image_raises(self) -> None:
-        with pytest.raises(ValueError, match="No image or volume found"):
-            get_shape({"bboxes": np.array([[0, 0, 1, 1]])})
-
-    @pytest.mark.pytorch
-    def test_torch_chw_under_alias(self) -> None:
-        torch = pytest.importorskip("torch")
-        data = {"x_img": torch.zeros(3, 10, 20)}
-        assert get_shape(data, {"x_img": "image"}) == (10, 20)
-
-
-# ---------------------------------------------------------------------------
-# get_volume_shape
-# ---------------------------------------------------------------------------
-
-
-class TestGetVolumeShape:
-    def test_canonical_volume(self) -> None:
-        data = {"volume": np.zeros((5, 10, 20, 3), dtype=np.uint8)}
-        assert get_volume_shape(data) == (5, 10, 20)
-
-    def test_aliased_volume(self) -> None:
-        data = {"my_vol": np.zeros((5, 10, 20, 3), dtype=np.uint8)}
-        assert get_volume_shape(data, {"my_vol": "volume"}) == (5, 10, 20)
-
-    def test_returns_none_when_no_volume(self) -> None:
-        data = {"image": np.zeros((10, 20, 3), dtype=np.uint8)}
-        assert get_volume_shape(data) is None
-
-    def test_canonical_volume_none_uses_aliased_key(self) -> None:
-        """`volume: None` must not shadow a non-`None` value under an alias (regression: PR review)."""
-        data = {
-            "volume": None,
-            "my_vol": np.zeros((5, 10, 20, 3), dtype=np.uint8),
-        }
-        assert get_volume_shape(data, {"my_vol": "volume"}) == (5, 10, 20)
-
-    def test_canonical_volume_wins_over_alias_when_both_set(self) -> None:
-        vol = np.zeros((5, 10, 20, 3), dtype=np.uint8)
-        other = np.zeros((2, 3, 4, 3), dtype=np.uint8)
-        data = {"my_vol": other, "volume": vol}
-        assert get_volume_shape(data, {"my_vol": "volume"}) == (5, 10, 20)
-
-
-# ---------------------------------------------------------------------------
-# BasicTransform._extract_shape_from_data + .get_image_data
-# ---------------------------------------------------------------------------
-
-
-class _DummyDual(A.DualTransform):
-    """Minimal dual transform exposing _extract_shape_from_data for tests."""
-
-    def apply(self, img, **params):
-        return img
-
-    def apply_to_mask(self, mask, **params):
-        return mask
 
 
 @pytest.mark.parametrize(
-    ("data_key", "shape_in", "expected"),
+    ("additional_targets", "data", "alias", "target"),
     [
-        ("image", (10, 20, 3), (10, 20, 3)),
-        ("mask", (10, 20), (10, 20)),
-        ("images", (4, 10, 20, 3), (10, 20, 3)),
-        ("masks", (4, 10, 20), (10, 20)),
-        ("volume", (5, 10, 20, 3), (10, 20, 3)),
-        ("mask3d", (5, 10, 20), (10, 20)),
-        ("images", (0, 10, 20, 3), (10, 20, 3)),
-        ("masks", (0, 10, 20), (10, 20)),
-        ("volume", (0, 10, 20, 3), (10, 20, 3)),
-        ("mask3d", (0, 10, 20), (10, 20)),
+        (
+            {"image2": "image"},
+            {"image2": np.zeros((4, 5, 3), dtype=np.uint8)},
+            "image2",
+            "image",
+        ),
+        (
+            {"mask2": "mask"},
+            {
+                "image": np.zeros((4, 5, 3), dtype=np.uint8),
+                "mask2": np.zeros((4, 5), dtype=np.uint8),
+            },
+            "mask2",
+            "mask",
+        ),
+        (
+            {"scan": "volume"},
+            {"scan": np.zeros((3, 4, 5, 1), dtype=np.uint8)},
+            "scan",
+            "volume",
+        ),
+        (
+            {"segmentation": "mask3d"},
+            {"segmentation": np.zeros((3, 4, 5), dtype=np.uint8)},
+            "segmentation",
+            "mask3d",
+        ),
     ],
 )
-def test_extract_shape_aliased(
-    data_key: str,
-    shape_in: tuple[int, ...],
-    expected: tuple[int, ...],
+def test_additional_target_requires_canonical_source(
+    additional_targets: dict[str, str],
+    data: dict[str, np.ndarray],
+    alias: str,
+    target: str,
 ) -> None:
-    """Each canonical target keyed under an alias still resolves to the right .shape."""
-    transform = _DummyDual(p=1.0)
-    alias = f"my_{data_key}"
-    transform.add_targets({alias: data_key})
-    data = {alias: np.zeros(shape_in, dtype=np.uint8)}
-    assert transform._extract_shape_from_data(data) == expected
+    transform = A.Compose([A.NoOp(p=1.0)], additional_targets=additional_targets, strict=True)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"Additional target '{alias}' requires canonical target '{target}' to be present",
+    ):
+        transform(**data)
 
 
-def test_extract_shape_no_data_returns_none() -> None:
-    transform = _DummyDual(p=1.0)
-    assert transform._extract_shape_from_data({"bboxes": np.zeros((0, 4))}) is None
+def test_unused_additional_target_does_not_require_its_source() -> None:
+    image = np.zeros((4, 5, 3), dtype=np.uint8)
+    transform = A.Compose([A.NoOp(p=1.0)], additional_targets={"image2": "image"}, strict=True)
+
+    result = transform(image=image)
+
+    assert result["image"] is image
 
 
-def test_extract_shape_canonical_wins_over_alias() -> None:
-    transform = _DummyDual(p=1.0)
-    transform.add_targets({"img2": "image"})
-    data = {
-        "image": np.zeros((10, 20, 3), dtype=np.uint8),
-        "img2": np.zeros((50, 60, 3), dtype=np.uint8),
-    }
-    assert transform._extract_shape_from_data(data) == (10, 20, 3)
+def test_additional_image_is_transformed_with_its_canonical_source() -> None:
+    image = np.arange(12, dtype=np.uint8).reshape(3, 4, 1)
+    image2 = np.arange(12, 24, dtype=np.uint8).reshape(3, 4, 1)
+    transform = A.Compose([A.HorizontalFlip(p=1.0)], additional_targets={"image2": "image"})
+
+    result = transform(image=image, image2=image2)
+
+    np.testing.assert_array_equal(result["image"], image[:, ::-1])
+    np.testing.assert_array_equal(result["image2"], image2[:, ::-1])
 
 
-def test_basictransform_get_image_data_uses_aliases() -> None:
-    transform = _DummyDual(p=1.0)
-    transform.add_targets({"my_img": "image"})
-    data = {"my_img": np.zeros((10, 20, 3), dtype=np.uint8)}
-    meta = transform.get_image_data(data)
-    assert meta["height"] == 10
-    assert meta["width"] == 20
-    assert meta["num_channels"] == 3
+def test_grayscale_additional_image_restores_its_original_shape() -> None:
+    image = np.zeros((3, 4, 1), dtype=np.uint8)
+    image2 = np.arange(12, dtype=np.uint8).reshape(3, 4)
+    transform = A.Compose([A.HorizontalFlip(p=1.0)], additional_targets={"image2": "image"})
 
+    result = transform(image=image, image2=image2)
 
-def test_basictransform_get_image_data_raises_without_image() -> None:
-    transform = _DummyDual(p=1.0)
-    with pytest.raises(ValueError, match="No valid image/volume data"):
-        transform.get_image_data({"bboxes": np.zeros((0, 4))})
-
-
-# ---------------------------------------------------------------------------
-# Compose._gather_shapes_from_data
-# ---------------------------------------------------------------------------
-
-
-def test_gather_shapes_aliased_consistent() -> None:
-    compose = A.Compose([A.NoOp()])
-    compose.add_targets({"img2": "image", "msk2": "mask"})
-    data = {
-        "img2": np.zeros((10, 20, 3), dtype=np.uint8),
-        "msk2": np.zeros((10, 20), dtype=np.uint8),
-    }
-    shapes, volume_shapes = compose._gather_shapes_from_data(data)
-    assert shapes == [(10, 20), (10, 20)]
-    assert volume_shapes == []
-
-
-def test_gather_shapes_aliased_inconsistent_raises() -> None:
-    compose = A.Compose([A.NoOp()], is_check_shapes=True)
-    compose.add_targets({"img2": "image", "msk2": "mask"})
-    with pytest.raises(ValueError):
-        compose(
-            img2=np.zeros((10, 20, 3), dtype=np.uint8),
-            msk2=np.zeros((50, 60), dtype=np.uint8),
-        )
-
-
-# ---------------------------------------------------------------------------
-# Compose grayscale channel handling
-# ---------------------------------------------------------------------------
-
-
-def test_grayscale_aliased_image_expanded_and_stripped() -> None:
-    compose = A.Compose([A.HorizontalFlip(p=1.0)])
-    compose.add_targets({"img2": "image"})
-    out = compose(img2=np.zeros((10, 20), dtype=np.uint8))
-    assert out["img2"].shape == (10, 20)
-
-
-def test_grayscale_aliased_mask_expanded_and_stripped() -> None:
-    compose = A.Compose([A.HorizontalFlip(p=1.0)])
-    compose.add_targets({"msk2": "mask"})
-    out = compose(
-        image=np.zeros((10, 20, 3), dtype=np.uint8),
-        msk2=np.zeros((10, 20), dtype=np.uint8),
-    )
-    assert out["msk2"].shape == (10, 20)
-
-
-def test_grayscale_aliased_image_with_channel_no_strip() -> None:
-    """If user already passes (H,W,C), preprocessor must not strip on output."""
-    compose = A.Compose([A.HorizontalFlip(p=1.0)])
-    compose.add_targets({"img2": "image"})
-    out = compose(img2=np.zeros((10, 20, 3), dtype=np.uint8))
-    assert out["img2"].shape == (10, 20, 3)
-
-
-def test_grayscale_aliased_added_channel_dim_tracking() -> None:
-    """Internal bookkeeping keys the alias under the user key with canonical map."""
-    compose = A.Compose([A.HorizontalFlip(p=1.0)])
-    compose.add_targets({"img2": "image"})
-    # Run preprocessing only, then inspect bookkeeping
-    data = {"img2": np.zeros((10, 20), dtype=np.uint8)}
-    compose._preprocess_arrays(data)
-    assert compose._added_channel_dim == {"img2": True}
-    assert compose._added_channel_canonical == {"img2": "image"}
-    assert data["img2"].shape == (10, 20, 1)
-
-
-# ---------------------------------------------------------------------------
-# Integration: user-reported bug pipeline
-# ---------------------------------------------------------------------------
-
-
-def _make_user_pipeline() -> A.Compose:
-    """Replicates the pipeline from the GitHub issue."""
-    return A.Compose(
-        [
-            A.Resize(p=1.0, height=64, width=64, interpolation=1, mask_interpolation=0),
-            A.HorizontalFlip(p=1.0),
-            A.Affine(
-                p=1.0,
-                border_mode=1,
-                fill=0.0,
-                fit_output=False,
-                interpolation=1,
-                keep_ratio=True,
-                mask_interpolation=0,
-                rotate=(-15.0, 15.0),
-                rotate_method="largest_box",
-            ),
-            A.ColorJitter(p=1.0),
-            A.OneOf(
-                [
-                    A.GaussNoise(p=1.0),
-                    A.ISONoise(p=1.0),
-                    A.MultiplicativeNoise(p=1.0),
-                ],
-                p=1.0,
-            ),
-            A.Normalize(p=1.0),
-        ],
-        p=1.0,
-        seed=43,
-    )
-
-
-def test_user_issue_pipeline_runs_with_aliased_keys() -> None:
-    pipeline = _make_user_pipeline()
-    pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
-    img = np.zeros((100, 100, 3), dtype=np.uint8)
-    mask = np.zeros((100, 100), dtype=np.uint8)
-    out = pipeline(custom_image_key=img, custom_mask_key=mask)
-    assert set(out.keys()) == {"custom_image_key", "custom_mask_key"}
-    assert out["custom_image_key"].shape == (64, 64, 3)
-    assert out["custom_mask_key"].shape == (64, 64)
-
-
-def test_user_issue_pipeline_many_seeds() -> None:
-    """OneOf with all branches at p=1.0 hits each noise transform across seeds; with the bug, this
-    used to KeyError 'shape' from Affine and ValueError from GaussNoise/ISONoise/MultiplicativeNoise.
-    """
-    img = np.zeros((100, 100, 3), dtype=np.uint8)
-    mask = np.zeros((100, 100), dtype=np.uint8)
-    for seed in range(20):
-        pipeline = A.Compose(
-            [
-                A.Affine(p=1.0),
-                A.ColorJitter(p=1.0),
-                A.OneOf(
-                    [A.GaussNoise(p=1.0), A.ISONoise(p=1.0), A.MultiplicativeNoise(p=1.0)],
-                    p=1.0,
-                ),
-            ],
-            seed=seed,
-        )
-        pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
-        pipeline(custom_image_key=img, custom_mask_key=mask)
-
-
-# ---------------------------------------------------------------------------
-# Integration: every shape-dependent transform under aliased keys
-# ---------------------------------------------------------------------------
-
-
-# Each entry is a transform constructor that forces p=1.0 and exercises a
-# get_params_dependent_on_data path that needs `params["shape"]` or get_image_data.
-_SHAPE_DEPENDENT_TRANSFORMS: list[tuple[str, A.BasicTransform]] = [
-    ("Affine", A.Affine(p=1.0)),
-    ("ColorJitter", A.ColorJitter(p=1.0)),
-    ("ChannelShuffle", A.ChannelShuffle(p=1.0)),
-    ("FancyPCA", A.FancyPCA(p=1.0)),
-    ("GaussNoise", A.GaussNoise(p=1.0)),
-    ("MultiplicativeNoise", A.MultiplicativeNoise(p=1.0)),
-    ("ISONoise", A.ISONoise(p=1.0)),
-    ("SaltAndPepper", A.SaltAndPepper(p=1.0)),
-    ("RandomFog", A.RandomFog(p=1.0)),
-    ("RandomRain", A.RandomRain(p=1.0)),
-    ("RandomGravel", A.RandomGravel(p=1.0)),
-    ("RandomShadow", A.RandomShadow(p=1.0)),
-    ("RandomSunFlare", A.RandomSunFlare(p=1.0)),
-    ("ChannelDropout", A.ChannelDropout(p=1.0)),
-    ("PlasmaShadow", A.PlasmaShadow(p=1.0)),
-]
-
-
-@pytest.mark.parametrize(
-    ("name", "transform"),
-    _SHAPE_DEPENDENT_TRANSFORMS,
-    ids=[name for name, _ in _SHAPE_DEPENDENT_TRANSFORMS],
-)
-def test_shape_dependent_transforms_under_aliased_keys(
-    name: str,
-    transform: BasicTransform,
-) -> None:
-    """Every transform that consults shape/image metadata at param time must work
-    when the user only passes aliased keys (the original GitHub issue).
-    """
-    img = np.full((40, 50, 3), 128, dtype=np.uint8)
-    mask = np.zeros((40, 50), dtype=np.uint8)
-    pipeline = A.Compose([transform], seed=0)
-    pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
-    out = pipeline(custom_image_key=img, custom_mask_key=mask)
-    assert "custom_image_key" in out
-    assert out["custom_image_key"].shape == img.shape
-    assert "custom_mask_key" in out
-    assert out["custom_mask_key"].shape == mask.shape
-
-
-# ---------------------------------------------------------------------------
-# Integration: bbox postprocess path (get_shape used by check_data_post_transform)
-# ---------------------------------------------------------------------------
-
-
-def test_bbox_postprocess_with_aliased_image() -> None:
-    pipeline = A.Compose(
-        [A.HorizontalFlip(p=1.0), A.Affine(p=1.0)],
-        bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["lab"]),
-        seed=0,
-    )
-    pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
-    out = pipeline(
-        custom_image_key=np.zeros((100, 100, 3), dtype=np.uint8),
-        custom_mask_key=np.zeros((100, 100), dtype=np.uint8),
-        bboxes=[[0, 0, 10, 10]],
-        lab=[1],
-    )
-    assert "bboxes" in out
-    assert len(out["bboxes"]) == 1
-
-
-def test_keypoint_postprocess_with_aliased_image() -> None:
-    pipeline = A.Compose(
-        [A.HorizontalFlip(p=1.0), A.Affine(p=1.0)],
-        keypoint_params=A.KeypointParams(coord_format="xy", label_fields=["lab"]),
-        seed=0,
-    )
-    pipeline.add_targets({"custom_image_key": "image"})
-    out = pipeline(
-        custom_image_key=np.zeros((100, 100, 3), dtype=np.uint8),
-        keypoints=[[10, 20]],
-        lab=[1],
-    )
-    assert "keypoints" in out
-    assert len(out["keypoints"]) == 1
-
-
-# ---------------------------------------------------------------------------
-# Integration: mixed default + alias
-# ---------------------------------------------------------------------------
-
-
-def test_mixed_default_and_alias_image() -> None:
-    """Both `image` and an aliased `image2` must be transformed identically."""
-    img1 = np.full((40, 50, 3), 10, dtype=np.uint8)
-    img2 = np.full((40, 50, 3), 200, dtype=np.uint8)
-    pipeline = A.Compose([A.HorizontalFlip(p=1.0)], seed=0)
-    pipeline.add_targets({"image2": "image"})
-    out = pipeline(image=img1, image2=img2)
-    np.testing.assert_array_equal(out["image"], img1[:, ::-1])
-    np.testing.assert_array_equal(out["image2"], img2[:, ::-1])
-
-
-def test_mixed_default_and_alias_mask() -> None:
-    img = np.zeros((40, 50, 3), dtype=np.uint8)
-    mask1 = np.zeros((40, 50), dtype=np.uint8)
-    mask1[:, :10] = 1
-    mask2 = np.zeros((40, 50), dtype=np.uint8)
-    mask2[:, -10:] = 5
-    pipeline = A.Compose([A.HorizontalFlip(p=1.0)], seed=0)
-    pipeline.add_targets({"mask2": "mask"})
-    out = pipeline(image=img, mask=mask1, mask2=mask2)
-    np.testing.assert_array_equal(out["mask"], mask1[:, ::-1])
-    np.testing.assert_array_equal(out["mask2"], mask2[:, ::-1])
-
-
-# ---------------------------------------------------------------------------
-# Regression: the exact errors reported in the GitHub issue
-# ---------------------------------------------------------------------------
-
-
-def test_regression_keyerror_shape_no_longer_raised() -> None:
-    """Affine used to raise `KeyError: 'shape'` when only aliased keys were present."""
-    pipeline = A.Compose([A.Affine(p=1.0)], seed=0)
-    pipeline.add_targets({"custom_image_key": "image", "custom_mask_key": "mask"})
-    pipeline(
-        custom_image_key=np.zeros((40, 50, 3), dtype=np.uint8),
-        custom_mask_key=np.zeros((40, 50), dtype=np.uint8),
-    )
-
-
-def test_regression_no_valid_image_data_no_longer_raised() -> None:
-    """GaussNoise/ISONoise/MultiplicativeNoise used to raise
-    'No valid image/volume data found in data dict'.
-    """
-    pipeline = A.Compose([A.GaussNoise(p=1.0)], seed=0)
-    pipeline.add_targets({"custom_image_key": "image"})
-    pipeline(custom_image_key=np.zeros((40, 50, 3), dtype=np.uint8))
+    assert result["image2"].shape == image2.shape
+    np.testing.assert_array_equal(result["image2"], image2[:, ::-1])

--- a/tests/test_compose_operators.py
+++ b/tests/test_compose_operators.py
@@ -466,6 +466,7 @@ def test_compose_operators_preserve_additional_targets(sample_image):
     data = {
         "image": sample_image,
         "image2": sample_image.copy(),
+        "mask": mask2.copy(),
         "mask2": mask2,
     }
 
@@ -473,6 +474,7 @@ def test_compose_operators_preserve_additional_targets(sample_image):
 
     assert "image" in result
     assert "image2" in result
+    assert "mask" in result
     assert "mask2" in result
 
 

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -383,6 +383,7 @@ def test_transpose_rejects_tensor_routes_outside_accepted_capability(
         A.CubicSymmetry(p=1.0),
         A.Pad3D(padding=(1, 2, 2), p=1.0),
         A.RandomRotate90_3D(axis_pair=(0, 2), group_element="r90", p=1.0),
+        A.Flip3D(flip_axes=(0, 2), p=1.0),
     ],
 )
 def test_3d_transforms_remain_rejected_until_their_tensor_routes_pass_the_performance_gate(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -324,9 +324,10 @@ def test_resize_with_additional_targets_mask():
         additional_targets={"semantic_mask": "mask"},
     )
 
-    augmented = transform(image=image, semantic_mask=mask)
+    augmented = transform(image=image, mask=mask, semantic_mask=mask.copy())
 
     assert augmented["image"].shape == (512, 512, 3)
+    assert augmented["mask"].shape == (512, 512)
     assert augmented["semantic_mask"].shape == (512, 512)
     assert augmented["semantic_mask"].ndim == 2
 

--- a/tests/transforms3d/test_functions.py
+++ b/tests/transforms3d/test_functions.py
@@ -269,6 +269,22 @@ def test_rotate90_3d_matches_numpy(axis_pair, rotation_count):
     assert result.dtype == volume.dtype
 
 
+@pytest.mark.parametrize("flip_axes", [(0,), (1,), (2,), (0, 2), (0, 1, 2)])
+def test_keypoints_flip3d_matches_reflected_volume(flip_axes):
+    volume = np.zeros((3, 4, 5), dtype=np.uint8)
+    keypoints = np.array([[1, 1, 0, 7], [3, 2, 1, 9], [4, 3, 2, 11]], dtype=np.float32)
+
+    for value, (x_coordinate, y_coordinate, z_coordinate) in enumerate(keypoints[:, :3], start=1):
+        volume[int(z_coordinate), int(y_coordinate), int(x_coordinate)] = value
+
+    transformed_volume = np.flip(volume, axis=flip_axes)
+    transformed_keypoints = f3d.keypoints_flip_3d(keypoints, flip_axes, volume.shape)
+
+    for value, (x_coordinate, y_coordinate, z_coordinate) in enumerate(transformed_keypoints[:, :3], start=1):
+        assert transformed_volume[int(z_coordinate), int(y_coordinate), int(x_coordinate)] == value
+    np.testing.assert_array_equal(transformed_keypoints[:, 3:], keypoints[:, 3:])
+
+
 @pytest.mark.parametrize("axis_pair", [(0, 1), (0, 2), (1, 2)])
 @pytest.mark.parametrize("rotation_count", [1, 2, 3])
 def test_keypoints_rotate90_3d_matches_rotated_volume(axis_pair, rotation_count):

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1191,3 +1191,77 @@ def test_random_rotate90_3d_rejects_invalid_configuration(kwargs):
 def test_random_rotate90_3d_random_mode_cannot_be_inverted():
     with pytest.raises(ValueError, match="random mode"):
         A.RandomRotate90_3D().inverse()
+
+
+def test_flip3d_reflects_volume_mask_and_keypoints_without_reordering_axes():
+    volume = np.arange(3 * 4 * 5 * 2, dtype=np.uint8).reshape(3, 4, 5, 2)
+    mask3d = (volume[..., 0] % 2).astype(np.uint8)
+    keypoints = np.array([[1, 1, 0], [3, 2, 1], [4, 3, 2]], dtype=np.float32)
+    keypoint_labels = [7, 9, 11]
+    transform = A.Flip3D(flip_axes=(0, 2), p=1.0)
+    compose = A.Compose(
+        [transform],
+        keypoint_params=A.KeypointParams(coord_format="xyz", label_fields=["keypoint_labels"]),
+        strict=True,
+    )
+
+    result = compose(
+        volume=volume,
+        mask3d=mask3d,
+        keypoints=keypoints,
+        keypoint_labels=keypoint_labels,
+    )
+
+    np.testing.assert_array_equal(result["volume"], np.flip(volume, axis=(0, 2)))
+    np.testing.assert_array_equal(result["mask3d"], np.flip(mask3d, axis=(0, 2)))
+    np.testing.assert_array_equal(result["keypoints"], np.array([[3, 1, 2], [1, 2, 1], [0, 3, 0]], dtype=np.float32))
+    assert result["volume"].shape == volume.shape
+    assert result["mask3d"].shape == mask3d.shape
+    assert result["volume"].dtype == volume.dtype
+    assert result["mask3d"].dtype == mask3d.dtype
+    assert result["keypoint_labels"] == keypoint_labels
+
+    restored = A.Compose(
+        [transform.inverse()],
+        keypoint_params=A.KeypointParams(coord_format="xyz", label_fields=["keypoint_labels"]),
+        strict=True,
+    )(**result)
+    np.testing.assert_array_equal(restored["volume"], volume)
+    np.testing.assert_array_equal(restored["mask3d"], mask3d)
+    np.testing.assert_array_equal(restored["keypoints"], keypoints)
+
+
+def test_flip3d_seeded_replay_records_realized_axes():
+    volume = np.arange(3 * 4 * 5, dtype=np.uint8).reshape(3, 4, 5, 1)
+    pipeline = A.Compose(
+        [A.Flip3D(axes=(0, 2), p=1.0)],
+        save_applied_params=True,
+        seed=137,
+        strict=True,
+    )
+
+    result = pipeline(volume=volume)
+    replay = A.Compose.from_applied_transforms(result["applied_transforms"], strict=True)
+    replayed = replay(volume=volume)
+
+    np.testing.assert_array_equal(replayed["volume"], result["volume"])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"axes": ()},
+        {"axes": (0, 0)},
+        {"flip_axes": ()},
+        {"axes": (0,), "flip_axes": (1,)},
+        {"flip_axes": (0, 0)},
+    ],
+)
+def test_flip3d_rejects_invalid_configuration(kwargs):
+    with pytest.raises(ValueError):
+        A.Flip3D(**kwargs)
+
+
+def test_flip3d_random_mode_cannot_be_inverted():
+    with pytest.raises(ValueError, match="random mode"):
+        A.Flip3D().inverse()

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -220,6 +220,7 @@ VOLUME_ALIAS_TO_TRANSFORM = {
     "center_crop3d": "CenterCrop3D",
     "coarse_dropout3d": "CoarseDropout3D",
     "cubic_symmetry": "CubicSymmetry",
+    "flip3d": "Flip3D",
     "grid_shuffle3d": "GridShuffle3D",
     "pad3d": "Pad3D",
     "pad_if_needed3d": "PadIfNeeded3D",


### PR DESCRIPTION
## Summary

Adds `Flip3D` for independent depth, height, and width reflections of `volume`, `mask3d`, and 3D keypoints. It preserves shape and dtype, supports fixed-axis self-inverse TTA, and records realized random axes for exact replay.

Plural `volumes` and `masks3d` targets are intentionally not introduced.

## Tensor decision

Benchmarked a native CPU Tensor candidate that accepts and returns `torch.Tensor` through `Compose`, without NumPy conversion. `torch.flip` copies data while `np.flip` returns a view, so the Tensor candidate is slower in every tested configuration (up to 84.8x direct and 9.5x through Compose). The public CPU Tensor route remains explicitly rejected until it clears the performance gate.

## Benchmarks and validation

- Registered direct-kernel and volumetric Compose ASV coverage for `Flip3D`.
- `uv run pytest -m 'not slow' -q -n auto` — 12938 passed, 42 skipped
- `uv run python -m tools.quality_gate fast` — passed
- `pre-commit run --all-files` — passed

## Summary by Sourcery

Introduce a Flip3D transform and functional kernels for 3D volume reflections, integrating them into the 3D augmentation, benchmarking, and documentation suites.

New Features:
- Add Flip3D transform that reflects 3D volumes, masks, and keypoints across configurable spatial axes with optional deterministic test-time augmentation support.

Enhancements:
- Register flip3d functional kernel in the benchmark catalog, coverage tooling, and family matrix to measure and compare performance.
- Include Flip3D in shared transform-case helpers and positional parameter metadata for broader pipeline and API coverage.
- Update README transform table to document Flip3D as a public 3D augmentation.

Tests:
- Add unit tests validating Flip3D behavior on volumes, masks, keypoints, seeded replay, configuration validation, and invertibility constraints.
- Add functional tests ensuring flip3d and keypoints_flip_3d match NumPy-based reflections and preserve shape and dtype.
- Extend tensor-compose tests to keep Flip3D in the rejected CPU tensor route until performance requirements are met.