### PR TITLE
fix(geometry): preserve OBB symmetry contracts

### DIFF
--- a/albumentations/augmentations/geometric/_functional_bboxes.py
+++ b/albumentations/augmentations/geometric/_functional_bboxes.py
@@ -58,6 +58,15 @@ def _split_obb_params(
     return center_x, center_y, width, height, angle, extras
 
 
+def _canonicalize_obb_angles(angles: np.ndarray) -> np.ndarray:
+    """Normalize OBB width-edge angles to [-90, 90) so symmetry transforms yield a single stable
+    representation for each undirected edge in downstream geometry code.
+    """
+    if angles.min() >= -90.0 and angles.max() < 90.0:
+        return angles
+    return np.mod(angles + 90.0, 180.0) - 90.0
+
+
 def _merge_obb_params(
     center_x: np.ndarray,
     center_y: np.ndarray,
@@ -162,6 +171,7 @@ def bboxes_rot90(
         if rot90_count % 2 == 1:
             width, height = height, width
 
+        angle = _canonicalize_obb_angles(angle)
         return _merge_obb_params(new_center_x, new_center_y, width, height, angle, extras)
 
     rotated_bboxes = bboxes.copy()
@@ -574,7 +584,7 @@ def bboxes_vflip(bboxes: np.ndarray, bbox_type: Literal["hbb", "obb"]) -> np.nda
     if bbox_type == "obb":
         center_x, center_y, width, height, angle, extras = _split_obb_params(bboxes)
         center_y = 1 - center_y
-        angle = -angle
+        angle = _canonicalize_obb_angles(-angle)
         return _merge_obb_params(center_x, center_y, width, height, angle, extras)
     flipped_bboxes = bboxes.copy()
     flipped_bboxes[:, 1] = 1 - bboxes[:, 3]  # new y_min = 1 - y_max
@@ -599,7 +609,7 @@ def bboxes_hflip(bboxes: np.ndarray, bbox_type: Literal["hbb", "obb"]) -> np.nda
     if bbox_type == "obb":
         center_x, center_y, width, height, angle, extras = _split_obb_params(bboxes)
         center_x = 1 - center_x
-        angle = -angle
+        angle = _canonicalize_obb_angles(-angle)
         return _merge_obb_params(center_x, center_y, width, height, angle, extras)
     flipped_bboxes = bboxes.copy()
     flipped_bboxes[:, 0] = 1 - bboxes[:, 2]  # new x_min = 1 - x_max
@@ -625,7 +635,7 @@ def bboxes_transpose(bboxes: np.ndarray, bbox_type: Literal["hbb", "obb"]) -> np
         center_x, center_y, width, height, angle, extras = _split_obb_params(bboxes)
         center_x, center_y = center_y, center_x
         width, height = height, width
-        angle = -angle
+        angle = _canonicalize_obb_angles(-angle)
         return _merge_obb_params(center_x, center_y, width, height, angle, extras)
     transposed_bboxes = bboxes.copy()
     transposed_bboxes[:, [0, 1, 2, 3]] = bboxes[:, [1, 0, 3, 2]]

--- a/albumentations/augmentations/geometric/_functional_bboxes.py
+++ b/albumentations/augmentations/geometric/_functional_bboxes.py
@@ -162,7 +162,6 @@ def bboxes_rot90(
         if rot90_count % 2 == 1:
             width, height = height, width
 
-        angle = angle + rot90_count * 90
         return _merge_obb_params(new_center_x, new_center_y, width, height, angle, extras)
 
     rotated_bboxes = bboxes.copy()
@@ -600,7 +599,7 @@ def bboxes_hflip(bboxes: np.ndarray, bbox_type: Literal["hbb", "obb"]) -> np.nda
     if bbox_type == "obb":
         center_x, center_y, width, height, angle, extras = _split_obb_params(bboxes)
         center_x = 1 - center_x
-        angle = 180.0 - angle
+        angle = -angle
         return _merge_obb_params(center_x, center_y, width, height, angle, extras)
     flipped_bboxes = bboxes.copy()
     flipped_bboxes[:, 0] = 1 - bboxes[:, 2]  # new x_min = 1 - x_max
@@ -626,7 +625,7 @@ def bboxes_transpose(bboxes: np.ndarray, bbox_type: Literal["hbb", "obb"]) -> np
         center_x, center_y, width, height, angle, extras = _split_obb_params(bboxes)
         center_x, center_y = center_y, center_x
         width, height = height, width
-        angle = 90.0 - angle
+        angle = -angle
         return _merge_obb_params(center_x, center_y, width, height, angle, extras)
     transposed_bboxes = bboxes.copy()
     transposed_bboxes[:, [0, 1, 2, 3]] = bboxes[:, [1, 0, 3, 2]]

--- a/albumentations/augmentations/geometric/_functional_keypoints.py
+++ b/albumentations/augmentations/geometric/_functional_keypoints.py
@@ -520,11 +520,7 @@ def keypoints_transpose(keypoints: np.ndarray) -> np.ndarray:
 
     # Adjust angles to reflect the coordinate swap
     angles = keypoints[:, 3]
-    transposed_keypoints[:, 3] = np.where(
-        angles <= np.pi,
-        np.pi / 2 - angles,
-        3 * np.pi / 2 - angles,
-    )
+    transposed_keypoints[:, 3] = np.pi / 2 - angles
 
     return transposed_keypoints
 

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -480,8 +480,8 @@ def keypoints_rotate90_3d(
 
 
 def transform_cube(cube: np.ndarray, index: int) -> np.ndarray:
-    """Transform cube by index (0-47). One of 48 cubic symmetries; no interpolation. For
-    CubicSymmetry; inverse via inverse index.
+    """Reorient a cube with one of 48 exact cubic symmetries, using only axis permutations and
+    reflections to move voxels without interpolation.
 
     Args:
         cube (np.ndarray): Input array with shape (D, H, W) or (D, H, W, C)

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -1876,8 +1876,10 @@ class Flip3D(Transform3D):
 
 
 class CubicSymmetry(Transform3D):
-    """Apply random cubic symmetry (one of 48) to a 3D volume. No interpolation; remaps voxels.
-    3D extension of D4. For TTA or augmentation; inverse() supported.
+    """Randomly reorient a 3D volume with one of 48 exact cubic symmetries, using only axis permutations and
+    reflections for interpolation-free augmentation.
+
+    This transform is intended for augmentation. Use a transform with explicit deterministic parameters for TTA.
 
     This transform is a 3D extension of D4. While D4 handles the 8 symmetries
     of a square (4 rotations x 2 reflections), CubicSymmetry handles all 48 symmetries of a cube.

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -723,7 +723,8 @@ def test_obb_rot90_updates_corners():
     exp_cy = 1 - cx
     exp_w = h
     exp_h = w
-    exp_angle = angle + 90.0
+    # The local axes exchange under a quarter turn, so the canonical width-edge angle is unchanged.
+    exp_angle = angle
 
     expected = np.column_stack(
         [

--- a/tests/test_symmetry_contracts.py
+++ b/tests/test_symmetry_contracts.py
@@ -79,7 +79,16 @@ def _make_2d_data(bbox_type: BboxType) -> dict[str, object]:
         "mask": image[..., 0] % 3,
         "volume": volume,
         "mask3d": volume[..., 0] % 5,
-        "keypoints": [[1.0, 1.0, 0.1], [4.0, 2.0, 1.5 * np.pi]],
+        "keypoints": [
+            [1.0, 1.0, 0.1],
+            [4.0, 2.0, 1.5 * np.pi],
+            [2.0, 1.0, -1e-6],
+            [3.0, 1.0, 0.5 * np.pi - 1e-6],
+            [3.0, 2.0, 0.5 * np.pi + 1e-6],
+            [2.0, 2.0, np.pi - 1e-6],
+            [2.0, 3.0, np.pi + 1e-6],
+            [1.0, 3.0, 2.0 * np.pi - 1e-6],
+        ],
         "bboxes": bboxes,
     }
 
@@ -218,6 +227,8 @@ def _transform_d4_corners(corners: np.ndarray, group_element: str) -> np.ndarray
     transformed = corners.copy()
     x_coordinates = corners[:, 0]
     y_coordinates = corners[:, 1]
+    if group_element == "e":
+        return transformed
     if group_element == "r90":
         transformed[:, 0], transformed[:, 1] = y_coordinates, 1.0 - x_coordinates
     elif group_element == "r180":
@@ -232,12 +243,30 @@ def _transform_d4_corners(corners: np.ndarray, group_element: str) -> np.ndarray
         transformed[:, 0] = 1.0 - x_coordinates
     elif group_element == "t":
         transformed[:, 0], transformed[:, 1] = y_coordinates, x_coordinates
+    else:
+        msg = f"Unknown D4 group element: {group_element}"
+        raise ValueError(msg)
     return transformed
 
 
 @pytest.mark.parametrize("group_element", ["e", "r90", "r180", "r270", *D4_REFLECTIONS])
 def test_d4_obb_corners_follow_the_independent_group_mapping(group_element: str) -> None:
     data = _make_2d_data("obb")
+    compose = _make_2d_compose([A.D4(group_element=group_element, p=1.0)], "obb")
+
+    result = compose(**data)
+    source_corners = obb_to_polygons(np.asarray(data["bboxes"], dtype=np.float32))[0]
+    actual_corners = obb_to_polygons(np.asarray(result["bboxes"], dtype=np.float32))[0]
+
+    assert obb_corners_equivalent(actual_corners, _transform_d4_corners(source_corners, group_element))
+    assert -90.0 <= result["bboxes"][0][4] < 90.0
+
+
+@pytest.mark.parametrize("source_angle", [-450.0, 450.0])
+@pytest.mark.parametrize("group_element", ["r90", "r180", "r270", *D4_REFLECTIONS])
+def test_d4_obb_symmetries_canonicalize_noncanonical_input_angles(group_element: str, source_angle: float) -> None:
+    data = _make_2d_data("obb")
+    data["bboxes"][0][4] = source_angle
     compose = _make_2d_compose([A.D4(group_element=group_element, p=1.0)], "obb")
 
     result = compose(**data)

--- a/tests/test_symmetry_contracts.py
+++ b/tests/test_symmetry_contracts.py
@@ -1,0 +1,282 @@
+"""Finite-group contracts for geometric symmetries through public Compose routes."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+
+import numpy as np
+import pytest
+
+import albumentations as A
+from albumentations.augmentations.transforms3d import functional as f3d
+from albumentations.core.bbox_utils import obb_to_polygons
+from albumentations.core.transforms_interface import BasicTransform
+from tests.helpers import obb_corners_equivalent
+
+BboxType = Literal["hbb", "obb"]
+D4_REFLECTIONS = ("v", "hvt", "h", "t")
+CUBIC_SYMMETRY_ORDERS = (
+    1,
+    4,
+    2,
+    4,
+    2,
+    2,
+    2,
+    2,
+    4,
+    3,
+    2,
+    3,
+    4,
+    3,
+    2,
+    3,
+    4,
+    3,
+    2,
+    3,
+    4,
+    3,
+    2,
+    3,
+    2,
+    2,
+    2,
+    2,
+    2,
+    4,
+    2,
+    4,
+    2,
+    6,
+    4,
+    6,
+    2,
+    6,
+    4,
+    6,
+    4,
+    6,
+    2,
+    6,
+    4,
+    6,
+    2,
+    6,
+)
+
+
+def _make_2d_data(bbox_type: BboxType) -> dict[str, object]:
+    image = np.arange(4 * 6, dtype=np.uint8).reshape(4, 6, 1)
+    volume = np.arange(2 * 4 * 6, dtype=np.uint8).reshape(2, 4, 6, 1)
+    bboxes: list[list[float]] = [[0.2, 0.3, 0.4, 0.6]]
+    if bbox_type == "obb":
+        bboxes[0].append(30.0)
+    return {
+        "image": image,
+        "mask": image[..., 0] % 3,
+        "volume": volume,
+        "mask3d": volume[..., 0] % 5,
+        "keypoints": [[1.0, 1.0, 0.1], [4.0, 2.0, 1.5 * np.pi]],
+        "bboxes": bboxes,
+    }
+
+
+def _make_2d_compose(transforms: Sequence[BasicTransform], bbox_type: BboxType) -> A.Compose:
+    return A.Compose(
+        transforms,
+        bbox_params=A.BboxParams(coord_format="albumentations", bbox_type=bbox_type),
+        keypoint_params=A.KeypointParams(coord_format="xya", angle_in_degrees=False),
+        strict=True,
+        telemetry=False,
+    )
+
+
+def _apply_repeatedly(transform: A.Compose, data: dict[str, object], count: int) -> dict[str, object]:
+    result = data
+    for _ in range(count):
+        result = transform(**result)
+    return result
+
+
+def _assert_keypoints_equal_modulo_2pi(actual: object, expected: object) -> None:
+    actual_keypoints = np.asarray(actual)
+    expected_keypoints = np.asarray(expected)
+    np.testing.assert_allclose(actual_keypoints[:, :2], expected_keypoints[:, :2], atol=1e-6)
+    angle_difference = np.mod(actual_keypoints[:, 2] - expected_keypoints[:, 2] + np.pi, 2 * np.pi) - np.pi
+    np.testing.assert_allclose(angle_difference, 0.0, atol=1e-6)
+
+
+def _assert_bboxes_equal(actual: object, expected: object, bbox_type: BboxType) -> None:
+    actual_bboxes = np.asarray(actual)
+    expected_bboxes = np.asarray(expected)
+    if bbox_type == "hbb":
+        np.testing.assert_allclose(actual_bboxes, expected_bboxes, atol=1e-6)
+        return
+
+    assert np.all((actual_bboxes[:, 4] >= -90.0) & (actual_bboxes[:, 4] < 90.0))
+    for actual_bbox, expected_bbox in zip(actual_bboxes, expected_bboxes, strict=True):
+        assert obb_corners_equivalent(
+            obb_to_polygons(actual_bbox[None, :])[0],
+            obb_to_polygons(expected_bbox[None, :])[0],
+        )
+
+
+def _assert_2d_targets_equal(actual: dict[str, object], expected: dict[str, object], bbox_type: BboxType) -> None:
+    for target in ("image", "mask", "volume", "mask3d"):
+        np.testing.assert_array_equal(actual[target], expected[target])
+    _assert_keypoints_equal_modulo_2pi(actual["keypoints"], expected["keypoints"])
+    _assert_bboxes_equal(actual["bboxes"], expected["bboxes"], bbox_type)
+
+
+@pytest.mark.parametrize("bbox_type", ["hbb", "obb"])
+@pytest.mark.parametrize("transform_cls", [A.HorizontalFlip, A.VerticalFlip, A.Transpose])
+def test_c2_symmetries_are_involutions_for_all_2d_targets(
+    transform_cls: type[BasicTransform],
+    bbox_type: BboxType,
+) -> None:
+    data = _make_2d_data(bbox_type)
+    compose = _make_2d_compose([transform_cls(p=1.0)], bbox_type)
+
+    _assert_2d_targets_equal(_apply_repeatedly(compose, data, 2), data, bbox_type)
+
+
+@pytest.mark.parametrize("flip_axes", [(), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)])
+def test_fixed_flip3d_is_an_involution(flip_axes: tuple[int, ...]) -> None:
+    volume = np.arange(2 * 3 * 5, dtype=np.uint8).reshape(2, 3, 5, 1)
+    data: dict[str, object] = {
+        "volume": volume,
+        "mask3d": volume[..., 0] % 3,
+        "keypoints": [[0.0, 0.0, 0.0], [4.0, 2.0, 1.0]],
+    }
+    compose = A.Compose(
+        [A.Flip3D(flip_axes=flip_axes, p=1.0)],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        strict=True,
+        telemetry=False,
+    )
+
+    result = _apply_repeatedly(compose, data, 2)
+
+    for target in ("volume", "mask3d", "keypoints"):
+        np.testing.assert_array_equal(result[target], data[target])
+
+
+@pytest.mark.parametrize("bbox_type", ["hbb", "obb"])
+def test_d4_r90_has_order_four_for_all_2d_targets(bbox_type: BboxType) -> None:
+    data = _make_2d_data(bbox_type)
+    compose = _make_2d_compose([A.D4(group_element="r90", p=1.0)], bbox_type)
+
+    _assert_2d_targets_equal(_apply_repeatedly(compose, data, 4), data, bbox_type)
+
+
+@pytest.mark.parametrize("axis_pair", [(0, 1), (0, 2), (1, 2)])
+def test_fixed_3d_r90_has_order_four_for_every_axis_pair(axis_pair: tuple[int, int]) -> None:
+    volume = np.arange(2 * 3 * 5, dtype=np.uint8).reshape(2, 3, 5, 1)
+    data: dict[str, object] = {
+        "volume": volume,
+        "mask3d": volume[..., 0] % 3,
+        "keypoints": [[0.0, 0.0, 0.0], [4.0, 2.0, 1.0]],
+    }
+    compose = A.Compose(
+        [A.RandomRotate90_3D(axis_pair=axis_pair, group_element="r90", p=1.0)],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        strict=True,
+        telemetry=False,
+    )
+
+    result = _apply_repeatedly(compose, data, 4)
+
+    for target in ("volume", "mask3d", "keypoints"):
+        np.testing.assert_array_equal(result[target], data[target])
+
+
+@pytest.mark.parametrize("bbox_type", ["hbb", "obb"])
+@pytest.mark.parametrize("reflection", D4_REFLECTIONS)
+def test_d4_reflections_are_involutions_for_all_2d_targets(reflection: str, bbox_type: BboxType) -> None:
+    data = _make_2d_data(bbox_type)
+    compose = _make_2d_compose([A.D4(group_element=reflection, p=1.0)], bbox_type)
+
+    _assert_2d_targets_equal(_apply_repeatedly(compose, data, 2), data, bbox_type)
+
+
+@pytest.mark.parametrize("bbox_type", ["hbb", "obb"])
+def test_d4_transpose_conjugates_r90_to_r270_for_all_2d_targets(bbox_type: BboxType) -> None:
+    data = _make_2d_data(bbox_type)
+    conjugated = _make_2d_compose(
+        [A.D4(group_element="t", p=1.0), A.D4(group_element="r90", p=1.0), A.D4(group_element="t", p=1.0)],
+        bbox_type,
+    )
+    r270 = _make_2d_compose([A.D4(group_element="r270", p=1.0)], bbox_type)
+
+    _assert_2d_targets_equal(conjugated(**data), r270(**data), bbox_type)
+
+
+def _transform_d4_corners(corners: np.ndarray, group_element: str) -> np.ndarray:
+    transformed = corners.copy()
+    x_coordinates = corners[:, 0]
+    y_coordinates = corners[:, 1]
+    if group_element == "r90":
+        transformed[:, 0], transformed[:, 1] = y_coordinates, 1.0 - x_coordinates
+    elif group_element == "r180":
+        transformed[:, 0], transformed[:, 1] = 1.0 - x_coordinates, 1.0 - y_coordinates
+    elif group_element == "r270":
+        transformed[:, 0], transformed[:, 1] = 1.0 - y_coordinates, x_coordinates
+    elif group_element == "v":
+        transformed[:, 1] = 1.0 - y_coordinates
+    elif group_element == "hvt":
+        transformed[:, 0], transformed[:, 1] = 1.0 - y_coordinates, 1.0 - x_coordinates
+    elif group_element == "h":
+        transformed[:, 0] = 1.0 - x_coordinates
+    elif group_element == "t":
+        transformed[:, 0], transformed[:, 1] = y_coordinates, x_coordinates
+    return transformed
+
+
+@pytest.mark.parametrize("group_element", ["e", "r90", "r180", "r270", *D4_REFLECTIONS])
+def test_d4_obb_corners_follow_the_independent_group_mapping(group_element: str) -> None:
+    data = _make_2d_data("obb")
+    compose = _make_2d_compose([A.D4(group_element=group_element, p=1.0)], "obb")
+
+    result = compose(**data)
+    source_corners = obb_to_polygons(np.asarray(data["bboxes"], dtype=np.float32))[0]
+    actual_corners = obb_to_polygons(np.asarray(result["bboxes"], dtype=np.float32))[0]
+
+    assert obb_corners_equivalent(actual_corners, _transform_d4_corners(source_corners, group_element))
+    assert -90.0 <= result["bboxes"][0][4] < 90.0
+
+
+@pytest.mark.parametrize(("index", "order"), list(enumerate(CUBIC_SYMMETRY_ORDERS)))
+def test_cubic_symmetry_table_preserves_target_alignment_and_element_order(index: int, order: int) -> None:
+    volume = np.arange(3 * 4 * 5, dtype=np.int16).reshape(3, 4, 5)
+    mask3d = volume % 7
+    z_coordinates, y_coordinates, x_coordinates = np.indices(volume.shape)
+    keypoints = np.column_stack((x_coordinates.ravel(), y_coordinates.ravel(), z_coordinates.ravel())).astype(
+        np.float32
+    )
+
+    transformed_volume = f3d.transform_cube(volume, index)
+    transformed_mask3d = f3d.transform_cube(mask3d, index)
+    transformed_keypoints = f3d.transform_cube_keypoints(keypoints, index, volume.shape)
+    transformed_x = transformed_keypoints[:, 0].astype(int)
+    transformed_y = transformed_keypoints[:, 1].astype(int)
+    transformed_z = transformed_keypoints[:, 2].astype(int)
+
+    np.testing.assert_array_equal(transformed_mask3d, transformed_volume % 7)
+    np.testing.assert_array_equal(
+        transformed_volume[transformed_z, transformed_y, transformed_x],
+        volume[z_coordinates.ravel(), y_coordinates.ravel(), x_coordinates.ravel()],
+    )
+
+    current_volume = volume
+    current_keypoints = keypoints
+    current_shape = volume.shape
+    for _ in range(order):
+        current_volume = f3d.transform_cube(current_volume, index)
+        current_keypoints = f3d.transform_cube_keypoints(current_keypoints, index, current_shape)
+        current_shape = current_volume.shape
+
+    np.testing.assert_array_equal(current_volume, volume)
+    np.testing.assert_array_equal(current_keypoints, keypoints)


### PR DESCRIPTION
## Summary

- Correct oriented-bounding-box local-axis handling for quarter turns, horizontal flips, and transpose while retaining canonical angles in `[-90, 90)`.
- Add public `Compose` finite-group contracts for C2, D4, fixed 3D rotations, `Flip3D`, and every cubic-symmetry-table member.
- Correct transpose keypoint angles across the full `[0, 2π)` range, and clarify that `CubicSymmetry` is augmentation-only rather than exposing an unsupported inverse API.

Closes #412

## Root cause

The previous OBB formulas changed the local frame inconsistently: a quarter turn exchanged width and height while also accumulating its angle, and transpose used an incompatible reflected orientation. The result could describe a different rectangle and leave the canonical-angle range.

## Validation

- `uv run pytest -q -m "not slow"` — 13,315 passed, 43 skipped, 38 deselected, 9 xfailed, 3 xpassed.
- `uv run python -m tools.quality_gate fast` — passed, including Ruff, mypy, Pyrefly, policy checks, and 1,276 contract tests.
- `pre-commit run --all-files` — passed.
- `uv run pytest -q tests/test_symmetry_contracts.py tests/test_bbox.py::test_obb_rot90_updates_corners tests/test_bbox.py::test_bbox_processor_roundtrip_with_angle_and_labels` — 104 passed.

## Performance

The initial implementation is vectorized over boxes and adds no whole-array copies, conversions, RNG, or image-kernel work. A candidate that canonicalized full arrays with `np.where` was rejected because it slowed direct OBB calls to 0.56–0.66x. Albucore has no reusable helper for this transform-specific annotation mapping.

Controlled `bboxes_transpose` timing, microseconds per call (lower is better):

| Boxes | HBB before → after (speed) | OBB before → after (speed) |
| ---: | ---: | ---: |
| 1 | 1.780 → 1.802 (0.988x) | 7.107 → 6.920 (1.027x) |
| 32 | 2.051 → 2.055 (0.998x) | 7.469 → 7.036 (1.062x) |
| 1,024 | 4.456 → 4.455 (1.000x) | 11.863 → 11.814 (1.004x) |

Controlled `A.Compose([A.Transpose(p=1)])` timing, microseconds per call, `uint8`, 1,000 iterations:

| Shape × batch | HBB before → after (speed) | OBB before → after (speed) |
| --- | --- | --- |
| 256² × 1 | 111.356 → 113.149 (0.984x) | 158.077 → 147.957 (1.068x) |
| 256² × 3 | 124.985 → 125.595 (0.995x) | 174.356 → 172.277 (1.012x) |
| 256² × 5 | 105.122 → 104.476 (1.006x) | 141.435 → 151.376 (0.934x) |
| 512² × 1 | 122.262 → 122.426 (0.999x) | 158.063 → 168.666 (0.937x) |
| 512² × 3 | 227.305 → 224.289 (1.013x) | 258.171 → 272.946 (0.946x) |
| 512² × 5 | 104.185 → 105.210 (0.990x) | 139.701 → 139.841 (0.999x) |
| 1,024² × 1 | 256.300 → 256.046 (1.001x) | 290.365 → 293.497 (0.989x) |
| 1,024² × 3 | 644.058 → 616.250 (1.045x) | 652.853 → 651.876 (1.001x) |
| 1,024² × 5 | 113.683 → 104.625 (1.087x) | 139.640 → 140.215 (0.996x) |

The isolated direct route has no regression. The worst Compose OBB result is 0.934x for `256² × 5`; image processing is unchanged and the variation is consistent with measurement noise around the added test/annotation work. It is recorded here rather than averaged away.

## Follow-up: noncanonical OBB input

The initial fix preserved a supplied `450°` OBB angle through the analytic symmetry mapping, violating the documented output range. The follow-up canonicalizes outputs from all non-identity OBB symmetry helpers and adds public `Compose` coverage for `±450°` across all seven non-identity D4 elements, angle-wraparound keypoints, and explicit validation of the independent D4 test oracle.

The guarded implementation first checks the OBB angle vector's minimum and maximum. Canonical inputs avoid modulo allocation; noncanonical inputs are folded to `[-90, 90)`. No image, mask, volume, HBB, RNG, LUT, grouped-reduction, backend, or Albucore route applies. An allocation-free output-buffer candidate was slower, so it was rejected.

Paired timings below compare the prior branch behavior with the final guard on the same machine, `uint8`, 100,000 direct iterations and 1,000 Compose iterations. HBB code is unchanged. The direct OBB scan is a deliberate correctness cost: worst case is 0.824x, while the full public Compose matrix is 0.898x or better. The added scan is necessary because supported input formats preserve noncanonical OBB angles until a geometry-changing transform produces canonical output.

Direct OBB helpers, microseconds per call (lower is better):

| Helper | Boxes | Before → after (speed) |
| --- | ---: | ---: |
| `bboxes_hflip` | 1 | 7.636 → 8.435 (0.905x) |
| `bboxes_hflip` | 32 | 7.593 → 8.795 (0.863x) |
| `bboxes_hflip` | 1,024 | 11.845 → 13.430 (0.882x) |
| `bboxes_rot90(r90)` | 1 | 7.214 → 8.660 (0.833x) |
| `bboxes_rot90(r90)` | 32 | 7.800 → 8.504 (0.917x) |
| `bboxes_rot90(r90)` | 1,024 | 11.758 → 13.587 (0.865x) |
| `bboxes_transpose` | 1 | 7.138 → 8.302 (0.860x) |
| `bboxes_transpose` | 32 | 6.903 → 8.376 (0.824x) |
| `bboxes_transpose` | 1,024 | 11.345 → 12.682 (0.895x) |
| `bboxes_vflip` | 1 | 7.378 → 8.453 (0.873x) |
| `bboxes_vflip` | 32 | 7.615 → 8.590 (0.887x) |
| `bboxes_vflip` | 1,024 | 11.768 → 13.712 (0.858x) |

Public Compose OBB routes, microseconds per call (lower is better):

| Route | Shape × channels | Before → after (speed) |
| --- | --- | ---: |
| `HorizontalFlip` | 256² × 1 | 157.681 → 159.059 (0.991x) |
| `HorizontalFlip` | 256² × 3 | 147.345 → 164.073 (0.898x) |
| `HorizontalFlip` | 256² × 5 | 197.478 → 213.835 (0.924x) |
| `HorizontalFlip` | 512² × 1 | 146.242 → 149.818 (0.976x) |
| `HorizontalFlip` | 512² × 3 | 154.855 → 156.669 (0.988x) |
| `HorizontalFlip` | 512² × 5 | 378.485 → 377.830 (1.002x) |
| `HorizontalFlip` | 1,024² × 1 | 166.709 → 170.416 (0.978x) |
| `HorizontalFlip` | 1,024² × 3 | 213.253 → 213.020 (1.001x) |
| `HorizontalFlip` | 1,024² × 5 | 1,100.273 → 1,076.574 (1.022x) |
| `D4(r90)` | 256² × 1 | 146.196 → 150.659 (0.970x) |
| `D4(r90)` | 256² × 3 | 165.865 → 174.721 (0.949x) |
| `D4(r90)` | 256² × 5 | 146.980 → 149.251 (0.985x) |
| `D4(r90)` | 512² × 1 | 163.348 → 161.723 (1.010x) |
| `D4(r90)` | 512² × 3 | 272.293 → 272.455 (0.999x) |
| `D4(r90)` | 512² × 5 | 149.002 → 149.157 (0.999x) |
| `D4(r90)` | 1,024² × 1 | 302.995 → 289.895 (1.045x) |
| `D4(r90)` | 1,024² × 3 | 751.060 → 752.762 (0.998x) |
| `D4(r90)` | 1,024² × 5 | 150.803 → 160.208 (0.941x) |
| `Transpose` | 256² × 1 | 139.880 → 143.478 (0.975x) |
| `Transpose` | 256² × 3 | 162.879 → 164.752 (0.989x) |
| `Transpose` | 256² × 5 | 137.032 → 139.658 (0.981x) |
| `Transpose` | 512² × 1 | 157.934 → 158.782 (0.995x) |
| `Transpose` | 512² × 3 | 258.863 → 256.407 (1.010x) |
| `Transpose` | 512² × 5 | 144.455 → 138.740 (1.041x) |
| `Transpose` | 1,024² × 1 | 311.921 → 327.382 (0.953x) |
| `Transpose` | 1,024² × 3 | 684.407 → 702.283 (0.975x) |
| `Transpose` | 1,024² × 5 | 138.983 → 141.308 (0.984x) |
| `VerticalFlip` | 256² × 1 | 144.779 → 150.722 (0.961x) |
| `VerticalFlip` | 256² × 3 | 151.849 → 157.673 (0.963x) |
| `VerticalFlip` | 256² × 5 | 146.910 → 150.490 (0.976x) |
| `VerticalFlip` | 512² × 1 | 154.927 → 160.203 (0.967x) |
| `VerticalFlip` | 512² × 3 | 187.215 → 179.351 (1.044x) |
| `VerticalFlip` | 512² × 5 | 180.983 → 173.428 (1.044x) |
| `VerticalFlip` | 1,024² × 1 | 204.351 → 213.264 (0.958x) |
| `VerticalFlip` | 1,024² × 3 | 302.554 → 322.411 (0.938x) |
| `VerticalFlip` | 1,024² × 5 | 237.170 → 241.460 (0.982x) |
