### PR TITLE
fix(Flip3D): preserve reflection-group sampling

### DIFF
--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -1700,15 +1700,16 @@ class Flip3D(Transform3D):
     """Reflect a volume independently across depth, height, and width voxel-index axes while retaining its shape and
     channel layout.
 
-    In random mode, each allowed axis is independently reflected. Set `flip_axes` to a fixed subset for reversible
-    test-time augmentation; reflections are self-inverse. This is a voxel-index reflection only: it does not update
-    affine metadata or perform a physical-space reorientation.
+    In random mode, each allowed axis is independently reflected, including the empty subset (identity). This samples
+    the full reflection group uniformly. Set `flip_axes` to a fixed subset, including `()`, for reversible test-time
+    augmentation; reflections are self-inverse. This is a voxel-index reflection only: it does not update affine
+    metadata or perform a physical-space reorientation.
 
     Args:
         axes (tuple[int, ...]): Non-empty spatial axes that random mode may flip, in `(depth, height, width)` order.
             Default: `(0, 1, 2)`.
         flip_axes (tuple[int, ...] | None): Fixed subset of `axes` to reflect for deterministic test-time augmentation.
-            Default: None.
+            Use `()` for identity. Default: None.
         p (float): Probability of applying the transform. Default: 1.0.
 
     Targets:
@@ -1721,8 +1722,8 @@ class Flip3D(Transform3D):
         - A realized reflection across an odd number of axes emits the `Flip3D` label-mapping event. Its semantic-mask
           mapping applies only to `mask3d`; keypoint label mappings rename label values without changing coordinate-row
           order.
-        - A reflection across an even number of axes preserves orientation and does not emit this event. Without an
-          explicit mapping, labels stay unchanged.
+        - A reflection across an even number of axes, including identity, preserves orientation and does not emit this
+          event. Without an explicit mapping, labels stay unchanged.
 
     Examples:
         >>> import numpy as np
@@ -1751,8 +1752,6 @@ class Flip3D(Transform3D):
             if len(self.axes) != len(set(self.axes)):
                 raise ValueError("axes must not contain duplicate spatial axes")
             if self.flip_axes is not None:
-                if not self.flip_axes:
-                    raise ValueError("flip_axes must contain at least one spatial axis")
                 if len(self.flip_axes) != len(set(self.flip_axes)):
                     raise ValueError("flip_axes must not contain duplicate spatial axes")
                 if not set(self.flip_axes).issubset(self.axes):
@@ -1777,8 +1776,6 @@ class Flip3D(Transform3D):
         flip_axes = self.flip_axes
         if flip_axes is None:
             flip_axes = tuple(axis for axis in self.axes if self.py_random.random() < 0.5)
-            if not flip_axes:
-                flip_axes = (self.py_random.choice(self.axes),)
 
         self.applied_config = {"flip_axes": flip_axes}
         return {"flip_axes": flip_axes, "volume_shape": _get_volume_spatial_shape(data)}
@@ -1788,7 +1785,8 @@ class Flip3D(Transform3D):
         and keypoint labels to follow it.
 
         Each voxel-index reflection changes orientation parity. An odd number of reflected axes has determinant
-        negative and therefore applies the configured semantic mapping; an even number preserves orientation.
+        negative and therefore applies the configured semantic mapping; an even number, including identity, preserves
+        orientation.
         """
         return "Flip3D" if len(params["flip_axes"]) % 2 else None
 
@@ -1827,6 +1825,8 @@ class Flip3D(Transform3D):
         flip_axes: tuple[AxisIndex3D, ...],
         **params: Any,
     ) -> VolumeType:
+        if not flip_axes:
+            return volume
         flipped: np.ndarray = np.flip(volume, axis=flip_axes)
         return cast("VolumeType", flipped)
 
@@ -1836,6 +1836,8 @@ class Flip3D(Transform3D):
         flip_axes: tuple[AxisIndex3D, ...],
         **params: Any,
     ) -> VolumeType:
+        if not flip_axes:
+            return mask3d
         flipped: np.ndarray = np.flip(mask3d, axis=flip_axes)
         return cast("VolumeType", flipped)
 
@@ -1846,6 +1848,8 @@ class Flip3D(Transform3D):
         volume_shape: tuple[int, int, int],
         **params: Any,
     ) -> np.ndarray:
+        if not flip_axes:
+            return keypoints
         return f3d.keypoints_flip_3d(keypoints, flip_axes, volume_shape)
 
     def inverse(self) -> Self:

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -1718,9 +1718,11 @@ class Flip3D(Transform3D):
         uint8, float32
 
     Note:
-        - A realized width/X flip (axis `2`) emits the `Flip3D` label-mapping event. Its semantic-mask mapping applies
-          only to `mask3d`; keypoint label mappings rename label values without changing coordinate-row order.
-        - Depth-only and height-only flips do not emit this event. Without an explicit mapping, labels stay unchanged.
+        - A realized reflection across an odd number of axes emits the `Flip3D` label-mapping event. Its semantic-mask
+          mapping applies only to `mask3d`; keypoint label mappings rename label values without changing coordinate-row
+          order.
+        - A reflection across an even number of axes preserves orientation and does not emit this event. Without an
+          explicit mapping, labels stay unchanged.
 
     Examples:
         >>> import numpy as np
@@ -1782,17 +1784,17 @@ class Flip3D(Transform3D):
         return {"flip_axes": flip_axes, "volume_shape": _get_volume_spatial_shape(data)}
 
     def _get_label_transform_name(self, **params: Any) -> str | None:
-        """Return the Flip3D semantic-mapping event when the realized axes include width/X, so mask3d and keypoint
-        labels can follow the reflection.
+        """Return the Flip3D semantic-mapping event for a realized orientation-reversing reflection, allowing mask3d
+        and keypoint labels to follow it.
 
-        In canonical medical-image orientation, width is the left-right axis. Reflections across depth or height
-        alone preserve left/right class semantics, while a width reflection swaps them.
+        Each voxel-index reflection changes orientation parity. An odd number of reflected axes has determinant
+        negative and therefore applies the configured semantic mapping; an even number preserves orientation.
         """
-        return "Flip3D" if 2 in params["flip_axes"] else None
+        return "Flip3D" if len(params["flip_axes"]) % 2 else None
 
     def _apply_label_mapping_to_keypoints(self, keypoints: np.ndarray, **params: Any) -> np.ndarray:
-        """Rename mapped keypoint label values after a width/X reflection while preserving transformed coordinate
-        rows and their original order.
+        """Rename keypoint label values after a realized orientation-reversing reflection while preserving transformed
+        coordinates and input row order.
         """
         processor = self.processors.get("keypoints")
         transform_name = self._get_label_transform_name(**params)

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -25,6 +25,7 @@ from albumentations.core.type_definitions import (
     CV2_BORDER_CONSTANT,
     CV2_INTER_LINEAR,
     CV2_INTER_NEAREST,
+    NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS,
     C4GroupElement,
     Targets,
     VolumeType,
@@ -1716,6 +1717,11 @@ class Flip3D(Transform3D):
     Image types:
         uint8, float32
 
+    Note:
+        - A realized width/X flip (axis `2`) emits the `Flip3D` label-mapping event. Its semantic-mask mapping applies
+          only to `mask3d`; keypoint label mappings rename label values without changing coordinate-row order.
+        - Depth-only and height-only flips do not emit this event. Without an explicit mapping, labels stay unchanged.
+
     Examples:
         >>> import numpy as np
         >>> import albumentations as A
@@ -1774,6 +1780,44 @@ class Flip3D(Transform3D):
 
         self.applied_config = {"flip_axes": flip_axes}
         return {"flip_axes": flip_axes, "volume_shape": _get_volume_spatial_shape(data)}
+
+    def _get_label_transform_name(self, **params: Any) -> str | None:
+        """Return the Flip3D semantic-mapping event when the realized axes include width/X, so mask3d and keypoint
+        labels can follow the reflection.
+
+        In canonical medical-image orientation, width is the left-right axis. Reflections across depth or height
+        alone preserve left/right class semantics, while a width reflection swaps them.
+        """
+        return "Flip3D" if 2 in params["flip_axes"] else None
+
+    def _apply_label_mapping_to_keypoints(self, keypoints: np.ndarray, **params: Any) -> np.ndarray:
+        """Rename mapped keypoint label values after a width/X reflection while preserving transformed coordinate
+        rows and their original order.
+        """
+        processor = self.processors.get("keypoints")
+        transform_name = self._get_label_transform_name(**params)
+        if (
+            not isinstance(processor, KeypointsProcessor)
+            or not processor.params.label_fields
+            or keypoints.size == 0
+            or transform_name is None
+        ):
+            return keypoints
+
+        field_mappings = processor.encoded_label_mappings.get(transform_name)
+        if not field_mappings:
+            return keypoints
+
+        result = keypoints.copy()
+        for label_offset, label_field in enumerate(processor.params.label_fields):
+            mapping = field_mappings.get(label_field)
+            column_index = NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS + label_offset
+            if not mapping or column_index >= keypoints.shape[1]:
+                continue
+            source_values = keypoints[:, column_index]
+            for source_label, target_label in mapping.items():
+                result[source_values == source_label, column_index] = target_label
+        return result
 
     def apply_to_volume(
         self,

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -1788,7 +1788,8 @@ class Flip3D(Transform3D):
         negative and therefore applies the configured semantic mapping; an even number, including identity, preserves
         orientation.
         """
-        return "Flip3D" if len(params["flip_axes"]) % 2 else None
+        flip_axes = params.get("flip_axes", ())
+        return "Flip3D" if len(flip_axes) % 2 else None
 
     def _apply_label_mapping_to_keypoints(self, keypoints: np.ndarray, **params: Any) -> np.ndarray:
         """Rename keypoint label values after a realized orientation-reversing reflection while preserving transformed

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -1768,6 +1768,15 @@ class Flip3D(Transform3D):
         self.axes = axes
         self.flip_axes = flip_axes
 
+    def get_transform_init_args(self) -> dict[str, Any]:
+        """Return constructor arguments while preserving the empty axis tuple that selects deterministic identity
+        instead of random sampling.
+        """
+        args = super().get_transform_init_args()
+        if self.flip_axes == ():
+            args["flip_axes"] = self.flip_axes
+        return args
+
     def get_params_dependent_on_data(
         self,
         params: dict[str, Any],

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1176,10 +1176,11 @@ class Compose(BaseCompose, HubMixin):
         additional_targets (dict[str, str] | None): A dictionary mapping additional target names
             to their types. For example, {'image2': 'image'}. Passing a spatial alias also
             requires passing its canonical target (`image` in this example). Default is None.
-        semantic_mask_label_mappings (dict[str, dict[int, int]] | None): Label replacements applied to
-            `mask`, `masks`, `mask3d`, and their aliases after a realized label-changing spatial transform.
-            The outer key is `HorizontalFlip`, `VerticalFlip`, or `Transpose`; the inner dictionary maps
-            source class IDs to target class IDs. Default: None.
+        semantic_mask_label_mappings (dict[str, dict[int, int]] | None): Label replacements applied to spatial mask
+            targets after a realized label-changing transform. The outer key is `HorizontalFlip`, `VerticalFlip`,
+            `Transpose`, or `Flip3D`; the inner dictionary maps source class IDs to target class IDs. `Flip3D` runs
+            only for a realized width/X flip and remaps `mask3d` and its aliases, not 2D `mask` or `masks` targets.
+            Default: None.
         p (float): Probability of applying all transforms. Should be in range [0, 1]. Default is 1.0.
         is_check_shapes (bool): If True, checks consistency of shapes for image/mask/masks on each call.
             Disable only if you are sure about your data consistency. Default is True.
@@ -1263,6 +1264,7 @@ class Compose(BaseCompose, HubMixin):
         - Semantic-mask mappings replace class IDs simultaneously, so paired swaps do not overwrite one another.
           Unmapped labels stay unchanged. For D4/SquareSymmetry, configure the realized reflection name:
           `HorizontalFlip`, `VerticalFlip`, or `Transpose`; identity and rotations do not remap labels.
+          `Flip3D` emits its mapping event only when the realized axes include width/X (axis `2`).
         - Configure semantic-mask mappings only when the transformed and relabeled sample remains valid for your
           domain. Compose applies the declared mapping but cannot verify its semantic truth.
         - When strict mode is enabled, it performs additional validation to ensure data and transform

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1179,8 +1179,8 @@ class Compose(BaseCompose, HubMixin):
         semantic_mask_label_mappings (dict[str, dict[int, int]] | None): Label replacements applied to spatial mask
             targets after a realized label-changing transform. The outer key is `HorizontalFlip`, `VerticalFlip`,
             `Transpose`, or `Flip3D`; the inner dictionary maps source class IDs to target class IDs. `Flip3D` runs
-            only for a realized width/X flip and remaps `mask3d` and its aliases, not 2D `mask` or `masks` targets.
-            Default: None.
+            for a realized reflection across an odd number of axes and remaps `mask3d` and its aliases, not 2D `mask`
+            or `masks` targets. Default: None.
         p (float): Probability of applying all transforms. Should be in range [0, 1]. Default is 1.0.
         is_check_shapes (bool): If True, checks consistency of shapes for image/mask/masks on each call.
             Disable only if you are sure about your data consistency. Default is True.
@@ -1264,7 +1264,7 @@ class Compose(BaseCompose, HubMixin):
         - Semantic-mask mappings replace class IDs simultaneously, so paired swaps do not overwrite one another.
           Unmapped labels stay unchanged. For D4/SquareSymmetry, configure the realized reflection name:
           `HorizontalFlip`, `VerticalFlip`, or `Transpose`; identity and rotations do not remap labels.
-          `Flip3D` emits its mapping event only when the realized axes include width/X (axis `2`).
+          `Flip3D` emits its mapping event only when the realized reflection includes an odd number of axes.
         - Configure semantic-mask mappings only when the transformed and relabeled sample remains valid for your
           domain. Compose applies the declared mapping but cannot verify its semantic truth.
         - When strict mode is enabled, it performs additional validation to ensure data and transform

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1177,10 +1177,12 @@ class Compose(BaseCompose, HubMixin):
             to their types. For example, {'image2': 'image'}. Passing a spatial alias also
             requires passing its canonical target (`image` in this example). Default is None.
         semantic_mask_label_mappings (dict[str, dict[int, int]] | None): Label replacements applied to spatial mask
-            targets after a realized label-changing transform. The outer key is `HorizontalFlip`, `VerticalFlip`,
-            `Transpose`, or `Flip3D`; the inner dictionary maps source class IDs to target class IDs. `Flip3D` runs
-            for a realized reflection across an odd number of axes and remaps `mask3d` and its aliases, not 2D `mask`
-            or `masks` targets. Default: None.
+            targets when a realized transform emits a label-mapping event. The outer key is the emitted event name;
+            `D4` and `SquareSymmetry` emit the corresponding base reflection event (`HorizontalFlip`, `VerticalFlip`,
+            or `Transpose`) rather than their class name. Other transforms may emit their own events, such as
+            `Flip3D`. The inner dictionary maps source class IDs to target class IDs. `Flip3D` emits its event for a
+            realized reflection across an odd number of axes and remaps `mask3d` and its aliases, not 2D `mask` or
+            `masks` targets. Default: None.
         p (float): Probability of applying all transforms. Should be in range [0, 1]. Default is 1.0.
         is_check_shapes (bool): If True, checks consistency of shapes for image/mask/masks on each call.
             Disable only if you are sure about your data consistency. Default is True.

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -1228,7 +1228,11 @@ class DualTransform(BasicTransform):
 
         for data_name, value in data.items():
             canonical_name = self._additional_targets.get(data_name, data_name)
-            if canonical_name in {"mask", "masks", "mask3d"} and isinstance(value, (np.ndarray, torch.Tensor)):
+            if (
+                data_name in self._key2func
+                and canonical_name in {"mask", "masks", "mask3d"}
+                and isinstance(value, (np.ndarray, torch.Tensor))
+            ):
                 data[data_name] = self._remap_semantic_mask_labels(value, mapping, uint8_lut)
         return data
 

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -1066,6 +1066,7 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
     ("subset-elements", A.RandomRotate90, {"group_elements": ("r90", "r270")}),
     ("fixed-axis-rotation", A.RandomRotate90_3D, {"axis_pair": (0, 2), "group_element": "r90"}),
     ("fixed-axes", A.Flip3D, {"flip_axes": (0, 2)}),
+    ("fixed-identity", A.Flip3D, {"flip_axes": ()}),
     ("constant-fill", A.Affine3D, {"border_mode": cv2.BORDER_CONSTANT}),
     ("anisotropic-range", A.RandomScale, {"scale_range": {"x": (-0.2, 0.3), "y": (-0.1, 0.15)}}),
     ("downscale-aware", A.RandomScale, {"mask_interpolation": cv2.INTER_LINEAR, "area_for_downscale": "image_mask"}),

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -79,6 +79,21 @@ def test_semantic_mask_label_mapping_flip3d_does_not_remap_2d_masks() -> None:
     np.testing.assert_array_equal(result["masks"], masks)
 
 
+def test_semantic_mask_label_mapping_flip3d_identity_does_not_remap_mask3d() -> None:
+    volume = np.zeros((1, 2, 3, 1), dtype=np.float32)
+    mask3d = np.array([[[2, 0, 3], [3, 2, 0]]], dtype=np.uint8)
+    transform = A.Compose(
+        [A.Flip3D(flip_axes=(), p=1.0)],
+        semantic_mask_label_mappings={"Flip3D": {2: 3, 3: 2}},
+        strict=True,
+        telemetry=False,
+    )
+
+    result = transform(volume=volume, mask3d=mask3d)
+
+    np.testing.assert_array_equal(result["mask3d"], mask3d)
+
+
 @pytest.mark.parametrize("flip_axes", [(0, 1), (0, 2), (1, 2)])
 def test_semantic_mask_label_mapping_flip3d_ignores_even_reflections(flip_axes: tuple[int, ...]) -> None:
     volume = np.zeros((2, 2, 3, 1), dtype=np.float32)

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -33,7 +33,8 @@ def test_semantic_mask_label_mapping_swaps_labels_after_horizontal_flip() -> Non
     np.testing.assert_array_equal(mask, np.array([[2, 0, 3, 2]], dtype=np.uint8))
 
 
-def test_semantic_mask_label_mapping_swaps_mask3d_after_width_flip3d() -> None:
+@pytest.mark.parametrize("flip_axes", [(0,), (1,), (2,), (0, 1, 2)])
+def test_semantic_mask_label_mapping_swaps_mask3d_after_odd_flip3d(flip_axes: tuple[int, ...]) -> None:
     volume = np.arange(2 * 2 * 4, dtype=np.float32).reshape(2, 2, 4, 1)
     mask3d = np.array(
         [
@@ -43,7 +44,7 @@ def test_semantic_mask_label_mapping_swaps_mask3d_after_width_flip3d() -> None:
         dtype=np.uint8,
     )
     transform = A.Compose(
-        [A.Flip3D(flip_axes=(2,), p=1.0)],
+        [A.Flip3D(flip_axes=flip_axes, p=1.0)],
         additional_targets={"mask3d_alias": "mask3d"},
         semantic_mask_label_mappings={"Flip3D": {2: 3, 3: 2}},
         strict=True,
@@ -52,14 +53,11 @@ def test_semantic_mask_label_mapping_swaps_mask3d_after_width_flip3d() -> None:
 
     result = transform(volume=volume, mask3d=mask3d, mask3d_alias=mask3d.copy())
 
-    np.testing.assert_array_equal(result["volume"], np.flip(volume, axis=2))
-    expected_mask3d = np.array(
-        [
-            [[4, 2, 0, 3], [3, 0, 2, 4]],
-            [[0, 4, 3, 2], [2, 3, 4, 0]],
-        ],
-        dtype=np.uint8,
-    )
+    np.testing.assert_array_equal(result["volume"], np.flip(volume, axis=flip_axes))
+    expected_mask3d = np.flip(mask3d, axis=flip_axes).copy()
+    source_labels = expected_mask3d.copy()
+    expected_mask3d[source_labels == 2] = 3
+    expected_mask3d[source_labels == 3] = 2
     np.testing.assert_array_equal(result["mask3d"], expected_mask3d)
     np.testing.assert_array_equal(result["mask3d_alias"], expected_mask3d)
 
@@ -81,8 +79,8 @@ def test_semantic_mask_label_mapping_flip3d_does_not_remap_2d_masks() -> None:
     np.testing.assert_array_equal(result["masks"], masks)
 
 
-@pytest.mark.parametrize("flip_axes", [(0,), (1,), (0, 1)])
-def test_semantic_mask_label_mapping_flip3d_ignores_non_width_flips(flip_axes: tuple[int, ...]) -> None:
+@pytest.mark.parametrize("flip_axes", [(0, 1), (0, 2), (1, 2)])
+def test_semantic_mask_label_mapping_flip3d_ignores_even_reflections(flip_axes: tuple[int, ...]) -> None:
     volume = np.zeros((2, 2, 3, 1), dtype=np.float32)
     mask3d = np.array(
         [

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -33,6 +33,76 @@ def test_semantic_mask_label_mapping_swaps_labels_after_horizontal_flip() -> Non
     np.testing.assert_array_equal(mask, np.array([[2, 0, 3, 2]], dtype=np.uint8))
 
 
+def test_semantic_mask_label_mapping_swaps_mask3d_after_width_flip3d() -> None:
+    volume = np.arange(2 * 2 * 4, dtype=np.float32).reshape(2, 2, 4, 1)
+    mask3d = np.array(
+        [
+            [[2, 0, 3, 4], [4, 3, 0, 2]],
+            [[3, 2, 4, 0], [0, 4, 2, 3]],
+        ],
+        dtype=np.uint8,
+    )
+    transform = A.Compose(
+        [A.Flip3D(flip_axes=(2,), p=1.0)],
+        additional_targets={"mask3d_alias": "mask3d"},
+        semantic_mask_label_mappings={"Flip3D": {2: 3, 3: 2}},
+        strict=True,
+        telemetry=False,
+    )
+
+    result = transform(volume=volume, mask3d=mask3d, mask3d_alias=mask3d.copy())
+
+    np.testing.assert_array_equal(result["volume"], np.flip(volume, axis=2))
+    expected_mask3d = np.array(
+        [
+            [[4, 2, 0, 3], [3, 0, 2, 4]],
+            [[0, 4, 3, 2], [2, 3, 4, 0]],
+        ],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(result["mask3d"], expected_mask3d)
+    np.testing.assert_array_equal(result["mask3d_alias"], expected_mask3d)
+
+
+def test_semantic_mask_label_mapping_flip3d_does_not_remap_2d_masks() -> None:
+    volume = np.zeros((1, 2, 3, 1), dtype=np.float32)
+    mask = np.array([[2, 0, 3], [3, 2, 0]], dtype=np.uint8)
+    masks = np.stack([mask, np.array([[0, 3, 2], [2, 0, 3]], dtype=np.uint8)])
+    transform = A.Compose(
+        [A.Flip3D(flip_axes=(2,), p=1.0)],
+        semantic_mask_label_mappings={"Flip3D": {2: 3, 3: 2}},
+        strict=True,
+        telemetry=False,
+    )
+
+    result = transform(volume=volume, mask=mask, masks=masks)
+
+    np.testing.assert_array_equal(result["mask"], mask)
+    np.testing.assert_array_equal(result["masks"], masks)
+
+
+@pytest.mark.parametrize("flip_axes", [(0,), (1,), (0, 1)])
+def test_semantic_mask_label_mapping_flip3d_ignores_non_width_flips(flip_axes: tuple[int, ...]) -> None:
+    volume = np.zeros((2, 2, 3, 1), dtype=np.float32)
+    mask3d = np.array(
+        [
+            [[2, 0, 3], [3, 2, 0]],
+            [[0, 3, 2], [2, 0, 3]],
+        ],
+        dtype=np.uint8,
+    )
+    transform = A.Compose(
+        [A.Flip3D(flip_axes=flip_axes, p=1.0)],
+        semantic_mask_label_mappings={"Flip3D": {2: 3, 3: 2}},
+        strict=True,
+        telemetry=False,
+    )
+
+    result = transform(volume=volume, mask3d=mask3d)
+
+    np.testing.assert_array_equal(result["mask3d"], np.flip(mask3d, axis=flip_axes))
+
+
 def test_semantic_mask_label_mapping_preserves_custom_apply_with_params_hook() -> None:
     image = np.zeros((1, 4, 3), dtype=np.uint8)
     mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1506,6 +1506,12 @@ def test_flip3d_fixed_identity_preserves_targets_and_is_self_inverse() -> None:
     np.testing.assert_array_equal(restored["mask3d"], mask3d)
     np.testing.assert_array_equal(restored["keypoints"], keypoints)
 
+    serialized = A.to_dict(compose)
+    assert serialized["transform"]["transforms"][0]["flip_axes"] == []
+    deserialized = A.from_dict(serialized)
+
+    np.testing.assert_array_equal(deserialized(volume=volume)["volume"], volume)
+
 
 @pytest.mark.parametrize(
     "kwargs",

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1367,6 +1367,48 @@ def test_flip3d_reflects_volume_mask_and_keypoints_without_reordering_axes():
     np.testing.assert_array_equal(restored["keypoints"], keypoints)
 
 
+def test_flip3d_width_flip_remaps_keypoint_labels_without_reordering_rows() -> None:
+    volume = np.zeros((2, 3, 5, 1), dtype=np.float32)
+    keypoints = np.array([[1, 1, 0], [3, 2, 1]], dtype=np.float32)
+    side = [2, 3]
+    transform = A.Compose(
+        [A.Flip3D(flip_axes=(2,), p=1.0)],
+        keypoint_params=A.KeypointParams(
+            coord_format="xyz",
+            label_fields=["side"],
+            label_mapping={"Flip3D": {"side": {2: 3, 3: 2}}},
+        ),
+        strict=True,
+        telemetry=False,
+    )
+
+    result = transform(volume=volume, keypoints=keypoints, side=side)
+
+    np.testing.assert_array_equal(result["keypoints"], np.array([[3, 1, 0], [1, 2, 1]], dtype=np.float32))
+    assert result["side"] == [3, 2]
+
+
+@pytest.mark.parametrize("flip_axes", [(0,), (1,), (0, 1)])
+def test_flip3d_non_width_flips_preserve_keypoint_labels(flip_axes: tuple[int, ...]) -> None:
+    volume = np.zeros((2, 3, 5, 1), dtype=np.float32)
+    keypoints = np.array([[1, 1, 0], [3, 2, 1]], dtype=np.float32)
+    side = [2, 3]
+    transform = A.Compose(
+        [A.Flip3D(flip_axes=flip_axes, p=1.0)],
+        keypoint_params=A.KeypointParams(
+            coord_format="xyz",
+            label_fields=["side"],
+            label_mapping={"Flip3D": {"side": {2: 3, 3: 2}}},
+        ),
+        strict=True,
+        telemetry=False,
+    )
+
+    result = transform(volume=volume, keypoints=keypoints, side=side)
+
+    assert result["side"] == side
+
+
 def test_flip3d_seeded_replay_records_realized_axes():
     volume = np.arange(3 * 4 * 5, dtype=np.uint8).reshape(3, 4, 5, 1)
     pipeline = A.Compose(

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1400,6 +1400,40 @@ def test_flip3d_odd_reflections_remap_keypoint_labels_without_reordering_rows(
     assert result["side"] == [3, 2]
 
 
+@pytest.mark.parametrize(
+    ("label_mapping", "expected_side", "expected_view"),
+    [
+        ({"Flip3D": {"side": {2: 3, 3: 2}}}, [3, 2], [4, 5]),
+        ({"Flip3D": {"view": {4: 5, 5: 4}}}, [2, 3], [5, 4]),
+    ],
+)
+def test_flip3d_keypoint_label_mapping_handles_multiple_fields_independently(
+    label_mapping: dict[str, dict[str, dict[int, int]]],
+    expected_side: list[int],
+    expected_view: list[int],
+) -> None:
+    volume = np.zeros((2, 3, 5, 1), dtype=np.float32)
+    keypoints = np.array([[1, 1, 0], [3, 2, 1]], dtype=np.float32)
+    side = [2, 3]
+    view = [4, 5]
+    transform = A.Compose(
+        [A.Flip3D(flip_axes=(2,), p=1.0)],
+        keypoint_params=A.KeypointParams(
+            coord_format="xyz",
+            label_fields=["side", "view"],
+            label_mapping=label_mapping,
+        ),
+        strict=True,
+        telemetry=False,
+    )
+
+    result = transform(volume=volume, keypoints=keypoints, side=side, view=view)
+
+    np.testing.assert_array_equal(result["keypoints"], np.array([[3, 1, 0], [1, 2, 1]], dtype=np.float32))
+    assert result["side"] == expected_side
+    assert result["view"] == expected_view
+
+
 @pytest.mark.parametrize("flip_axes", [(0, 1), (0, 2), (1, 2)])
 def test_flip3d_even_reflections_preserve_keypoint_labels(flip_axes: tuple[int, ...]) -> None:
     volume = np.zeros((2, 3, 5, 1), dtype=np.float32)

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1367,12 +1367,24 @@ def test_flip3d_reflects_volume_mask_and_keypoints_without_reordering_axes():
     np.testing.assert_array_equal(restored["keypoints"], keypoints)
 
 
-def test_flip3d_width_flip_remaps_keypoint_labels_without_reordering_rows() -> None:
+@pytest.mark.parametrize(
+    ("flip_axes", "expected_keypoints"),
+    [
+        ((0,), np.array([[1, 1, 1], [3, 2, 0]], dtype=np.float32)),
+        ((1,), np.array([[1, 1, 0], [3, 0, 1]], dtype=np.float32)),
+        ((2,), np.array([[3, 1, 0], [1, 2, 1]], dtype=np.float32)),
+        ((0, 1, 2), np.array([[3, 1, 1], [1, 0, 0]], dtype=np.float32)),
+    ],
+)
+def test_flip3d_odd_reflections_remap_keypoint_labels_without_reordering_rows(
+    flip_axes: tuple[int, ...],
+    expected_keypoints: np.ndarray,
+) -> None:
     volume = np.zeros((2, 3, 5, 1), dtype=np.float32)
     keypoints = np.array([[1, 1, 0], [3, 2, 1]], dtype=np.float32)
     side = [2, 3]
     transform = A.Compose(
-        [A.Flip3D(flip_axes=(2,), p=1.0)],
+        [A.Flip3D(flip_axes=flip_axes, p=1.0)],
         keypoint_params=A.KeypointParams(
             coord_format="xyz",
             label_fields=["side"],
@@ -1384,12 +1396,12 @@ def test_flip3d_width_flip_remaps_keypoint_labels_without_reordering_rows() -> N
 
     result = transform(volume=volume, keypoints=keypoints, side=side)
 
-    np.testing.assert_array_equal(result["keypoints"], np.array([[3, 1, 0], [1, 2, 1]], dtype=np.float32))
+    np.testing.assert_array_equal(result["keypoints"], expected_keypoints)
     assert result["side"] == [3, 2]
 
 
-@pytest.mark.parametrize("flip_axes", [(0,), (1,), (0, 1)])
-def test_flip3d_non_width_flips_preserve_keypoint_labels(flip_axes: tuple[int, ...]) -> None:
+@pytest.mark.parametrize("flip_axes", [(0, 1), (0, 2), (1, 2)])
+def test_flip3d_even_reflections_preserve_keypoint_labels(flip_axes: tuple[int, ...]) -> None:
     volume = np.zeros((2, 3, 5, 1), dtype=np.float32)
     keypoints = np.array([[1, 1, 0], [3, 2, 1]], dtype=np.float32)
     side = [2, 3]

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1437,12 +1437,47 @@ def test_flip3d_seeded_replay_records_realized_axes():
     np.testing.assert_array_equal(replayed["volume"], result["volume"])
 
 
+def test_flip3d_random_mode_samples_the_full_reflection_group() -> None:
+    transform = A.Flip3D(axes=(0, 2), p=1.0)
+    transform.set_random_seed(137)
+    volume = np.zeros((2, 3, 5, 1), dtype=np.uint8)
+
+    sampled_axes = {transform.get_params_dependent_on_data({}, {"volume": volume})["flip_axes"] for _ in range(64)}
+
+    assert sampled_axes == {(), (0,), (2,), (0, 2)}
+
+
+def test_flip3d_fixed_identity_preserves_targets_and_is_self_inverse() -> None:
+    volume = np.arange(2 * 3 * 5, dtype=np.uint8).reshape(2, 3, 5, 1)
+    mask3d = (volume[..., 0] % 2).astype(np.uint8)
+    keypoints = np.array([[1, 1, 0], [3, 2, 1]], dtype=np.float32)
+    transform = A.Flip3D(flip_axes=(), p=1.0)
+    compose = A.Compose(
+        [transform],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        save_applied_params=True,
+        strict=True,
+    )
+
+    result = compose(volume=volume, mask3d=mask3d, keypoints=keypoints)
+    restored = A.Compose([transform.inverse()], keypoint_params=A.KeypointParams(coord_format="xyz"), strict=True)(
+        **result,
+    )
+
+    np.testing.assert_array_equal(result["volume"], volume)
+    np.testing.assert_array_equal(result["mask3d"], mask3d)
+    np.testing.assert_array_equal(result["keypoints"], keypoints)
+    assert result["applied_transforms"][0][1]["flip_axes"] == ()
+    np.testing.assert_array_equal(restored["volume"], volume)
+    np.testing.assert_array_equal(restored["mask3d"], mask3d)
+    np.testing.assert_array_equal(restored["keypoints"], keypoints)
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
         {"axes": ()},
         {"axes": (0, 0)},
-        {"flip_axes": ()},
         {"axes": (0,), "flip_axes": (1,)},
         {"flip_axes": (0, 0)},
     ],


### PR DESCRIPTION
Fixes #411.

## Decision

`Flip3D` now independently samples every allowed reflection axis, including the empty subset. Random mode therefore samples the full `C₂^len(axes)` reflection group uniformly; `flip_axes=()` selects deterministic identity for TTA. The label-mapping event still uses the realized selection: `len(flip_axes) % 2 == 1`. One or three reflections remap `mask3d` labels and configured keypoint-label fields; zero or two reflections preserve orientation and do not remap either target.

The mapping remains scoped to `mask3d` and its aliases; `Flip3D` does not spatially transform 2D `mask` or `masks`. Keypoint mappings rename values from a source snapshot, preserving transformed coordinate rows and their order.

## Why

Each axis reflection has determinant `-1`; a composition of `k` reflections has determinant `(-1)^k`. A vertical reflection is therefore a horizontal reflection followed by a 180° rotation, and both single reflections reverse orientation. The former fallback chose one axis whenever every random draw rejected reflection, excluding identity from random mode and breaking the `C₂^n` group. The prior width/X-only predicate also made `(0,)` and `(1,)` skip the required mapping while mapping the orientation-preserving pairs `(0, 2)` and `(1, 2)`.

## Validation

- `uv run pytest -m "not slow"` — 13,208 passed, 43 skipped, 38 deselected, 9 xfailed, 3 xpassed
- `uv run python -m tools.quality_gate fast` — passed (Ruff, mypy, Pyrefly, 1,274 contract tests, policy gates)
- `pre-commit run --all-files` — passed

## Benchmark

The parity benchmark compares the committed width/X predicate (`2 in flip_axes`) with the parity predicate on macOS arm64, Python 3.10.16, NumPy 2.2.6, and OpenCV 5.0.0. Inputs are `uint8` volumes of shape `(3, H, W, C)` with `uint8 mask3d`; each result is the median of five 100-call runs in µs/call. “Direct” uses `apply_with_params`; “Compose” uses a strict `Compose` pipeline. The identity benchmark uses 500 calls per repeat on the same machine.

Only the four axis selections below change the label-mapping event. `(2,)`, `(0, 1)`, and `(0, 1, 2)` keep their prior mapping outcome, so they are intentionally outside this differential matrix. Identity was previously excluded from random mode and is reported separately below.

### Odd reflection: axis (0)

| Volume | Direct before → after | Compose before → after |
| --- | --- | --- |
| 256²×1 | 2.55 → 23.08 | 15.47 → 37.20 |
| 256²×3 | 2.25 → 22.98 | 14.57 → 36.25 |
| 256²×5 | 2.41 → 24.06 | 14.10 → 36.31 |
| 512²×1 | 2.34 → 75.62 | 14.97 → 89.01 |
| 512²×3 | 2.58 → 83.46 | 15.49 → 94.84 |
| 512²×5 | 2.26 → 77.02 | 15.21 → 88.16 |
| 1024²×1 | 2.39 → 286.79 | 15.30 → 300.11 |
| 1024²×3 | 2.30 → 286.27 | 14.75 → 300.20 |
| 1024²×5 | 2.53 → 286.43 | 14.81 → 301.96 |

### Odd reflection: axis (1)

| Volume | Direct before → after | Compose before → after |
| --- | --- | --- |
| 256²×1 | 2.35 → 24.40 | 14.38 → 37.05 |
| 256²×3 | 2.28 → 24.01 | 14.39 → 37.23 |
| 256²×5 | 2.38 → 24.54 | 14.85 → 37.10 |
| 512²×1 | 2.30 → 78.61 | 14.36 → 93.75 |
| 512²×3 | 2.78 → 83.56 | 17.24 → 96.11 |
| 512²×5 | 2.42 → 78.25 | 15.42 → 91.90 |
| 1024²×1 | 2.32 → 293.73 | 14.69 → 327.15 |
| 1024²×3 | 2.31 → 292.72 | 15.17 → 305.22 |
| 1024²×5 | 2.28 → 291.49 | 14.66 → 308.17 |

### Even reflection: axes (0, 2)

| Volume | Direct before → after | Compose before → after |
| --- | --- | --- |
| 256²×1 | 80.70 → 2.50 | 94.00 → 14.80 |
| 256²×3 | 79.80 → 2.52 | 99.17 → 15.40 |
| 256²×5 | 80.77 → 2.42 | 95.27 → 15.12 |
| 512²×1 | 287.15 → 2.54 | 300.10 → 14.40 |
| 512²×3 | 306.63 → 2.70 | 315.27 → 16.28 |
| 512²×5 | 288.69 → 2.42 | 303.92 → 15.34 |
| 1024²×1 | 1103.11 → 2.81 | 1201.25 → 16.51 |
| 1024²×3 | 1100.12 → 2.59 | 1207.30 → 17.12 |
| 1024²×5 | 1093.94 → 2.46 | 1188.89 → 16.41 |

### Even reflection: axes (1, 2)

| Volume | Direct before → after | Compose before → after |
| --- | --- | --- |
| 256²×1 | 71.49 → 2.55 | 87.07 → 14.89 |
| 256²×3 | 72.83 → 2.44 | 85.12 → 14.28 |
| 256²×5 | 71.82 → 2.54 | 85.63 → 14.25 |
| 512²×1 | 281.79 → 2.79 | 305.41 → 16.70 |
| 512²×3 | 270.01 → 2.52 | 287.20 → 14.96 |
| 512²×5 | 271.87 → 2.50 | 289.28 → 15.16 |
| 1024²×1 | 1089.56 → 2.57 | 1088.64 → 15.49 |
| 1024²×3 | 1067.05 → 2.50 | 1091.92 → 14.96 |
| 1024²×5 | 1130.14 → 2.53 | 1089.47 → 15.30 |

The odd cases add the required atomic semantic-mask remap, so their before/after numbers do not represent equal behavior. The even cases remove an incorrect full-mask remap. The implementation retains the existing `uint8` LUT route and adds no pixel kernel, dtype conversion, backend route, or volume copy beyond the required remapped target.

### Keypoint-label mapping through Compose

| Reflected axes | Keypoints | Before → after (µs/call) |
| --- | ---: | ---: |
| (0) | 16 | 65.37 → 69.86 |
| (0) | 256 | 81.25 → 84.33 |
| (0) | 4096 | 345.68 → 374.52 |
| (1) | 16 | 62.84 → 67.61 |
| (1) | 256 | 83.48 → 89.97 |
| (1) | 4096 | 352.51 → 386.74 |
| (0, 2) | 16 | 69.08 → 65.52 |
| (0, 2) | 256 | 90.48 → 81.65 |
| (0, 2) | 4096 | 387.79 → 380.00 |
| (1, 2) | 16 | 66.71 → 64.21 |
| (1, 2) | 256 | 86.42 → 81.46 |
| (1, 2) | 4096 | 414.31 → 378.04 |

The odd keypoint cases add the necessary label-value copy/remap and cost 3.8–9.7%. The even cases eliminate the former incorrect remap and improve by 2.0–9.8%. The copy is intentional: it preserves caller-owned data and applies paired mappings atomically. No Albucore extraction is appropriate because this change is transform-target and annotation-semantics policy.
### Identity path

With `p=1`, random `axes=(0, 2)` now samples `()`, `(0,)`, `(2,)`, and `(0, 2)` with equal probability. Fixed `flip_axes=()` exposes the same identity element for TTA. Identity has even parity, so it leaves semantic-mask and keypoint-label mappings unchanged.

The before column reproduces the pre-fast-path no-op work: `np.flip(..., axis=())` for volume and mask3d, and the empty-loop keypoint helper. Older public `Flip3D` rejected fixed `flip_axes=()`, so this reference isolates the work removed after identity became a supported group element.

#### Volume and mask3d identity

| Volume | Direct before → after (µs/call) | Compose before → after (µs/call) |
| --- | --- | --- |
| 256²×1 | 1.67 → 0.66 | 14.12 → 12.19 |
| 256²×3 | 1.63 → 0.58 | 13.95 → 12.46 |
| 256²×5 | 1.66 → 0.59 | 14.03 → 11.96 |
| 512²×1 | 1.72 → 0.60 | 14.13 → 12.48 |
| 512²×3 | 1.66 → 0.59 | 14.38 → 12.60 |
| 512²×5 | 1.72 → 0.67 | 14.86 → 12.62 |
| 1024²×1 | 1.73 → 0.61 | 14.49 → 12.42 |
| 1024²×3 | 1.69 → 0.61 | 14.03 → 12.53 |
| 1024²×5 | 1.67 → 0.61 | 13.94 → 12.27 |

#### Keypoint identity

| Keypoints | Direct before → after (µs/call) | Compose before → after (µs/call) |
| ---: | --- | --- |
| 16 | 0.29 → 0.06 | 49.38 → 45.26 |
| 256 | 0.38 → 0.06 | 59.95 → 56.98 |
| 4096 | 0.86 → 0.06 | 205.63 → 191.06 |

The identity fast path removes only redundant wrapper/view work and the empty keypoint copy. No pixel kernel, dtype conversion, full-array copy, backend route, RNG implementation, grouped reduction, LUT, or Albucore primitive is involved.

## Summary by Sourcery

Preserve Flip3D reflection-group semantics while making identity and orientation parity drive semantic label mapping.

Bug Fixes:
- Correct Flip3D semantic-mask and keypoint-label remapping to trigger only for orientation-reversing (odd-axis) reflections and skip identity/even reflections.
- Ensure Flip3D random mode samples all combinations of the configured reflection axes, including the identity element, uniformly.
- Prevent Flip3D from remapping 2D mask targets when applying 3D semantic-mask mappings.

Enhancements:
- Add identity fast paths for Flip3D volume, mask3d, and keypoint targets and allow flip_axes=() for deterministic no-op TTA.
- Document Flip3D’s reflection-group behavior and integration with Compose semantic-mask mappings and keypoint labels.
- Limit semantic-mask label remapping to declared spatial targets by checking that a handler exists before applying mappings.

Tests:
- Add Flip3D tests covering odd/even reflection parity for keypoint labels and mask3d mappings, random reflection-group sampling, identity behavior, and exclusion of 2D masks from 3D mappings.
- Extend semantic mask label mapping tests to cover Flip3D-specific behavior, including identity and even-reflection cases.