### PR TITLE
docs: sync backend policy and retire batch-volume references

### DIFF
--- a/.codex/skills/performance-optimization/references/performance-optimization.md
+++ b/.codex/skills/performance-optimization/references/performance-optimization.md
@@ -210,7 +210,7 @@ After removing work and comparing straight implementations, consider routing by:
 - uint8 versus float32;
 - scalar versus per-channel parameters;
 - 1, 3, 4, and high-channel inputs;
-- image, batch, volume, and batch-of-volumes rank;
+- image, image-batch, and single-volume rank;
 - contiguous versus strided input;
 - small versus large arrays;
 - dense versus sparse labels;
@@ -235,7 +235,7 @@ For Albucore, benchmark the public router, not only its private backend. Include
 Check these shared entry points before writing a local kernel:
 
 - `albucore.apply_uint8_lut` and `albucore.sz_lut` for benchmark-routed uint8 tables;
-- `albucore.stats` for `sum`, `mean`, `std`, and `mean_std` across images, batches, and volumes;
+- `albucore.stats` for `sum`, `mean`, `std`, and `mean_std` across supported array ranks;
 - Albucore arithmetic and weighted routers for add, multiply, normalize, power, blend, and fused multiply-add;
 - Albucore geometric and resize functions for channel-safe OpenCV routing;
 - `pairwise_distances_squared` for the routed small-set NumKong and larger NumPy paths.

--- a/.codex/skills/performance-optimization/references/performance-optimization.md
+++ b/.codex/skills/performance-optimization/references/performance-optimization.md
@@ -8,6 +8,8 @@ This file is canonical at `albucore/docs/performance-optimization.md`. Albumenta
 copy under `.codex/skills/performance-optimization/references/` so its performance skill can load the guide without a
 sibling Albucore checkout.
 
+For eager CPU PyTorch candidates, also follow Albucore's `docs/torch-performance-optimization.md` workflow.
+
 ## Run the optimization pass in this order
 
 ### 1. Delete work first
@@ -128,6 +130,7 @@ For each atomic operation, benchmark viable implementations end to end:
 - OpenCV;
 - NumKong;
 - StringZilla;
+- CPU PyTorch for documented Tensor or volume contracts;
 - a LUT route;
 - a small Python or `math` implementation when the data is scalar or tiny.
 
@@ -142,6 +145,17 @@ globally fastest:
 - NumPy wins other float32 and high-channel paths;
 - OpenCV wins many dense image operations but has channel and layout constraints;
 - StringZilla is competitive for selected uint8 translation paths.
+- CPU PyTorch is competitive for selected eager 3D volume operations when the complete interop route wins.
+
+### 6a. Escalate missing backend capabilities
+
+When a viable optimization requires an operation that PyTorch, NumKong, OpenCV, or NumPy does not provide, first open
+a Feature Request in the relevant upstream project. Link the request from the Albucore issue, benchmark note, or pull
+request so the dependency is explicit.
+
+When we can implement the operation and the upstream contribution rules allow it, open a linked upstream pull request.
+Until the operation is available, benchmark the portable alternatives and document the capability gap. Do not add a
+private substitute solely to avoid upstream coordination.
 
 ### 7. Compare random-generation paths
 
@@ -196,7 +210,7 @@ After removing work and comparing straight implementations, consider routing by:
 - uint8 versus float32;
 - scalar versus per-channel parameters;
 - 1, 3, 4, and high-channel inputs;
-- image, image-batch, volume, and 3D-mask-batch rank;
+- image, batch, volume, and batch-of-volumes rank;
 - contiguous versus strided input;
 - small versus large arrays;
 - dense versus sparse labels;
@@ -221,7 +235,7 @@ For Albucore, benchmark the public router, not only its private backend. Include
 Check these shared entry points before writing a local kernel:
 
 - `albucore.apply_uint8_lut` and `albucore.sz_lut` for benchmark-routed uint8 tables;
-- `albucore.stats` for `sum`, `mean`, `std`, and `mean_std` across images, batches, and volume data;
+- `albucore.stats` for `sum`, `mean`, `std`, and `mean_std` across images, batches, and volumes;
 - Albucore arithmetic and weighted routers for add, multiply, normalize, power, blend, and fused multiply-add;
 - Albucore geometric and resize functions for channel-safe OpenCV routing;
 - `pairwise_distances_squared` for the routed small-set NumKong and larger NumPy paths.
@@ -280,7 +294,8 @@ Every performance task should report:
 - grouped integer-label reductions reviewed, including `bincount`;
 - LUT applicability and candidates;
 - random-generation candidates;
-- NumPy, OpenCV, NumKong, StringZilla, and Python candidates that apply;
+- NumPy, OpenCV, NumKong, StringZilla, CPU PyTorch, and Python candidates that apply;
+- any missing upstream primitive, its Feature Request, and a linked implementation pull request when we can provide one;
 - reusable atoms moved or proposed for Albucore;
 - safe in-place opportunities;
 - correctness evidence;

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -189,13 +189,13 @@ class Resize3D(Transform3D):
     channels, dtype, and its public layout intact.
 
     `Resize3D` resamples all three spatial axes together; depth is never treated as a
-    batch axis. Intensity volumes and categorical masks use independently configurable
+    batch axis. Single-volume intensity data and categorical masks use independently configurable
     interpolation. The routed Albucore backend supports only linear and nearest-neighbor
     interpolation, ensuring the same public contract for NumPy and CPU Tensor inputs.
 
     Args:
         size (tuple[int, int, int]): Target spatial shape in `(depth, height, width)` order.
-        interpolation (Literal[0, 1]): Interpolation for volumes: `cv2.INTER_LINEAR` or
+        interpolation (Literal[0, 1]): Interpolation for a volume: `cv2.INTER_LINEAR` or
             `cv2.INTER_NEAREST`. Default: `cv2.INTER_LINEAR`.
         mask_interpolation (Literal[0, 1]): Interpolation for `mask3d`:
             `cv2.INTER_LINEAR` or `cv2.INTER_NEAREST`. Default: `cv2.INTER_NEAREST`.
@@ -208,7 +208,7 @@ class Resize3D(Transform3D):
         uint8, float32
 
     Notes:
-        - NumPy volumes use channel-last `(D, H, W, C)` layout. CPU Tensor volumes
+        - NumPy volume data use channel-last `(D, H, W, C)` layout. CPU Tensor volume data
           use channel-first `(C, D, H, W)` layout.
         - `uint8` output preserves dtype; linear resampling rounds and saturates to
           `[0, 255]`. Float32 output remains float32.

--- a/benchmark/pytorch_benchmarks/test_tensor.py
+++ b/benchmark/pytorch_benchmarks/test_tensor.py
@@ -148,7 +148,7 @@ class TimeTensorNativeTranspose:
 class TimeTensorNativeAnisotropy3D:
     """Benchmark the accepted Tensor `Anisotropy3D(volume=...)` capability.
 
-    The direct Tensor route uses C,D,H,W volumes. Its NumPy comparison paths
+    The direct Tensor route uses C,D,H,W single-volume data. Its NumPy comparison paths
     use the matching D,H,W,C volume and the normal `ToTensor3D` handoff.
     """
 
@@ -205,7 +205,7 @@ class TimeTensorNativeAnisotropy3D:
 class TimeTensorNativeResize3D:
     """Benchmark the accepted Tensor `Resize3D(volume=...)` capability.
 
-    The direct Tensor route uses C,D,H,W volumes. Its NumPy comparison paths use
+    The direct Tensor route uses C,D,H,W single-volume data. Its NumPy comparison paths use
     the matching D,H,W,C volume and the normal `ToTensor3D` handoff.
     """
 

--- a/docs/contributing/codex_guidelines.md
+++ b/docs/contributing/codex_guidelines.md
@@ -65,7 +65,7 @@ AlbumentationsX is a high-performance computer vision augmentation library. We p
 - Single images are `(H, W, C)`; grayscale is `(H, W, 1)`, not `(H, W)`.
 - Image batches are `(N, H, W, C)`, and a volume is `(D, H, W, C)`.
 - Do not add functional-layer compatibility branches for 2D grayscale images when code is used through `Compose`.
-- Branching on `ndim` is appropriate to distinguish image, batch, volume, and 3D-mask batch paths, not to infer channels.
+- Branching on `ndim` is appropriate to distinguish image, image-batch, and single-volume paths, not to infer channels.
 
 ### Validation Principles
 

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -235,7 +235,7 @@ def apply(self, img: np.ndarray, **params) -> np.ndarray:
   - Single volume: `(D, H, W, C)`
 - Do not add compatibility branches for grayscale images shaped as `(H, W)` in transform `apply_*` methods or functional
   kernels used by `Compose`; normalize inputs before they reach transform logic.
-- It is fine to branch on `img.ndim` when selecting between image, image batch, volume, and 3D-mask batch logic. Do not
+- It is fine to branch on `img.ndim` when selecting between image, image-batch, and single-volume logic. Do not
   use `img.ndim` to infer whether a Compose image has channels.
 
 ### Handling Auxiliary Data via Metadata


### PR DESCRIPTION
## Summary

- Synchronize the Albucore performance workflow into AlbumentationsX, including CPU PyTorch as an eligible backend and the upstream Feature Request / implementation-PR policy for missing primitives.
- Remove retired batch-volume and 3D-mask batch target terminology from contributor guidance, the fallback performance guide, and `Resize3D` documentation.
- Describe rank-5 numerical inputs as generic five-dimensional arrays rather than transform targets.
- Keep the fallback guide byte-for-byte synchronized with Albucore.

## Validation

- `uv run --python 3.10 pre-commit run --all-files` — passed
- `cmp -s ../albucore-performance-docs/docs/performance-optimization.md .codex/skills/performance-optimization/references/performance-optimization.md` — passed

Canonical Albucore PR: https://github.com/albumentations-team/albucore/pull/140