### PR TITLE
feat: remap semantic mask labels after flips

### DIFF
--- a/albumentations/augmentations/geometric/_functional_images.py
+++ b/albumentations/augmentations/geometric/_functional_images.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from operator import index
+from operator import attrgetter, index
 from typing import Any, Literal, Protocol, cast
+
+import torch
 
 from ._functional_shared import (
     NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS,
@@ -1253,6 +1255,10 @@ def hflip_images(volume: np.ndarray) -> np.ndarray:
     return np.flip(volume, axis=2)
 
 
+# Tensor spatial primitives are aliases rather than wrappers so transform dispatch does not add a Python frame.
+flip_tensor = torch.flip
+
+
 def vflip_images(volume: np.ndarray) -> np.ndarray:
     """Perform vertical flip on a single volume (D, H, W) or (D, H, W, C). Flips
     along height axis. For Transforms3D VerticalFlip.
@@ -1268,6 +1274,9 @@ def vflip_images(volume: np.ndarray) -> np.ndarray:
 
     """
     return np.flip(volume, axis=1)
+
+
+transpose_tensor = attrgetter("mT")
 
 
 @preserve_channel_dim
@@ -1400,6 +1409,7 @@ __all__ = [
     "dilate",
     "distort_image",
     "erode",
+    "flip_tensor",
     "get_pad_grid_dimensions",
     "hflip_images",
     "is_identity_matrix",
@@ -1420,5 +1430,6 @@ __all__ = [
     "scale_xy",
     "transpose",
     "transpose_images",
+    "transpose_tensor",
     "vflip_images",
 ]

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -115,8 +115,12 @@ class VerticalFlip(DualTransform):
 
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
+    _supports_cpu_tensor = True
+    _cpu_tensor_targets = frozenset({"image", "images", "volume", "mask", "masks", "mask3d"})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
+        if isinstance(img, torch.Tensor):
+            return cast("ImageType", torch.flip(img, dims=(-2,)))
         return vflip(img)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
@@ -133,14 +137,20 @@ class VerticalFlip(DualTransform):
         return self.apply(mask, **params)
 
     def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
+        if isinstance(masks, torch.Tensor):
+            return cast("StackedMasks4D", torch.flip(masks, dims=(-2,)))
         if masks.size == 0:
             return masks
         return StackedMasks4D(self.apply_to_images(masks, **params))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
+        if isinstance(images, torch.Tensor):
+            return cast("ImageType", torch.flip(images, dims=(-2,)))
         return fgeometric.vflip_images(images)
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
+        if isinstance(volume, torch.Tensor):
+            return cast("VolumeType", torch.flip(volume, dims=(-2,)))
         return fgeometric.vflip_images(volume)
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
@@ -213,8 +223,12 @@ class HorizontalFlip(DualTransform):
 
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
+    _supports_cpu_tensor = True
+    _cpu_tensor_targets = frozenset({"image", "images", "volume", "mask", "masks", "mask3d"})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
+        if isinstance(img, torch.Tensor):
+            return cast("ImageType", torch.flip(img, dims=(-1,)))
         return hflip(img)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
@@ -231,14 +245,20 @@ class HorizontalFlip(DualTransform):
         return self.apply(mask, **params)
 
     def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
+        if isinstance(masks, torch.Tensor):
+            return cast("StackedMasks4D", torch.flip(masks, dims=(-1,)))
         if masks.size == 0:
             return masks
         return StackedMasks4D(self.apply_to_images(masks, **params))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
+        if isinstance(images, torch.Tensor):
+            return cast("ImageType", torch.flip(images, dims=(-1,)))
         return fgeometric.hflip_images(images)
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
+        if isinstance(volume, torch.Tensor):
+            return cast("VolumeType", torch.flip(volume, dims=(-1,)))
         return fgeometric.hflip_images(volume)
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
@@ -319,8 +339,7 @@ class Transpose(DualTransform):
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
     _supports_cpu_tensor = True
-    _cpu_tensor_targets = frozenset({"image", "mask", "masks", "mask3d"})
-    _cpu_tensor_channels = frozenset({1, 3})
+    _cpu_tensor_targets = frozenset({"image", "images", "volume", "mask", "masks", "mask3d"})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if isinstance(img, torch.Tensor):
@@ -353,7 +372,14 @@ class Transpose(DualTransform):
         return StackedMasks4D(self.apply_to_images(masks, **params))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
+        if isinstance(images, torch.Tensor):
+            return cast("ImageType", images.transpose(-1, -2))
         return fgeometric.transpose_images(images)
+
+    def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
+        if isinstance(volume, torch.Tensor):
+            return cast("VolumeType", volume.transpose(-1, -2))
+        return fgeometric.transpose_images(volume)
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
         if isinstance(mask3d, torch.Tensor):

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -120,7 +120,7 @@ class VerticalFlip(DualTransform):
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if isinstance(img, torch.Tensor):
-            return cast("ImageType", torch.flip(img, dims=(-2,)))
+            return cast("ImageType", fgeometric.flip_tensor(img, dims=(-2,)))
         return vflip(img)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
@@ -138,19 +138,19 @@ class VerticalFlip(DualTransform):
 
     def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
         if isinstance(masks, torch.Tensor):
-            return cast("StackedMasks4D", torch.flip(masks, dims=(-2,)))
+            return cast("StackedMasks4D", fgeometric.flip_tensor(masks, dims=(-2,)))
         if masks.size == 0:
             return masks
         return StackedMasks4D(self.apply_to_images(masks, **params))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         if isinstance(images, torch.Tensor):
-            return cast("ImageType", torch.flip(images, dims=(-2,)))
+            return cast("ImageType", fgeometric.flip_tensor(images, dims=(-2,)))
         return fgeometric.vflip_images(images)
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
         if isinstance(volume, torch.Tensor):
-            return cast("VolumeType", torch.flip(volume, dims=(-2,)))
+            return cast("VolumeType", fgeometric.flip_tensor(volume, dims=(-2,)))
         return fgeometric.vflip_images(volume)
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
@@ -228,7 +228,7 @@ class HorizontalFlip(DualTransform):
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if isinstance(img, torch.Tensor):
-            return cast("ImageType", torch.flip(img, dims=(-1,)))
+            return cast("ImageType", fgeometric.flip_tensor(img, dims=(-1,)))
         return hflip(img)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
@@ -246,19 +246,19 @@ class HorizontalFlip(DualTransform):
 
     def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
         if isinstance(masks, torch.Tensor):
-            return cast("StackedMasks4D", torch.flip(masks, dims=(-1,)))
+            return cast("StackedMasks4D", fgeometric.flip_tensor(masks, dims=(-1,)))
         if masks.size == 0:
             return masks
         return StackedMasks4D(self.apply_to_images(masks, **params))
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         if isinstance(images, torch.Tensor):
-            return cast("ImageType", torch.flip(images, dims=(-1,)))
+            return cast("ImageType", fgeometric.flip_tensor(images, dims=(-1,)))
         return fgeometric.hflip_images(images)
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
         if isinstance(volume, torch.Tensor):
-            return cast("VolumeType", torch.flip(volume, dims=(-1,)))
+            return cast("VolumeType", fgeometric.flip_tensor(volume, dims=(-1,)))
         return fgeometric.hflip_images(volume)
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
@@ -343,7 +343,7 @@ class Transpose(DualTransform):
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if isinstance(img, torch.Tensor):
-            return cast("ImageType", img.mT)
+            return cast("ImageType", fgeometric.transpose_tensor(img))
         return fgeometric.transpose(img)
 
     def apply_to_bboxes(self, bboxes: np.ndarray, **params: Any) -> np.ndarray:
@@ -355,7 +355,7 @@ class Transpose(DualTransform):
 
     def apply_to_mask(self, mask: ImageType, **params: Any) -> ImageType:
         if isinstance(mask, torch.Tensor):
-            return cast("ImageType", mask.mT)
+            return cast("ImageType", fgeometric.transpose_tensor(mask))
         if mask.size == 0:
             # Transpose swaps H and W
             # Assume mask shape is (H, W, C) -> (W, H, C)
@@ -364,7 +364,7 @@ class Transpose(DualTransform):
 
     def apply_to_masks(self, masks: StackedMasks4D, **params: Any) -> StackedMasks4D:
         if isinstance(masks, torch.Tensor):
-            return cast("StackedMasks4D", masks.transpose(-1, -2))
+            return cast("StackedMasks4D", fgeometric.transpose_tensor(masks))
         if masks.size == 0:
             return StackedMasks4D(
                 np.empty((0, masks.shape[2], masks.shape[1], masks.shape[3]), dtype=masks.dtype),
@@ -373,17 +373,17 @@ class Transpose(DualTransform):
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         if isinstance(images, torch.Tensor):
-            return cast("ImageType", images.transpose(-1, -2))
+            return cast("ImageType", fgeometric.transpose_tensor(images))
         return fgeometric.transpose_images(images)
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
         if isinstance(volume, torch.Tensor):
-            return cast("VolumeType", volume.transpose(-1, -2))
+            return cast("VolumeType", fgeometric.transpose_tensor(volume))
         return fgeometric.transpose_images(volume)
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
         if isinstance(mask3d, torch.Tensor):
-            return cast("VolumeType", mask3d.transpose(-1, -2))
+            return cast("VolumeType", fgeometric.transpose_tensor(mask3d))
         if mask3d.size == 0:
             # Transpose swaps H and W
             # Assume mask3d shape is (D, H, W, C) -> (D, W, H, C)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -51,7 +51,7 @@ from .tensor import (
     tensor_to_numpy_annotation,
     validate_tensor_input,
 )
-from .transforms_interface import BasicTransform
+from .transforms_interface import BasicTransform, DualTransform
 from .type_definitions import StackedMasks4D
 from .utils import DataProcessor, format_args, get_shape
 
@@ -73,6 +73,53 @@ __all__ = [
 NUM_ONEOF_TRANSFORMS = 2
 
 _REPLAY_PARAM_ANNOTATIONS_CACHE: dict[type, dict[str, Any]] = {}
+
+
+def _normalize_semantic_mask_source_label(source_label: Any) -> int:
+    if isinstance(source_label, str):
+        try:
+            normalized_source = int(source_label)
+        except ValueError as exc:
+            raise TypeError("semantic mask source labels must be integers") from exc
+        if source_label == str(normalized_source):
+            return normalized_source
+    elif isinstance(source_label, (int, np.integer)) and not isinstance(source_label, (bool, np.bool_)):
+        return int(source_label)
+    raise TypeError("semantic mask source labels must be integers")
+
+
+def _normalize_semantic_mask_target_label(target_label: Any) -> int:
+    if isinstance(target_label, (int, np.integer)) and not isinstance(target_label, (bool, np.bool_)):
+        return int(target_label)
+    raise TypeError("semantic mask target labels must be integers")
+
+
+def _normalize_semantic_mask_label_mappings(mappings: Any) -> dict[str, dict[int, int]] | None:
+    """Normalize integer semantic-mask label keys after JSON transport and reject invalid, ambiguous,
+    or duplicate mappings before use.
+    """
+    if mappings is None:
+        return None
+    if not isinstance(mappings, dict):
+        raise TypeError("semantic_mask_label_mappings must be a dictionary")
+
+    normalized: dict[str, dict[int, int]] = {}
+    for transform_name, mapping in mappings.items():
+        if not isinstance(transform_name, str):
+            raise TypeError("semantic_mask_label_mappings transform names must be strings")
+        if not isinstance(mapping, dict):
+            raise TypeError(f"semantic_mask_label_mappings['{transform_name}'] must be a dictionary")
+
+        normalized_mapping: dict[int, int] = {}
+        for source_label, target_label in mapping.items():
+            normalized_source = _normalize_semantic_mask_source_label(source_label)
+            normalized_target = _normalize_semantic_mask_target_label(target_label)
+            if normalized_source in normalized_mapping:
+                raise ValueError(f"Duplicate semantic mask source label after normalization: {normalized_source}")
+            normalized_mapping[normalized_source] = normalized_target
+
+        normalized[transform_name] = normalized_mapping
+    return normalized
 
 
 def _get_replay_param_annotations(cls: type) -> dict[str, Any]:
@@ -1129,6 +1176,10 @@ class Compose(BaseCompose, HubMixin):
         additional_targets (dict[str, str] | None): A dictionary mapping additional target names
             to their types. For example, {'image2': 'image'}. Passing a spatial alias also
             requires passing its canonical target (`image` in this example). Default is None.
+        semantic_mask_label_mappings (dict[str, dict[int, int]] | None): Label replacements applied to
+            `mask`, `masks`, `mask3d`, and their aliases after a realized label-changing spatial transform.
+            The outer key is `HorizontalFlip`, `VerticalFlip`, or `Transpose`; the inner dictionary maps
+            source class IDs to target class IDs. Default: None.
         p (float): Probability of applying all transforms. Should be in range [0, 1]. Default is 1.0.
         is_check_shapes (bool): If True, checks consistency of shapes for image/mask/masks on each call.
             Disable only if you are sure about your data consistency. Default is True.
@@ -1182,6 +1233,13 @@ class Compose(BaseCompose, HubMixin):
         ... ], seed=137)
         >>> transformed = transform(image=image)
 
+        >>> # Swap left/right semantic-mask class IDs after a realized horizontal flip:
+        >>> transform = A.Compose(
+        ...     [A.HorizontalFlip(p=1.0)],
+        ...     semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        ... )
+        >>> transformed = transform(image=image, mask=mask)
+
         >>> # Pipeline modification after initialization:
         >>> # Create initial pipeline with bbox support
         >>> base_transform = A.Compose([
@@ -1202,6 +1260,11 @@ class Compose(BaseCompose, HubMixin):
         - The class checks the validity of input data and shapes if is_check_args and is_check_shapes are True.
         - When bbox_params or keypoint_params are provided, it sets up the corresponding processors.
         - The transform can handle additional targets specified in the additional_targets dictionary.
+        - Semantic-mask mappings replace class IDs simultaneously, so paired swaps do not overwrite one another.
+          Unmapped labels stay unchanged. For D4/SquareSymmetry, configure the realized reflection name:
+          `HorizontalFlip`, `VerticalFlip`, or `Transpose`; identity and rotations do not remap labels.
+        - Configure semantic-mask mappings only when the transformed and relabeled sample remains valid for your
+          domain. Compose applies the declared mapping but cannot verify its semantic truth.
         - When strict mode is enabled, it performs additional validation to ensure data and transform
           configuration correctness.
         - Pipeline modification operators (+, -, __radd__) preserve all Compose parameters including
@@ -1225,6 +1288,7 @@ class Compose(BaseCompose, HubMixin):
         telemetry: bool = True,
         instance_binding: Sequence[str] | None = None,
         strict_instance_invariant: bool = True,
+        semantic_mask_label_mappings: dict[str, dict[int, int]] | None = None,
     ):
         # Strict-invariant mode (2.2.2+ default) raises RuntimeError when a transform breaks
         # the masks/bboxes positional alignment contract instead of trying to recover.
@@ -1249,6 +1313,9 @@ class Compose(BaseCompose, HubMixin):
         self._instance_binding = self._setup_instance_binding(instance_binding)
 
         self.add_targets(additional_targets)
+        normalized_mask_mappings = _normalize_semantic_mask_label_mappings(semantic_mask_label_mappings)
+        self.semantic_mask_label_mappings = normalized_mask_mappings
+        self._set_semantic_mask_label_mappings_for_transforms(self.transforms, normalized_mask_mappings)
         if not self.transforms:  # if no transforms -> do nothing, all keys will be available
             self._available_keys.update(AVAILABLE_KEYS)
         if self._instance_binding:
@@ -1267,6 +1334,20 @@ class Compose(BaseCompose, HubMixin):
 
         # Telemetry runs after nested composes so main_compose=False is already set on them.
         self._maybe_send_telemetry(telemetry)
+
+    def _set_semantic_mask_label_mappings_for_transforms(
+        self,
+        transforms: TransformsSeqType,
+        mappings: dict[str, dict[int, int]] | None,
+    ) -> None:
+        effective_mappings = mappings or {}
+        for transform in transforms:
+            if isinstance(transform, DualTransform):
+                transform.set_semantic_mask_label_mappings(effective_mappings)
+            elif isinstance(transform, Compose) and mappings is None:
+                continue
+            elif isinstance(transform, BaseCompose):
+                self._set_semantic_mask_label_mappings_for_transforms(transform.transforms, mappings)
 
     def _resolve_processors(
         self,
@@ -2489,6 +2570,8 @@ class Compose(BaseCompose, HubMixin):
                 "seed": getattr(self, "_base_seed", None),
             },
         )
+        if self.semantic_mask_label_mappings is not None:
+            dictionary["semantic_mask_label_mappings"] = self.semantic_mask_label_mappings
         if self._instance_binding:
             dictionary["instance_binding"] = sorted(self._instance_binding)
         return dictionary
@@ -2519,6 +2602,8 @@ class Compose(BaseCompose, HubMixin):
                 "is_check_shapes": self.is_check_shapes,
             },
         )
+        if self.semantic_mask_label_mappings is not None:
+            dictionary["semantic_mask_label_mappings"] = self.semantic_mask_label_mappings
         if self._instance_binding:
             dictionary["instance_binding"] = sorted(self._instance_binding)
         return dictionary
@@ -2674,6 +2759,7 @@ class Compose(BaseCompose, HubMixin):
             "bbox_params": bbox_params,
             "keypoint_params": kp_params,
             "additional_targets": self.additional_targets,
+            "semantic_mask_label_mappings": self.semantic_mask_label_mappings,
             "p": self.p,
             "is_check_shapes": self.is_check_shapes,
             "strict": self.strict,
@@ -3059,6 +3145,8 @@ class ReplayCompose(Compose):
             Parameters for keypoint transforms.
         additional_targets (dict[str, str] | None):
             Dictionary of additional targets.
+        semantic_mask_label_mappings (dict[str, dict[int, int]] | None):
+            Transform-aware semantic-mask class-ID replacements.
         p (float):
             Probability of applying the compose.
         is_check_shapes (bool):
@@ -3082,6 +3170,7 @@ class ReplayCompose(Compose):
         save_key: str = "replay",
         seed: int | None = None,
         instance_binding: Sequence[str] | None = None,
+        semantic_mask_label_mappings: dict[str, dict[int, int]] | None = None,
     ):
         super().__init__(
             transforms,
@@ -3092,6 +3181,7 @@ class ReplayCompose(Compose):
             is_check_shapes,
             seed=seed,
             instance_binding=instance_binding,
+            semantic_mask_label_mappings=semantic_mask_label_mappings,
         )
         self.set_deterministic(True, save_key=save_key)
         self.save_key = save_key

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -75,23 +75,17 @@ NUM_ONEOF_TRANSFORMS = 2
 _REPLAY_PARAM_ANNOTATIONS_CACHE: dict[type, dict[str, Any]] = {}
 
 
-def _normalize_semantic_mask_source_label(source_label: Any) -> int:
-    if isinstance(source_label, str):
+def _normalize_semantic_mask_label(label: Any, label_kind: str) -> int:
+    if isinstance(label, str):
         try:
-            normalized_source = int(source_label)
+            normalized_label = int(label)
         except ValueError as exc:
-            raise TypeError("semantic mask source labels must be integers") from exc
-        if source_label == str(normalized_source):
-            return normalized_source
-    elif isinstance(source_label, (int, np.integer)) and not isinstance(source_label, (bool, np.bool_)):
-        return int(source_label)
-    raise TypeError("semantic mask source labels must be integers")
-
-
-def _normalize_semantic_mask_target_label(target_label: Any) -> int:
-    if isinstance(target_label, (int, np.integer)) and not isinstance(target_label, (bool, np.bool_)):
-        return int(target_label)
-    raise TypeError("semantic mask target labels must be integers")
+            raise TypeError(f"semantic mask {label_kind} labels must be integers") from exc
+        if label == str(normalized_label):
+            return normalized_label
+    elif isinstance(label, (int, np.integer)) and not isinstance(label, (bool, np.bool_)):
+        return int(label)
+    raise TypeError(f"semantic mask {label_kind} labels must be integers")
 
 
 def _normalize_semantic_mask_label_mappings(mappings: Any) -> dict[str, dict[int, int]] | None:
@@ -112,8 +106,8 @@ def _normalize_semantic_mask_label_mappings(mappings: Any) -> dict[str, dict[int
 
         normalized_mapping: dict[int, int] = {}
         for source_label, target_label in mapping.items():
-            normalized_source = _normalize_semantic_mask_source_label(source_label)
-            normalized_target = _normalize_semantic_mask_target_label(target_label)
+            normalized_source = _normalize_semantic_mask_label(source_label, "source")
+            normalized_target = _normalize_semantic_mask_label(target_label, "target")
             if normalized_source in normalized_mapping:
                 raise ValueError(f"Duplicate semantic mask source label after normalization: {normalized_source}")
             normalized_mapping[normalized_source] = normalized_target
@@ -1344,8 +1338,9 @@ class Compose(BaseCompose, HubMixin):
         for transform in transforms:
             if isinstance(transform, DualTransform):
                 transform.set_semantic_mask_label_mappings(effective_mappings)
-            elif isinstance(transform, Compose) and mappings is None:
-                continue
+            elif isinstance(transform, Compose):
+                if transform.semantic_mask_label_mappings is None:
+                    self._set_semantic_mask_label_mappings_for_transforms(transform.transforms, mappings)
             elif isinstance(transform, BaseCompose):
                 self._set_semantic_mask_label_mappings_for_transforms(transform.transforms, mappings)
 

--- a/albumentations/core/tensor.py
+++ b/albumentations/core/tensor.py
@@ -21,7 +21,7 @@ TENSOR_SPATIAL_TARGETS: Final[frozenset[str]] = frozenset(
     {"image", "images", "volume", "mask", "masks", "mask3d", "bboxes", "keypoints"},
 )
 TENSOR_IMAGE_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.uint8, torch.float32})
-TENSOR_MASK_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.uint8, torch.float32, torch.bool})
+TENSOR_MASK_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.uint8, torch.uint16, torch.float32})
 TENSOR_ANNOTATION_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.float32})
 TENSOR_TARGET_DTYPES: Final[dict[str, frozenset[torch.dtype]]] = {
     "image": TENSOR_IMAGE_DTYPES,

--- a/albumentations/core/tensor.py
+++ b/albumentations/core/tensor.py
@@ -21,7 +21,7 @@ TENSOR_SPATIAL_TARGETS: Final[frozenset[str]] = frozenset(
     {"image", "images", "volume", "mask", "masks", "mask3d", "bboxes", "keypoints"},
 )
 TENSOR_IMAGE_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.uint8, torch.float32})
-TENSOR_MASK_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.uint8, torch.int64, torch.float32, torch.bool})
+TENSOR_MASK_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.uint8, torch.float32, torch.bool})
 TENSOR_ANNOTATION_DTYPES: Final[frozenset[torch.dtype]] = frozenset({torch.float32})
 TENSOR_TARGET_DTYPES: Final[dict[str, frozenset[torch.dtype]]] = {
     "image": TENSOR_IMAGE_DTYPES,

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -1019,14 +1019,18 @@ class DualTransform(BasicTransform):
     """
 
     _supported_bbox_types: frozenset[str] = frozenset({"hbb"})  # Default: only axis-aligned boxes
-    _semantic_mask_label_mappings: ClassVar[dict[str, dict[int, int]]] = {}
-    _semantic_mask_uint8_luts: ClassVar[dict[str, NDArray[np.uint8]]] = {}
+    _semantic_mask_label_mappings: dict[str, dict[int, int]]
+    _semantic_mask_uint8_luts: dict[str, NDArray[np.uint8]]
+
+    def __init__(self, p: float = 0.5, **kwargs: Any):
+        super().__init__(p=p, **kwargs)
+        self._semantic_mask_label_mappings = {}
+        self._semantic_mask_uint8_luts = {}
 
     def set_semantic_mask_label_mappings(self, mappings: dict[str, dict[int, int]]) -> None:
         """Set transform-aware semantic-mask label mappings, discard no-op entries, and compile reusable
         uint8 lookup tables once per instance.
         """
-        self.__dict__.pop("apply_with_params", None)
         compiled_mappings = {
             transform_name: {
                 source_label: target_label
@@ -1042,10 +1046,8 @@ class DualTransform(BasicTransform):
                 for source_label, target_label in mapping.items():
                     lut[source_label] = target_label
                 compiled_uint8_luts[transform_name] = lut
-        self.__dict__["_semantic_mask_label_mappings"] = compiled_mappings
-        self.__dict__["_semantic_mask_uint8_luts"] = compiled_uint8_luts
-        if any(compiled_mappings.values()):
-            self.__dict__["apply_with_params"] = self._apply_with_semantic_mask_params
+        self._semantic_mask_label_mappings = compiled_mappings
+        self._semantic_mask_uint8_luts = compiled_uint8_luts
 
     @property
     def targets(self) -> dict[str, Callable[..., Any]]:
@@ -1230,15 +1232,6 @@ class DualTransform(BasicTransform):
                 data[data_name] = self._remap_semantic_mask_labels(value, mapping, uint8_lut)
         return data
 
-    def _apply_with_semantic_mask_params(
-        self,
-        params: dict[str, Any],
-        *args: Any,
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        result = DualTransform.apply_with_params(self, params, *args, **kwargs)
-        return self._apply_label_mapping_to_semantic_masks(result, **params)
-
     def _swap_keypoint_rows_by_labels(
         self,
         keypoints: np.ndarray,
@@ -1343,6 +1336,9 @@ class DualTransform(BasicTransform):
         # Apply label mapping to keypoints if they were transformed
         if "keypoints" in res and res["keypoints"] is not None:
             res["keypoints"] = self._apply_label_mapping_to_keypoints(res["keypoints"], **params)
+
+        if self._semantic_mask_label_mappings:
+            res = self._apply_label_mapping_to_semantic_masks(res, **params)
 
         return res
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -1203,7 +1203,14 @@ class DualTransform(BasicTransform):
         if isinstance(mask, np.ndarray) and mask.dtype == np.uint8 and uint8_lut is not None:
             return sz_lut(mask, uint8_lut, inplace=False)
 
-        result = mask.copy() if isinstance(mask, np.ndarray) else mask.clone()
+        if isinstance(mask, torch.Tensor):
+            result = mask.clone()
+            for source_label, target_label in mapping.items():
+                target = torch.tensor(target_label, dtype=mask.dtype, device=mask.device)
+                torch.where(mask == source_label, target, result, out=result)
+            return result
+
+        result = mask.copy()
         for source_label, target_label in mapping.items():
             result[mask == source_label] = target_label
         return result

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -17,7 +17,8 @@ from warnings import warn
 import cv2
 import numpy as np
 import torch
-from albucore import batch_transform
+from albucore import batch_transform, sz_lut
+from numpy.typing import NDArray
 from pydantic import BaseModel, ConfigDict, Field
 
 from albumentations.core.bbox_utils import BboxProcessor
@@ -1018,6 +1019,33 @@ class DualTransform(BasicTransform):
     """
 
     _supported_bbox_types: frozenset[str] = frozenset({"hbb"})  # Default: only axis-aligned boxes
+    _semantic_mask_label_mappings: ClassVar[dict[str, dict[int, int]]] = {}
+    _semantic_mask_uint8_luts: ClassVar[dict[str, NDArray[np.uint8]]] = {}
+
+    def set_semantic_mask_label_mappings(self, mappings: dict[str, dict[int, int]]) -> None:
+        """Set transform-aware semantic-mask label mappings, discard no-op entries, and compile reusable
+        uint8 lookup tables once per instance.
+        """
+        self.__dict__.pop("apply_with_params", None)
+        compiled_mappings = {
+            transform_name: {
+                source_label: target_label
+                for source_label, target_label in mapping.items()
+                if source_label != target_label
+            }
+            for transform_name, mapping in mappings.items()
+        }
+        compiled_uint8_luts: dict[str, NDArray[np.uint8]] = {}
+        for transform_name, mapping in compiled_mappings.items():
+            if mapping and all(0 <= label <= 255 for pair in mapping.items() for label in pair):
+                lut = np.arange(256, dtype=np.uint8)
+                for source_label, target_label in mapping.items():
+                    lut[source_label] = target_label
+                compiled_uint8_luts[transform_name] = lut
+        self.__dict__["_semantic_mask_label_mappings"] = compiled_mappings
+        self.__dict__["_semantic_mask_uint8_luts"] = compiled_uint8_luts
+        if any(compiled_mappings.values()):
+            self.__dict__["apply_with_params"] = self._apply_with_semantic_mask_params
 
     @property
     def targets(self) -> dict[str, Callable[..., Any]]:
@@ -1118,12 +1146,14 @@ class DualTransform(BasicTransform):
                 "r180": None,
                 "r270": None,
             }
-            mapped_name = d4_to_base_transform.get(group_element)
-            return mapped_name or class_name
+            return d4_to_base_transform.get(group_element)
 
         # Only parity-changing transforms should apply label mappings
         parity_changing_transforms = {"HorizontalFlip", "VerticalFlip", "Transpose"}
-        return class_name if class_name in parity_changing_transforms else None
+        return next(
+            (base.__name__ for base in self.__class__.__mro__ if base.__name__ in parity_changing_transforms),
+            None,
+        )
 
     def _apply_label_mapping_to_keypoints(self, keypoints: np.ndarray, **params: Any) -> np.ndarray:
         """Apply label mapping by reordering entire keypoint rows. For keypoint regression, row
@@ -1160,6 +1190,47 @@ class DualTransform(BasicTransform):
             return keypoints
 
         return self._swap_keypoint_rows_by_labels(keypoints, processor.params.label_fields, field_mappings)
+
+    @staticmethod
+    def _remap_semantic_mask_labels(
+        mask: NDArray[np.generic] | torch.Tensor,
+        mapping: dict[int, int],
+        uint8_lut: NDArray[np.uint8] | None,
+    ) -> NDArray[np.generic] | torch.Tensor:
+        is_empty = mask.size == 0 if isinstance(mask, np.ndarray) else mask.numel() == 0
+        if is_empty:
+            return mask
+        if isinstance(mask, np.ndarray) and mask.dtype == np.uint8 and uint8_lut is not None:
+            return sz_lut(mask, uint8_lut, inplace=False)
+
+        result = mask.copy() if isinstance(mask, np.ndarray) else mask.clone()
+        for source_label, target_label in mapping.items():
+            result[mask == source_label] = target_label
+        return result
+
+    def _apply_label_mapping_to_semantic_masks(self, data: dict[str, Any], **params: Any) -> dict[str, Any]:
+        transform_name = self._get_label_transform_name(**params)
+        if transform_name is None:
+            return data
+        mapping = self._semantic_mask_label_mappings.get(transform_name)
+        if not mapping:
+            return data
+        uint8_lut = self._semantic_mask_uint8_luts.get(transform_name)
+
+        for data_name, value in data.items():
+            canonical_name = self._additional_targets.get(data_name, data_name)
+            if canonical_name in {"mask", "masks", "mask3d"} and isinstance(value, (np.ndarray, torch.Tensor)):
+                data[data_name] = self._remap_semantic_mask_labels(value, mapping, uint8_lut)
+        return data
+
+    def _apply_with_semantic_mask_params(
+        self,
+        params: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        result = DualTransform.apply_with_params(self, params, *args, **kwargs)
+        return self._apply_label_mapping_to_semantic_masks(result, **params)
 
     def _swap_keypoint_rows_by_labels(
         self,
@@ -1257,8 +1328,8 @@ class DualTransform(BasicTransform):
         return keypoints
 
     def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Apply transforms with parameters, including automatic keypoint label swapping. After
-        super().apply_with_params, applies _apply_label_mapping_to_keypoints.
+        """Apply a dual transform with its parameters, including configured keypoint and transform-aware
+        semantic-mask label mappings.
         """
         res = super().apply_with_params(params, *args, **kwargs)
 

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -1,10 +1,21 @@
 import json
+from typing import Any
 
 import numpy as np
 import pytest
 import torch
 
 import albumentations as A
+
+
+class _ApplyWithParamsTrackingFlip(A.HorizontalFlip):
+    def __init__(self) -> None:
+        super().__init__(p=1.0)
+        self.apply_with_params_calls = 0
+
+    def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+        self.apply_with_params_calls += 1
+        return super().apply_with_params(params, *args, **kwargs)
 
 
 def test_semantic_mask_label_mapping_swaps_labels_after_horizontal_flip() -> None:
@@ -20,6 +31,70 @@ def test_semantic_mask_label_mapping_swaps_labels_after_horizontal_flip() -> Non
 
     np.testing.assert_array_equal(result["mask"], np.array([[3, 2, 0, 3]], dtype=np.uint8))
     np.testing.assert_array_equal(mask, np.array([[2, 0, 3, 2]], dtype=np.uint8))
+
+
+def test_semantic_mask_label_mapping_preserves_custom_apply_with_params_hook() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)
+    flip = _ApplyWithParamsTrackingFlip()
+    transform = A.Compose(
+        [flip],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    assert flip.apply_with_params_calls == 1
+    np.testing.assert_array_equal(result["mask"], np.array([[3, 2, 0, 3]], dtype=np.uint8))
+
+
+def test_semantic_mask_label_mapping_preserves_nested_compose_configuration() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)
+    nested = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+    transform = A.Compose(
+        [nested],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 4, 4: 2}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    np.testing.assert_array_equal(result["mask"], np.array([[3, 2, 0, 3]], dtype=np.uint8))
+
+
+def test_semantic_mask_label_mapping_propagates_to_unconfigured_nested_compose() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)
+    transform = A.Compose(
+        [A.Compose([A.HorizontalFlip(p=1.0)], telemetry=False)],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    np.testing.assert_array_equal(result["mask"], np.array([[3, 2, 0, 3]], dtype=np.uint8))
+
+
+def test_semantic_mask_label_mapping_normalizes_string_target_labels() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)
+    transform = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        semantic_mask_label_mappings={"HorizontalFlip": {"2": "3", "3": "2"}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    assert transform.semantic_mask_label_mappings == {"HorizontalFlip": {2: 3, 3: 2}}
+    np.testing.assert_array_equal(result["mask"], np.array([[3, 2, 0, 3]], dtype=np.uint8))
 
 
 def test_semantic_mask_label_mapping_survives_json_replay() -> None:

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -84,19 +84,19 @@ def test_semantic_mask_label_mapping_one_way_preserves_unmapped_and_ignore_label
     np.testing.assert_array_equal(result["mask"], np.array([[4, 255, 7, 3]], dtype=np.uint8))
 
 
-def test_semantic_mask_label_mapping_preserves_int32_mask_dtype() -> None:
+def test_semantic_mask_label_mapping_preserves_uint16_mask_dtype() -> None:
     image = np.zeros((1, 4, 3), dtype=np.uint8)
-    mask = np.array([[2, 0, 3, 2]], dtype=np.int32)
+    mask = np.array([[300, 0, 400, 300]], dtype=np.uint16)
     transform = A.Compose(
         [A.HorizontalFlip(p=1.0)],
-        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        semantic_mask_label_mappings={"HorizontalFlip": {300: 400, 400: 300}},
         telemetry=False,
     )
 
     result = transform(image=image, mask=mask)
 
-    assert result["mask"].dtype == np.int32
-    np.testing.assert_array_equal(result["mask"], np.array([[3, 2, 0, 3]], dtype=np.int32))
+    assert result["mask"].dtype == np.uint16
+    np.testing.assert_array_equal(result["mask"], np.array([[400, 300, 0, 400]], dtype=np.uint16))
 
 
 def test_semantic_mask_label_mapping_covers_masks_mask3d_and_aliases() -> None:

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -1,0 +1,230 @@
+import json
+
+import numpy as np
+import pytest
+import torch
+
+import albumentations as A
+
+
+def test_semantic_mask_label_mapping_swaps_labels_after_horizontal_flip() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)
+    transform = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    np.testing.assert_array_equal(result["mask"], np.array([[3, 2, 0, 3]], dtype=np.uint8))
+    np.testing.assert_array_equal(mask, np.array([[2, 0, 3, 2]], dtype=np.uint8))
+
+
+def test_semantic_mask_label_mapping_survives_json_replay() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)
+    transform = A.ReplayCompose(
+        [A.HorizontalFlip(p=1.0)],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+    )
+
+    first = transform(image=image, mask=mask)
+    replay = json.loads(json.dumps(first["replay"], allow_nan=False))
+    replayed = A.ReplayCompose.replay(replay, image=image, mask=mask)
+
+    np.testing.assert_array_equal(replayed["mask"], first["mask"])
+
+
+def test_semantic_mask_label_mapping_survives_pipeline_json_roundtrip() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)
+    original = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+
+    transported = json.loads(json.dumps(A.to_dict(original), allow_nan=False))
+    restored = A.from_dict(transported)
+
+    assert isinstance(restored, A.Compose)
+    assert restored.semantic_mask_label_mappings == {"HorizontalFlip": {2: 3, 3: 2}}
+    np.testing.assert_array_equal(restored(image=image, mask=mask)["mask"], original(image=image, mask=mask)["mask"])
+
+
+def test_compose_without_semantic_mapping_clears_reused_transform_mapping() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)
+    flip = A.HorizontalFlip(p=1.0)
+    A.Compose(
+        [flip],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+
+    transform = A.Compose([flip], telemetry=False)
+    result = transform(image=image, mask=mask)
+
+    np.testing.assert_array_equal(result["mask"], np.array([[2, 3, 0, 2]], dtype=np.uint8))
+
+
+def test_semantic_mask_label_mapping_one_way_preserves_unmapped_and_ignore_labels() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 7, 255, 4]], dtype=np.uint8)
+    transform = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    np.testing.assert_array_equal(result["mask"], np.array([[4, 255, 7, 3]], dtype=np.uint8))
+
+
+def test_semantic_mask_label_mapping_preserves_int32_mask_dtype() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    mask = np.array([[2, 0, 3, 2]], dtype=np.int32)
+    transform = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    assert result["mask"].dtype == np.int32
+    np.testing.assert_array_equal(result["mask"], np.array([[3, 2, 0, 3]], dtype=np.int32))
+
+
+def test_semantic_mask_label_mapping_covers_masks_mask3d_and_aliases() -> None:
+    image = np.zeros((1, 4, 3), dtype=np.uint8)
+    first_mask = np.array([[2, 0, 3, 255]], dtype=np.uint8)
+    second_mask = np.array([[3, 3, 2, 0]], dtype=np.uint8)
+    masks = np.stack([first_mask, second_mask])
+    mask3d = masks.copy()
+    transform = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        additional_targets={
+            "mask_alias": "mask",
+            "masks_alias": "masks",
+            "mask3d_alias": "mask3d",
+        },
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        strict=True,
+        telemetry=False,
+    )
+
+    result = transform(
+        image=image,
+        mask=first_mask,
+        mask_alias=first_mask.copy(),
+        masks=masks,
+        masks_alias=masks.copy(),
+        mask3d=mask3d,
+        mask3d_alias=mask3d.copy(),
+    )
+
+    expected_mask = np.array([[255, 2, 0, 3]], dtype=np.uint8)
+    expected_stacked = np.stack([expected_mask, np.array([[0, 3, 2, 2]], dtype=np.uint8)])
+    np.testing.assert_array_equal(result["mask"], expected_mask)
+    np.testing.assert_array_equal(result["mask_alias"], expected_mask)
+    np.testing.assert_array_equal(result["masks"], expected_stacked)
+    np.testing.assert_array_equal(result["masks_alias"], expected_stacked)
+    np.testing.assert_array_equal(result["mask3d"], expected_stacked)
+    np.testing.assert_array_equal(result["mask3d_alias"], expected_stacked)
+
+
+@pytest.mark.parametrize(("image_target", "mask_target"), [("images", "masks"), ("volume", "mask3d")])
+def test_semantic_mask_label_mapping_matches_image_batch_and_volume_routes(
+    image_target: str,
+    mask_target: str,
+) -> None:
+    first_mask = np.array([[2, 0, 3, 255]], dtype=np.uint8)
+    second_mask = np.array([[3, 3, 2, 0]], dtype=np.uint8)
+    masks = np.stack([first_mask, second_mask])
+    images = np.zeros((2, 1, 4, 3), dtype=np.uint8)
+    transform = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+
+    result = transform(**{image_target: images, mask_target: masks})
+
+    expected_mask = np.array([[255, 2, 0, 3]], dtype=np.uint8)
+    expected_stacked = np.stack([expected_mask, np.array([[0, 3, 2, 2]], dtype=np.uint8)])
+    np.testing.assert_array_equal(result[mask_target], expected_stacked)
+
+
+@pytest.mark.parametrize(
+    ("group_element", "expected_label"),
+    [
+        ("e", 2),
+        ("r90", 2),
+        ("r180", 2),
+        ("r270", 2),
+        ("h", 3),
+        ("v", 3),
+        ("t", 3),
+        ("hvt", 3),
+    ],
+)
+def test_semantic_mask_label_mapping_follows_realized_d4_operation(
+    group_element: str,
+    expected_label: int,
+) -> None:
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+    mask = np.array([[2, 0], [0, 0]], dtype=np.uint8)
+    transform = A.Compose(
+        [A.D4(p=1.0, group_element=group_element)],
+        semantic_mask_label_mappings={
+            "HorizontalFlip": {2: 3},
+            "VerticalFlip": {2: 3},
+            "Transpose": {2: 3},
+        },
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    assert np.count_nonzero(result["mask"] == expected_label) == 1
+    assert np.count_nonzero(result["mask"] == (3 if expected_label == 2 else 2)) == 0
+
+
+@pytest.mark.parametrize("group_element", ["e", "r90", "r180", "r270"])
+def test_semantic_mask_label_mapping_does_not_remap_d4_identity_or_rotations(group_element: str) -> None:
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+    mask = np.array([[2, 0], [0, 0]], dtype=np.uint8)
+    transform = A.Compose(
+        [A.D4(p=1.0, group_element=group_element)],
+        semantic_mask_label_mappings={"D4": {2: 3}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask)
+
+    assert np.count_nonzero(result["mask"] == 2) == 1
+    assert np.count_nonzero(result["mask"] == 3) == 0
+
+
+@pytest.mark.pytorch
+def test_semantic_mask_label_mapping_preserves_tensor_mask_and_mask3d() -> None:
+    image = torch.zeros((3, 2, 3), dtype=torch.uint8)
+    mask = torch.tensor([[2, 0, 3], [3, 2, 0]], dtype=torch.uint8)
+    mask3d = torch.stack([mask, mask + 4])
+    transform = A.Compose(
+        [A.Transpose(p=1.0)],
+        semantic_mask_label_mappings={"Transpose": {2: 3, 3: 2}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask, mask3d=mask3d)
+
+    expected_mask = torch.tensor([[3, 2], [0, 3], [2, 0]], dtype=torch.uint8)
+    assert isinstance(result["mask"], torch.Tensor)
+    assert isinstance(result["mask3d"], torch.Tensor)
+    torch.testing.assert_close(result["mask"], expected_mask, rtol=0, atol=0)
+    torch.testing.assert_close(result["mask3d"], torch.stack([expected_mask, (mask + 4).mT]), rtol=0, atol=0)

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -211,20 +211,46 @@ def test_semantic_mask_label_mapping_does_not_remap_d4_identity_or_rotations(gro
 
 
 @pytest.mark.pytorch
-def test_semantic_mask_label_mapping_preserves_tensor_mask_and_mask3d() -> None:
+def test_semantic_mask_label_mapping_preserves_uint16_tensor_masks() -> None:
     image = torch.zeros((3, 2, 3), dtype=torch.uint8)
-    mask = torch.tensor([[2, 0, 3], [3, 2, 0]], dtype=torch.uint8)
-    mask3d = torch.stack([mask, mask + 4])
+    mask = torch.tensor([[300, 0, 400], [400, 300, 0]], dtype=torch.uint16)
+    other_mask = torch.tensor([[400, 300, 0], [0, 400, 300]], dtype=torch.uint16)
+    stacked_masks = torch.stack([mask, other_mask])
+    transform = A.Compose(
+        [A.Transpose(p=1.0)],
+        semantic_mask_label_mappings={"Transpose": {300: 400, 400: 300}},
+        telemetry=False,
+    )
+
+    result = transform(image=image, mask=mask, masks=stacked_masks, mask3d=stacked_masks)
+
+    expected_mask = torch.tensor([[400, 300], [0, 400], [300, 0]], dtype=torch.uint16)
+    expected_other_mask = torch.tensor([[300, 0], [400, 300], [0, 400]], dtype=torch.uint16)
+    expected_stacked_masks = torch.stack([expected_mask, expected_other_mask])
+    assert isinstance(result["mask"], torch.Tensor)
+    assert isinstance(result["masks"], torch.Tensor)
+    assert isinstance(result["mask3d"], torch.Tensor)
+    assert result["mask"].dtype == torch.uint16
+    assert result["masks"].dtype == torch.uint16
+    assert result["mask3d"].dtype == torch.uint16
+    torch.testing.assert_close(result["mask"], expected_mask, rtol=0, atol=0)
+    torch.testing.assert_close(result["masks"], expected_stacked_masks, rtol=0, atol=0)
+    torch.testing.assert_close(result["mask3d"], expected_stacked_masks, rtol=0, atol=0)
+
+
+@pytest.mark.pytorch
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
+def test_semantic_mask_label_mapping_preserves_tensor_mask_dtype(dtype: torch.dtype) -> None:
+    image = torch.zeros((3, 2, 3), dtype=torch.uint8)
+    mask = torch.tensor([[2, 0, 3], [3, 2, 0]], dtype=dtype)
     transform = A.Compose(
         [A.Transpose(p=1.0)],
         semantic_mask_label_mappings={"Transpose": {2: 3, 3: 2}},
         telemetry=False,
     )
 
-    result = transform(image=image, mask=mask, mask3d=mask3d)
+    result = transform(image=image, mask=mask)
 
-    expected_mask = torch.tensor([[3, 2], [0, 3], [2, 0]], dtype=torch.uint8)
-    assert isinstance(result["mask"], torch.Tensor)
-    assert isinstance(result["mask3d"], torch.Tensor)
-    torch.testing.assert_close(result["mask"], expected_mask, rtol=0, atol=0)
-    torch.testing.assert_close(result["mask3d"], torch.stack([expected_mask, (mask + 4).mT]), rtol=0, atol=0)
+    expected = torch.tensor([[3, 2], [0, 3], [2, 0]], dtype=dtype)
+    assert result["mask"].dtype == dtype
+    torch.testing.assert_close(result["mask"], expected, rtol=0, atol=0)

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -210,9 +210,25 @@ def test_tensor_boundary_rejects_invalid_annotation_contract(
         )
 
 
+@pytest.mark.parametrize(
+    ("target", "shape"),
+    [
+        ("mask", (11, 13)),
+        ("masks", (2, 11, 13)),
+        ("mask3d", (2, 11, 13)),
+    ],
+)
+def test_tensor_boundary_rejects_int64_masks(target: str, shape: tuple[int, ...]) -> None:
+    with pytest.raises(TypeError, match="dtype one of"):
+        A.Compose([])(
+            image=torch.zeros((3, 11, 13), dtype=torch.uint8),
+            **{target: torch.zeros(shape, dtype=torch.int64)},
+        )
+
+
 def test_noop_preserves_tensor_spatial_targets_at_compose_boundary() -> None:
     image = torch.arange(3 * 5 * 7, dtype=torch.float32).reshape(3, 5, 7)
-    mask = torch.arange(5 * 7, dtype=torch.int64).reshape(5, 7)
+    mask = torch.arange(5 * 7, dtype=torch.uint8).reshape(5, 7)
     masks = torch.arange(2 * 5 * 7, dtype=torch.uint8).reshape(2, 5, 7)
     bboxes = torch.tensor([[1.0, 1.0, 5.0, 4.0]], dtype=torch.float32)
     keypoints = torch.tensor([[2.0, 3.0]], dtype=torch.float32)
@@ -238,7 +254,7 @@ def test_noop_preserves_tensor_spatial_targets_at_compose_boundary() -> None:
 
 def test_noop_preserves_tensor_volume_and_mask3d_without_numpy_batch_dispatch() -> None:
     volume = torch.arange(3 * 5 * 7 * 9, dtype=torch.float32).reshape(3, 5, 7, 9)
-    mask3d = torch.arange(5 * 7 * 9, dtype=torch.int64).reshape(5, 7, 9)
+    mask3d = torch.zeros((5, 7, 9), dtype=torch.uint8)
 
     result = A.Compose([A.NoOp(p=1.0)], strict=True)(volume=volume, mask3d=mask3d)
 
@@ -314,7 +330,7 @@ def test_transpose_keeps_tensor_masks_bboxes_and_keypoints_aligned_with_tensor_i
     image = torch.arange(3 * 5 * 7, dtype=torch.uint8).reshape(3, 5, 7)
     numpy_image = image.permute(1, 2, 0).numpy().copy()
     mask = np.arange(5 * 7, dtype=np.uint8).reshape(5, 7)
-    masks = np.arange(2 * 5 * 7, dtype=np.int64).reshape(2, 5, 7)
+    masks = np.arange(2 * 5 * 7, dtype=np.uint8).reshape(2, 5, 7)
     mask3d = np.arange(3 * 5 * 7, dtype=np.uint8).reshape(3, 5, 7)
     bboxes = np.array([[1, 1, 5, 4]], dtype=np.float32)
     keypoints = np.array([[2, 3]], dtype=np.float32)

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -191,7 +191,6 @@ def test_tensor_boundary_rejects_invalid_image_contract(tensor: torch.Tensor, me
     [
         ("mask", torch.zeros((1, 11, 13), dtype=torch.uint8), "must have shape"),
         ("masks", torch.zeros((11, 13), dtype=torch.uint8), "must have shape"),
-        ("mask3d", torch.zeros((1, 11, 13), dtype=torch.int32), "dtype one of"),
         ("bboxes", torch.zeros((1, 4), dtype=torch.int64), "dtype one of"),
         ("keypoints", torch.zeros((1, 2, 1), dtype=torch.float32), "must have shape"),
     ],
@@ -214,6 +213,9 @@ def test_tensor_boundary_rejects_invalid_annotation_contract(
         ("mask", (11, 13), torch.int64),
         ("masks", (2, 11, 13), torch.int64),
         ("mask3d", (2, 11, 13), torch.int64),
+        ("mask", (11, 13), torch.int32),
+        ("masks", (2, 11, 13), torch.int32),
+        ("mask3d", (2, 11, 13), torch.int32),
         ("mask", (11, 13), torch.bool),
         ("masks", (2, 11, 13), torch.bool),
         ("mask3d", (2, 11, 13), torch.bool),

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -159,8 +159,6 @@ def test_nested_compose_preserves_tensor_annotations() -> None:
 @pytest.mark.parametrize(
     "transform",
     [
-        A.HorizontalFlip(p=1.0),
-        A.VerticalFlip(p=1.0),
         _NumpyOnlyProbe(),
     ],
 )
@@ -211,18 +209,25 @@ def test_tensor_boundary_rejects_invalid_annotation_contract(
 
 
 @pytest.mark.parametrize(
-    ("target", "shape"),
+    ("target", "shape", "dtype"),
     [
-        ("mask", (11, 13)),
-        ("masks", (2, 11, 13)),
-        ("mask3d", (2, 11, 13)),
+        ("mask", (11, 13), torch.int64),
+        ("masks", (2, 11, 13), torch.int64),
+        ("mask3d", (2, 11, 13), torch.int64),
+        ("mask", (11, 13), torch.bool),
+        ("masks", (2, 11, 13), torch.bool),
+        ("mask3d", (2, 11, 13), torch.bool),
     ],
 )
-def test_tensor_boundary_rejects_int64_masks(target: str, shape: tuple[int, ...]) -> None:
+def test_tensor_boundary_rejects_unsupported_mask_dtypes(
+    target: str,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+) -> None:
     with pytest.raises(TypeError, match="dtype one of"):
         A.Compose([])(
             image=torch.zeros((3, 11, 13), dtype=torch.uint8),
-            **{target: torch.zeros(shape, dtype=torch.int64)},
+            **{target: torch.zeros(shape, dtype=dtype)},
         )
 
 
@@ -375,20 +380,37 @@ def test_transpose_keeps_tensor_masks_bboxes_and_keypoints_aligned_with_tensor_i
 
 
 @pytest.mark.parametrize(
-    ("target", "tensor", "message"),
+    ("transform_cls", "dimensions"),
     [
-        ("image", torch.zeros((5, 5, 7), dtype=torch.uint8), "accepted channel counts are 1, 3"),
-        ("images", torch.zeros((3, 2, 5, 7), dtype=torch.uint8), "accepted targets are image"),
-        ("volume", torch.zeros((3, 2, 5, 7), dtype=torch.uint8), "accepted targets are image"),
+        (A.HorizontalFlip, (-1,)),
+        (A.VerticalFlip, (-2,)),
+        (A.Transpose, None),
     ],
 )
-def test_transpose_rejects_tensor_routes_outside_accepted_capability(
+@pytest.mark.parametrize(
+    ("target", "shape"),
+    [
+        ("image", (5, 3, 4)),
+        ("images", (5, 2, 3, 4)),
+        ("volume", (5, 2, 3, 4)),
+        ("mask", (3, 4)),
+        ("masks", (2, 3, 4)),
+        ("mask3d", (2, 3, 4)),
+    ],
+)
+def test_flip_transforms_support_all_tensor_spatial_targets(
+    transform_cls: type[A.DualTransform],
+    dimensions: tuple[int, ...] | None,
     target: str,
-    tensor: torch.Tensor,
-    message: str,
+    shape: tuple[int, ...],
 ) -> None:
-    with pytest.raises(TypeError, match=message):
-        A.Compose([A.Transpose(p=1.0)], strict=True)(**{target: tensor})
+    value = torch.arange(int(np.prod(shape)), dtype=torch.uint8).reshape(shape)
+
+    result = A.Compose([transform_cls(p=1.0)], strict=True)(**{target: value})[target]
+
+    expected = value.transpose(-1, -2) if dimensions is None else torch.flip(value, dimensions)
+    assert result.dtype == value.dtype
+    torch.testing.assert_close(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add `semantic_mask_label_mappings` to `Compose` and `ReplayCompose`
- remap labels simultaneously after realized horizontal/vertical/transpose spatial operations, including `D4` and `SquareSymmetry`
- support `mask`, `masks`, `mask3d`, aliases, batch/volume routes, Tensor inputs, replay, and JSON serialization
- Tensor masks accept only `uint8`, `uint16`, and `float32`; reject `int64` and `bool`
- use the Tensor-native `torch.where(..., out=...)` route so semantic mappings also work for `uint16`
- extend native Tensor support in `HorizontalFlip`, `VerticalFlip`, and `Transpose` to all spatial targets, including `images`, `volume`, `masks`, and `mask3d`; no artificial 1/3-channel restriction

Fixes #400.

## Why

Spatial flips can change a semantic class such as left/right. The mapping is applied only when the realized operation changes that semantic meaning; rotations and identity operations do not remap labels.

`uint16` covers semantic masks with more than 256 labels. `bool` is intentionally outside the mask contract to keep the supported Tensor dtype set small and unambiguous.

## Review follow-up

- remove the instance-level `apply_with_params` replacement: custom `DualTransform` overrides now run normally and can delegate to the base mapping path
- let nested `Compose` retain its explicitly configured mappings, while propagating the parent configuration into unconfigured nested pipelines
- normalize canonical integer strings for both source and target labels
- move Tensor flip/transpose primitives to the geometric functional layer; transform methods retain dispatch and axis policy only

## Tensor dispatch benchmark

Median of five interleaved A/B runs on CPU Tensor `uint8`. Before uses the direct Tensor calls previously in the transform methods; after uses the functional primitives. Horizontal/vertical rows use 500 iterations; transpose rows use 5,000. Values are µs/call; speedup is `before / after`.

| Transform/shape | Direct before | Direct after | Direct speedup | Compose before | Compose after | Compose speedup |
|---|---:|---:|---:|---:|---:|---:|
| HorizontalFlip 256×256×1 | 2.46 | 2.27 | 1.086× | 10.40 | 9.84 | 1.057× |
| HorizontalFlip 256×256×3 | 5.07 | 5.35 | 0.948× | 12.58 | 12.92 | 0.974× |
| HorizontalFlip 256×256×5 | 7.48 | 7.45 | 1.003× | 14.66 | 14.58 | 1.005× |
| HorizontalFlip 512×512×1 | 6.15 | 6.11 | 1.006× | 13.22 | 13.39 | 0.987× |
| HorizontalFlip 512×512×3 | 16.65 | 16.70 | 0.997× | 23.79 | 23.78 | 1.000× |
| HorizontalFlip 512×512×5 | 26.73 | 26.93 | 0.993× | 35.64 | 36.70 | 0.971× |
| HorizontalFlip 1024×1024×1 | 21.69 | 21.87 | 0.992× | 29.06 | 28.94 | 1.004× |
| HorizontalFlip 1024×1024×3 | 63.87 | 63.80 | 1.001× | 70.75 | 71.67 | 0.987× |
| HorizontalFlip 1024×1024×5 | 108.11 | 109.94 | 0.983× | 112.92 | 113.07 | 0.999× |
| VerticalFlip 256×256×1 | 2.15 | 2.24 | 0.958× | 9.44 | 9.51 | 0.992× |
| VerticalFlip 256×256×3 | 4.94 | 5.19 | 0.951× | 12.72 | 12.78 | 0.995× |
| VerticalFlip 256×256×5 | 7.75 | 7.73 | 1.003× | 14.80 | 14.87 | 0.995× |
| VerticalFlip 512×512×1 | 6.20 | 6.46 | 0.961× | 13.31 | 13.01 | 1.023× |
| VerticalFlip 512×512×3 | 16.65 | 16.78 | 0.992× | 23.60 | 23.93 | 0.986× |
| VerticalFlip 512×512×5 | 28.84 | 28.24 | 1.021× | 36.79 | 37.09 | 0.992× |
| VerticalFlip 1024×1024×1 | 21.98 | 22.00 | 0.999× | 29.09 | 29.14 | 0.998× |
| VerticalFlip 1024×1024×3 | 65.12 | 65.08 | 1.001× | 71.72 | 71.55 | 1.002× |
| VerticalFlip 1024×1024×5 | 106.21 | 105.35 | 1.008× | 116.00 | 114.26 | 1.015× |
| Transpose 256×256×1 | 0.41 | 0.44 | 0.926× | 6.35 | 6.43 | 0.988× |
| Transpose 256×256×3 | 0.40 | 0.45 | 0.880× | 6.00 | 6.04 | 0.993× |
| Transpose 256×256×5 | 0.40 | 0.42 | 0.950× | 5.89 | 6.06 | 0.971× |
| Transpose 512×512×1 | 0.38 | 0.41 | 0.913× | 6.04 | 6.24 | 0.968× |
| Transpose 512×512×3 | 0.38 | 0.42 | 0.913× | 6.13 | 6.24 | 0.983× |
| Transpose 512×512×5 | 0.43 | 0.46 | 0.931× | 6.39 | 6.59 | 0.970× |
| Transpose 1024×1024×1 | 0.39 | 0.43 | 0.905× | 6.25 | 6.34 | 0.986× |
| Transpose 1024×1024×3 | 0.41 | 0.46 | 0.876× | 6.33 | 6.50 | 0.973× |
| Transpose 1024×1024×5 | 0.40 | 0.43 | 0.941× | 6.13 | 6.17 | 0.994× |

Every public Compose cell remains within the 5% regression threshold. Direct `Transpose` returns a view, so routing its `mT` property through the functional layer costs 0.02–0.05 µs/call; this is documented rather than hidden.

## LUT backend benchmark

Median per call in µs, uint8, 5 repetitions; `cv2.LUT / sz_lut` is the speedup.

| Shape | `sz_lut` | `cv2.LUT` | Speedup |
|---|---:|---:|---:|
| 256×256×1 | 6.5 | 19.1 | 2.95× |
| 256×256×3 | 18.0 | 54.5 | 3.03× |
| 256×256×5 | 27.3 | 91.0 | 3.34× |
| 512×512×1 | 22.4 | 74.9 | 3.35× |
| 512×512×3 | 62.4 | 216.9 | 3.48× |
| 512×512×5 | 105.8 | 364.6 | 3.45× |
| 1024×1024×1 | 77.1 | 269.6 | 3.50× |
| 1024×1024×3 | 235.4 | 813.6 | 3.46× |
| 1024×1024×5 | 392.1 | 1355.4 | 3.46× |

`sz_lut` and `cv2.LUT` produced identical values in every cell. The OpenCV candidate restores the trailing grayscale channel before timing.

## Validation

- `uv run --python 3.10 pytest -m 'not slow'` — 13,006 passed, 43 skipped, 38 deselected, 9 xfailed, 3 xpassed
- `uv run --python 3.10 python -m tools.quality_gate fast` — ruff, mypy, Pyrefly, 1,244 contract tests, CI/benchmark/legal/regression checks, and pre-commit all passed
- focused semantic mask and Tensor route tests — 97 passed