### PR TITLE
fix(compose): allow Tensor input for mixed transform pipelines

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -49,7 +49,9 @@ from .tensor import (
     TENSOR_ANNOTATION_TARGETS,
     TENSOR_SPATIAL_TARGETS,
     numpy_to_tensor_annotation,
+    numpy_to_tensor_spatial,
     tensor_to_numpy_annotation,
+    tensor_to_numpy_spatial,
     validate_tensor_input,
 )
 from .tracing import TraceOptions, TraceResult, _TraceContext
@@ -318,6 +320,8 @@ class BaseCompose(Serializable):
     main_compose: bool = True
     _tensor_capability_is_transparent: bool = True
     _tensor_annotation_targets: tuple[tuple[str, str], ...] = ()
+    _tensor_spatial_targets: tuple[tuple[str, str], ...] = ()
+    _tensor_requires_numpy_bridge: bool = False
 
     @property
     def tensor_capability_is_transparent(self) -> bool:
@@ -1562,9 +1566,11 @@ class Compose(BaseCompose, HubMixin):
 
         need_to_run = force_apply or self.py_random.random() < self.p
         if not need_to_run:
+            self._clear_tensor_annotation_targets()
             return data
 
         try:
+            self._bridge_tensor_data_to_numpy(data)
             self.preprocess(data)
             resync = self._resync_instance_ids if self.main_compose and self._instance_binding else None
             for t in self.transforms:
@@ -1575,13 +1581,14 @@ class Compose(BaseCompose, HubMixin):
                     resync(data)
 
             result = self.postprocess(data)
+            self._restore_tensor_spatial_data(result)
             self._restore_tensor_annotations(result)
             return result
         finally:
             # Clear per-call unpack/repack flags if preprocess or a transform raised mid-call.
             if self.main_compose and self._instance_binding:
                 self._clear_instance_binding_call_state_if_pending()
-            self._tensor_annotation_targets = ()
+            self._clear_tensor_annotation_targets()
 
     def run_with_trace(
         self,
@@ -1615,9 +1622,11 @@ class Compose(BaseCompose, HubMixin):
 
         if not (force_apply or self.py_random.random() < self.p):
             self._emit_skipped_trace_tree(self, trace_context, (), _TRACE_STATUS_SKIPPED_PROBABILITY)
+            self._clear_tensor_annotation_targets()
             return trace_context.finish(data)
 
         try:
+            self._bridge_tensor_data_to_numpy(data)
             self.preprocess(data)
             data = self._run_traced_node_children(
                 self,
@@ -1628,12 +1637,13 @@ class Compose(BaseCompose, HubMixin):
             )
             self._emit_composition_record(self, trace_context, (), _TRACE_STATUS_APPLIED)
             result = self.postprocess(data)
+            self._restore_tensor_spatial_data(result)
             self._restore_tensor_annotations(result)
             return trace_context.finish(result)
         finally:
             if self.main_compose and self._instance_binding:
                 self._clear_instance_binding_call_state_if_pending()
-            self._tensor_annotation_targets = ()
+            self._clear_tensor_annotation_targets()
 
     def _validate_trace_options(self, options: TraceOptions, data: dict[str, Any]) -> None:
         known_targets = set(data) | self._available_keys | set(AVAILABLE_KEYS)
@@ -2172,13 +2182,14 @@ class Compose(BaseCompose, HubMixin):
         """Validate Tensor boundary contracts before Compose samples probability or parameters,
         ensuring each spatial target uses a single representation.
 
-        Tensor execution is opt-in at the capability level. This prevents a NumPy-only
-        helper from receiving a Tensor and performing an ad hoc representation bridge.
+        A pipeline uses its direct Tensor route only when every selectable transform supports the supplied targets.
+        Otherwise, Compose bridges all spatial targets to NumPy once before dispatch and restores Tensor output after
+        postprocessing. Individual helpers never perform representation conversion.
         """
         tensor_targets: list[tuple[str, str, torch.Tensor]] = []
         spatial_representations: set[str] = set()
         annotation_targets: list[tuple[str, str]] = []
-        self._tensor_annotation_targets = ()
+        self._clear_tensor_annotation_targets()
 
         for data_name, value in data.items():
             canonical_name = self._additional_targets.get(data_name, data_name)
@@ -2208,53 +2219,45 @@ class Compose(BaseCompose, HubMixin):
             )
 
         self._tensor_annotation_targets = tuple(annotation_targets)
+        self._tensor_spatial_targets = tuple(
+            (data_name, canonical_name) for data_name, canonical_name, _ in tensor_targets
+        )
 
         tensor_image_inputs = tuple(
             (canonical_name, value)
             for _, canonical_name, value in tensor_targets
             if canonical_name not in TENSOR_ANNOTATION_TARGETS
         )
-        self._validate_tensor_pipeline(self.transforms, tensor_image_inputs)
+        self._tensor_requires_numpy_bridge = not self._tensor_pipeline_supports_cpu_inputs(
+            self.transforms,
+            tensor_image_inputs,
+        )
 
-    def _validate_tensor_pipeline(
+    def _tensor_pipeline_supports_cpu_inputs(
         self,
         transforms: TransformsSeqType,
         tensor_inputs: tuple[tuple[str, torch.Tensor], ...],
-    ) -> None:
-        """Require every selectable transform branch to declare CPU Tensor capability before a
-        caller-provided Tensor can reach any helper or fallback implementation.
+    ) -> bool:
+        """Check whether every selectable branch can run supplied CPU Tensor targets directly without selecting
+        Compose's NumPy bridge.
+
+        A False result selects Compose's one-time NumPy bridge for the whole pipeline. This keeps arbitrary public
+        transform combinations usable with Tensor input without allowing transform helpers to create ad hoc bridges.
         """
         for transform in transforms:
             if isinstance(transform, BaseCompose):
                 if not transform.tensor_capability_is_transparent:
-                    raise TypeError(f"{transform.__class__.__name__} does not support CPU Tensor input")
-                self._validate_tensor_pipeline(transform.transforms, tensor_inputs)
+                    return False
+                if not self._tensor_pipeline_supports_cpu_inputs(transform.transforms, tensor_inputs):
+                    return False
                 continue
             if getattr(transform, "_is_tensor_terminal", False):
                 raise TypeError(
                     "Tensor input is already model-ready; remove ToTensorV2 or ToTensor3D from this Compose pipeline",
                 )
             if not transform.supports_cpu_tensor_inputs(tensor_inputs):
-                supported_targets = transform.cpu_tensor_targets
-                supported_channels = transform.cpu_tensor_channels
-                tensor_targets = frozenset(target for target, _ in tensor_inputs)
-                target_note = (
-                    ""
-                    if supported_targets is None
-                    else f" for Tensor target(s) {', '.join(sorted(tensor_targets))}; accepted targets are "
-                    f"{', '.join(sorted(supported_targets))}"
-                )
-                channel_note = (
-                    ""
-                    if supported_channels is None
-                    else "; accepted channel counts are "
-                    + ", ".join(str(channel) for channel in sorted(supported_channels))
-                )
-                raise TypeError(
-                    f"{transform.__class__.__name__} does not yet declare CPU Tensor capability"
-                    f"{target_note}{channel_note}; "
-                    "use a NumPy input until its Tensor route is accepted",
-                )
+                return False
+        return True
 
     @staticmethod
     def from_applied_transforms(
@@ -2333,6 +2336,17 @@ class Compose(BaseCompose, HubMixin):
             value = data.get(data_name)
             if isinstance(value, torch.Tensor):
                 data[data_name] = tensor_to_numpy_annotation(value, canonical_name)
+
+    def _bridge_tensor_data_to_numpy(self, data: dict[str, Any]) -> None:
+        """Convert all Tensor spatial targets to NumPy once before a pipeline containing a transform without a direct
+        Tensor route.
+        """
+        if not self._tensor_requires_numpy_bridge:
+            return
+        for data_name, canonical_name in self._tensor_spatial_targets:
+            value = data.get(data_name)
+            if isinstance(value, torch.Tensor):
+                data[data_name] = tensor_to_numpy_spatial(value, canonical_name)
 
     def _gather_shapes_from_data(self, data: dict[str, Any]) -> tuple[list[tuple[int, ...]], list[tuple[int, ...]]]:
         """Gather shapes from data for validation. Collects (H,W) or (D,H,W) from
@@ -2549,8 +2563,21 @@ class Compose(BaseCompose, HubMixin):
             if isinstance(value, np.ndarray):
                 data[data_name] = numpy_to_tensor_annotation(value, canonical_name)
 
+    def _restore_tensor_spatial_data(self, data: dict[str, Any]) -> None:
+        """Convert NumPy spatial results back to public Tensor layouts after Compose finishes a pipeline using its
+        central representation bridge.
+        """
+        if not self._tensor_requires_numpy_bridge:
+            return
+        for data_name, canonical_name in self._tensor_spatial_targets:
+            value = data.get(data_name)
+            if isinstance(value, np.ndarray) and canonical_name not in TENSOR_ANNOTATION_TARGETS:
+                data[data_name] = numpy_to_tensor_spatial(value, canonical_name)
+
     def _clear_tensor_annotation_targets(self) -> None:
         self._tensor_annotation_targets = ()
+        self._tensor_spatial_targets = ()
+        self._tensor_requires_numpy_bridge = False
 
     def _filter_bound_bboxes_before_postprocess(self, data: dict[str, Any]) -> None:
         """Filter bound bboxes at the final boundary and mirror their keep mask before postprocessing removes internal

--- a/albumentations/core/tensor.py
+++ b/albumentations/core/tensor.py
@@ -81,6 +81,35 @@ def tensor_to_numpy_annotation(value: torch.Tensor, target: str) -> NDArray[np.g
     return value.numpy()
 
 
+def tensor_to_numpy_spatial(value: torch.Tensor, target: str) -> NDArray[np.generic]:
+    """Convert a validated Tensor target to the channel-last NumPy layout that existing Compose preprocessing and
+    transforms expect.
+
+    The bridge owns every layout conversion. Transform helpers only receive their established NumPy layout and never
+    decide whether to convert a caller's Tensor themselves.
+    """
+    validate_tensor_input(value, target, target)
+    if target == "image":
+        return value.permute(1, 2, 0).numpy()
+    if target in {"images", "volume"}:
+        return value.permute(1, 2, 3, 0).numpy()
+    return value.numpy()
+
+
+def numpy_to_tensor_spatial(value: NDArray[np.generic], target: str) -> torch.Tensor:
+    """Convert a NumPy result from Compose back to the caller-facing Tensor layout, copying only when negative strides
+    require it.
+
+    NumPy transforms may return a negative-stride view, such as after a reflection. PyTorch cannot share that storage,
+    so materialize only that incompatible case before returning the Tensor result.
+    """
+    if target in {"image", "images", "volume"}:
+        value = np.moveaxis(value, -1, 0)
+    if any(stride < 0 for stride in value.strides):
+        value = np.ascontiguousarray(value)
+    return torch.from_numpy(value)
+
+
 def numpy_to_tensor_annotation(value: NDArray[np.generic], target: str) -> torch.Tensor:
     """Return a Tensor bbox or keypoint matrix from a processor result, materializing only
     negative-stride NumPy storage that PyTorch cannot safely share.

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -123,15 +123,17 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
 
     @property
     def supports_cpu_tensor(self) -> bool:
-        """Return whether this transform exposes an accepted CPU Tensor capability
-        route rather than relying on an unsupported implicit representation conversion.
+        """Return whether this transform can run CPU Tensor inputs directly, allowing Compose to keep data in Tensor
+        form without a NumPy bridge.
         """
         return self._supports_cpu_tensor
 
     @property
     def cpu_tensor_targets(self) -> frozenset[str] | None:
-        """Return canonical Compose targets covered by this Tensor capability so callers can
-        reject unsupported target combinations before sampling transform parameters.
+        """Return canonical targets this transform handles directly as CPU Tensor inputs, allowing Compose to decide
+        whether to keep a Tensor route.
+
+        Compose bridges a pipeline through NumPy when its Tensor targets fall outside this set.
         """
         return self._cpu_tensor_targets
 
@@ -146,22 +148,19 @@ class BasicTransform(Serializable, metaclass=CombinedMeta):
         """Return whether accepted Tensor capability routes cover every caller-provided
         canonical target before Compose samples parameters or enters transform dispatch.
 
-        `None` means that this transform's accepted Tensor route is target
-        agnostic. Transforms with a narrower first capability declare the
-        canonical target names explicitly, so Compose rejects unsupported Tensor
-        targets before sampling parameters.
+        `None` means that this transform's direct Tensor route is target agnostic. Transforms with a narrower route
+        declare canonical target names explicitly so Compose can choose a NumPy bridge before sampling parameters.
         """
         return self.supports_cpu_tensor and (
             self._cpu_tensor_targets is None or targets.issubset(self._cpu_tensor_targets)
         )
 
     def supports_cpu_tensor_inputs(self, tensor_inputs: tuple[tuple[str, Any], ...]) -> bool:
-        """Return whether the accepted Tensor route covers every supplied target and image
-        channel count before Compose samples parameters or calls transform helpers.
+        """Check every supplied target and image channel count to decide whether this transform can run them directly
+        as CPU Tensor data.
 
-        Compose calls this before transform parameter sampling. Capability records
-        may be deliberately narrow while a route is being introduced; callers get
-        a boundary error instead of an unsupported helper receiving a Tensor.
+        Compose uses a False result to select its one-time NumPy bridge for the full pipeline. Transform helpers never
+        receive Tensor data through an ad hoc conversion.
         """
         targets = frozenset(target for target, _ in tensor_inputs)
         if not self.supports_cpu_tensor_targets(targets):

--- a/docs/design/torch-cpu-backend-migration.md
+++ b/docs/design/torch-cpu-backend-migration.md
@@ -3,10 +3,11 @@
 **Status:** In progress
 
 **Decision:** `torch` becomes a required dependency. The existing `Compose` accepts both NumPy arrays and CPU
-`torch.Tensor` values. One execution engine routes each compatible *segment* to NumPy/OpenCV/NumKong or Torch based on
-full-path benchmark evidence. A Tensor input may use a faster NumPy segment and return to Tensor form. A NumPy input
-may use a faster Torch segment and return to NumPy form, unless an existing explicit terminal `ToTensorV2` or
-`ToTensor3D` transform requests Tensor output.
+`torch.Tensor` values. Every valid Tensor pipeline returns Tensor output. Before transform parameters are sampled,
+`Compose` chooses one representation for the entire pipeline: direct Tensor execution when every selectable child
+supports the supplied Tensor targets, otherwise one Tensor-to-NumPy bridge before the pipeline and one NumPy-to-Tensor
+bridge after it. New direct Tensor routes require full-path benchmark evidence. NumPy input retains its existing NumPy
+flow unless an explicit terminal `ToTensorV2` or `ToTensor3D` transform requests Tensor output.
 
 **Primary workload:** a PyTorch training process in which Torch is already imported. Steady-state `DataLoader`
 throughput is a milestone integration gate. Individual transform pull requests use direct and `Compose` benchmarks
@@ -14,16 +15,18 @@ without rebuilding and timing a complete loader for every matrix cell.
 
 ## Current implementation status
 
-The repository is in the foundation stage. `torch` is now a required dependency. `Compose` accepts CPU Tensor image,
-mask, bbox, and keypoint targets, preserves their public representation through the existing dispatch flow, and rejects
-accelerators, autograd inputs, mixed spatial representations, and legacy terminal Tensor transforms. Bbox and keypoint
-processors still use one centralized NumPy bridge internally and restore their `float32` Tensor output at the public
-boundary. A private probe and a `DataLoader` collation test cover this plumbing.
+The repository is in the foundation stage. `torch` is now a required dependency. `Compose` accepts every validated CPU
+Tensor pipeline and returns Tensor output. If every selectable transform supports the supplied Tensor targets, the
+pipeline runs directly on Tensor values. If any transform lacks that direct route, `Compose` converts every spatial
+target to its established channel-last NumPy layout once before the pipeline and restores Tensor layouts once after
+postprocessing. This keeps arbitrary transform combinations usable without letting individual helpers call `.numpy()`
+or `torch.from_numpy()` themselves.
 
-`NoOp` accepts every supported Tensor target. The measured `Transpose` capability accepts C=1 and C=3 Tensor images,
-plus `mask`, `masks`, and `mask3d`; it keeps Tensor bbox and keypoint entry and exit through the central processor
-bridge. Its Tensor `images` and `volume` routes remain unsupported. Every accepted Tensor-image pipeline requires each
-supplied spatial target to be a Tensor; the prior image-Tensor plus NumPy-target combination is no longer accepted.
+The boundary continues to reject accelerators, autograd inputs, mixed spatial representations, and legacy terminal
+Tensor transforms. Bbox and keypoint processors use the same central bridge and return `float32` Tensor matrices at the
+public boundary. Tensor capabilities now choose the direct fast path; they no longer decide whether a valid `Compose`
+pipeline can accept Tensor input. `NoOp` accepts every supported Tensor target. `Flip3D` accepts Tensor `volume` and
+`mask3d` through the central NumPy bridge while retaining semantic label mappings.
 
 The repository also contains `python -m tools.tensor_compose_benchmark`. It records raw model-ready `Compose` and
 optional steady-state `DataLoader` measurements as JSON. Run it after a change to Compose, a bridge, batching, or
@@ -44,7 +47,7 @@ volume matrix (C=1, C=3, C=5; `uint8` and `float32`). Reusing the NumPy crop hel
 slower still. A correctness-equivalent `CubicSymmetry` prototype reduced all 48 symmetries to one Tensor permutation
 and at most one flip or clone, but it still lost on required common cells; only the medium C=5 `float32` subset won.
 `Pad3D` with `torch.nn.functional.pad` likewise lost by 1.10x to 3.43x outside the one medium C=5 `float32` win. The
-needed Torch operations exist, so no upstream feature request is open. These transforms remain explicitly rejected
+needed Torch operations exist, so no upstream feature request is open. These transforms use Compose's NumPy bridge
 until a future CPU release or a different full-path implementation passes every required cell.
 
 The initial integration run measured workers 0 and 2 successfully. The 8-worker run did not finish on this macOS ARM
@@ -69,28 +72,37 @@ There is one public `Compose`, one transform hierarchy, and one parameter-sampli
 `apply_to_images`, and `apply_to_volume` decide target policy and dispatch. Reusable pixel arithmetic remains in the
 functional layer or Albucore.
 
-The planner may choose either representation for any compatible contiguous segment:
+For Tensor input, `Compose` makes one route decision for the complete transform chain:
 
 ```mermaid
 flowchart LR
-    NI["NumPy input"] --> NS1["NumPy / OpenCV / NumKong segment"]
-    NS1 --> NT["Measured bridge"]
-    NT --> TS["Torch segment"]
-    TS --> NO["NumPy output"]
-
-    TI["Tensor input"] --> TS1["Torch segment"]
-    TS1 --> TN["Measured bridge"]
-    TN --> NS["NumPy / OpenCV / NumKong segment"]
-    NS --> TO["Tensor output"]
+    TI["Tensor input"] --> D{"Every selectable child supports\nthese Tensor targets?"}
+    D -->|"Yes"| T["Whole pipeline runs on Tensor"]
+    T --> TO["Tensor output"]
+    D -->|"No"| N1["Bridge every spatial target\nTensor to NumPy once"]
+    N1 --> N2["Whole pipeline runs on NumPy"]
+    N2 --> N3["Bridge every spatial target\nNumPy to Tensor once"]
+    N3 --> TO
 ```
 
-The diagram shows possible boundaries, not a required alternation. The planner groups adjacent helpers with the same
-backend. It must not convert around every helper: a Tensor → NumPy → Tensor crossing is paid once per accepted NumPy
-segment, and a NumPy → Tensor → NumPy crossing is paid once per accepted Torch segment.
+This route prevents representation changes between individual transforms. A pipeline with several NumPy-backed
+transforms pays one pair of bridges, not one pair per transform. An empty pipeline and a pipeline skipped by `p=0`
+return the original Tensor objects without a bridge.
 
-The first segment may use either backend. No helper may add an ad hoc `.numpy()`, `torch.from_numpy()`, or layout
-conversion. The central bridge and capability registry own every crossing. The registry records why a route is
-eligible, rejected, or blocked.
+`Compose` owns every spatial conversion, layout adapter, and output repair. Transform helpers receive either their
+established NumPy layout or their declared Tensor layout. They must not add an ad hoc `.numpy()`, `torch.from_numpy()`,
+or layout conversion.
+
+### Compose route-selection invariant
+
+For every valid CPU Tensor call, `Compose` evaluates all selectable descendants before parameter sampling. `OneOf`,
+`SomeOf`, `Sequential`, and other nested compositions qualify for direct Tensor execution only when every branch that
+may run supports every supplied Tensor target. A wrapper that creates its own representation boundary also selects the
+NumPy route.
+
+The direct route is an optimization. A missing direct capability never rejects a valid Tensor input; it selects the
+whole-pipeline NumPy route. Tensor input still rejects accelerator tensors, autograd tensors, mixed spatial
+representations, and redundant `ToTensorV2` or `ToTensor3D` terminal transforms.
 
 ### Tensor boundary contract
 
@@ -133,9 +145,9 @@ conventions rather than the image channel convention:
 instance axis, not an image-channel axis. If a model needs a channel-first target, the dataset or collate function
 creates that model-specific form after `Compose`.
 
-The implementation keeps one transform hierarchy. A route may bridge Tensor annotations to the current NumPy
-processor or helper when that full route is faster, then return Tensor. The bridge owns conversion, layout, and
-ownership checks. No transform-specific helper may convert an annotation silently.
+The implementation keeps one transform hierarchy. The central bridge converts Tensor annotations for NumPy processors
+and restores Tensor output. The bridge owns conversion, layout, and ownership checks. No transform-specific helper may
+convert an annotation silently.
 
 ### CPU-only boundary
 
@@ -155,7 +167,7 @@ asks the caller to remove it.
 Accelerator support is a later project phase. It reuses the Tensor and capability contracts only after the CPU routes
 have passed their performance gate.
 
-## Bidirectional segment planner
+## Compose route selection
 
 ### Capability declaration
 
@@ -165,12 +177,11 @@ Each transform family and reusable functional helper receives a private capabili
 - exact output shape, dtype, range, mutation, aliasing, RNG, replay, and annotation behavior;
 - available implementations: current backend, Torch, or both;
 - valid entry and exit bridges, including all required layout views and copies;
-- supported predecessor and successor capability IDs; and
 - benchmark cells and status: `accepted`, `partial_route`, `existing_backend`, `rejected`, or `blocked_upstream`.
 
-`Compose` builds the route from the ordered transforms and their target set. Nested `OneOf`, `SomeOf`, and `Sequential`
-branches must all have a valid plan before execution. A plan must not change probabilities, parameter sampling, replay,
-or transform order.
+`Compose` uses the capability records only to select the whole-pipeline Tensor or NumPy route. It does not stitch
+Tensor and NumPy subsegments. Route selection must not change probabilities, parameter sampling, replay, or transform
+order.
 
 ### Bridges are operations, not bookkeeping
 
@@ -178,30 +189,30 @@ On a supported CPU array/Tensor, `torch.from_numpy(array)` and `tensor.numpy()` 
 route free. Torch dispatch, reference lifetime, unsupported strides, read-only storage, layout views, and a required
 contiguous copy all affect wall time and ownership.
 
-A Tensor NumPy segment commonly needs these steps:
+A Tensor pipeline using the NumPy route commonly needs these steps:
 
 ```text
 C,L,H,W Tensor → layout view for the NumPy helper → NumPy helper → output layout view → Tensor
 ```
 
-Any `.contiguous()`, `np.ascontiguousarray()`, dtype cast, or allocation is O(n). The benchmark includes it. If the
-NumPy helper only accepts a layout requiring a copy, the planner uses that route only when the entire segment remains
-at least as fast as its baseline and preserves the stated ownership contract.
+Any `.contiguous()`, `np.ascontiguousarray()`, dtype cast, or allocation is O(n). The benchmark includes it. The
+compatibility bridge is chosen when a pipeline needs a NumPy-only transform, so it may cost more than a direct Tensor
+route. It still preserves the input representation and gives every valid pipeline one `Compose` API.
 
-The analogous rule applies to NumPy callers entering Torch. A fast Torch kernel does not qualify if its bridge,
-layout conversion, and return conversion make the whole route slower.
+NumPy-to-Tensor routing is outside this CPU stage. A future route must include its bridge, layout conversion, and return
+conversion in the complete-path benchmark.
 
 ### Backend decision rule
 
 For every matrix cell:
 
-1. Keep the current backend when it is faster or is the only implementation with the required semantics.
-2. Route a compatible segment through Torch when the full route is faster or tied within calibrated noise and every
-   other contract is equal.
-3. At a measured tie, prefer Torch when it removes a boundary or extends a proven adjacent Torch segment.
-4. Route a Tensor segment through NumPy/OpenCV/NumKong when that complete Tensor → NumPy → Tensor route is faster
-   and the enclosing Tensor `Compose` route passes its direct performance gate.
-5. Split a segment when a required operation loses. A later win cannot compensate for a repeatable regression.
+1. Keep the direct Tensor route when every selectable transform supports every supplied Tensor target and the complete
+   path meets the performance gate.
+2. If any selectable transform lacks that direct route, bridge all spatial targets once to NumPy, execute the full
+   pipeline there, and restore Tensor output once.
+3. Add a new direct Tensor route only when it is faster or tied within calibrated noise and every other contract is
+   equal.
+4. At a measured tie, prefer the direct route because it removes the whole-pipeline representation boundary.
 
 The input representation does not force the backend. It determines only the input and output representation seen by
 the caller.
@@ -210,7 +221,11 @@ the caller.
 
 ### Acceptance condition
 
-> No accepted route may show a repeatable CPU slowdown in any required benchmark cell.
+> No direct Tensor route may show a repeatable CPU slowdown in any required benchmark cell.
+
+The one-time NumPy bridge is a compatibility route, not evidence that a transform has a fast Tensor implementation. It
+must preserve values, target alignment, layouts, dtypes, replay, and output representation. Its measured cost is
+reported when shared Compose or bridge code changes.
 
 Torch is imported before both baseline and candidate timing. Cold import time, wheel size, and install time are tracked
 as dependency diagnostics; they do not decide a hot training-path route.
@@ -226,11 +241,11 @@ two blocking comparisons that do not construct a `DataLoader`:
    `ToTensor3D` conversion with direct Tensor `Compose`. This is a controlled `Compose` benchmark with pre-created
    inputs; it does not include collation or `DataLoader` workers.
 
-The direct gate detects Tensor-dispatch or planner overhead. The model-ready output gate measures the cost to produce
-the Tensor that the model consumes. A candidate includes every bridge and layout operation that occurs inside its
-timed path.
+The direct gate detects Tensor-dispatch and route-selection overhead. The model-ready output gate measures the cost to
+produce the Tensor that the model consumes. A candidate includes every bridge and layout operation that occurs inside
+its timed path.
 
-A transform PR reports every direct helper, segment, direct-Compose, and model-ready-output cell. The output report
+A transform PR reports every direct helper, ordered-chain, direct-Compose, and model-ready-output cell. The output report
 records raw before/after measurements rather than aggregates alone.
 
 ### Benchmark cadence
@@ -240,10 +255,10 @@ runtime without isolating that transform's kernel or dispatch cost. Use this cad
 
 | Change | Required benchmark |
 |---|---|
-| `Compose`, preprocessing, postprocessing, shape handling, common bridge, or planner | Direct microbenchmarks, `Compose`, and representative `DataLoader`/collation cases |
-| One transform or functional family gains Tensor capability | Direct functional, ordered segment, direct `Compose`, and model-ready output; no `DataLoader` |
-| Several accepted capabilities form a new mixed-backend segment | Ordered segment and `Compose`; add one representative `DataLoader` case only when a shared boundary or batch behavior changed |
-| Milestone, release candidate, or scheduled performance run | Full representative `DataLoader` suite for NumPy, Tensor, and mixed routes |
+| `Compose`, preprocessing, postprocessing, shape handling, or common bridge | Direct microbenchmarks, `Compose`, and representative `DataLoader`/collation cases |
+| One transform or functional family gains Tensor capability | Direct functional, ordered chain, direct `Compose`, and model-ready output; no `DataLoader` |
+| Capability coverage changes a pipeline from NumPy to direct Tensor execution | Ordered chain and `Compose`; add one representative `DataLoader` case only when a shared boundary or batch behavior changed |
+| Milestone, release candidate, or scheduled performance run | Full representative `DataLoader` suite for NumPy, direct Tensor, and bridged Tensor routes |
 
 This keeps per-transform feedback short while preserving an integration gate for changes that can affect the whole
 training input pipeline.
@@ -263,8 +278,8 @@ read-only storage, non-contiguous Tensor inputs, image sequences, video-through-
 annotations where applicable, and the selected parameter axes.
 
 When the integration suite runs, it holds batch size, workers, persistent workers, prefetching, pinning, collation, and
-output consumption constant. It compares decoded NumPy samples, Tensor samples, mixed backend segments, and 0, 2, and
-8 workers where the workload is relevant.
+output consumption constant. It compares decoded NumPy samples, direct Tensor samples, bridged Tensor samples, and 0,
+2, and 8 workers where the workload is relevant.
 
 ### Correctness and ownership gates
 
@@ -277,8 +292,8 @@ An accepted route preserves:
 - output representation: backend routing returns the input representation. Existing explicit terminal `ToTensorV2`
   and `ToTensor3D` transforms retain their documented NumPy-to-Tensor behavior.
 
-A Tensor route may use a NumPy segment internally. This boundary is planner-controlled and reported in the route
-artifact. It is not an implicit fallback hidden inside a helper.
+A Tensor call may use the whole-pipeline NumPy route internally. `Compose` controls and reports that boundary. It is
+not an implicit fallback hidden inside a helper.
 
 ## Implementation phases
 
@@ -287,8 +302,8 @@ artifact. It is not an implicit fallback hidden inside a helper.
 1. Add the validated Torch floor to runtime dependencies. Keep TorchVision optional.
 2. Update lockfile, CI, platform/Python support checks, SBOM/security inputs, and environment reporting.
 3. Measure baseline variance on a stable Linux x86-64 machine. Calibrate a repeatability threshold no larger than 1%.
-4. Add the route-result JSON schema: environment, input representation, helper/segment IDs, every bridge, raw samples,
-   correctness result, memory result, and decision.
+4. Add the route-result JSON schema: environment, input representation, transform IDs, selected route, every bridge,
+   raw samples, correctness result, memory result, and decision.
 
 Exit: a default install includes Torch, and the benchmark runner can distinguish a real regression from noise.
 
@@ -303,26 +318,26 @@ transform.
 3. Pass Tensor values through `BasicTransform.__call__`, `apply_with_params`, and the existing `apply_*` dispatch.
 4. Use a minimal private probe transform to prove that the Tensor arriving at `apply` or `apply_to_images` also leaves
    `Compose` as Tensor. Test empty pipelines, `p=0`, nested compositions, additional targets, masks, annotations,
-   replay, and failure before parameter sampling.
+   replay, and boundary failures.
 5. Reject accelerator tensors, `requires_grad=True`, and Tensor-input pipelines containing `ToTensorV2` or
    `ToTensor3D` with actionable errors.
 6. Preserve every NumPy test and benchmark result.
 7. Run the representative `DataLoader` and collation suite once for this shared lifecycle change.
 
-Exit: the full `Compose` wrapper carries supported CPU Tensor targets from input to a transform and from its result to
-the caller. No public transform is considered Tensor-capable until its own capability PR lands.
+Exit: the full `Compose` wrapper accepts every valid CPU Tensor pipeline and returns Tensor output. Direct Tensor
+capabilities remain opt-in performance routes and land with their own evidence.
 
 ### Phase 2 — add the central bridge and the first two capabilities
 
 1. Build one bridge API for Tensor/NumPy conversion, axis adapters, ownership checks, and route diagnostics.
-2. Add the capability record and single-transform routing needed by the first pilots. Do not build a global optimizer
-   before real capabilities exist.
+2. Add the capability record and whole-pipeline route selection needed by the first pilots. Do not build a
+   segment-level optimizer before real capabilities exist.
 3. Prove one Tensor input that uses a faster NumPy/OpenCV helper and returns Tensor.
-4. Prove one NumPy input that uses a faster or tied Torch helper and returns NumPy.
+4. Preserve the current NumPy input flow and its output representation.
 5. Run direct, `Compose`, model-ready-output, and one representative `DataLoader` benchmark for each bridge direction.
 
-Exit: both bridge directions preserve correctness and pass their full-path performance gates. Adjacent accepted
-capabilities can then be grouped into longer segments without changing transform order.
+Exit: the compatibility bridge preserves correctness for every valid Tensor pipeline. Direct Tensor capabilities pass
+their full-path performance gates before they are enabled.
 
 ### Phase 3 — add Tensor support one transform family at a time
 
@@ -330,27 +345,27 @@ Each transform-family pull request follows the same bounded workflow:
 
 1. Freeze the current NumPy contract and save reference outputs for every target, dtype, channel count, and parameter
    mode in scope.
-2. Identify the best Tensor route. It may call a Torch helper or cross once into an existing NumPy/OpenCV/NumKong
-   helper and return to Tensor.
+2. Identify the best direct Tensor route. It may call a Torch helper or an existing backend that accepts the declared
+   Tensor layout. A transform that still needs NumPy remains on the Compose NumPy route.
 3. Add the Tensor implementation to the existing functional and `apply_*` flow. Keep reusable arithmetic in the
    functional layer or Albucore; do not add a parallel transform class.
 4. Add correctness tests for Tensor input and confirm that NumPy input remains unchanged.
-5. Run direct functional, ordered-segment, direct `Compose`, and model-ready-output benchmarks for NumPy and Tensor.
-   Do not run `DataLoader` for this transform PR unless it changes shared bridge, planner, batching, or collation code.
+5. Run direct functional, ordered-chain, direct `Compose`, and model-ready-output benchmarks for NumPy and Tensor.
+   Do not run `DataLoader` for this transform PR unless it changes shared bridge, route selection, batching, or
+   collation code.
 6. Accept, narrow, reject, or mark the capability `blocked_upstream`.
-7. After the Tensor path is accepted, test whether the same Torch helper should serve NumPy input. Route NumPy through
-   Torch only when the full NumPy → Torch → NumPy path is no slower.
+7. Preserve the existing NumPy route. A NumPy-to-Tensor proposal is separate work with its own full-path benchmark.
 
 Land one operation family, capability record, tests, benchmark artifact, and routing change per pull request.
 
-### Phase 4 — consolidate segments and run milestones
+### Phase 4 — broaden capability coverage and run milestones
 
-As accepted capabilities accumulate, group adjacent compatible operations so each NumPy/Tensor boundary is paid once
-per segment. A segment change runs its ordered-chain and `Compose` benchmarks. Add a representative `DataLoader` case
-only when the segment changes shared boundaries or batch behavior.
+As accepted capabilities accumulate, more pipelines qualify for direct Tensor execution. A capability change runs its
+ordered-chain and `Compose` benchmarks. Add a representative `DataLoader` case only when it changes a shared bridge,
+route selection, or batch behavior.
 
-Run the complete `DataLoader` suite on scheduled milestones and before release. It covers NumPy input, Tensor input,
-mixed backend segments, video-through-`images`, volume, and the supported worker matrix.
+Run the complete `DataLoader` suite on scheduled milestones and before release. It covers NumPy input, direct Tensor
+input, bridged Tensor input, video-through-`images`, volume, and the supported worker matrix.
 
 ### Phase 5 — audit retained backends and prepare accelerators
 
@@ -386,12 +401,12 @@ unrelated migration work.
 The CPU program is complete when:
 
 - Torch is a required dependency on supported platforms;
-- `Compose` accepts the declared CPU Tensor forms and returns Tensor output for Tensor input;
-- the route planner can use accepted NumPy and Torch segments in either input representation;
+- `Compose` accepts every valid declared CPU Tensor pipeline and returns Tensor output for Tensor input;
+- `Compose` selects either direct Tensor execution or the whole-pipeline NumPy route before parameter sampling;
 - every accepted route has permanent correctness tests and full per-cell performance evidence;
-- every accepted Tensor route passes both the direct Tensor-Compose and model-ready-output performance gates;
-- Compose/planner milestones and release candidates pass the representative `DataLoader` suite;
-- no accepted route has a repeatable CPU regression;
+- every direct Tensor route passes both the direct Tensor-Compose and model-ready-output performance gates;
+- Compose route-selection milestones and release candidates pass the representative `DataLoader` suite;
+- no direct Tensor route has a repeatable CPU regression;
 - all missing primitives have an upstream artifact or explicit retained-backend decision; and
 - the audit explains every retained backend and leaves a reusable capability contract for future accelerator work.
 

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -33,17 +33,15 @@ class _TensorProbe(ImageOnlyTransform):
         return volume + 1
 
 
-class _NumpyOnlyProbe(_TensorProbe):
-    """Private probe whose parameter sampling must not run for Tensor input."""
+class _NumpyOnlyProbe(ImageOnlyTransform):
+    """Private probe that accepts a Tensor caller only through Compose's whole-pipeline NumPy route."""
 
-    _supports_cpu_tensor = False
+    def __init__(self) -> None:
+        super().__init__(p=1.0)
 
-    def get_params_dependent_on_data(
-        self,
-        params: dict[str, Any],
-        data: dict[str, Any],
-    ) -> dict[str, Any]:
-        pytest.fail("Compose must reject an unsupported Tensor transform before parameter sampling")
+    def apply(self, image: np.ndarray, **params: Any) -> np.ndarray:
+        assert isinstance(image, np.ndarray)
+        return image + 1
 
 
 @pytest.mark.parametrize(
@@ -156,17 +154,6 @@ def test_nested_compose_preserves_tensor_annotations() -> None:
         torch.testing.assert_close(result[target], expected)
 
 
-@pytest.mark.parametrize(
-    "transform",
-    [
-        _NumpyOnlyProbe(),
-    ],
-)
-def test_tensor_rejects_unsupported_transform_before_parameter_sampling(transform: A.BasicTransform) -> None:
-    with pytest.raises(TypeError, match="does not yet declare CPU Tensor capability"):
-        A.Compose([transform], p=0.0)(image=torch.zeros((3, 11, 13), dtype=torch.uint8))
-
-
 @pytest.mark.parametrize("terminal", [A.ToTensorV2(p=1.0), A.ToTensor3D(p=1.0)])
 def test_tensor_rejects_legacy_terminal_transforms(terminal: A.BasicTransform) -> None:
     with pytest.raises(TypeError, match="remove ToTensorV2 or ToTensor3D"):
@@ -267,6 +254,124 @@ def test_noop_preserves_tensor_volume_and_mask3d_without_numpy_batch_dispatch() 
 
     assert result["volume"] is volume
     assert result["mask3d"] is mask3d
+
+
+def test_flip3d_tensor_compose_preserves_volume_mask_and_semantic_mapping() -> None:
+    volume = torch.arange(3 * 4 * 5, dtype=torch.float32).reshape(1, 3, 4, 5)
+    mask3d = (torch.arange(3 * 4 * 5, dtype=torch.uint8).reshape(3, 4, 5) % 2) + 2
+
+    result = A.Compose(
+        [A.Flip3D(flip_axes=(2,), p=1.0)],
+        semantic_mask_label_mappings={"Flip3D": {2: 3, 3: 2}},
+        strict=True,
+    )(volume=volume, mask3d=mask3d)
+
+    expected_mask3d = torch.flip(mask3d, dims=(2,))
+    expected_mask3d = torch.where(expected_mask3d == 2, 3, 2).to(dtype=mask3d.dtype)
+    assert isinstance(result["volume"], torch.Tensor)
+    assert isinstance(result["mask3d"], torch.Tensor)
+    assert result["volume"].dtype == volume.dtype
+    assert result["mask3d"].dtype == mask3d.dtype
+    torch.testing.assert_close(result["volume"], torch.flip(volume, dims=(3,)))
+    torch.testing.assert_close(result["mask3d"], expected_mask3d)
+
+
+def test_tensor_compose_combines_3d_transforms() -> None:
+    volume = torch.arange(3 * 4 * 5, dtype=torch.float32).reshape(1, 3, 4, 5)
+    mask3d = (torch.arange(3 * 4 * 5, dtype=torch.uint8).reshape(3, 4, 5) % 2) + 2
+    transforms = [
+        A.Flip3D(flip_axes=(2,), p=1.0),
+        A.CenterCrop3D(size=(2, 3, 4), p=1.0),
+    ]
+    tensor_compose = A.Compose(
+        transforms,
+        semantic_mask_label_mappings={"Flip3D": {2: 3, 3: 2}},
+        strict=True,
+    )
+    numpy_compose = A.Compose(
+        transforms,
+        semantic_mask_label_mappings={"Flip3D": {2: 3, 3: 2}},
+        strict=True,
+    )
+
+    result = tensor_compose(volume=volume, mask3d=mask3d)
+    expected = numpy_compose(
+        volume=volume.permute(1, 2, 3, 0).numpy(),
+        mask3d=mask3d.numpy(),
+    )
+
+    assert isinstance(result["volume"], torch.Tensor)
+    assert isinstance(result["mask3d"], torch.Tensor)
+    expected_volume = torch.from_numpy(np.ascontiguousarray(expected["volume"])).permute(3, 0, 1, 2)
+    expected_mask3d = torch.from_numpy(np.ascontiguousarray(expected["mask3d"]))
+    torch.testing.assert_close(result["volume"], expected_volume)
+    torch.testing.assert_close(result["mask3d"], expected_mask3d)
+
+
+def test_tensor_compose_bridges_numpy_2d_targets_and_annotations() -> None:
+    image = torch.arange(5 * 5 * 7, dtype=torch.uint8).reshape(5, 5, 7)
+    images = torch.arange(5 * 2 * 5 * 7, dtype=torch.uint8).reshape(5, 2, 5, 7)
+    mask = torch.arange(5 * 7, dtype=torch.uint8).reshape(5, 7)
+    masks = torch.arange(2 * 5 * 7, dtype=torch.uint8).reshape(2, 5, 7)
+    bboxes = torch.tensor([[1, 1, 5, 4]], dtype=torch.float32)
+    keypoints = torch.tensor([[2, 3]], dtype=torch.float32)
+    compose_kwargs = {
+        "bbox_params": A.BboxParams(coord_format="pascal_voc"),
+        "keypoint_params": A.KeypointParams(coord_format="xy"),
+        "strict": True,
+    }
+    tensor_result = A.Compose([A.CenterCrop(height=3, width=5, p=1.0)], **compose_kwargs)(
+        image=image,
+        images=images,
+        mask=mask,
+        masks=masks,
+        bboxes=bboxes,
+        keypoints=keypoints,
+    )
+    numpy_result = A.Compose([A.CenterCrop(height=3, width=5, p=1.0)], **compose_kwargs)(
+        image=image.permute(1, 2, 0).numpy(),
+        images=images.permute(1, 2, 3, 0).numpy(),
+        mask=mask.numpy(),
+        masks=masks.numpy(),
+        bboxes=bboxes.numpy(),
+        keypoints=keypoints.numpy(),
+    )
+
+    expected_image = torch.from_numpy(np.ascontiguousarray(numpy_result["image"])).permute(2, 0, 1)
+    expected_images = torch.from_numpy(np.ascontiguousarray(numpy_result["images"])).permute(3, 0, 1, 2)
+    torch.testing.assert_close(tensor_result["image"], expected_image)
+    torch.testing.assert_close(tensor_result["images"], expected_images)
+    for target in ("mask", "masks", "bboxes", "keypoints"):
+        assert isinstance(tensor_result[target], torch.Tensor)
+        expected = torch.from_numpy(np.ascontiguousarray(numpy_result[target])).to(dtype=tensor_result[target].dtype)
+        torch.testing.assert_close(tensor_result[target], expected)
+
+
+def test_tensor_compose_bridges_nested_numpy_transform() -> None:
+    image = torch.arange(3 * 5 * 7, dtype=torch.uint8).reshape(3, 5, 7)
+    tensor_compose = A.Compose(
+        [A.Sequential([A.CenterCrop(height=3, width=5, p=1.0)], p=1.0)],
+        strict=True,
+    )
+    numpy_compose = A.Compose(
+        [A.Sequential([A.CenterCrop(height=3, width=5, p=1.0)], p=1.0)],
+        strict=True,
+    )
+
+    result = tensor_compose(image=image)["image"]
+    expected = numpy_compose(image=image.permute(1, 2, 0).numpy())["image"]
+
+    assert isinstance(result, torch.Tensor)
+    torch.testing.assert_close(result, torch.from_numpy(np.ascontiguousarray(expected)).permute(2, 0, 1))
+
+
+def test_tensor_compose_bridges_all_selectable_oneof_branches() -> None:
+    image = torch.arange(3 * 5 * 7, dtype=torch.uint8).reshape(3, 5, 7)
+
+    result = A.Compose([A.OneOf([_NumpyOnlyProbe()], p=1.0)], strict=True)(image=image)["image"]
+
+    assert isinstance(result, torch.Tensor)
+    torch.testing.assert_close(result, image + 1)
 
 
 @pytest.mark.parametrize(
@@ -413,23 +518,3 @@ def test_flip_transforms_support_all_tensor_spatial_targets(
     expected = value.transpose(-1, -2) if dimensions is None else torch.flip(value, dimensions)
     assert result.dtype == value.dtype
     torch.testing.assert_close(result, expected)
-
-
-@pytest.mark.parametrize(
-    "transform",
-    [
-        A.CenterCrop3D(size=(3, 5, 7), pad_if_needed=False, p=1.0),
-        A.RandomCrop3D(size=(3, 5, 7), pad_if_needed=False, p=1.0),
-        A.CubicSymmetry(p=1.0),
-        A.Pad3D(padding=(1, 2, 2), p=1.0),
-        A.RandomRotate90_3D(axis_pair=(0, 2), group_element="r90", p=1.0),
-        A.Flip3D(flip_axes=(0, 2), p=1.0),
-    ],
-)
-def test_3d_transforms_remain_rejected_until_their_tensor_routes_pass_the_performance_gate(
-    transform: A.BasicTransform,
-) -> None:
-    with pytest.raises(TypeError, match="does not yet declare CPU Tensor capability"):
-        A.Compose([transform], strict=True)(
-            volume=torch.zeros((3, 5, 7, 9), dtype=torch.uint8),
-        )

--- a/tests/test_tensor_dataloader.py
+++ b/tests/test_tensor_dataloader.py
@@ -21,6 +21,24 @@ class _TensorComposeDataset(torch.utils.data.Dataset[dict[str, torch.Tensor]]):
         return self.transform(image=self.images[index])
 
 
+class _TensorFallbackVolumeDataset(torch.utils.data.Dataset[dict[str, torch.Tensor]]):
+    """Small picklable volume dataset that requires Compose's NumPy bridge."""
+
+    def __init__(self) -> None:
+        self.volumes = torch.arange(6 * 1 * 3 * 5 * 7, dtype=torch.float32).reshape(6, 1, 3, 5, 7)
+        self.masks = torch.arange(6 * 3 * 5 * 7, dtype=torch.uint8).reshape(6, 3, 5, 7) % 4
+        self.transform = A.Compose(
+            [A.Flip3D(flip_axes=(2,), p=1.0), A.CenterCrop3D(size=(2, 3, 5), p=1.0)],
+            strict=True,
+        )
+
+    def __len__(self) -> int:
+        return len(self.volumes)
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        return self.transform(volume=self.volumes[index], mask3d=self.masks[index])
+
+
 def test_tensor_compose_output_collates_into_model_ready_nchw() -> None:
     loader = torch.utils.data.DataLoader(
         _TensorComposeDataset(),
@@ -32,3 +50,18 @@ def test_tensor_compose_output_collates_into_model_ready_nchw() -> None:
 
     assert [batch["image"].shape for batch in batches] == [(4, 3, 11, 13)] * 3
     assert all(batch["image"].dtype == torch.float32 for batch in batches)
+
+
+def test_tensor_compose_bridge_output_collates_volume_and_mask3d() -> None:
+    loader = torch.utils.data.DataLoader(
+        _TensorFallbackVolumeDataset(),
+        batch_size=2,
+        num_workers=0,
+    )
+
+    batch = next(iter(loader))
+
+    assert batch["volume"].shape == (2, 1, 2, 3, 5)
+    assert batch["mask3d"].shape == (2, 2, 3, 5)
+    assert batch["volume"].dtype == torch.float32
+    assert batch["mask3d"].dtype == torch.uint8


### PR DESCRIPTION
Fixes #417.

## What changed

`Compose` now accepts valid CPU Tensor inputs even when a selected transform has no direct Tensor route. It keeps the whole pipeline as Tensor only when every selectable branch supports the supplied targets. Otherwise it bridges all spatial targets once to NumPy before dispatch and restores Tensor output once after postprocessing.

## Why

The old capability check treated a transform direct Tensor fast path as permission to use Tensor input. `Flip3D` therefore failed before parameter sampling, and a regression test encoded that failure as expected behavior.

## Contract

The design document now defines the route-selection invariant: evaluate every selectable nested branch before sampling; choose direct Tensor only when all support the supplied targets; otherwise use the one whole-pipeline NumPy bridge. Transform helpers never add their own representation conversion.

## Validation

- `UV_CACHE_DIR=/private/tmp/albumentationsx-uv-cache uv run pytest -n auto -q -m "not slow" --disable-warnings` — 13319 passed, 43 skipped.
- `pre-commit run --files` for all six changed files — passed, including mypy, Pyrefly, and docs hooks.
- `uv run python -m tools.quality_gate fast` passed every substantive check; its all-files pre-commit invocation could not write managed read-only `.codex` files.
- The direct C=3 256x256 Tensor route measured 0.010 ms versus 0.066 ms for NumPy plus `ToTensor`; 0-worker DataLoader median was 0.091 versus 0.158 ms/sample. The NumPy fallback remains a compatibility path and its C=3 layout/copy cost is documented.

## Summary by Sourcery

Allow Compose pipelines with mixed Tensor and NumPy-capable transforms by introducing a single whole-pipeline NumPy bridge for unsupported Tensor routes, while preserving Tensor I/O and clarifying the torch CPU backend design.

Enhancements:
- Clarify the torch CPU backend migration design to define a route-selection invariant and whole-pipeline NumPy bridge behavior for Tensor input.
- Update Compose route selection to keep Tensor pipelines on Tensor when all transforms support CPU Tensor targets, or otherwise bridge all spatial targets once to NumPy and back.
- Centralize Tensor↔NumPy spatial conversions in bridge helpers and prevent individual transforms from performing ad hoc representation changes.
- Refine Tensor capability APIs so transforms declare which targets they can handle directly, letting Compose decide when to use Tensor routes versus the NumPy bridge.

Tests:
- Add Tensor Compose tests covering 3D Flip3D behavior, mixed 3D pipelines, NumPy-bridged 2D targets and annotations, nested compositions, OneOf branches, and DataLoader collation for bridged Tensor volume pipelines.