### PR TITLE
feat: add true 3D mode to GaussianBlur

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,7 +91,7 @@ jobs:
         numpy==2.2.6
         scipy==1.15.3
         pydantic==2.12.4
-        albucore==0.2.9
+        albucore==0.2.12
         opencv-python-headless==5.0.0.93
         hypothesis
         pytest

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -2,10 +2,11 @@
 defocus, zoom). Each transform documents its parameters and behavior in Args and Examples.
 """
 
-from typing import Annotated, Any, ClassVar, Literal
+from typing import Annotated, Any, ClassVar, Literal, cast
 
 import numpy as np
 from albucore import median_blur, reduce_sum
+from albucore.filter3d import gaussian_blur3d
 from pydantic import (
     Field,
     ValidationInfo,
@@ -24,7 +25,7 @@ from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
 )
-from albumentations.core.type_definitions import ImageType
+from albumentations.core.type_definitions import ImageType, VolumeType
 
 from . import functional as fblur
 
@@ -668,12 +669,13 @@ class ModeFilter(ImageOnlyTransform):
 
 
 class GaussianBlur(ImageOnlyTransform):
-    """Smooth an image with Gaussian blur to reduce noise and fine detail. Blur strength and
-    size are sampled independently on every call.
+    """Smooth images or volumes with a Gaussian kernel, including optional true 3D spatial filtering
+    for volumetric data with anisotropic depth resolution.
 
     This transform blurs the input image using a Gaussian filter with a random kernel size
     and sigma value. Gaussian blur is a widely used image processing technique that reduces
-    image noise and detail, creating a smoothing effect.
+    image noise and detail, creating a smoothing effect. Use 3D volume mode when medical
+    resolution changes affect depth as well as height and width.
 
     Args:
         sigma_range (tuple[float, float]): Inclusive range for the Gaussian kernel standard
@@ -685,6 +687,22 @@ class GaussianBlur(ImageOnlyTransform):
             three-pass extended-box approximation. Positive values use a discrete Gaussian
             kernel with the sampled size.
             Default: (0, 0)
+
+        volume_mode (Literal["slice", "3d"]): How to blur the `volume` target. `"slice"`
+            applies the 2D image kernel independently to each depth slice and preserves the
+            previous behavior. `"3d"` applies a separable kernel along depth, height, and width.
+            Default: "slice".
+
+        sigma_z_range (tuple[float, float] | None): Inclusive range for the depth-axis sigma
+            in `volume_mode="3d"`. `None` reuses the sampled `sigma_range` value, producing an
+            isotropic 3D blur. Set `(0, 0)` to leave the depth axis unblurred.
+            Default: None.
+
+        blur_z_range (tuple[int, int] | None): Inclusive range for the depth-axis kernel size
+            in `volume_mode="3d"`. `None` reuses the sampled `blur_range` value. `(0, 0)`
+            chooses Albucore's automatic kernel size from the depth sigma; other values are
+            sampled as positive odd sizes.
+            Default: None.
 
         p (float): Probability of applying the transform. Default: 0.5
 
@@ -703,6 +721,10 @@ class GaussianBlur(ImageOnlyTransform):
         - Float32 images use the same extended-box approximation without uint8 quantization.
         - Positive `blur_range` values select a discrete Gaussian kernel independently of
           sigma, so some size and sigma combinations can truncate the blur substantially.
+        - `volume_mode="3d"` uses `BORDER_REFLECT_101` along all spatial axes. It does not blur
+          channels, and a zero sigma skips its corresponding axis.
+        - In 3D mode, `sigma_range` and `blur_range` control the height and width axes;
+          `sigma_z_range` and `blur_z_range` independently control depth.
         - The default sigma range (0.5, 3.0) provides a good balance between subtle
           and strong blur effects:
           * sigma=0.5 results in a subtle blur
@@ -791,6 +813,18 @@ class GaussianBlur(ImageOnlyTransform):
         >>> pipeline_result = pipeline(image=image)
         >>> transformed_image = pipeline_result["image"]
         >>> # The image may have Gaussian blur applied with 30% probability along with other effects
+        >>>
+        >>> # Example 7: Anisotropic volumetric blur for medical data
+        >>> volume = np.random.default_rng(137).random((16, 128, 128, 1), dtype=np.float32)
+        >>> volumetric_blur = A.Compose([
+        ...     A.GaussianBlur(
+        ...         sigma_range=(1.0, 1.0),
+        ...         sigma_z_range=(0.5, 0.5),
+        ...         volume_mode="3d",
+        ...         p=1.0,
+        ...     )
+        ... ])
+        >>> blurred_volume = volumetric_blur(volume=volume)["volume"]
 
     References:
         - OpenCV Gaussian Blur: https://docs.opencv.org/master/d4/d86/group__imgproc__filter.html#gaabe8c836e97159a9193fb0b11ac52cf1
@@ -809,16 +843,51 @@ class GaussianBlur(ImageOnlyTransform):
             AfterValidator(check_range_bounds(0)),
             AfterValidator(nondecreasing),
         ]
+        volume_mode: Literal["slice", "3d"]
+        sigma_z_range: (
+            Annotated[
+                tuple[float, float],
+                AfterValidator(check_range_bounds(0)),
+                AfterValidator(nondecreasing),
+            ]
+            | None
+        )
+        blur_z_range: (
+            Annotated[
+                tuple[int, int],
+                AfterValidator(check_range_bounds(0)),
+                AfterValidator(nondecreasing),
+            ]
+            | None
+        )
+
+        @field_validator("blur_z_range")
+        @classmethod
+        def _validate_blur_z_range(
+            cls,
+            value: tuple[int, int] | None,
+            info: ValidationInfo,
+        ) -> tuple[int, int] | None:
+            if value is None or value == (0, 0):
+                return value
+            return fblur.process_blur_range(value, info, min_value=3)
 
     def __init__(
         self,
         blur_range: tuple[int, int] = (0, 0),
         sigma_range: tuple[float, float] = (0.5, 3.0),
         p: float = 0.5,
-    ):
+        *,
+        volume_mode: Literal["slice", "3d"] = "slice",
+        sigma_z_range: tuple[float, float] | None = None,
+        blur_z_range: tuple[int, int] | None = None,
+    ) -> None:
         super().__init__(p=p)
         self.blur_range = blur_range
         self.sigma_range = sigma_range
+        self.volume_mode = volume_mode
+        self.sigma_z_range = sigma_z_range
+        self.blur_z_range = blur_z_range
 
     def apply(
         self,
@@ -830,13 +899,56 @@ class GaussianBlur(ImageOnlyTransform):
             return fblur.pillow_gaussian_blur(img, kernel)
         return fpixel.separable_convolve(img, kernel=kernel)
 
+    def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
+        if self.volume_mode == "slice":
+            return super().apply_to_volume(volume, **params)
+        return cast(
+            "VolumeType",
+            gaussian_blur3d(
+                volume,
+                sigma=params["volume_sigma"],
+                kernel_size=params["volume_kernel_size"],
+            ),
+        )
+
+    def _sample_3d_kernel_size(self, blur_range: tuple[int, int]) -> int:
+        if blur_range == (0, 0):
+            return 0
+        return fblur.sample_odd_from_range(self.py_random, *blur_range)
+
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         sigma = self.py_random.uniform(*self.sigma_range)
-        ksize = self.py_random.randint(*self.blur_range)
+        ksize = (
+            self._sample_3d_kernel_size(self.blur_range)
+            if self.volume_mode == "3d"
+            else self.py_random.randint(*self.blur_range)
+        )
         self.applied_config = {"sigma_range": sigma, "blur_range": ksize}
-        if ksize == 0:
-            return {"kernel": fblur.create_pillow_gaussian_kernel(sigma), "pillow_mode": True}
-        return {"kernel": fblur.create_gaussian_kernel_1d(sigma, ksize), "pillow_mode": False}
+        result: dict[str, Any] = {
+            "kernel": fblur.create_pillow_gaussian_kernel(sigma)
+            if ksize == 0
+            else fblur.create_gaussian_kernel_1d(sigma, ksize),
+            "pillow_mode": ksize == 0,
+        }
+        if self.volume_mode == "slice":
+            return result
+
+        sigma_z = sigma if self.sigma_z_range is None else self.py_random.uniform(*self.sigma_z_range)
+        kernel_size_z = ksize if self.blur_z_range is None else self._sample_3d_kernel_size(self.blur_z_range)
+        self.applied_config.update(
+            {
+                "volume_mode": self.volume_mode,
+                "sigma_z_range": sigma_z,
+                "blur_z_range": kernel_size_z,
+            },
+        )
+        result.update(
+            {
+                "volume_sigma": (sigma_z, sigma, sigma),
+                "volume_kernel_size": (kernel_size_z, ksize, ksize),
+            },
+        )
+        return result
 
 
 class GlassBlur(ImageOnlyTransform):

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -912,9 +912,9 @@ class GaussianBlur(ImageOnlyTransform):
         )
 
     def _sample_3d_kernel_size(self, blur_range: tuple[int, int]) -> int:
-        if blur_range == (0, 0):
-            return 0
-        return fblur.sample_odd_from_range(self.py_random, *blur_range)
+        lower_bound, upper_bound = blur_range
+        kernel_size = lower_bound if lower_bound == upper_bound else self.py_random.randint(lower_bound, upper_bound)
+        return kernel_size + 1 if kernel_size > 1 and kernel_size % 2 == 0 else kernel_size
 
     def get_params_dependent_on_data(self, params: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
         sigma = self.py_random.uniform(*self.sigma_range)

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -669,7 +669,7 @@ class ModeFilter(ImageOnlyTransform):
 
 
 class GaussianBlur(ImageOnlyTransform):
-    """Smooth images or volumes with a Gaussian kernel, including optional true 3D spatial filtering
+    """Smooth images or a volume with a Gaussian kernel, including optional true 3D spatial filtering
     for volumetric data with anisotropic depth resolution.
 
     This transform blurs the input image using a Gaussian filter with a random kernel size

--- a/benchmark/benchmarks/test_volumetric.py
+++ b/benchmark/benchmarks/test_volumetric.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import albumentations
-from benchmarks.common import make_volume
+from benchmarks.common import DTYPES, VOLUME_SIZES, make_volume
 
 
 class TimeVolumetricTransforms:
@@ -22,3 +22,31 @@ class TimeVolumetricTransforms:
 
     def peakmem_center_crop3d(self) -> None:
         self.center_crop(volume=self.volume)
+
+
+class TimeGaussianBlur3D:
+    """Benchmark true-3D Gaussian blur through its public Compose route."""
+
+    params = (tuple(VOLUME_SIZES), (1, 3, 5), tuple(DTYPES))
+    param_names = ("size", "channels", "dtype")
+
+    def setup(self, size: str, channels: int, dtype: str) -> None:
+        self.volume = make_volume(size, channels, DTYPES[dtype])
+        self.gaussian_blur = albumentations.Compose(
+            [
+                albumentations.GaussianBlur(
+                    blur_range=(0, 0),
+                    sigma_range=(1.25, 1.25),
+                    volume_mode="3d",
+                    sigma_z_range=(0.75, 0.75),
+                    p=1.0,
+                ),
+            ],
+            strict=True,
+        )
+
+    def time_gaussian_blur3d(self, size: str, channels: int, dtype: str) -> None:
+        self.gaussian_blur(volume=self.volume)
+
+    def peakmem_gaussian_blur3d(self, size: str, channels: int, dtype: str) -> None:
+        self.gaussian_blur(volume=self.volume)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=5.0.0.93
-    - albucore==0.2.10
+    - albucore==0.2.12
     - numkong!=7.7.1
     - pytorch>=2.13.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "albucore==0.2.10",
+  "albucore==0.2.12",
   "numkong!=7.7.1",
   "numpy>=2.2.6",
   "pydantic>=2.12.4",

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -836,6 +836,15 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
     ),
     ("wide-sigma", A.GaussianBlur, {"sigma_range": (0.2, 1.5)}),
     (
+        "true-3d-anisotropic",
+        A.GaussianBlur,
+        {
+            "volume_mode": "3d",
+            "sigma_z_range": (0.2, 1.5),
+            "blur_z_range": (3, 5),
+        },
+    ),
+    (
         "unnormalized-direct",
         A.GridDistortion,
         {

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -288,6 +288,54 @@ def test_gaussian_blur_true_3d_matches_albucore(dtype: np.dtype, num_channels: i
     np.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
+def test_gaussian_blur_true_3d_defaults_to_isotropic_kernel(dtype: np.dtype, num_channels: int) -> None:
+    rng = np.random.default_rng(137)
+    shape = (4, 7, 11, num_channels)
+    if dtype == np.uint8:
+        volume = rng.integers(0, 256, shape, dtype=np.uint8)
+    else:
+        volume = rng.random(shape, dtype=np.float32)
+    transform = A.Compose(
+        [
+            A.GaussianBlur(
+                blur_range=(5, 5),
+                sigma_range=(1.25, 1.25),
+                volume_mode="3d",
+                p=1.0,
+            ),
+        ],
+    )
+
+    result = transform(volume=volume)["volume"]
+    expected = gaussian_blur3d(volume, sigma=(1.25, 1.25, 1.25), kernel_size=(5, 5, 5))
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_gaussian_blur_true_3d_preserves_unit_spatial_kernel() -> None:
+    rng = np.random.default_rng(137)
+    volume = rng.integers(0, 256, (4, 7, 11, 3), dtype=np.uint8)
+    transform = A.Compose(
+        [
+            A.GaussianBlur(
+                blur_range=(1, 1),
+                sigma_range=(1.25, 1.25),
+                volume_mode="3d",
+                sigma_z_range=(0.75, 0.75),
+                blur_z_range=(3, 3),
+                p=1.0,
+            ),
+        ],
+    )
+
+    result = transform(volume=volume)["volume"]
+    expected = gaussian_blur3d(volume, sigma=(0.75, 1.25, 1.25), kernel_size=(3, 1, 1))
+
+    np.testing.assert_array_equal(result, expected)
+
+
 def test_gaussian_blur_volume_defaults_to_slice_wise_behavior() -> None:
     rng = np.random.default_rng(137)
     volume = rng.integers(0, 256, (4, 9, 13, 3), dtype=np.uint8)

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -1,8 +1,10 @@
+import json
 import warnings
 from typing import Any
 
 import numpy as np
 import pytest
+from albucore.filter3d import gaussian_blur3d
 from PIL import Image, ImageFilter
 
 import albumentations as A
@@ -255,6 +257,113 @@ def test_gaussian_blur_explicit_kernel_uses_discrete_gaussian() -> None:
     result = transform(image=image)["image"]
 
     np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
+def test_gaussian_blur_true_3d_matches_albucore(dtype: np.dtype, num_channels: int) -> None:
+    rng = np.random.default_rng(137)
+    shape = (4, 7, 11, num_channels)
+    if dtype == np.uint8:
+        volume = rng.integers(0, 256, shape, dtype=np.uint8)
+    else:
+        volume = rng.random(shape, dtype=np.float32)
+
+    transform = A.Compose(
+        [
+            A.GaussianBlur(
+                blur_range=(5, 5),
+                sigma_range=(1.25, 1.25),
+                volume_mode="3d",
+                sigma_z_range=(0.5, 0.5),
+                blur_z_range=(3, 3),
+                p=1.0,
+            ),
+        ],
+    )
+
+    result = transform(volume=volume)["volume"]
+    expected = gaussian_blur3d(volume, sigma=(0.5, 1.25, 1.25), kernel_size=(3, 5, 5))
+
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_gaussian_blur_volume_defaults_to_slice_wise_behavior() -> None:
+    rng = np.random.default_rng(137)
+    volume = rng.integers(0, 256, (4, 9, 13, 3), dtype=np.uint8)
+    transform = A.Compose([A.GaussianBlur(blur_range=(5, 5), sigma_range=(1.25, 1.25), p=1.0)])
+
+    result = transform(volume=volume)["volume"]
+    expected = np.stack(
+        [A.GaussianBlur(blur_range=(5, 5), sigma_range=(1.25, 1.25), p=1.0)(image=image)["image"] for image in volume],
+    )
+
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_gaussian_blur_true_3d_supports_single_slice_and_zero_sigma_axes(dtype: np.dtype) -> None:
+    rng = np.random.default_rng(137)
+    shape = (1, 7, 11, 3)
+    if dtype == np.uint8:
+        volume = rng.integers(0, 256, shape, dtype=np.uint8)
+    else:
+        volume = rng.random(shape, dtype=np.float32)
+
+    transform = A.Compose(
+        [
+            A.GaussianBlur(
+                blur_range=(0, 0),
+                sigma_range=(0.0, 0.0),
+                volume_mode="3d",
+                sigma_z_range=(0.75, 0.75),
+                blur_z_range=(3, 3),
+                p=1.0,
+            ),
+        ],
+    )
+
+    result = transform(volume=volume)["volume"]
+
+    assert result.shape == volume.shape
+    assert result.dtype == volume.dtype
+    if dtype == np.uint8:
+        np.testing.assert_array_equal(result, volume)
+    else:
+        np.testing.assert_allclose(result, volume, rtol=1e-6, atol=1e-6)
+
+
+def test_gaussian_blur_true_3d_applied_config_replays_after_json_transport() -> None:
+    rng = np.random.default_rng(137)
+    volume = rng.random((4, 7, 11, 3), dtype=np.float32)
+    original = A.Compose(
+        [
+            A.GaussianBlur(
+                blur_range=(3, 7),
+                sigma_range=(0.5, 1.5),
+                volume_mode="3d",
+                sigma_z_range=(0.2, 0.8),
+                blur_z_range=(3, 5),
+                p=1.0,
+            ),
+        ],
+        save_applied_params=True,
+        seed=137,
+    )
+
+    original_result = original(volume=volume)
+    record = json.loads(json.dumps(original_result["applied_transforms"], allow_nan=False))
+    replay = A.Compose.from_applied_transforms(record, seed=137)
+    replay_result = replay(volume=volume)
+
+    np.testing.assert_array_equal(replay_result["volume"], original_result["volume"])
+
+
+def test_gaussian_blur_true_3d_keeps_mask3d_outside_its_targets() -> None:
+    transform = A.GaussianBlur(volume_mode="3d", p=1.0)
+
+    assert "mask3d" not in transform.targets
+    assert "volumes" not in transform.targets
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -359,13 +359,6 @@ def test_gaussian_blur_true_3d_applied_config_replays_after_json_transport() -> 
     np.testing.assert_array_equal(replay_result["volume"], original_result["volume"])
 
 
-def test_gaussian_blur_true_3d_keeps_mask3d_outside_its_targets() -> None:
-    transform = A.GaussianBlur(volume_mode="3d", p=1.0)
-
-    assert "mask3d" not in transform.targets
-    assert "volumes" not in transform.targets
-
-
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 @pytest.mark.parametrize("num_channels", [1, 3, 5])
 @pytest.mark.parametrize("kernel_size", [3, 5, 7])

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -71,7 +71,7 @@ LOWER_BOUND_REQUIREMENTS = (
     "numpy==2.2.6",
     "scipy==1.15.3",
     "pydantic==2.12.4",
-    "albucore==0.2.9",
+    "albucore==0.2.12",
     "opencv-python-headless==5.0.0.93",
 )
 CI_DEPENDENCY_GROUPS = {

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "albucore"
-version = "0.2.10"
+version = "0.2.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numkong" },
@@ -36,9 +36,9 @@ dependencies = [
     { name = "stringzilla" },
     { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/a0/38a950121bf97a671755e86d82617dad9afa6627de612d833fd4b99d1b1e/albucore-0.2.10.tar.gz", hash = "sha256:b9f5ae6627342ca901ab668d1531b23b5aa73e879187d5adf60421a679c13520", size = 227993, upload-time = "2026-08-03T11:44:47.966Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/03/0d81c80164397d29f413b81cfeea5c9b989a970ee2b1a43f3f09f461d0f3/albucore-0.2.12.tar.gz", hash = "sha256:314cafc3f1ec3c1ecb87fe4e5168f56694217aa27287bc7e6ffb13aeb61a9e02", size = 254563, upload-time = "2026-08-05T09:31:58.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/4e/ee6bb9d1aad14443beb1e23084f64813cdd01ee2b179d1fb846d6a6bebee/albucore-0.2.10-py3-none-any.whl", hash = "sha256:6e3111374b2ee1089f8e5b9002eb6381c9f7b4036cd5d74871b1844556b04ed6", size = 52457, upload-time = "2026-08-03T11:44:46.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/4b6fa19d445fca566e7a6ba1cf67852f527a094a5dcb63ffa82af47efa54/albucore-0.2.12-py3-none-any.whl", hash = "sha256:f516da25592367abf09c3c54b88ce697b6eddeb574a10049067a3b224f484404", size = 58160, upload-time = "2026-08-05T09:31:56.844Z" },
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "albucore", specifier = "==0.2.10" },
+    { name = "albucore", specifier = "==0.2.12" },
     { name = "huggingface-hub", marker = "extra == 'hub'" },
     { name = "numkong", specifier = "!=7.7.1" },
     { name = "numpy", specifier = ">=2.2.6" },


### PR DESCRIPTION
## Summary

- Add opt-in true 3D Gaussian smoothing to `GaussianBlur` through `volume_mode="3d"`.
- Add independent depth-axis sampling with `sigma_z_range` and `blur_z_range`; existing slice-wise single-volume behavior remains the default.
- Upgrade Albucore to 0.2.12 and use its separable D/H/W kernel.
- Add coverage for dtypes, channel counts, non-cubic volumes, zero-sigma axes, and replay.
- Keep the transform scoped to its documented image and single-volume paths.

Closes #333.

## Validation

- `uv run pytest -n auto -q tests/test_blur.py` — 138 passed
- `uv run --python 3.10 pre-commit run --all-files` — passed