### PR TITLE
feat(transforms3d): add volumetric resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Where:
 | [PadIfNeeded3D](https://albumentations.ai/explore/transform/PadIfNeeded3D/)         | ✓      | ✓      | ✓         |
 | [RandomCrop3D](https://albumentations.ai/explore/transform/RandomCrop3D/)           | ✓      | ✓      | ✓         |
 | [RandomRotate90_3D](https://albumentations.ai/explore/transform/RandomRotate90_3D/) | ✓      | ✓      | ✓         |
+| [Resize3D](https://albumentations.ai/explore/transform/Resize3D/)                   | ✓      | ✓      | ✓         |
 
 ## A few more examples of **augmentations**
 

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -67,6 +67,31 @@ def anisotropy_3d(
 
 
 @handle_empty_array("keypoints")
+def keypoints_scale_3d(
+    keypoints: np.ndarray,
+    source_shape: tuple[int, int, int],
+    target_shape: tuple[int, int, int],
+) -> np.ndarray:
+    """Scale XYZ keypoints across voxel grids while preserving columns and the internal\
+    scale metadata used by 2D resize rules.
+
+    Coordinates use Albumentations' pixel-index convention: `x`, `y`, and `z`
+    scale from the origin by the output-to-input ratio. The optional internal keypoint
+    scale column follows the established 2D convention and uses the greatest axis scale.
+    """
+    depth_scale, height_scale, width_scale = np.asarray(target_shape, dtype=np.float32) / np.asarray(
+        source_shape, dtype=np.float32
+    )
+    result = keypoints.copy()
+    result[:, 0] *= width_scale
+    result[:, 1] *= height_scale
+    result[:, 2] *= depth_scale
+    if result.shape[1] > 4:
+        result[:, 4] *= max(depth_scale, height_scale, width_scale)
+    return result
+
+
+@handle_empty_array("keypoints")
 def keypoints_flip_3d(
     keypoints: np.ndarray,
     flip_axes: tuple[Literal[0, 1, 2], ...],

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -72,12 +72,12 @@ def keypoints_scale_3d(
     source_shape: tuple[int, int, int],
     target_shape: tuple[int, int, int],
 ) -> np.ndarray:
-    """Scale XYZ keypoints across voxel grids while preserving columns and the internal\
-    scale metadata used by 2D resize rules.
+    """Scale XYZ keypoints across voxel grids while leaving every user-provided\
+    attribute after their three spatial coordinates unchanged.
 
     Coordinates use Albumentations' pixel-index convention: `x`, `y`, and `z`
-    scale from the origin by the output-to-input ratio. The optional internal keypoint
-    scale column follows the established 2D convention and uses the greatest axis scale.
+    scale from the origin by the output-to-input ratio. All remaining columns preserve
+    their input values.
     """
     depth_scale, height_scale, width_scale = np.asarray(target_shape, dtype=np.float32) / np.asarray(
         source_shape, dtype=np.float32
@@ -86,8 +86,6 @@ def keypoints_scale_3d(
     result[:, 0] *= width_scale
     result[:, 1] *= height_scale
     result[:, 2] *= depth_scale
-    if result.shape[1] > 4:
-        result[:, 4] *= max(depth_scale, height_scale, width_scale)
     return result
 
 

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any, ClassVar, Literal, cast
 
 import numpy as np
 import torch
+from albucore import resize3d
 from pydantic import AfterValidator, field_validator, model_validator
 from typing_extensions import Self
 
@@ -19,7 +20,15 @@ from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
 from albumentations.core.transforms_interface import BaseTransformInitSchema, Transform3D, VolumeOnlyTransform
-from albumentations.core.type_definitions import C4_INVERSE, C4GroupElement, Targets, VolumeType, c4_group_elements
+from albumentations.core.type_definitions import (
+    C4_INVERSE,
+    CV2_INTER_LINEAR,
+    CV2_INTER_NEAREST,
+    C4GroupElement,
+    Targets,
+    VolumeType,
+    c4_group_elements,
+)
 
 __all__ = [
     "Anisotropy3D",
@@ -32,6 +41,7 @@ __all__ = [
     "PadIfNeeded3D",
     "RandomCrop3D",
     "RandomRotate90_3D",
+    "Resize3D",
 ]
 
 NUM_DIMENSIONS = 3
@@ -172,6 +182,101 @@ class Anisotropy3D(VolumeOnlyTransform):
         **params: Any,
     ) -> VolumeType:
         return cast("VolumeType", f3d.anisotropy_3d(volume, downsample_shape, self.antialias))
+
+
+class Resize3D(Transform3D):
+    """Resize a volume to a fixed `(depth, height, width)` shape, preserving all\
+    channels, dtype, and its public layout intact.
+
+    `Resize3D` resamples all three spatial axes together; depth is never treated as a
+    batch axis. Intensity volumes and categorical masks use independently configurable
+    interpolation. The routed Albucore backend supports only linear and nearest-neighbor
+    interpolation, ensuring the same public contract for NumPy and CPU Tensor inputs.
+
+    Args:
+        size (tuple[int, int, int]): Target spatial shape in `(depth, height, width)` order.
+        interpolation (Literal[0, 1]): Interpolation for volumes: `cv2.INTER_LINEAR` or
+            `cv2.INTER_NEAREST`. Default: `cv2.INTER_LINEAR`.
+        mask_interpolation (Literal[0, 1]): Interpolation for `mask3d`:
+            `cv2.INTER_LINEAR` or `cv2.INTER_NEAREST`. Default: `cv2.INTER_NEAREST`.
+        p (float): Probability of applying the transform. Default: `1.0`.
+
+    Targets:
+        volume, mask3d, keypoints
+
+    Image types:
+        uint8, float32
+
+    Notes:
+        - NumPy volumes use channel-last `(D, H, W, C)` layout. CPU Tensor volumes
+          use channel-first `(C, D, H, W)` layout.
+        - `uint8` output preserves dtype; linear resampling rounds and saturates to
+          `[0, 255]`. Float32 output remains float32.
+        - Keypoints use `(x, y, z)` order and scale from the voxel-grid origin by
+          `(W2 / W1, H2 / H1, D2 / D1)`, matching the 2D resize convention.
+        - This transform changes voxel-grid coordinates only. It does not update physical
+          voxel spacing or orientation metadata.
+
+    Examples:
+        >>> import albumentations as A
+        >>> import cv2
+        >>> import numpy as np
+        >>> volume = np.random.default_rng(137).random((16, 64, 96, 1), dtype=np.float32)
+        >>> mask3d = np.zeros((16, 64, 96), dtype=np.uint8)
+        >>> transform = A.Compose([
+        ...     A.Resize3D(
+        ...         size=(32, 128, 128),
+        ...         interpolation=cv2.INTER_LINEAR,
+        ...         mask_interpolation=cv2.INTER_NEAREST,
+        ...     ),
+        ... ])
+        >>> result = transform(volume=volume, mask3d=mask3d)
+        >>> result["volume"].shape, result["mask3d"].shape
+        ((32, 128, 128, 1), (32, 128, 128))
+
+    """
+
+    _targets = (Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS)
+    _supports_cpu_tensor = True
+    _cpu_tensor_targets = frozenset({"volume"})
+
+    class InitSchema(BaseTransformInitSchema):
+        size: Annotated[tuple[int, int, int], AfterValidator(check_range_bounds(1, None))]
+        interpolation: Literal[0, 1]
+        mask_interpolation: Literal[0, 1]
+
+    def __init__(
+        self,
+        size: tuple[int, int, int],
+        interpolation: Literal[0, 1] = CV2_INTER_LINEAR,
+        mask_interpolation: Literal[0, 1] = CV2_INTER_NEAREST,
+        p: float = 1.0,
+    ):
+        super().__init__(p=p)
+        self.size = size
+        self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, tuple[int, int, int]]:
+        return {"source_shape": _get_volume_spatial_shape(data)}
+
+    def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
+        return cast("VolumeType", resize3d(volume, self.size, self.interpolation))
+
+    def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
+        return cast("VolumeType", resize3d(mask3d, self.size, self.mask_interpolation))
+
+    def apply_to_keypoints(
+        self,
+        keypoints: np.ndarray,
+        source_shape: tuple[int, int, int],
+        **params: Any,
+    ) -> np.ndarray:
+        return f3d.keypoints_scale_3d(keypoints, source_shape, self.size)
 
 
 class _BaseCropAndPad3DInitSchema(BaseTransformInitSchema):

--- a/benchmark/benchmarks/catalog.py
+++ b/benchmark/benchmarks/catalog.py
@@ -73,6 +73,7 @@ PARAM_OVERRIDES: Mapping[str, Mapping[str, Any]] = {
     "RandomSizedBBoxSafeCrop": {"height": 96, "width": 96},
     "RandomSizedCrop": {"min_max_height": (96, 128), "size": (96, 96)},
     "Resize": {"height": 128, "width": 128},
+    "Resize3D": {"size": (12, 96, 96)},
     "SmallestMaxSize": {"max_size": 160},
     "TextImage": {
         "augmentations": (None,),

--- a/benchmark/benchmarks/test_family_matrix.py
+++ b/benchmark/benchmarks/test_family_matrix.py
@@ -266,6 +266,7 @@ VOLUME_TRANSFORMS: Mapping[str, Factory] = {
     "cubic_symmetry": lambda: albumentations.CubicSymmetry(p=1.0),
     "flip3d": lambda: albumentations.Flip3D(flip_axes=(0, 1, 2), p=1.0),
     "random_rotate90_3d": lambda: albumentations.RandomRotate90_3D(axis_pair=(0, 2), group_element="r90", p=1.0),
+    "resize3d": lambda: albumentations.Resize3D(size=(12, 96, 96), p=1.0),
 }
 
 REFERENCE_TRANSFORMS = (
@@ -518,6 +519,7 @@ class PeakMemoryHotPaths:
             [albumentations.PadIfNeeded3D(min_zyx=(18, 144, 144), p=1.0)],
             strict=True,
         )
+        self.volume_resize = albumentations.Compose([albumentations.Resize3D(size=(12, 96, 96), p=1.0)], strict=True)
         self.volume_data = {"mask3d": make_mask3d("medium"), "volume": make_volume("medium")}
 
     def peakmem_resize_large_rgb(self) -> None:
@@ -540,3 +542,6 @@ class PeakMemoryHotPaths:
 
     def peakmem_volume_pad_medium(self) -> None:
         self.volume_pad(**self.volume_data)
+
+    def peakmem_volume_resize_medium(self) -> None:
+        self.volume_resize(**self.volume_data)

--- a/benchmark/benchmarks/test_functional_kernels.py
+++ b/benchmark/benchmarks/test_functional_kernels.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import cv2
 import numpy as np
+from albucore import resize3d
 
 from albumentations.augmentations.blur import functional as fblur
 from albumentations.augmentations.geometric import functional as fgeometric
@@ -53,6 +54,7 @@ FUNCTIONAL_GEOMETRY_ANNOTATION_COUNTS: Mapping[str, tuple[int, ...]] = {
 }
 FUNCTIONAL_3D_KERNELS = (
     "anisotropy_3d",
+    "resize3d",
     "crop3d",
     "pad_3d_with_params",
     "cutout3d",
@@ -418,6 +420,10 @@ def _call_anisotropy_3d(benchmark: Any) -> np.ndarray:
     return f3d.anisotropy_3d(benchmark.volume, benchmark.anisotropy_downsample_shape, antialias=True)
 
 
+def _call_resize3d(benchmark: Any) -> np.ndarray:
+    return resize3d(benchmark.volume, benchmark.resize_shape, cv2.INTER_LINEAR)
+
+
 def _call_cutout3d(benchmark: Any) -> np.ndarray:
     return f3d.cutout3d(benchmark.volume, benchmark.holes, 0)
 
@@ -436,6 +442,7 @@ def _call_swap_tiles_on_volume(benchmark: Any) -> np.ndarray:
 
 FUNCTIONAL_3D_CALLS: Mapping[str, ImageKernelCall] = {
     "anisotropy_3d": _call_anisotropy_3d,
+    "resize3d": _call_resize3d,
     "crop3d": _call_crop3d,
     "pad_3d_with_params": _call_pad_3d_with_params,
     "cutout3d": _call_cutout3d,
@@ -559,6 +566,7 @@ class TimeFunctional3DKernels:
         self.name = name
         self.volume = make_volume(size_name, 1, dtype_from_name(dtype_name))
         self.anisotropy_downsample_shape = (max(1, depth // 2), height, max(1, width // 2))
+        self.resize_shape = (max(1, depth * 3 // 2), max(1, height * 3 // 4), max(1, width * 3 // 2))
         self.crop_coords = (1, depth - 1, height // 4, height * 3 // 4, width // 4, width * 3 // 4)
         self.holes = np.array(
             [[1, height // 4, width // 4, min(depth - 1, 4), height // 2, width // 2]],

--- a/benchmark/pytorch_benchmarks/test_tensor.py
+++ b/benchmark/pytorch_benchmarks/test_tensor.py
@@ -200,3 +200,42 @@ class TimeTensorNativeAnisotropy3D:
 
     def peakmem_tensor_direct(self, case_id: str) -> None:
         self.tensor_direct(volume=self.tensor)
+
+
+class TimeTensorNativeResize3D:
+    """Benchmark the accepted Tensor `Resize3D(volume=...)` capability.
+
+    The direct Tensor route uses C,D,H,W volumes. Its NumPy comparison paths use
+    the matching D,H,W,C volume and the normal `ToTensor3D` handoff.
+    """
+
+    params = (TENSOR_NATIVE_VOLUME_CASES,)
+    param_names = ("case_id",)
+
+    def setup(self, case_id: str) -> None:
+        size_name, channels, dtype_name = _parse_image_case(case_id)
+        self.volume = make_volume(size_name, channels, dtype_from_name(dtype_name))
+        self.tensor = torch.from_numpy(np.ascontiguousarray(self.volume.transpose(3, 0, 1, 2)))
+        self.size = (
+            max(1, self.volume.shape[0] * 3 // 2),
+            max(1, self.volume.shape[1] * 3 // 4),
+            max(1, self.volume.shape[2] * 3 // 2),
+        )
+        self.numpy_direct = albumentations.Compose([albumentations.Resize3D(size=self.size, p=1.0)], strict=True)
+        self.numpy_model_ready = albumentations.Compose(
+            [albumentations.Resize3D(size=self.size, p=1.0), albumentations.ToTensor3D(p=1.0)],
+            strict=True,
+        )
+        self.tensor_direct = albumentations.Compose([albumentations.Resize3D(size=self.size, p=1.0)], strict=True)
+
+    def time_numpy_direct(self, case_id: str) -> None:
+        self.numpy_direct(volume=self.volume)
+
+    def time_numpy_model_ready(self, case_id: str) -> None:
+        self.numpy_model_ready(volume=self.volume)
+
+    def time_tensor_direct(self, case_id: str) -> None:
+        self.tensor_direct(volume=self.tensor)
+
+    def peakmem_tensor_direct(self, case_id: str) -> None:
+        self.tensor_direct(volume=self.tensor)

--- a/tests/files/public_transform_positional_parameters.json
+++ b/tests/files/public_transform_positional_parameters.json
@@ -109,6 +109,7 @@
   "RandomSunFlare": ["flare_roi", "src_radius", "src_color", "angle_range", "num_flare_circles_range", "method", "p"],
   "RandomToneCurve": ["scale", "per_channel", "p"],
   "Resize": ["height", "width", "interpolation", "mask_interpolation", "area_for_downscale", "p"],
+  "Resize3D": ["size", "interpolation", "mask_interpolation", "p"],
   "RingingOvershoot": ["blur_range", "cutoff_range", "p"],
   "Rotate": ["angle_range", "interpolation", "border_mode", "rotate_method", "crop_border", "mask_interpolation", "fill", "fill_mask", "p"],
   "SafeRotate": ["angle_range", "interpolation", "border_mode", "rotate_method", "mask_interpolation", "fill", "fill_mask", "p"],

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -581,6 +581,7 @@ _BASE_CASE_SPECS: list[list[Any]] = [
             "antialias": False,
         },
     ],
+    [A.Resize3D, {"size": (2, 30, 30), "interpolation": cv2.INTER_NEAREST, "mask_interpolation": cv2.INTER_LINEAR}],
     [A.CenterCrop3D, {"size": (2, 30, 30)}],
     [A.RandomCrop3D, {"size": (2, 30, 30)}],
     [
@@ -1215,6 +1216,7 @@ _EXACT_TRANSFORMS = {
     A.RandomRotate90,
     A.RandomRotate90_3D,
     A.Resize,
+    A.Resize3D,
     A.Transpose,
     A.VerticalFlip,
 }

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn.functional as torch_f
 
 import albumentations as A
+from albumentations.augmentations.transforms3d import functional as f3d
 from tests.conftest import RECTANGULAR_UINT8_IMAGE
 from tests.utils import (
     get_primary_2d_transform_params,
@@ -106,15 +107,29 @@ def test_resize_3d_supports_cpu_tensor_volume():
 def test_resize_3d_scales_xyz_keypoints():
     volume = np.zeros((2, 4, 8, 1), dtype=np.uint8)
     keypoints = np.array([[2.0, 2.0, 1.0], [6.0, 1.0, 0.0]], dtype=np.float32)
+    keypoint_labels = [7, 9]
     transform = A.Compose(
         [A.Resize3D(size=(4, 2, 16), p=1.0)],
-        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        keypoint_params=A.KeypointParams(coord_format="xyz", label_fields=["keypoint_labels"]),
         strict=True,
     )
 
-    result = transform(volume=volume, keypoints=keypoints)
+    result = transform(volume=volume, keypoints=keypoints, keypoint_labels=keypoint_labels)
 
     np.testing.assert_allclose(result["keypoints"], [[4.0, 1.0, 2.0], [12.0, 0.5, 0.0]])
+    assert result["keypoint_labels"] == keypoint_labels
+
+
+def test_resize_3d_preserves_keypoint_attributes_after_xyz_coordinates():
+    keypoints = np.array([[2.0, 2.0, 1.0, 7.0, 11.0], [6.0, 1.0, 0.0, 9.0, 13.0]], dtype=np.float32)
+
+    result = f3d.keypoints_scale_3d(
+        keypoints,
+        source_shape=(2, 4, 8),
+        target_shape=(4, 2, 16),
+    )
+
+    np.testing.assert_array_equal(result, [[4.0, 1.0, 2.0, 7.0, 11.0], [12.0, 0.5, 0.0, 9.0, 13.0]])
 
 
 @pytest.mark.parametrize("interpolation", [cv2.INTER_CUBIC, cv2.INTER_AREA])

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -3,6 +3,8 @@ from typing import Any
 import cv2
 import numpy as np
 import pytest
+import torch
+import torch.nn.functional as torch_f
 
 import albumentations as A
 from tests.conftest import RECTANGULAR_UINT8_IMAGE
@@ -11,6 +13,114 @@ from tests.utils import (
     get_primary_3d_transform_params,
     get_primary_dual_transform_params,
 )
+
+
+@pytest.mark.parametrize(
+    ("source_shape", "size"),
+    [
+        ((3, 4, 5, 1), (6, 2, 1)),
+        ((1, 4, 5, 3), (3, 8, 10)),
+        ((3, 5, 4, 9), (1, 10, 8)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_resize_3d_preserves_shape_dtype_and_mask_labels(source_shape, size, dtype):
+    rng = np.random.default_rng(137)
+    if dtype == np.uint8:
+        volume = rng.integers(0, 256, source_shape, dtype=dtype)
+    else:
+        volume = rng.random(source_shape, dtype=dtype)
+    mask3d = rng.integers(0, 4, source_shape[:3], dtype=np.uint8)
+
+    transform = A.Compose([A.Resize3D(size=size, p=1.0)], strict=True)
+    result = transform(volume=volume, mask3d=mask3d)
+
+    assert result["volume"].shape == (*size, source_shape[-1])
+    assert result["mask3d"].shape == size
+    assert result["volume"].dtype == dtype
+    assert result["mask3d"].dtype == mask3d.dtype
+    assert set(np.unique(result["mask3d"])).issubset(set(np.unique(mask3d)))
+    if dtype == np.uint8:
+        assert result["volume"].min() >= 0
+        assert result["volume"].max() <= 255
+
+
+def test_resize_3d_identity_and_integer_nearest_scale_are_exact():
+    volume = np.arange(8, dtype=np.uint8).reshape(2, 2, 2, 1)
+    mask3d = np.arange(8, dtype=np.uint8).reshape(2, 2, 2)
+
+    identity = A.Compose([A.Resize3D(size=(2, 2, 2), p=1.0)], strict=True)
+    identity_result = identity(volume=volume, mask3d=mask3d)
+    np.testing.assert_array_equal(identity_result["volume"], volume)
+    np.testing.assert_array_equal(identity_result["mask3d"], mask3d)
+
+    transform = A.Compose(
+        [
+            A.Resize3D(
+                size=(4, 4, 4),
+                interpolation=cv2.INTER_NEAREST,
+                mask_interpolation=cv2.INTER_NEAREST,
+                p=1.0,
+            ),
+        ],
+        strict=True,
+    )
+    result = transform(volume=volume, mask3d=mask3d)
+    expected_volume = np.repeat(np.repeat(np.repeat(volume, 2, axis=0), 2, axis=1), 2, axis=2)
+    expected_mask3d = np.repeat(np.repeat(np.repeat(mask3d, 2, axis=0), 2, axis=1), 2, axis=2)
+    np.testing.assert_array_equal(result["volume"], expected_volume)
+    np.testing.assert_array_equal(result["mask3d"], expected_mask3d)
+
+
+def test_resize_3d_matches_trilinear_reference():
+    volume = np.random.default_rng(137).random((3, 4, 5, 3), dtype=np.float32)
+    size = (5, 3, 7)
+    expected = (
+        torch_f.interpolate(
+            torch.from_numpy(volume).permute(3, 0, 1, 2).unsqueeze(0),
+            size=size,
+            mode="trilinear",
+            align_corners=False,
+        )
+        .squeeze(0)
+        .permute(1, 2, 3, 0)
+        .numpy()
+    )
+
+    result = A.Compose([A.Resize3D(size=size, p=1.0)], strict=True)(volume=volume)["volume"]
+
+    np.testing.assert_allclose(result, expected, rtol=2e-4, atol=3e-5)
+
+
+def test_resize_3d_supports_cpu_tensor_volume():
+    volume = np.random.default_rng(137).random((3, 4, 5, 2), dtype=np.float32)
+    tensor = torch.from_numpy(np.ascontiguousarray(volume.transpose(3, 0, 1, 2)))
+
+    result = A.Compose([A.Resize3D(size=(5, 3, 7), p=1.0)], strict=True)(volume=tensor)["volume"]
+
+    assert isinstance(result, torch.Tensor)
+    assert result.shape == (2, 5, 3, 7)
+    assert result.dtype == torch.float32
+
+
+def test_resize_3d_scales_xyz_keypoints():
+    volume = np.zeros((2, 4, 8, 1), dtype=np.uint8)
+    keypoints = np.array([[2.0, 2.0, 1.0], [6.0, 1.0, 0.0]], dtype=np.float32)
+    transform = A.Compose(
+        [A.Resize3D(size=(4, 2, 16), p=1.0)],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        strict=True,
+    )
+
+    result = transform(volume=volume, keypoints=keypoints)
+
+    np.testing.assert_allclose(result["keypoints"], [[4.0, 1.0, 2.0], [12.0, 0.5, 0.0]])
+
+
+@pytest.mark.parametrize("interpolation", [cv2.INTER_CUBIC, cv2.INTER_AREA])
+def test_resize_3d_rejects_unsupported_interpolation(interpolation):
+    with pytest.raises(ValueError, match="Input should be 0 or 1"):
+        A.Resize3D(size=(2, 3, 4), interpolation=interpolation)
 
 
 @pytest.mark.parametrize(
@@ -916,6 +1026,7 @@ def test_center_crop3d_keypoints(
             A.RandomCrop3D: {"size": (4, 4, 4)},
             A.CenterCrop3D: {"size": (4, 4, 4)},
             A.CubicSymmetry: {},
+            A.Resize3D: {"size": (12, 12, 12), "interpolation": cv2.INTER_NEAREST},
         },
         except_augmentations={
             A.CoarseDropout3D,

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -227,6 +227,7 @@ VOLUME_ALIAS_TO_TRANSFORM = {
     "pad_if_needed3d": "PadIfNeeded3D",
     "random_crop3d": "RandomCrop3D",
     "random_rotate90_3d": "RandomRotate90_3D",
+    "resize3d": "Resize3D",
 }
 
 BATCH_ALIAS_TO_TRANSFORM = {
@@ -280,6 +281,7 @@ DIRECT_KERNEL_TRANSFORMS = frozenset(
         "RandomGamma",
         "RandomToneCurve",
         "Resize",
+        "Resize3D",
         "Solarize",
         "ToGray",
         "Transpose",
@@ -297,6 +299,7 @@ MEMORY_BENCHMARKS = (
     "peakmem_resize_large_rgb",
     "peakmem_spatter_batch_large_rgb",
     "peakmem_volume_pad_medium",
+    "peakmem_volume_resize_medium",
 )
 
 MEMORY_COVERED_TRANSFORMS = frozenset(
@@ -310,12 +313,14 @@ MEMORY_COVERED_TRANSFORMS = frozenset(
         "PadIfNeeded3D",
         "RandomBrightnessContrast",
         "Resize",
+        "Resize3D",
         "Spatter",
     },
 )
 
 PYTORCH_TERMINAL_TENSOR_TRANSFORMS = frozenset({"ToTensor3D", "ToTensorV2"})
-PYTORCH_NATIVE_TENSOR_TRANSFORMS = frozenset({"Anisotropy3D", "Transpose"})
+PYTORCH_NATIVE_VOLUME_TRANSFORMS = frozenset({"Anisotropy3D", "Resize3D"})
+PYTORCH_NATIVE_TENSOR_TRANSFORMS = PYTORCH_NATIVE_VOLUME_TRANSFORMS | frozenset({"Transpose"})
 PYTORCH_TENSOR_TRANSFORMS = PYTORCH_TERMINAL_TENSOR_TRANSFORMS | PYTORCH_NATIVE_TENSOR_TRANSFORMS
 PYTORCH_IMAGE_CASES = pytorch_tensor_benchmarks.IMAGE_CASES
 PYTORCH_VOLUME_CASES = pytorch_tensor_benchmarks.VOLUME_CASES
@@ -349,6 +354,7 @@ DIRECT_KERNEL_CASE_PREFIXES_BY_TRANSFORM = {
     "RandomGamma": ("gamma_transform",),
     "RandomToneCurve": ("move_tone_curve_shared", "move_tone_curve_per_channel"),
     "Resize": ("resize", "resize_bboxes"),
+    "Resize3D": ("resize3d",),
     "Solarize": ("solarize",),
     "ToGray": ("to_gray",),
     "Transpose": ("transpose",),
@@ -366,6 +372,7 @@ MEMORY_CASES_BY_TRANSFORM = {
     "PadIfNeeded3D": ("peakmem_volume_pad_medium",),
     "RandomBrightnessContrast": ("peakmem_batch_pipeline_medium_rgb",),
     "Resize": ("peakmem_resize_large_rgb",),
+    "Resize3D": ("peakmem_volume_resize_medium",),
     "Spatter": ("peakmem_spatter_batch_large_rgb",),
 }
 
@@ -394,6 +401,7 @@ ASV_BENCHMARKS = {
     "pytorch_tensor_3d": "pytorch_benchmarks.test_tensor.TimeToTensor3D",
     "pytorch_tensor_native": "pytorch_benchmarks.test_tensor.TimeTensorNativeTranspose",
     "pytorch_tensor_native_3d": "pytorch_benchmarks.test_tensor.TimeTensorNativeAnisotropy3D",
+    "pytorch_tensor_native_resize3d": "pytorch_benchmarks.test_tensor.TimeTensorNativeResize3D",
     "reference_data": "benchmarks.test_family_matrix.TimeReferenceDataFullMatrix.time_transform",
     "target_matrix": "benchmarks.test_family_matrix.TimeSpecialTargetMatrix.time_transform",
     "volumetric_matrix": "benchmarks.test_family_matrix.TimeVolumetricFullMatrix.time_transform",
@@ -532,7 +540,7 @@ def _coverage_expectation(name: str, route: str) -> CoverageExpectation:
             required_layers=frozenset({"pytorch_tensor"}),
             reason="PyTorch Tensor transforms are benchmarked in the dedicated Tensor ASV lane",
         )
-    if name == "Anisotropy3D":
+    if name in PYTORCH_NATIVE_VOLUME_TRANSFORMS:
         return CoverageExpectation(
             required_layers=frozenset({"catalog_smoke", "direct_kernel", "pytorch_tensor", "volumetric_matrix"}),
             reason="the NumPy, direct kernel, and accepted CPU Tensor volume routes have dedicated evidence",
@@ -798,7 +806,7 @@ def _pytorch_tensor_scenario(case: Mapping[str, str], route: str, transform_name
         return {
             **_parse_pytorch_case(case["case_id"]),
             "scope": "tensor_native_compose",
-            "targets": ["mask3d", "volume"] if transform_name == "Anisotropy3D" else ["image"],
+            "targets": ["volume"] if transform_name in PYTORCH_NATIVE_VOLUME_TRANSFORMS else ["image"],
         }
     targets = ["mask3d", "volume"] if transform_name == "ToTensor3D" else ["image", "images", "mask", "masks"]
     return {
@@ -1160,15 +1168,19 @@ def _benchmark_case_index() -> dict[str, list[dict[str, str]]]:
             config="pytorch",
             layer="pytorch_tensor",
         )
-    for case_id in PYTORCH_NATIVE_VOLUME_CASES:
-        _add_asv_case(
-            cases,
-            "Anisotropy3D",
-            benchmark=ASV_BENCHMARKS["pytorch_tensor_native_3d"],
-            case_id=case_id,
-            config="pytorch",
-            layer="pytorch_tensor",
-        )
+    for transform_name, benchmark_name in {
+        "Anisotropy3D": "pytorch_tensor_native_3d",
+        "Resize3D": "pytorch_tensor_native_resize3d",
+    }.items():
+        for case_id in PYTORCH_NATIVE_VOLUME_CASES:
+            _add_asv_case(
+                cases,
+                transform_name,
+                benchmark=ASV_BENCHMARKS[benchmark_name],
+                case_id=case_id,
+                config="pytorch",
+                layer="pytorch_tensor",
+            )
     return {
         name: sorted(items, key=lambda item: (item["layer"], item["benchmark"], item["case_id"]))
         for name, items in cases.items()


### PR DESCRIPTION
## Summary

- add `Resize3D` for volumetric resizing with independent volume and mask interpolation
- delegate pixel resampling directly to Albucore `resize3d`
- scale XYZ keypoints and cover NumPy, CPU Tensor-volume, serialization, contracts, documentation, and benchmarks
- add the public transform to the README 3D table

Closes #357.

## Validation

- `uv run pytest -q -m 'not slow'`
- `pre-commit run --all-files`
- `uv run python -m tools.quality_gate fast`

## Summary by Sourcery

Add a volumetric Resize3D transform with Albucore-backed resampling and keypoint support, and integrate it into tests, benchmarks, and public APIs.

New Features:
- Introduce Resize3D transform for resizing 3D volumes and masks with configurable interpolation for each.
- Support scaling of 3D XYZ keypoints in line with resize semantics for volumetric data.
- Allow direct CPU tensor volumes as inputs to Resize3D and benchmark native tensor resize performance.

Enhancements:
- Wire Resize3D and its resize3d functional kernel into the benchmarking matrix, coverage tooling, and functional kernel benchmarks.
- Extend transform catalogs, helper cases, and public listings to include Resize3D in 3D transform suites.

Tests:
- Add unit tests validating Resize3D behavior for NumPy and tensor volumes, masks, keypoints, interpolation constraints, and trilinear consistency.