### PR TITLE
chore: bump patch version to 2.3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.3.9"
+version = "2.3.10"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.3.9"
+version = "2.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## What changed

- Bump the package version from `2.3.9` to `2.3.10` in `pyproject.toml`.
- Update the corresponding editable-package version in `uv.lock`.

## Why

Prepare the next patch release without changing runtime behavior.

## Validation

- `uv lock --check`
- Installed package version check: `2.3.10`
- `uv run pytest -q`: 13,358 passed, 43 skipped, 9 xfailed, 3 xpassed
- `pre-commit run --all-files`: passed

## Summary by Sourcery

Build:
- Update pyproject.toml and uv.lock to reflect the new 2.3.10 package version.