### PR TITLE
feat(transforms3d): add Anisotropy3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ Spatial-level transforms will simultaneously change both an input image as well 
 
 ### 3D transforms
 
-3D transforms operate on volumetric data and can modify both the input volume and associated 3D mask.
+3D transforms operate on volumetric data. Spatial transforms can also modify associated 3D masks and keypoints, while
+volume-intensity transforms leave those targets unchanged.
 
 Where:
 
@@ -349,6 +350,7 @@ Where:
 
 | Transform                                                                           | Volume | Mask3D | Keypoints |
 | ----------------------------------------------------------------------------------- | :----: | :----: | :-------: |
+| [Anisotropy3D](https://albumentations.ai/explore/transform/Anisotropy3D/)           | ✓      |        |           |
 | [CenterCrop3D](https://albumentations.ai/explore/transform/CenterCrop3D/)           | ✓      | ✓      | ✓         |
 | [CoarseDropout3D](https://albumentations.ai/explore/transform/CoarseDropout3D/)     | ✓      | ✓      | ✓         |
 | [CubicSymmetry](https://albumentations.ai/explore/transform/CubicSymmetry/)         | ✓      | ✓      | ✓         |

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -9,10 +9,61 @@ specifically designed for 3D data.
 import random
 from typing import Literal, cast
 
+import cv2
 import numpy as np
+import torch
+from albucore import resize3d
 
 from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.type_definitions import NUM_VOLUME_DIMENSIONS, ImageType, VolumeType
+
+
+def get_anisotropy_downsample_shape(
+    spatial_shape: tuple[int, int, int],
+    axes: tuple[int, ...],
+    downscale_factor: float,
+) -> tuple[int, int, int]:
+    """Derive an anisotropic intermediate shape by scaling selected axes while retaining non-selected axes, ensuring
+    every requested spatial dimension remains valid.
+    """
+    return cast(
+        "tuple[int, int, int]",
+        tuple(
+            max(1, round(axis_size / downscale_factor)) if axis_index in axes else axis_size
+            for axis_index, axis_size in enumerate(spatial_shape)
+        ),
+    )
+
+
+def anisotropy_3d(
+    volume: VolumeType | torch.Tensor,
+    downsample_shape: tuple[int, int, int],
+    antialias: bool,
+) -> VolumeType | torch.Tensor:
+    """Simulate thicker or lower-resolution volume acquisition by shrinking selected spatial axes and restoring the
+    original shape for 3D robustness training.
+
+    Both routes delegate to Albucore `resize3d`, which resizes only spatial axes and preserves the input representation.
+    NumPy applies antialiasing while shrinking; PyTorch does not yet provide 5D trilinear antialiasing, so Tensor input
+    uses the non-antialiased native route until upstream support is available.
+    """
+    source_shape = cast(
+        "tuple[int, int, int]",
+        tuple(volume.shape[1:]) if isinstance(volume, torch.Tensor) else volume.shape[:3],
+    )
+    if source_shape == downsample_shape:
+        return volume
+
+    is_channel_less_numpy_volume = isinstance(volume, np.ndarray) and volume.ndim == NUM_VOLUME_DIMENSIONS - 1
+    working_volume = volume[..., np.newaxis] if is_channel_less_numpy_volume else volume
+    downsampled = resize3d(
+        working_volume,
+        downsample_shape,
+        interpolation=cv2.INTER_LINEAR,
+        antialias=antialias and not isinstance(volume, torch.Tensor),
+    )
+    restored = resize3d(downsampled, source_shape, interpolation=cv2.INTER_LINEAR)
+    return restored[..., 0] if is_channel_less_numpy_volume else restored
 
 
 @handle_empty_array("keypoints")

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -10,6 +10,7 @@ interface and implements specific 3D augmentation logic.
 from typing import Annotated, Any, ClassVar, Literal, cast
 
 import numpy as np
+import torch
 from pydantic import AfterValidator, field_validator, model_validator
 from typing_extensions import Self
 
@@ -17,10 +18,11 @@ from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transforms_interface import BaseTransformInitSchema, Transform3D
+from albumentations.core.transforms_interface import BaseTransformInitSchema, Transform3D, VolumeOnlyTransform
 from albumentations.core.type_definitions import C4_INVERSE, C4GroupElement, Targets, VolumeType, c4_group_elements
 
 __all__ = [
+    "Anisotropy3D",
     "CenterCrop3D",
     "CoarseDropout3D",
     "CubicSymmetry",
@@ -45,7 +47,8 @@ def _get_volume_shape(data: dict[str, Any]) -> tuple[int, ...]:
     Avoids indexing empty leading axes.
     """
     if "volume" in data:
-        return data["volume"].shape
+        volume = data["volume"]
+        return tuple(volume.shape[1:]) if isinstance(volume, torch.Tensor) else volume.shape
     if "mask3d" in data:
         return data["mask3d"].shape
     raise ValueError("No volume or mask3d found in data")
@@ -56,6 +59,119 @@ def _get_volume_spatial_shape(data: dict[str, Any]) -> tuple[int, int, int]:
     Avoids indexing empty leading axes.
     """
     return cast("tuple[int, int, int]", _get_volume_shape(data)[:3])
+
+
+class Anisotropy3D(VolumeOnlyTransform):
+    """Simulate thicker or lower-resolution volume acquisition by degrading selected spatial axes and restoring the
+    original grid for 3D model robustness training.
+
+    The transform samples a subset from `axes` and one downsampling factor for every selected axis. Both NumPy and CPU
+    Tensor routes delegate spatial resizing to Albucore `resize3d`. PyTorch does not currently provide antialiasing for
+    5D trilinear interpolation, so Tensor input remains non-antialiased when `antialias=True`. `mask3d` remains
+    unchanged because this is an image-acquisition artifact, not a geometry transform.
+
+    Args:
+        axes (tuple[int, ...]): Eligible spatial axes in `(depth, height, width)` order. Default: `(0, 1, 2)`.
+        num_axes_range (tuple[int, int]): Inclusive range for the number of eligible axes to degrade.
+            Default: `(1, 1)`.
+        downscale_factor_range (tuple[float, float]): Inclusive range of downsampling factors, each greater than one.
+            Default: `(1.5, 4.0)`.
+        antialias (bool): Apply a low-pass filter while reducing spatial resolution. Default: `True`.
+        p (float): Probability of applying the transform. Default: `0.5`.
+
+    Targets:
+        volume
+
+    Image types:
+        uint8, float32
+
+    Examples:
+        >>> import albumentations as A
+        >>> import numpy as np
+        >>> volume = np.random.default_rng(137).integers(0, 256, (32, 128, 128, 1), dtype=np.uint8)
+        >>> transform = A.Compose([
+        ...     A.Anisotropy3D(
+        ...         axes=(0,),
+        ...         num_axes_range=(1, 1),
+        ...         downscale_factor_range=(2.0, 2.0),
+        ...         p=1.0,
+        ...     ),
+        ... ])
+        >>> result = transform(volume=volume)
+        >>> result["volume"].shape
+        (32, 128, 128, 1)
+
+    """
+
+    _supports_cpu_tensor = True
+    _cpu_tensor_targets = frozenset({"volume", "mask3d"})
+
+    class InitSchema(BaseTransformInitSchema):
+        axes: tuple[AxisIndex3D, ...]
+        num_axes_range: Annotated[
+            tuple[int, int],
+            AfterValidator(check_range_bounds(1, None)),
+            AfterValidator(nondecreasing),
+        ]
+        downscale_factor_range: Annotated[
+            tuple[float, float],
+            AfterValidator(check_range_bounds(1, None, min_inclusive=False)),
+            AfterValidator(nondecreasing),
+        ]
+        antialias: bool
+
+        @model_validator(mode="after")
+        def _validate_axes(self) -> Self:
+            if not self.axes:
+                raise ValueError("axes must contain at least one spatial axis")
+            if len(self.axes) != len(set(self.axes)):
+                raise ValueError("axes must not contain duplicates")
+            if self.num_axes_range[1] > len(self.axes):
+                raise ValueError("num_axes_range cannot select more axes than are available in axes")
+            return self
+
+    def __init__(
+        self,
+        axes: tuple[AxisIndex3D, ...] = (0, 1, 2),
+        num_axes_range: tuple[int, int] = (1, 1),
+        downscale_factor_range: tuple[float, float] = (1.5, 4.0),
+        antialias: bool = True,
+        p: float = 0.5,
+    ):
+        super().__init__(p=p)
+        self.axes = axes
+        self.num_axes_range = num_axes_range
+        self.downscale_factor_range = downscale_factor_range
+        self.antialias = antialias
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        selected_axis_count = self.py_random.randint(*self.num_axes_range)
+        selected_axes = tuple(sorted(self.py_random.sample(self.axes, selected_axis_count)))
+        downscale_factor = self.py_random.uniform(*self.downscale_factor_range)
+        downsample_shape = f3d.get_anisotropy_downsample_shape(
+            _get_volume_spatial_shape(data),
+            selected_axes,
+            downscale_factor,
+        )
+
+        self.applied_config = {
+            "axes": selected_axes,
+            "num_axes_range": (selected_axis_count, selected_axis_count),
+            "downscale_factor_range": (downscale_factor, downscale_factor),
+        }
+        return {"downsample_shape": downsample_shape}
+
+    def apply_to_volume(
+        self,
+        volume: VolumeType,
+        downsample_shape: tuple[int, int, int],
+        **params: Any,
+    ) -> VolumeType:
+        return cast("VolumeType", f3d.anisotropy_3d(volume, downsample_shape, self.antialias))
 
 
 class _BaseCropAndPad3DInitSchema(BaseTransformInitSchema):

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -36,7 +36,15 @@ from .type_definitions import ALL_TARGETS, ImageType, StackedMasks4D, Targets, V
 from .utils import format_args
 from .utils import get_image_data as _get_image_data_impl
 
-__all__ = ["BasicTransform", "CustomTransformsApplyMixin", "DualTransform", "ImageOnlyTransform", "NoOp", "Transform3D"]
+__all__ = [
+    "BasicTransform",
+    "CustomTransformsApplyMixin",
+    "DualTransform",
+    "ImageOnlyTransform",
+    "NoOp",
+    "Transform3D",
+    "VolumeOnlyTransform",
+]
 
 
 class Interpolation:
@@ -1420,6 +1428,29 @@ class Transform3D(DualTransform):
             "volume": self.apply_to_volume,
             "mask3d": self.apply_to_mask3d,
             "keypoints": self.apply_to_keypoints,
+            "user_data": self.apply_to_user_data,
+        }
+
+
+class VolumeOnlyTransform(BasicTransform):
+    """Provide a base for volume-intensity transforms that leave masks and keypoints untouched, keeping acquisition
+    artifacts separate from label geometry changes.
+
+    Unlike `Transform3D`, subclasses do not dispatch to `mask3d` or
+    `keypoints`. Compose therefore preserves those targets unchanged, which
+    is appropriate for acquisition and photometric artifacts that do not alter
+    label geometry.
+    """
+
+    _targets = (Targets.VOLUME,)
+
+    def apply_to_volume(self, volume: VolumeType, *args: Any, **params: Any) -> VolumeType:
+        raise NotImplementedError
+
+    @property
+    def targets(self) -> dict[str, Callable[..., Any]]:
+        return {
+            "volume": self.apply_to_volume,
             "user_data": self.apply_to_user_data,
         }
 

--- a/benchmark/benchmarks/catalog.py
+++ b/benchmark/benchmarks/catalog.py
@@ -17,7 +17,7 @@ from typing import Any
 import numpy as np
 
 import albumentations
-from albumentations.core.transforms_interface import BasicTransform, Transform3D
+from albumentations.core.transforms_interface import BasicTransform, Transform3D, VolumeOnlyTransform
 from benchmarks.common import SIZES, make_image, make_volume
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -29,6 +29,7 @@ ABSTRACT_TRANSFORM_NAMES = frozenset(
         "DualTransform",
         "ImageOnlyTransform",
         "Transform3D",
+        "VolumeOnlyTransform",
     },
 )
 
@@ -46,6 +47,11 @@ EXPECTED_INIT_WARNINGS = (
 
 PARAM_OVERRIDES: Mapping[str, Mapping[str, Any]] = {
     "AtLeastOneBBoxRandomCrop": {"height": 96, "width": 96},
+    "Anisotropy3D": {
+        "axes": (0, 2),
+        "num_axes_range": (2, 2),
+        "downscale_factor_range": (2.0, 2.0),
+    },
     "CenterCrop": {"height": 96, "width": 96},
     "CenterCrop3D": {"size": (4, 48, 48)},
     "ConstrainedCoarseDropout": {"mask_indices": [1]},
@@ -156,7 +162,7 @@ def public_transform_names() -> tuple[str, ...]:
 def _route_for_transform(name: str, transform_cls: type[BasicTransform]) -> str:
     if name in DEDICATED_TENSOR_BENCHMARK_TRANSFORMS:
         return "dedicated_tensor"
-    if issubclass(transform_cls, Transform3D):
+    if issubclass(transform_cls, (Transform3D, VolumeOnlyTransform)):
         return "volume"
     if name in BBOX_ROUTE_TRANSFORMS:
         return "bboxes"

--- a/benchmark/benchmarks/test_family_matrix.py
+++ b/benchmark/benchmarks/test_family_matrix.py
@@ -251,6 +251,12 @@ HBB_KEYPOINT_TRANSFORMS = frozenset(
 )
 
 VOLUME_TRANSFORMS: Mapping[str, Factory] = {
+    "anisotropy3d": lambda: albumentations.Anisotropy3D(
+        axes=(0, 2),
+        num_axes_range=(2, 2),
+        downscale_factor_range=(2.0, 2.0),
+        p=1.0,
+    ),
     "center_crop3d": lambda: albumentations.CenterCrop3D(size=(4, 48, 48), p=1.0),
     "random_crop3d": lambda: albumentations.RandomCrop3D(size=(4, 48, 48), p=1.0),
     "pad3d": lambda: albumentations.Pad3D(padding=(1, 2, 2), p=1.0),

--- a/benchmark/benchmarks/test_functional_kernels.py
+++ b/benchmark/benchmarks/test_functional_kernels.py
@@ -52,6 +52,7 @@ FUNCTIONAL_GEOMETRY_ANNOTATION_COUNTS: Mapping[str, tuple[int, ...]] = {
     "keypoints_affine": (10, 100),
 }
 FUNCTIONAL_3D_KERNELS = (
+    "anisotropy_3d",
     "crop3d",
     "pad_3d_with_params",
     "cutout3d",
@@ -413,6 +414,10 @@ def _call_pad_3d_with_params(benchmark: Any) -> np.ndarray:
     return f3d.pad_3d_with_params(benchmark.volume, (1, 1, 2, 2, 2, 2), 0)
 
 
+def _call_anisotropy_3d(benchmark: Any) -> np.ndarray:
+    return f3d.anisotropy_3d(benchmark.volume, benchmark.anisotropy_downsample_shape, antialias=True)
+
+
 def _call_cutout3d(benchmark: Any) -> np.ndarray:
     return f3d.cutout3d(benchmark.volume, benchmark.holes, 0)
 
@@ -430,6 +435,7 @@ def _call_swap_tiles_on_volume(benchmark: Any) -> np.ndarray:
 
 
 FUNCTIONAL_3D_CALLS: Mapping[str, ImageKernelCall] = {
+    "anisotropy_3d": _call_anisotropy_3d,
     "crop3d": _call_crop3d,
     "pad_3d_with_params": _call_pad_3d_with_params,
     "cutout3d": _call_cutout3d,
@@ -552,6 +558,7 @@ class TimeFunctional3DKernels:
         depth, height, width = VOLUME_SIZES[size_name]
         self.name = name
         self.volume = make_volume(size_name, 1, dtype_from_name(dtype_name))
+        self.anisotropy_downsample_shape = (max(1, depth // 2), height, max(1, width // 2))
         self.crop_coords = (1, depth - 1, height // 4, height * 3 // 4, width // 4, width * 3 // 4)
         self.holes = np.array(
             [[1, height // 4, width // 4, min(depth - 1, 4), height // 2, width // 2]],

--- a/benchmark/pytorch_benchmarks/test_tensor.py
+++ b/benchmark/pytorch_benchmarks/test_tensor.py
@@ -41,6 +41,12 @@ VOLUME_CASES = tuple(
 TENSOR_NATIVE_IMAGE_CASES = tuple(
     f"{size_name}|{channels}|{dtype_name}" for size_name in SIZES for channels in (1, 3) for dtype_name in DTYPES
 )
+TENSOR_NATIVE_VOLUME_CASES = tuple(
+    f"{size_name}|{channels}|{dtype_name}"
+    for size_name in VOLUME_SIZES
+    for channels in (1, 3, 5)
+    for dtype_name in DTYPES
+)
 
 
 def _parse_image_case(case_id: str) -> tuple[str, int, str]:
@@ -137,3 +143,60 @@ class TimeTensorNativeTranspose:
 
     def peakmem_tensor_direct(self, case_id: str) -> None:
         self.tensor_direct(image=self.tensor)
+
+
+class TimeTensorNativeAnisotropy3D:
+    """Benchmark the accepted Tensor `Anisotropy3D(volume=...)` capability.
+
+    The direct Tensor route uses C,D,H,W volumes. Its NumPy comparison paths
+    use the matching D,H,W,C volume and the normal `ToTensor3D` handoff.
+    """
+
+    params = (TENSOR_NATIVE_VOLUME_CASES,)
+    param_names = ("case_id",)
+
+    def setup(self, case_id: str) -> None:
+        size_name, channels, dtype_name = _parse_image_case(case_id)
+        self.volume = make_volume(size_name, channels, dtype_from_name(dtype_name))
+        self.mask3d = make_mask3d(size_name)
+        self.tensor = torch.from_numpy(np.ascontiguousarray(self.volume.transpose(3, 0, 1, 2)))
+        self.tensor_mask3d = torch.from_numpy(self.mask3d)
+        anisotropy = albumentations.Anisotropy3D(
+            axes=(0, 2),
+            num_axes_range=(2, 2),
+            downscale_factor_range=(2.0, 2.0),
+            p=1.0,
+        )
+        self.numpy_direct = albumentations.Compose([anisotropy], seed=137, strict=True)
+        self.numpy_model_ready = albumentations.Compose(
+            [anisotropy, albumentations.ToTensor3D(p=1.0)],
+            seed=137,
+            strict=True,
+        )
+        self.tensor_direct = albumentations.Compose(
+            [
+                albumentations.Anisotropy3D(
+                    axes=(0, 2),
+                    num_axes_range=(2, 2),
+                    downscale_factor_range=(2.0, 2.0),
+                    p=1.0,
+                ),
+            ],
+            seed=137,
+            strict=True,
+        )
+
+    def time_numpy_direct(self, case_id: str) -> None:
+        self.numpy_direct(volume=self.volume)
+
+    def time_numpy_model_ready(self, case_id: str) -> None:
+        self.numpy_model_ready(volume=self.volume, mask3d=self.mask3d)
+
+    def time_tensor_direct(self, case_id: str) -> None:
+        self.tensor_direct(volume=self.tensor)
+
+    def time_tensor_and_mask3d(self, case_id: str) -> None:
+        self.tensor_direct(volume=self.tensor, mask3d=self.tensor_mask3d)
+
+    def peakmem_tensor_direct(self, case_id: str) -> None:
+        self.tensor_direct(volume=self.tensor)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=5.0.0.93
-    - albucore==0.2.9
+    - albucore==0.2.10
     - numkong!=7.7.1
     - pytorch>=2.13.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "albucore==0.2.9",
+  "albucore==0.2.10",
   "numkong!=7.7.1",
   "numpy>=2.2.6",
   "pydantic>=2.12.4",

--- a/tests/files/public_transform_positional_parameters.json
+++ b/tests/files/public_transform_positional_parameters.json
@@ -2,6 +2,7 @@
   "AdditiveNoise": ["noise_type", "spatial_mode", "noise_params", "p"],
   "AdvancedBlur": ["blur_range", "sigma_x_range", "sigma_y_range", "rotate_range", "beta_range", "noise_range", "p"],
   "Affine": ["scale", "translate_percent", "translate_px", "rotate", "shear", "interpolation", "mask_interpolation", "fit_output", "keep_ratio", "rotate_method", "balanced_scale", "border_mode", "fill", "fill_mask", "p"],
+  "Anisotropy3D": ["axes", "num_axes_range", "downscale_factor_range", "antialias", "p"],
   "AnnotationArtifacts": ["element_types", "element_probabilities", "count_range", "text_length_range", "font_scale_range", "thickness_range", "size_ratio_range", "line_length_ratio_range", "tip_length_range", "corner_prob", "black_white_prob", "p"],
   "AtLeastOneBBoxRandomCrop": ["height", "width", "erosion_factor", "p"],
   "AtmosphericFog": ["density_range", "fog_color", "depth_mode", "p"],

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -572,6 +572,15 @@ _BASE_CASE_SPECS: list[list[Any]] = [
         },
     ],
     [A.Pad3D, {"padding": 10}],
+    [
+        A.Anisotropy3D,
+        {
+            "axes": (0, 2),
+            "num_axes_range": (2, 2),
+            "downscale_factor_range": (2.0, 2.0),
+            "antialias": False,
+        },
+    ],
     [A.CenterCrop3D, {"size": (2, 30, 30)}],
     [A.RandomCrop3D, {"size": (2, 30, 30)}],
     [
@@ -1195,6 +1204,7 @@ _REFERENCE_METADATA_KEYS = {
     A.PixelDistributionAdaptation: "pda_metadata",
 }
 _EXACT_TRANSFORMS = {
+    A.Anisotropy3D,
     A.Blur,
     A.CropAndPad,
     A.ExposureMatching,
@@ -1214,7 +1224,7 @@ def _case_data(
     transform_cls: type[A.BasicTransform],
     init_kwargs: Mapping[str, Any],
 ) -> tuple[ContractDataFactory, ContractContextFactory, dict[str, Any], frozenset[str]]:
-    if issubclass(transform_cls, A.Transform3D):
+    if issubclass(transform_cls, (A.Transform3D, A.VolumeOnlyTransform)):
         return make_volume_data, make_empty_context, {}, frozenset()
     if transform_cls in _BBOX_TRANSFORMS:
         compose_kwargs = {

--- a/tests/regression/transform_contracts.py
+++ b/tests/regression/transform_contracts.py
@@ -51,6 +51,7 @@ ABSTRACT_PUBLIC_APIS = frozenset(
         "DualTransform",
         "ImageOnlyTransform",
         "Transform3D",
+        "VolumeOnlyTransform",
     },
 )
 COMPOSITION_PUBLIC_APIS = frozenset(

--- a/tests/test_transform_name_conventions.py
+++ b/tests/test_transform_name_conventions.py
@@ -45,6 +45,20 @@ class RandomParameterGenerator:
     assert check_source(source) == []
 
 
+def test_new_volume_only_transform_name_cannot_start_with_random() -> None:
+    source = """
+class RandomNewVolumeTransform(VolumeOnlyTransform):
+    pass
+"""
+
+    assert check_source(source) == [
+        (
+            2,
+            "New transform class 'RandomNewVolumeTransform' must not use the 'Random' prefix.",
+        ),
+    ]
+
+
 def test_indirect_transform_subclass_cannot_start_with_random() -> None:
     source = """
 class CustomTransform(ImageOnlyTransform):

--- a/tests/transforms3d/test_anisotropy3d.py
+++ b/tests/transforms3d/test_anisotropy3d.py
@@ -1,0 +1,153 @@
+import numpy as np
+import pytest
+import torch
+
+import albumentations as A
+from albumentations.core.type_definitions import Targets
+from tests.helpers import TestDataFactory
+
+
+def _fixed_anisotropy(
+    axes: tuple[int, ...] = (0, 2),
+    antialias: bool = True,
+) -> A.Anisotropy3D:
+    return A.Anisotropy3D(
+        axes=axes,
+        num_axes_range=(len(axes), len(axes)),
+        downscale_factor_range=(2.0, 2.0),
+        antialias=antialias,
+        p=1.0,
+    )
+
+
+def test_anisotropy3d_is_volume_only() -> None:
+    transform = _fixed_anisotropy()
+
+    assert isinstance(transform, A.VolumeOnlyTransform)
+    assert transform._targets == (Targets.VOLUME,)
+    assert set(transform.targets) == {"user_data", "volume"}
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("channels", [1, 3, 5])
+def test_anisotropy3d_numpy_preserves_shape_dtype_range_and_mask(dtype: type[np.generic], channels: int) -> None:
+    volume = TestDataFactory.create_volume((5, 11, 13, channels), dtype=dtype, seed=137)
+    mask3d = TestDataFactory.create_volume((5, 11, 13, 1), dtype=np.uint8, seed=138)[..., 0]
+
+    result = A.Compose([_fixed_anisotropy()], seed=137, strict=True)(volume=volume, mask3d=mask3d)
+
+    transformed_volume = result["volume"]
+    assert transformed_volume.shape == volume.shape
+    assert transformed_volume.dtype == volume.dtype
+    assert transformed_volume.min() >= volume.min()
+    assert transformed_volume.max() <= volume.max()
+    np.testing.assert_array_equal(result["mask3d"], mask3d)
+    assert not np.array_equal(transformed_volume, volume)
+
+
+@pytest.mark.parametrize(
+    ("axis", "volume_shape"),
+    [
+        (0, (1, 11, 13, 2)),
+        (1, (5, 1, 13, 2)),
+        (2, (5, 11, 1, 2)),
+    ],
+)
+def test_anisotropy3d_handles_unit_spatial_dimensions(axis: int, volume_shape: tuple[int, int, int, int]) -> None:
+    volume = TestDataFactory.create_volume(volume_shape, seed=137)
+
+    result = A.Compose([_fixed_anisotropy((axis,))], seed=137, strict=True)(volume=volume)["volume"]
+
+    assert result.shape == volume.shape
+    assert result.dtype == volume.dtype
+
+
+def test_anisotropy3d_numpy_accepts_a_channel_less_volume() -> None:
+    volume = TestDataFactory.create_volume((5, 11, 13, 1), seed=137)[..., 0]
+
+    result = A.Compose([_fixed_anisotropy()], seed=137, strict=True)(volume=volume)["volume"]
+
+    assert result.shape == volume.shape
+    assert result.dtype == volume.dtype
+    assert not np.array_equal(result, volume)
+
+
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
+@pytest.mark.parametrize("channels", [1, 3, 5])
+def test_anisotropy3d_tensor_preserves_channel_first_volume_and_mask3d(dtype: torch.dtype, channels: int) -> None:
+    numpy_dtype = np.uint8 if dtype == torch.uint8 else np.float32
+    volume = TestDataFactory.create_volume((5, 11, 13, channels), dtype=numpy_dtype, seed=137)
+    tensor_volume = torch.from_numpy(np.ascontiguousarray(volume.transpose(3, 0, 1, 2)))
+    mask3d = torch.from_numpy(TestDataFactory.create_volume((5, 11, 13, 1), seed=138)[..., 0])
+
+    result = A.Compose([_fixed_anisotropy()], seed=137, strict=True)(volume=tensor_volume, mask3d=mask3d)
+
+    transformed_volume = result["volume"]
+    assert isinstance(transformed_volume, torch.Tensor)
+    assert transformed_volume.shape == tensor_volume.shape
+    assert transformed_volume.dtype == dtype
+    assert torch.all(transformed_volume >= tensor_volume.min())
+    assert torch.all(transformed_volume <= tensor_volume.max())
+    torch.testing.assert_close(result["mask3d"], mask3d)
+    assert not torch.equal(transformed_volume, tensor_volume)
+
+
+def test_anisotropy3d_replay_reproduces_selected_axes_and_factor() -> None:
+    volume = TestDataFactory.create_volume((7, 11, 13, 2), seed=137)
+    transform = A.ReplayCompose(
+        [
+            A.Anisotropy3D(
+                axes=(0, 1, 2),
+                num_axes_range=(1, 3),
+                downscale_factor_range=(1.5, 3.0),
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    first_result = transform(volume=volume)
+    replay_result = A.ReplayCompose.replay(first_result["replay"], volume=volume)
+
+    np.testing.assert_array_equal(replay_result["volume"], first_result["volume"])
+
+
+def test_anisotropy3d_keeps_keypoints_in_their_original_coordinate_system() -> None:
+    volume = TestDataFactory.create_volume((5, 11, 13, 1), seed=137)
+    keypoints = np.array([[2, 3, 1], [8, 10, 4]], dtype=np.float32)
+    transform = A.Compose(
+        [_fixed_anisotropy()],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        seed=137,
+        strict=True,
+    )
+
+    result = transform(volume=volume, keypoints=keypoints)
+
+    np.testing.assert_array_equal(result["keypoints"], keypoints)
+
+
+def test_anisotropy3d_tensor_uses_current_non_antialiased_trilinear_fallback() -> None:
+    volume = TestDataFactory.create_volume((5, 11, 13, 3), dtype=np.float32, seed=137)
+    tensor_volume = torch.from_numpy(np.ascontiguousarray(volume.transpose(3, 0, 1, 2)))
+
+    antialiased = A.Compose([_fixed_anisotropy(antialias=True)], seed=137, strict=True)(volume=tensor_volume)["volume"]
+    non_antialiased = A.Compose([_fixed_anisotropy(antialias=False)], seed=137, strict=True)(volume=tensor_volume)[
+        "volume"
+    ]
+
+    torch.testing.assert_close(antialiased, non_antialiased)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"axes": ()}, "at least one"),
+        ({"axes": (0, 0)}, "duplicates"),
+        ({"axes": (0,), "num_axes_range": (2, 2)}, "more axes"),
+        ({"downscale_factor_range": (1.0, 2.0)}, "must be > 1"),
+    ],
+)
+def test_anisotropy3d_validates_configuration(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        A.Anisotropy3D(**kwargs)

--- a/tests/transforms3d/test_targets.py
+++ b/tests/transforms3d/test_targets.py
@@ -66,7 +66,7 @@ def get_targets_from_methods(cls):
     return targets
 
 
-TRASNFORM_3D_TARGETS = {}
+TRASNFORM_3D_TARGETS = {A.Anisotropy3D: {Targets.VOLUME}}
 
 str2target = {
     "mask": Targets.MASK3D,  # docstrings say "mask" for 3D mask target

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -118,7 +118,7 @@ def test_pad_if_needed_3d_fill_values():
 )
 def test_augmentations_match_uint8_float32(augmentation_cls, params):
     image_uint8 = RECTANGULAR_UINT8_IMAGE
-    image_float32 = image_uint8 / 255.0
+    image_float32 = image_uint8.astype(np.float32) / 255.0
 
     transform = A.Compose([augmentation_cls(p=1, **params)], seed=42)
 
@@ -275,7 +275,7 @@ def test_pad3d_2d_equivalence(pad3d_padding, pad2d_padding):
     ),
 )
 def test_change_volume(volume, mask3d, augmentation_cls, params):
-    """Checks whether resulting volume is different from the original one."""
+    """Check that the volume changes and that only geometric transforms change the paired mask."""
     aug = A.Compose([augmentation_cls(p=1, **params)], seed=0)
 
     original_volume = volume.copy()
@@ -288,7 +288,10 @@ def test_change_volume(volume, mask3d, augmentation_cls, params):
     transformed = aug(**data)
 
     assert not np.array_equal(transformed["volume"], original_volume)
-    assert not np.array_equal(transformed["mask3d"], original_mask3d)
+    if issubclass(augmentation_cls, A.VolumeOnlyTransform):
+        np.testing.assert_array_equal(transformed["mask3d"], original_mask3d)
+    else:
+        assert not np.array_equal(transformed["mask3d"], original_mask3d)
 
 
 @pytest.mark.parametrize(
@@ -916,6 +919,7 @@ def test_center_crop3d_keypoints(
         },
         except_augmentations={
             A.CoarseDropout3D,
+            A.Anisotropy3D,
         },
     ),
 )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -208,7 +208,12 @@ def get_primary_public_transform_params(
 ) -> list[tuple[type, dict]]:
     """Get all transforms (2D and 3D)."""
     return get_primary_filtered_transform_params(
-        base_classes=(albumentations.ImageOnlyTransform, albumentations.DualTransform, albumentations.Transform3D),
+        base_classes=(
+            albumentations.ImageOnlyTransform,
+            albumentations.DualTransform,
+            albumentations.Transform3D,
+            albumentations.VolumeOnlyTransform,
+        ),
         custom_arguments=custom_arguments,
         except_augmentations=except_augmentations,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -233,12 +233,12 @@ def get_primary_2d_transform_params(
 
 
 def get_primary_3d_transform_params(
-    custom_arguments: dict[type[albumentations.Transform3D], dict] | None = None,
-    except_augmentations: set[type[albumentations.Transform3D]] | None = None,
+    custom_arguments: dict[type[albumentations.BasicTransform], dict] | None = None,
+    except_augmentations: set[type[albumentations.BasicTransform]] | None = None,
 ) -> list[tuple[type, dict]]:
     """Get all 3D transforms."""
     return get_primary_filtered_transform_params(
-        base_classes=(albumentations.Transform3D,),
+        base_classes=(albumentations.Transform3D, albumentations.VolumeOnlyTransform),
         custom_arguments=custom_arguments,
         except_augmentations=except_augmentations,
     )

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -217,6 +217,7 @@ SPECIAL_TARGET_ALIAS_TO_TRANSFORM = {
 }
 
 VOLUME_ALIAS_TO_TRANSFORM = {
+    "anisotropy3d": "Anisotropy3D",
     "center_crop3d": "CenterCrop3D",
     "coarse_dropout3d": "CoarseDropout3D",
     "cubic_symmetry": "CubicSymmetry",
@@ -254,6 +255,7 @@ PARAMETER_SENSITIVITY_ALIAS_TO_TRANSFORM = {
 DIRECT_KERNEL_TRANSFORMS = frozenset(
     {
         "Affine",
+        "Anisotropy3D",
         "AutoContrast",
         "Blur",
         "CenterCrop3D",
@@ -313,14 +315,16 @@ MEMORY_COVERED_TRANSFORMS = frozenset(
 )
 
 PYTORCH_TERMINAL_TENSOR_TRANSFORMS = frozenset({"ToTensor3D", "ToTensorV2"})
-PYTORCH_NATIVE_TENSOR_TRANSFORMS = frozenset({"Transpose"})
+PYTORCH_NATIVE_TENSOR_TRANSFORMS = frozenset({"Anisotropy3D", "Transpose"})
 PYTORCH_TENSOR_TRANSFORMS = PYTORCH_TERMINAL_TENSOR_TRANSFORMS | PYTORCH_NATIVE_TENSOR_TRANSFORMS
 PYTORCH_IMAGE_CASES = pytorch_tensor_benchmarks.IMAGE_CASES
 PYTORCH_VOLUME_CASES = pytorch_tensor_benchmarks.VOLUME_CASES
 PYTORCH_NATIVE_IMAGE_CASES = pytorch_tensor_benchmarks.TENSOR_NATIVE_IMAGE_CASES
+PYTORCH_NATIVE_VOLUME_CASES = pytorch_tensor_benchmarks.TENSOR_NATIVE_VOLUME_CASES
 
 DIRECT_KERNEL_CASE_PREFIXES_BY_TRANSFORM = {
     "Affine": ("bboxes_affine", "keypoints_affine"),
+    "Anisotropy3D": ("anisotropy_3d",),
     "AutoContrast": ("auto_contrast",),
     "Blur": ("box_blur",),
     "CenterCrop3D": ("crop3d",),
@@ -389,6 +393,7 @@ ASV_BENCHMARKS = {
     "pytorch_tensor_2d": "pytorch_benchmarks.test_tensor.TimeToTensorV2",
     "pytorch_tensor_3d": "pytorch_benchmarks.test_tensor.TimeToTensor3D",
     "pytorch_tensor_native": "pytorch_benchmarks.test_tensor.TimeTensorNativeTranspose",
+    "pytorch_tensor_native_3d": "pytorch_benchmarks.test_tensor.TimeTensorNativeAnisotropy3D",
     "reference_data": "benchmarks.test_family_matrix.TimeReferenceDataFullMatrix.time_transform",
     "target_matrix": "benchmarks.test_family_matrix.TimeSpecialTargetMatrix.time_transform",
     "volumetric_matrix": "benchmarks.test_family_matrix.TimeVolumetricFullMatrix.time_transform",
@@ -526,6 +531,11 @@ def _coverage_expectation(name: str, route: str) -> CoverageExpectation:
         return CoverageExpectation(
             required_layers=frozenset({"pytorch_tensor"}),
             reason="PyTorch Tensor transforms are benchmarked in the dedicated Tensor ASV lane",
+        )
+    if name == "Anisotropy3D":
+        return CoverageExpectation(
+            required_layers=frozenset({"catalog_smoke", "direct_kernel", "pytorch_tensor", "volumetric_matrix"}),
+            reason="the NumPy, direct kernel, and accepted CPU Tensor volume routes have dedicated evidence",
         )
     if name in PYTORCH_NATIVE_TENSOR_TRANSFORMS:
         return CoverageExpectation(
@@ -788,7 +798,7 @@ def _pytorch_tensor_scenario(case: Mapping[str, str], route: str, transform_name
         return {
             **_parse_pytorch_case(case["case_id"]),
             "scope": "tensor_native_compose",
-            "targets": ["image"],
+            "targets": ["mask3d", "volume"] if transform_name == "Anisotropy3D" else ["image"],
         }
     targets = ["mask3d", "volume"] if transform_name == "ToTensor3D" else ["image", "images", "mask", "masks"]
     return {
@@ -1146,6 +1156,15 @@ def _benchmark_case_index() -> dict[str, list[dict[str, str]]]:
             cases,
             "Transpose",
             benchmark=ASV_BENCHMARKS["pytorch_tensor_native"],
+            case_id=case_id,
+            config="pytorch",
+            layer="pytorch_tensor",
+        )
+    for case_id in PYTORCH_NATIVE_VOLUME_CASES:
+        _add_asv_case(
+            cases,
+            "Anisotropy3D",
+            benchmark=ASV_BENCHMARKS["pytorch_tensor_native_3d"],
             case_id=case_id,
             config="pytorch",
             layer="pytorch_tensor",

--- a/tools/check_example_docstrings.py
+++ b/tools/check_example_docstrings.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from google_docstring_parser import parse_google_docstring
 
-TARGET_PARENT_CLASSES = {"DualTransform", "ImageOnlyTransform", "Transform3D"}
+TARGET_PARENT_CLASSES = {"DualTransform", "ImageOnlyTransform", "Transform3D", "VolumeOnlyTransform"}
 
 # We'll check for both, but have different error messages
 EXAMPLES_SECTION = "Examples"

--- a/tools/check_transform_names.py
+++ b/tools/check_transform_names.py
@@ -17,6 +17,7 @@ TRANSFORM_BASE_CLASS_NAMES = frozenset(
         "DualTransform",
         "ImageOnlyTransform",
         "Transform3D",
+        "VolumeOnlyTransform",
     },
 )
 

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -14,6 +14,7 @@ IGNORED_CLASSES = {
     "DualTransform",
     "ImageOnlyTransform",
     "Transform3D",
+    "VolumeOnlyTransform",
 }
 
 UTM_QUERY_RE = re.compile(r"\?utm_(?:source|medium|campaign|term|content)=[^)\s|]+")
@@ -98,7 +99,9 @@ def get_3d_transforms_info():
     members = inspect.getmembers(albumentations)
     for name, cls in members:
         if (
-            inspect.isclass(cls) and issubclass(cls, albumentations.Transform3D) and name not in IGNORED_CLASSES
+            inspect.isclass(cls)
+            and issubclass(cls, (albumentations.Transform3D, albumentations.VolumeOnlyTransform))
+            and name not in IGNORED_CLASSES
         ) and not is_deprecated(cls):
             # Get targets from class or parent class if not defined
             targets = cls._targets if hasattr(cls, "_targets") else albumentations.Transform3D._targets

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "albucore"
-version = "0.2.9"
+version = "0.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numkong" },
@@ -34,10 +34,11 @@ dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "stringzilla" },
+    { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/d2/cfcbe0778e60e091d0594c87269a8fe37ef83f5cf5d11c7db04e27230545/albucore-0.2.9.tar.gz", hash = "sha256:c7d94e902371a533237cf4894b42881229b64e3afb8780d0de4ba254ace445a3", size = 170347, upload-time = "2026-07-31T13:46:17.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/a0/38a950121bf97a671755e86d82617dad9afa6627de612d833fd4b99d1b1e/albucore-0.2.10.tar.gz", hash = "sha256:b9f5ae6627342ca901ab668d1531b23b5aa73e879187d5adf60421a679c13520", size = 227993, upload-time = "2026-08-03T11:44:47.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/ea/83fca154d58f695adf07540c79817af4dd2e51b2ae6e59aafd3d34892b83/albucore-0.2.9-py3-none-any.whl", hash = "sha256:5180bcc0cb2643a6916fda8bd8334eea018071795ec71654b4062ecc6e747365", size = 46851, upload-time = "2026-07-31T13:46:16.398Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4e/ee6bb9d1aad14443beb1e23084f64813cdd01ee2b179d1fb846d6a6bebee/albucore-0.2.10-py3-none-any.whl", hash = "sha256:6e3111374b2ee1089f8e5b9002eb6381c9f7b4036cd5d74871b1844556b04ed6", size = 52457, upload-time = "2026-08-03T11:44:46.452Z" },
 ]
 
 [[package]]
@@ -231,7 +232,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "albucore", specifier = "==0.2.9" },
+    { name = "albucore", specifier = "==0.2.10" },
     { name = "huggingface-hub", marker = "extra == 'hub'" },
     { name = "numkong", specifier = "!=7.7.1" },
     { name = "numpy", specifier = ">=2.2.6" },


### PR DESCRIPTION
## Summary

- add `Anisotropy3D` as a `VolumeOnlyTransform`, keeping masks and keypoints unchanged
- support NumPy `D,H,W` / `D,H,W,C` volumes and CPU Torch `C,D,H,W` volumes through Albucore `resize3d`
- update Albucore to 0.2.10 and add public-contract, Tensor-route, and benchmark coverage

## Notes

- No `volumes` or `masks3d` batch targets are introduced.
- PyTorch does not yet offer antialiasing for 5D trilinear interpolation, so Tensor input uses the non-antialiased native route when `antialias=True`.

## Validation

- `uv run pytest -q tests/transforms3d/test_anisotropy3d.py tests/transforms3d/test_transforms.py tests/transforms3d/test_targets.py tests/test_targets.py tests/test_serialization.py tests/contracts/test_constructor_parameter_coverage.py tests/contracts/test_applied_config_contract.py tests/contracts/test_target_cluster_contract.py tests/test_benchmark_coverage.py` — 3106 passed
- `uv run pytest -qq -m 'not slow'`
- `pre-commit run --files …` — including mypy and Pyrefly
- `uv run python tools/benchmark_coverage.py check` — 138 ASV cases, 2 dedicated Tensor cases, 140 public transforms accounted

## Summary by Sourcery

Introduce a new 3D anisotropy volume-intensity transform and wire it into the volumetric, tensor, and benchmarking infrastructure.

New Features:
- Add Anisotropy3D as a VolumeOnlyTransform to simulate anisotropic 3D volume acquisition while preserving masks and keypoints.
- Add a VolumeOnlyTransform base class for volume-intensity transforms that do not modify mask3d or keypoints.

Enhancements:
- Extend 3D functional utilities with anisotropy_3d and supporting shape helpers, backed by Albucore resize3d for NumPy and CPU tensors.
- Generalize volume shape handling to support channel-first Torch volumes in 3D transforms.
- Integrate Anisotropy3D into benchmark catalogs, functional kernel benchmarks, family matrix coverage, and PyTorch native tensor benchmarks, including new tensor-native 3D volume cases.
- Update transform discovery and contract helpers to treat VolumeOnlyTransform as a public volumetric route alongside Transform3D.

Build:
- Bump Albucore dependency from 0.2.9 to 0.2.10 to support 3D resize functionality.

Tests:
- Add dedicated anisotropy3d transform tests covering NumPy and Torch volumes, masks, keypoints, replay, configuration validation, and antialias behavior.
- Expand benchmark coverage tests and utilities to account for Anisotropy3D as a direct-kernel, volumetric, and PyTorch-tensor-covered transform.