### PR TITLE
ci: scope CodeQL analysis by changed paths

### DIFF
--- a/.codex/skills/performance-optimization/references/performance-optimization.md
+++ b/.codex/skills/performance-optimization/references/performance-optimization.md
@@ -1,5 +1,9 @@
 # Performance Optimization Workflow
 
+## Prevalidated caller boundary
+
+Albucore routers run after the caller has validated the input contract. Upstream code owns container, rank, channel-last layout, dtype, device, contiguity, autograd state, and operation-control validation. Albucore keeps only dispatch branches and kernel-required normalization needed to select and execute the benchmarked implementation; hot paths must not repeat those checks.
+
 Use this workflow whenever implementing, reviewing, or profiling runtime code in Albucore or AlbumentationsX. Its
 order matters: remove work before making the remaining work faster. Treat every proposed optimization as a hypothesis
 until correctness tests and representative benchmarks support it.
@@ -7,6 +11,8 @@ until correctness tests and representative benchmarks support it.
 This file is canonical at `albucore/docs/performance-optimization.md`. AlbumentationsX keeps a synchronized fallback
 copy under `.codex/skills/performance-optimization/references/` so its performance skill can load the guide without a
 sibling Albucore checkout.
+
+For eager CPU PyTorch candidates, also follow Albucore's `docs/torch-performance-optimization.md` workflow.
 
 ## Run the optimization pass in this order
 
@@ -128,6 +134,7 @@ For each atomic operation, benchmark viable implementations end to end:
 - OpenCV;
 - NumKong;
 - StringZilla;
+- CPU PyTorch for documented Tensor or volume contracts;
 - a LUT route;
 - a small Python or `math` implementation when the data is scalar or tiny.
 
@@ -142,6 +149,17 @@ globally fastest:
 - NumPy wins other float32 and high-channel paths;
 - OpenCV wins many dense image operations but has channel and layout constraints;
 - StringZilla is competitive for selected uint8 translation paths.
+- CPU PyTorch is competitive for selected eager 3D volume operations when the complete interop route wins.
+
+### 6a. Escalate missing backend capabilities
+
+When a viable optimization requires an operation that PyTorch, NumKong, OpenCV, or NumPy does not provide, first open
+a Feature Request in the relevant upstream project. Link the request from the Albucore issue, benchmark note, or pull
+request so the dependency is explicit.
+
+When we can implement the operation and the upstream contribution rules allow it, open a linked upstream pull request.
+Until the operation is available, benchmark the portable alternatives and document the capability gap. Do not add a
+private substitute solely to avoid upstream coordination.
 
 ### 7. Compare random-generation paths
 
@@ -196,7 +214,7 @@ After removing work and comparing straight implementations, consider routing by:
 - uint8 versus float32;
 - scalar versus per-channel parameters;
 - 1, 3, 4, and high-channel inputs;
-- image, image-batch, volume, and 3D-mask-batch rank;
+- image, image-batch, and single-volume rank;
 - contiguous versus strided input;
 - small versus large arrays;
 - dense versus sparse labels;
@@ -221,7 +239,7 @@ For Albucore, benchmark the public router, not only its private backend. Include
 Check these shared entry points before writing a local kernel:
 
 - `albucore.apply_uint8_lut` and `albucore.sz_lut` for benchmark-routed uint8 tables;
-- `albucore.stats` for `sum`, `mean`, `std`, and `mean_std` across images, batches, and volume data;
+- `albucore.stats` for `sum`, `mean`, `std`, and `mean_std` across supported array ranks;
 - Albucore arithmetic and weighted routers for add, multiply, normalize, power, blend, and fused multiply-add;
 - Albucore geometric and resize functions for channel-safe OpenCV routing;
 - `pairwise_distances_squared` for the routed small-set NumKong and larger NumPy paths.
@@ -230,11 +248,11 @@ The stats API already routes selected uint8 and low-channel reductions through N
 OpenCV where they win. Reimplementing these reductions inside AlbumentationsX loses both the routing and its benchmark
 coverage.
 
-In the Albucore checkout, use `docs/numkong-performance.md` for current NumKong route evidence and
-`docs/performance-regressions-plan.md` for known router regressions. When using the bundled fallback from an
-AlbumentationsX checkout, read the same files under `../albucore/docs/` if a sibling Albucore checkout is available.
-If it is absent, these supporting documents are unavailable: use repository-local benchmarks for candidate discovery
-and defer Albucore route or threshold changes until the canonical evidence can be checked.
+In the Albucore checkout, use `docs/numkong-performance.md` for current NumKong route evidence and the reports under
+`benchmarks/results/` for measured router comparisons. When using the bundled fallback from an AlbumentationsX
+checkout, read the same resources under `../albucore/` if a sibling Albucore checkout is available. If it is absent,
+these supporting documents are unavailable: use repository-local benchmarks for candidate discovery and defer
+Albucore route or threshold changes until the canonical evidence can be checked.
 
 Regenerate or extend the relevant benchmark when a route changes; do not update a threshold from an isolated
 microbenchmark alone.
@@ -280,7 +298,8 @@ Every performance task should report:
 - grouped integer-label reductions reviewed, including `bincount`;
 - LUT applicability and candidates;
 - random-generation candidates;
-- NumPy, OpenCV, NumKong, StringZilla, and Python candidates that apply;
+- NumPy, OpenCV, NumKong, StringZilla, CPU PyTorch, and Python candidates that apply;
+- any missing upstream primitive, its Feature Request, and a linked implementation pull request when we can provide one;
 - reusable atoms moved or proposed for Albucore;
 - safe in-place opportunities;
 - correctness evidence;

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,37 @@
+name: CodeQL Actions
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/**"
+      - "**/action.yml"
+      - "**/action.yaml"
+  schedule:
+    - cron: "17 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (actions)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          languages: actions
+          build-mode: none
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          category: "/language:actions"

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,6 +1,12 @@
 name: CodeQL Actions
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/**"
+      - "**/action.yml"
+      - "**/action.yaml"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/codeql-python.yml
+++ b/.github/workflows/codeql-python.yml
@@ -1,6 +1,13 @@
 name: CodeQL Python
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.py"
+      - "**/*.pyi"
+      - ".github/codeql/**"
+      - ".github/workflows/codeql-python.yml"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/codeql-python.yml
+++ b/.github/workflows/codeql-python.yml
@@ -1,0 +1,38 @@
+name: CodeQL Python
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.py"
+      - "**/*.pyi"
+      - ".github/codeql/**"
+      - ".github/workflows/codeql-python.yml"
+  schedule:
+    - cron: "7 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          languages: python
+          build-mode: none
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        with:
+          category: "/language:python"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  # CodeQL is managed by GitHub default setup for this repository. Adding an
-  # advanced CodeQL workflow here makes GitHub reject uploaded SARIF.
+  # The path-scoped advanced CodeQL workflows are separate so this scheduled
+  # evidence workflow remains focused on dependency and workflow audits.
   dependency_audit:
     name: Dependency audit
     runs-on: ubuntu-latest

--- a/docs/maintaining/ci-greenfield-plan.md
+++ b/docs/maintaining/ci-greenfield-plan.md
@@ -326,7 +326,8 @@ path filter finds no relevant input.
 
 Preferred policy:
 
-- keep CodeQL enabled for pull requests with relevant inputs and weekly scans;
+- keep CodeQL enabled for pull requests with relevant inputs, matching pushes
+  to the default branch, and weekly scans;
 - keep both language checks advisory because path filtering intentionally
   omits them from unrelated pull requests;
 - run Python analysis for runtime or Python tooling changes;

--- a/docs/maintaining/ci-greenfield-plan.md
+++ b/docs/maintaining/ci-greenfield-plan.md
@@ -321,27 +321,24 @@ never make its PR job name required.
 ### CodeQL
 
 Do not require `Analyze (actions)` or `Analyze (python)` as exact status-check
-names. They are implementation details of a dynamic analysis matrix.
+names. They are advisory language-specific checks that are skipped when their
+path filter finds no relevant input.
 
 Preferred policy:
 
-- keep CodeQL enabled for same-repository pull requests, pushes to the default
-  branch, and weekly scans;
-- do not require the aggregate `CodeQL` context while default setup excludes
-  pull requests from forks;
+- keep CodeQL enabled for pull requests with relevant inputs and weekly scans;
+- keep both language checks advisory because path filtering intentionally
+  omits them from unrelated pull requests;
 - run Python analysis for runtime or Python tooling changes;
 - run Actions analysis for workflow/local-action changes;
 - run the complete scan on the default branch and weekly;
 - do not run a language analysis for Markdown-only changes.
 
-GitHub default setup has limited trigger control and excludes pull requests
-from forks. If every pull request must pass CodeQL, or selective execution is
-important, migrate to
-[advanced setup](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types)
-in a separate change, and disable default setup before enabling the advanced
-workflow. Do not run both configurations accidentally. Advanced setup permits
-normal workflow triggers and CodeQL path configuration. Validate one
-fork-based pull request before adding CodeQL back to the required merge gates.
+This repository uses advanced setup. `codeql-python.yml` selects Python source,
+stubs, and CodeQL configuration. `codeql-actions.yml` selects workflow and
+composite-action files. GitHub Default Setup must remain disabled because it
+suppresses advanced workflows and blocks their SARIF uploads. Validate a
+fork-based pull request before making either CodeQL check a merge gate.
 
 ### Legal integrity
 

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -30,7 +30,9 @@ advisory ASV jobs or AI-review jobs.
 
 Direct pushes to `main` are outside the maintenance policy and should be
 blocked by the repository ruleset. Repository workflows use pull-request,
-scheduled, manual, and release events instead of `push` events.
+scheduled, manual, and release events instead of `push` events. CodeQL is the
+exception: its scoped `push` trigger updates default-branch alerts after a
+merged pull request.
 
 ## Path-based selection
 
@@ -144,7 +146,8 @@ CodeQL uses two path-scoped advanced workflows. `codeql-python.yml` runs for
 Python source, stubs, or CodeQL configuration changes. `codeql-actions.yml`
 runs for GitHub Actions and composite-action changes. Ordinary Markdown and
 `.codex` documentation changes start neither workflow. Both workflows run
-after a matching pull request, once each week, and on manual dispatch.
+after a matching pull request or push to `main`, once each week, and on manual
+dispatch.
 
 GitHub Default Setup must remain disabled. It suppresses advanced workflows
 and blocks their SARIF uploads. CodeQL check names remain advisory because a

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -23,14 +23,10 @@ closed when a selected leaf is missing, skipped, cancelled, or failed. A leaf
 that the router did not select may be skipped without leaving the pull request
 waiting for a status that will never arrive.
 
-Keep the external CLA check. Do not require the `CodeQL` status while code
-scanning uses GitHub default setup: default setup excludes pull requests from
-forks, so external contributions never report that status. Keep CodeQL enabled
-for same-repository pull requests, pushes to `main`, and weekly scans. If every
-pull request must pass CodeQL, migrate to advanced setup and verify a fork-based
-pull request before adding a stable required gate. Do not require dynamic
-CodeQL leaf names such as `Analyze (actions)` or `Analyze (python)`, advisory
-ASV jobs, or AI-review jobs.
+Keep the external CLA check. CodeQL is advisory, so do not require either
+language-specific analysis check. A skipped path-scoped CodeQL workflow must
+never leave a pull request waiting for a required status. Do not require
+advisory ASV jobs or AI-review jobs.
 
 Direct pushes to `main` are outside the maintenance policy and should be
 blocked by the repository ruleset. Repository workflows use pull-request,
@@ -144,13 +140,15 @@ Nightly and release-candidate workflows run the complete 3 × 5 base suite.
 They also retain lower-bound, property/regression, optional-extra, PyTorch,
 performance, and release artifact evidence where appropriate.
 
-CodeQL is managed by GitHub default setup. GitHub's
-[default-setup trigger policy](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types)
-excludes pull requests from forks, so the repository ruleset must not require
-the `CodeQL` status. Do not add an advanced CodeQL workflow while default setup
-is enabled, because duplicate configurations can reject SARIF uploads. Treat
-mandatory fork analysis or selective language analysis as a separate
-default-to-advanced migration.
+CodeQL uses two path-scoped advanced workflows. `codeql-python.yml` runs for
+Python source, stubs, or CodeQL configuration changes. `codeql-actions.yml`
+runs for GitHub Actions and composite-action changes. Ordinary Markdown and
+`.codex` documentation changes start neither workflow. Both workflows run
+after a matching pull request, once each week, and on manual dispatch.
+
+GitHub Default Setup must remain disabled. It suppresses advanced workflows
+and blocks their SARIF uploads. CodeQL check names remain advisory because a
+path filter correctly skips the language that cannot produce signal.
 
 ## Antigravity pull-request reviews
 

--- a/tests/test_codeql_workflows.py
+++ b/tests/test_codeql_workflows.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import yaml
 
+from tools import ci_matrix
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CODEQL_WORKFLOWS = {
     "codeql-python.yml": [
@@ -44,3 +46,36 @@ def test_codeql_triggers_are_language_scoped_and_refresh_default_branch_alerts()
         assert triggers["push"]["paths"] == expected_paths
         assert "schedule" in triggers
         assert "workflow_dispatch" in triggers
+
+
+def test_ci_matrix_rejects_codeql_workflow_without_push_trigger(tmp_path, monkeypatch) -> None:
+    """Prevent path-scoped CodeQL workflows from silently losing default-branch analysis."""
+    workflow_path = tmp_path / "codeql-python.yml"
+    workflow_path.write_text(
+        """\
+name: CodeQL Python
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.py"
+      - "**/*.pyi"
+      - ".github/codeql/**"
+      - ".github/workflows/codeql-python.yml"
+  schedule:
+    - cron: "7 3 * * 0"
+  workflow_dispatch:
+jobs: {}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ci_matrix, "_workflow_files", lambda: (workflow_path,))
+    monkeypatch.setattr(
+        ci_matrix,
+        "CODEQL_WORKFLOW_PATHS",
+        {workflow_path: ci_matrix.CODEQL_WORKFLOW_PATHS[ci_matrix.CODEQL_PYTHON_WORKFLOW]},
+    )
+
+    issues = ci_matrix._check_workflow_push_triggers()
+
+    assert f"{workflow_path} CodeQL workflow is missing 'push' trigger" in issues

--- a/tests/test_codeql_workflows.py
+++ b/tests/test_codeql_workflows.py
@@ -1,0 +1,46 @@
+"""Contracts for path-scoped CodeQL workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CODEQL_WORKFLOWS = {
+    "codeql-python.yml": [
+        "**/*.py",
+        "**/*.pyi",
+        ".github/codeql/**",
+        ".github/workflows/codeql-python.yml",
+    ],
+    "codeql-actions.yml": [
+        ".github/**",
+        "**/action.yml",
+        "**/action.yaml",
+    ],
+}
+
+
+def _load_workflow(filename: str) -> dict[str, Any]:
+    """Load a workflow while accounting for YAML 1.1 coercing the `on` key to a boolean."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / filename).read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def test_codeql_triggers_are_language_scoped_and_refresh_default_branch_alerts() -> None:
+    """Run each language only for relevant PR/main changes, plus weekly/manual scans."""
+    for filename, expected_paths in CODEQL_WORKFLOWS.items():
+        workflow = _load_workflow(filename)
+        triggers = workflow.get(True)
+        if triggers is None:
+            triggers = workflow["on"]
+
+        assert triggers["pull_request"]["branches"] == ["main"]
+        assert triggers["pull_request"]["paths"] == expected_paths
+        assert triggers["push"]["branches"] == ["main"]
+        assert triggers["push"]["paths"] == expected_paths
+        assert "schedule" in triggers
+        assert "workflow_dispatch" in triggers

--- a/tests/test_correctness_report.py
+++ b/tests/test_correctness_report.py
@@ -103,6 +103,7 @@ def test_generate_report_accepts_required_release_evidence(tmp_path) -> None:
     assert "memory: covered_advisory=1" in report
     assert "0 coverage contract failure(s)" in report
     assert "Security summary: provided" in report
+    assert "CodeQL: managed through path-scoped advanced workflows" in report
 
 
 @pytest.mark.parametrize(

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -50,6 +50,8 @@ PYTORCH_PERFORMANCE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pytorch-pe
 RELEASE_CANDIDATE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-candidate.yml"
 SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "upload_to_pypi.yml"
+CODEQL_ACTIONS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "codeql-actions.yml"
+CODEQL_PYTHON_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "codeql-python.yml"
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 WORKFLOWS = (
     PR_WORKFLOW,
@@ -60,7 +62,18 @@ WORKFLOWS = (
     RELEASE_CANDIDATE_WORKFLOW,
     SECURITY_WORKFLOW,
     RELEASE_WORKFLOW,
+    CODEQL_ACTIONS_WORKFLOW,
+    CODEQL_PYTHON_WORKFLOW,
 )
+CODEQL_WORKFLOW_PATHS = {
+    CODEQL_ACTIONS_WORKFLOW: (".github/**", "**/action.yml", "**/action.yaml"),
+    CODEQL_PYTHON_WORKFLOW: (
+        "**/*.py",
+        "**/*.pyi",
+        ".github/codeql/**",
+        ".github/workflows/codeql-python.yml",
+    ),
+}
 FORBIDDEN_WORKFLOWS = (
     REPO_ROOT / ".github" / "workflows" / "ci.yml",
     REPO_ROOT / ".github" / "workflows" / "legal-integrity.yml",
@@ -138,6 +151,15 @@ def _load_yaml(path: Path) -> dict[str, Any]:
         msg = f"{path} does not contain a YAML mapping"
         raise TypeError(msg)
     return data
+
+
+def _workflow_triggers(path: Path) -> dict[str, Any]:
+    with path.open() as workflow_file:
+        workflow = yaml.safe_load(workflow_file)
+    if not isinstance(workflow, dict):
+        return {}
+    triggers = workflow.get(True, workflow.get("on", {}))
+    return triggers if isinstance(triggers, dict) else {}
 
 
 def _read_text(path: Path) -> str:
@@ -398,8 +420,30 @@ def _check_workflow_push_triggers() -> list[str]:
     issues: list[str] = []
     for path in _workflow_files():
         workflow_header = _read_text(path).split("jobs:", maxsplit=1)[0]
-        if re.search(r"(?m)^  push:\s*$", workflow_header):
+        if not re.search(r"(?m)^  push:\s*$", workflow_header):
+            continue
+
+        expected_paths = CODEQL_WORKFLOW_PATHS.get(path)
+        if expected_paths is None:
             issues.append(f"{path} must not run from a push trigger; use PR, schedule, manual, or release events")
+            continue
+
+        triggers = _workflow_triggers(path)
+        for event_name in ("pull_request", "push"):
+            event = triggers.get(event_name)
+            if not isinstance(event, dict):
+                issues.append(f"{path} CodeQL workflow is missing {event_name!r} trigger")
+                continue
+            if event.get("branches") != ["main"]:
+                issues.append(f"{path} CodeQL {event_name} trigger must be limited to main")
+            if event.get("paths") != list(expected_paths):
+                issues.append(f"{path} CodeQL {event_name} trigger must use its documented path filter")
+
+        issues.extend(
+            f"{path} CodeQL workflow is missing {event_name!r} trigger"
+            for event_name in ("schedule", "workflow_dispatch")
+            if event_name not in triggers
+        )
     return issues
 
 

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -419,13 +419,11 @@ def _check_workflow_job_timeouts() -> list[str]:
 def _check_workflow_push_triggers() -> list[str]:
     issues: list[str] = []
     for path in _workflow_files():
-        workflow_header = _read_text(path).split("jobs:", maxsplit=1)[0]
-        if not re.search(r"(?m)^  push:\s*$", workflow_header):
-            continue
-
         expected_paths = CODEQL_WORKFLOW_PATHS.get(path)
         if expected_paths is None:
-            issues.append(f"{path} must not run from a push trigger; use PR, schedule, manual, or release events")
+            workflow_header = _read_text(path).split("jobs:", maxsplit=1)[0]
+            if re.search(r"(?m)^  push:\s*$", workflow_header):
+                issues.append(f"{path} must not run from a push trigger; use PR, schedule, manual, or release events")
             continue
 
         triggers = _workflow_triggers(path)

--- a/tools/generate_correctness_report.py
+++ b/tools/generate_correctness_report.py
@@ -368,7 +368,7 @@ Dependency sets tracked by the support policy: {dependency_sets}
 - Runtime dependency audit: see security workflow evidence
 - GitHub Actions hardening audit: see security workflow evidence
 - OpenSSF Scorecard: see security workflow evidence
-- CodeQL: managed through GitHub default setup where enabled
+- CodeQL: managed through path-scoped advanced workflows
 - SBOM and SHA256 checksums: attached to the GitHub Release
 - PyPI provenance: provided through trusted publishing attestations
 - {_evidence_status(security_summaries, "Security summary")}


### PR DESCRIPTION
## Summary

- Synchronizes AlbumentationsX's bundled performance-optimization workflow with the current canonical Albucore guide.
- Replaces GitHub-managed CodeQL Default Setup with versioned, path-scoped advanced workflows.
- Runs Python analysis for Python source, stubs, or CodeQL configuration; runs Actions analysis for workflow or composite-action changes; skips both for ordinary Markdown and `.codex` documentation.
- Retains matching pushes to `main`, weekly scans, and manual CodeQL dispatches; documents the trigger policy and Default Setup migration.

## Why

CodeQL Default Setup launched both configured language analyses for the documentation-only change in this PR. The repository PR router already skips product checks for this file class, so the security scans were the remaining unnecessary work. Default Setup cannot express the required path selection and suppresses advanced CodeQL workflow uploads.

## Validation

- `cmp -s ../albucore/docs/performance-optimization.md .codex/skills/performance-optimization/references/performance-optimization.md`
- `uv run python -m tools.ci_matrix check`
- `uv run pytest -q tests/test_codeql_workflows.py tests/test_ci_plan.py tests/test_pr_workflow.py`
- `uv run zizmor --format=plain --min-severity=medium --min-confidence=medium .github`
- `pre-commit run --files .github/workflows/codeql-python.yml .github/workflows/codeql-actions.yml .github/workflows/security.yml docs/maintaining/ci-policy.md docs/maintaining/ci-greenfield-plan.md`
