### PR TITLE
Make Compose invocations reentrant

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1578,8 +1578,7 @@ class Compose(BaseCompose, HubMixin):
             KeyError: If positional arguments are provided.
 
         """
-        self._call_lock.acquire()
-        try:
+        with self._call_lock:
             self._sync_runtime_random_state()
 
             if args:
@@ -1617,8 +1616,6 @@ class Compose(BaseCompose, HubMixin):
                 # Clear per-call unpack/repack flags if preprocess or a transform raised mid-call.
                 if self.main_compose and self._instance_binding:
                     self._clear_instance_binding_call_state_if_pending()
-        finally:
-            self._call_lock.release()
 
     def run_with_trace(
         self,
@@ -1639,8 +1636,7 @@ class Compose(BaseCompose, HubMixin):
             TraceResult: Final targets and, unless observer-only mode was selected, trace records.
 
         """
-        self._call_lock.acquire()
-        try:
+        with self._call_lock:
             options = TraceOptions() if options is None else options
             self._validate_trace_options(options, data)
             trace_context = _TraceContext(options)
@@ -1674,8 +1670,6 @@ class Compose(BaseCompose, HubMixin):
             finally:
                 if self.main_compose and self._instance_binding:
                     self._clear_instance_binding_call_state_if_pending()
-        finally:
-            self._call_lock.release()
 
     def _validate_trace_options(self, options: TraceOptions, data: dict[str, Any]) -> None:
         known_targets = set(data) | self._available_keys | set(AVAILABLE_KEYS)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -10,10 +10,12 @@ import contextlib
 import copy
 import inspect
 import random
+import threading
 import types
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass
 from time import perf_counter_ns
 from typing import Any, ClassVar, Union, cast
 
@@ -84,6 +86,16 @@ _TRACE_STATUS_SKIPPED_REPLAY = "skipped_replay"
 _TRACE_STATUS_SKIPPED_SELECTION = "skipped_selection"
 
 _REPLAY_PARAM_ANNOTATIONS_CACHE: dict[type, dict[str, Any]] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class _TensorCallState:
+    annotation_targets: tuple[tuple[str, str], ...] = ()
+    spatial_targets: tuple[tuple[str, str], ...] = ()
+    requires_numpy_bridge: bool = False
+
+
+_EMPTY_TENSOR_CALL_STATE = _TensorCallState()
 
 
 def _normalize_semantic_mask_label(label: Any, label_kind: str) -> int:
@@ -319,9 +331,6 @@ class BaseCompose(Serializable):
     check_each_transform: tuple[DataProcessor[Any], ...] | None = None
     main_compose: bool = True
     _tensor_capability_is_transparent: bool = True
-    _tensor_annotation_targets: tuple[tuple[str, str], ...] = ()
-    _tensor_spatial_targets: tuple[tuple[str, str], ...] = ()
-    _tensor_requires_numpy_bridge: bool = False
 
     @property
     def tensor_capability_is_transparent(self) -> bool:
@@ -1278,6 +1287,9 @@ class Compose(BaseCompose, HubMixin):
         - Pipeline modification operators (+, -, __radd__) preserve all Compose parameters including
           bbox_params, keypoint_params, additional_targets, and other configuration settings.
         - All operators return new Compose instances without modifying the original pipeline.
+        - Overlapping calls to one Compose instance are supported but execute serially. The complete invocation,
+          including RNG draws and tracing, runs under a reentrant lock, so acquisition order determines which caller
+          receives the next seeded random draw. Use independent Compose instances for parallel augmentation work.
 
     """
 
@@ -1311,6 +1323,7 @@ class Compose(BaseCompose, HubMixin):
             seed=seed,
             save_applied_params=save_applied_params,
         )
+        self._call_lock = threading.RLock()
 
         self.telemetry = telemetry
         self._resolve_processors(bbox_params, keypoint_params)
@@ -1342,6 +1355,21 @@ class Compose(BaseCompose, HubMixin):
 
         # Telemetry runs after nested composes so main_compose=False is already set on them.
         self._maybe_send_telemetry(telemetry)
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Return pipeline state without its invocation lock so synchronization remains process-local across worker
+        serialization boundaries.
+        """
+        state = self.__dict__.copy()
+        state.pop("_call_lock", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore a pickled pipeline with fresh RNG context and locking so runtime synchronization never crosses
+        process boundaries.
+        """
+        super().__setstate__(state)
+        self._call_lock = threading.RLock()
 
     def _set_semantic_mask_label_mappings_for_transforms(
         self,
@@ -1550,45 +1578,47 @@ class Compose(BaseCompose, HubMixin):
             KeyError: If positional arguments are provided.
 
         """
-        self._sync_runtime_random_state()
-
-        if args:
-            msg = "You have to pass data to augmentations as named arguments, for example: aug(image=image)"
-            raise KeyError(msg)
-
-        if self._additional_targets:
-            self._validate_additional_target_sources(data)
-        self._validate_tensor_inputs(data)
-
-        # Initialize applied_transforms only in top-level Compose if requested
-        if self.save_applied_params and self.main_compose:
-            data["applied_transforms"] = []
-
-        need_to_run = force_apply or self.py_random.random() < self.p
-        if not need_to_run:
-            self._clear_tensor_annotation_targets()
-            return data
-
+        self._call_lock.acquire()
         try:
-            self._bridge_tensor_data_to_numpy(data)
-            self.preprocess(data)
-            resync = self._resync_instance_ids if self.main_compose and self._instance_binding else None
-            for t in self.transforms:
-                data = t(**data)
-                self._track_transform_params(t, data)
-                data = self.check_data_post_transform(data)
-                if resync is not None:
-                    resync(data)
+            self._sync_runtime_random_state()
 
-            result = self.postprocess(data)
-            self._restore_tensor_spatial_data(result)
-            self._restore_tensor_annotations(result)
-            return result
+            if args:
+                msg = "You have to pass data to augmentations as named arguments, for example: aug(image=image)"
+                raise KeyError(msg)
+
+            if self._additional_targets:
+                self._validate_additional_target_sources(data)
+            tensor_call_state = self._validate_tensor_inputs(data)
+
+            # Initialize applied_transforms only in top-level Compose if requested
+            if self.save_applied_params and self.main_compose:
+                data["applied_transforms"] = []
+
+            need_to_run = force_apply or self.py_random.random() < self.p
+            if not need_to_run:
+                return data
+
+            try:
+                self._bridge_tensor_data_to_numpy(data, tensor_call_state)
+                self.preprocess(data, tensor_call_state)
+                resync = self._resync_instance_ids if self.main_compose and self._instance_binding else None
+                for t in self.transforms:
+                    data = t(**data)
+                    self._track_transform_params(t, data)
+                    data = self.check_data_post_transform(data)
+                    if resync is not None:
+                        resync(data)
+
+                result = self.postprocess(data)
+                self._restore_tensor_spatial_data(result, tensor_call_state)
+                self._restore_tensor_annotations(result, tensor_call_state)
+                return result
+            finally:
+                # Clear per-call unpack/repack flags if preprocess or a transform raised mid-call.
+                if self.main_compose and self._instance_binding:
+                    self._clear_instance_binding_call_state_if_pending()
         finally:
-            # Clear per-call unpack/repack flags if preprocess or a transform raised mid-call.
-            if self.main_compose and self._instance_binding:
-                self._clear_instance_binding_call_state_if_pending()
-            self._clear_tensor_annotation_targets()
+            self._call_lock.release()
 
     def run_with_trace(
         self,
@@ -1609,41 +1639,43 @@ class Compose(BaseCompose, HubMixin):
             TraceResult: Final targets and, unless observer-only mode was selected, trace records.
 
         """
-        options = TraceOptions() if options is None else options
-        self._validate_trace_options(options, data)
-        trace_context = _TraceContext(options)
-        self._sync_runtime_random_state()
-
-        if self._additional_targets:
-            self._validate_additional_target_sources(data)
-        self._validate_tensor_inputs(data)
-        if self.save_applied_params and self.main_compose:
-            data["applied_transforms"] = []
-
-        if not (force_apply or self.py_random.random() < self.p):
-            self._emit_skipped_trace_tree(self, trace_context, (), _TRACE_STATUS_SKIPPED_PROBABILITY)
-            self._clear_tensor_annotation_targets()
-            return trace_context.finish(data)
-
+        self._call_lock.acquire()
         try:
-            self._bridge_tensor_data_to_numpy(data)
-            self.preprocess(data)
-            data = self._run_traced_node_children(
-                self,
-                data,
-                trace_context,
-                (),
-                post_transform_container=self,
-            )
-            self._emit_composition_record(self, trace_context, (), _TRACE_STATUS_APPLIED)
-            result = self.postprocess(data)
-            self._restore_tensor_spatial_data(result)
-            self._restore_tensor_annotations(result)
-            return trace_context.finish(result)
+            options = TraceOptions() if options is None else options
+            self._validate_trace_options(options, data)
+            trace_context = _TraceContext(options)
+            self._sync_runtime_random_state()
+
+            if self._additional_targets:
+                self._validate_additional_target_sources(data)
+            tensor_call_state = self._validate_tensor_inputs(data)
+            if self.save_applied_params and self.main_compose:
+                data["applied_transforms"] = []
+
+            if not (force_apply or self.py_random.random() < self.p):
+                self._emit_skipped_trace_tree(self, trace_context, (), _TRACE_STATUS_SKIPPED_PROBABILITY)
+                return trace_context.finish(data)
+
+            try:
+                self._bridge_tensor_data_to_numpy(data, tensor_call_state)
+                self.preprocess(data, tensor_call_state)
+                data = self._run_traced_node_children(
+                    self,
+                    data,
+                    trace_context,
+                    (),
+                    post_transform_container=self,
+                )
+                self._emit_composition_record(self, trace_context, (), _TRACE_STATUS_APPLIED)
+                result = self.postprocess(data)
+                self._restore_tensor_spatial_data(result, tensor_call_state)
+                self._restore_tensor_annotations(result, tensor_call_state)
+                return trace_context.finish(result)
+            finally:
+                if self.main_compose and self._instance_binding:
+                    self._clear_instance_binding_call_state_if_pending()
         finally:
-            if self.main_compose and self._instance_binding:
-                self._clear_instance_binding_call_state_if_pending()
-            self._clear_tensor_annotation_targets()
+            self._call_lock.release()
 
     def _validate_trace_options(self, options: TraceOptions, data: dict[str, Any]) -> None:
         known_targets = set(data) | self._available_keys | set(AVAILABLE_KEYS)
@@ -1807,50 +1839,77 @@ class Compose(BaseCompose, HubMixin):
         finalize_leaf: bool,
         post_transform_container: "BaseCompose",
     ) -> dict[str, Any]:
+        with transform._call_lock:  # noqa: SLF001 - nested Compose shares the internal invocation boundary.
+            return self._run_traced_compose_impl(
+                transform,
+                data,
+                trace_context,
+                path,
+                force_apply=force_apply,
+                tracking_data=tracking_data,
+                event_data_factory=event_data_factory,
+                finalize_leaf=finalize_leaf,
+                post_transform_container=post_transform_container,
+            )
+
+    def _run_traced_compose_impl(
+        self,
+        transform: "Compose",
+        data: dict[str, Any],
+        trace_context: _TraceContext,
+        path: tuple[int, ...],
+        *,
+        force_apply: bool,
+        tracking_data: dict[str, Any] | None,
+        event_data_factory: Callable[[dict[str, Any]], dict[str, Any]] | None,
+        finalize_leaf: bool,
+        post_transform_container: "BaseCompose",
+    ) -> dict[str, Any]:
         replay_compose = transform if isinstance(transform, ReplayCompose) else None
         if replay_compose is not None:
             data[replay_compose.save_key] = defaultdict(dict)
-        self._prepare_traced_compose_input(transform, data)
+        tensor_call_state = self._prepare_traced_compose_input(transform, data)
         if not (transform.replay_mode or force_apply or transform.py_random.random() < transform.p):
             self._emit_skipped_trace_tree(transform, trace_context, path, _TRACE_STATUS_SKIPPED_PROBABILITY)
             if replay_compose is not None:
                 self._finalize_traced_replay_compose(replay_compose, data)
             return data
-        try:
-            transform.preprocess(data)
-            data = self._run_traced_node_children(
-                transform,
-                data,
-                trace_context,
-                path,
-                tracking_data=tracking_data,
-                event_data_factory=event_data_factory,
-                finalize_leaf=finalize_leaf,
-                post_transform_container=transform,
-            )
-            result = transform.postprocess(data)
-            self._restore_traced_compose_tensor_annotations(transform, result)
-            if replay_compose is not None:
-                self._finalize_traced_replay_compose(replay_compose, result)
-            data = self._finalize_traced_leaf(result, post_transform_container)
-            self._emit_composition_record(transform, trace_context, path, _TRACE_STATUS_APPLIED)
-            return data
-        finally:
-            Compose._clear_tensor_annotation_targets(transform)
+
+        transform.preprocess(data, tensor_call_state)
+        data = self._run_traced_node_children(
+            transform,
+            data,
+            trace_context,
+            path,
+            tracking_data=tracking_data,
+            event_data_factory=event_data_factory,
+            finalize_leaf=finalize_leaf,
+            post_transform_container=transform,
+        )
+        result = transform.postprocess(data)
+        self._restore_traced_compose_tensor_annotations(transform, result, tensor_call_state)
+        if replay_compose is not None:
+            self._finalize_traced_replay_compose(replay_compose, result)
+        data = self._finalize_traced_leaf(result, post_transform_container)
+        self._emit_composition_record(transform, trace_context, path, _TRACE_STATUS_APPLIED)
+        return data
 
     @staticmethod
-    def _prepare_traced_compose_input(transform: "Compose", data: dict[str, Any]) -> None:
+    def _prepare_traced_compose_input(transform: "Compose", data: dict[str, Any]) -> _TensorCallState:
         Compose._sync_runtime_random_state(transform)
         if transform.additional_targets:
             Compose._validate_additional_target_sources(transform, data)
         if any(isinstance(value, torch.Tensor) for value in data.values()):
-            Compose._validate_tensor_inputs(transform, data)
-        else:
-            Compose._clear_tensor_annotation_targets(transform)
+            return Compose._validate_tensor_inputs(transform, data)
+        return _EMPTY_TENSOR_CALL_STATE
 
     @staticmethod
-    def _restore_traced_compose_tensor_annotations(transform: "Compose", data: dict[str, Any]) -> None:
-        Compose._restore_tensor_annotations(transform, data)
+    def _restore_traced_compose_tensor_annotations(
+        transform: "Compose",
+        data: dict[str, Any],
+        tensor_call_state: _TensorCallState,
+    ) -> None:
+        Compose._restore_tensor_annotations(transform, data, tensor_call_state)
 
     @staticmethod
     def _finalize_traced_replay_compose(transform: "ReplayCompose", data: dict[str, Any]) -> None:
@@ -2178,7 +2237,7 @@ class Compose(BaseCompose, HubMixin):
                 msg = f"Additional target '{alias}' requires canonical target '{target}' to be present."
                 raise ValueError(msg)
 
-    def _validate_tensor_inputs(self, data: dict[str, Any]) -> None:
+    def _validate_tensor_inputs(self, data: dict[str, Any]) -> _TensorCallState:
         """Validate Tensor boundary contracts before Compose samples probability or parameters,
         ensuring each spatial target uses a single representation.
 
@@ -2189,7 +2248,6 @@ class Compose(BaseCompose, HubMixin):
         tensor_targets: list[tuple[str, str, torch.Tensor]] = []
         spatial_representations: set[str] = set()
         annotation_targets: list[tuple[str, str]] = []
-        self._clear_tensor_annotation_targets()
 
         for data_name, value in data.items():
             canonical_name = self._additional_targets.get(data_name, data_name)
@@ -2207,7 +2265,7 @@ class Compose(BaseCompose, HubMixin):
                 spatial_representations.add("numpy")
 
         if not tensor_targets:
-            return
+            return _EMPTY_TENSOR_CALL_STATE
 
         for data_name, canonical_name, value in tensor_targets:
             validate_tensor_input(value, data_name, canonical_name)
@@ -2218,19 +2276,20 @@ class Compose(BaseCompose, HubMixin):
                 "when Compose receives a Tensor image, masks, bboxes, and keypoints must also be Tensors",
             )
 
-        self._tensor_annotation_targets = tuple(annotation_targets)
-        self._tensor_spatial_targets = tuple(
-            (data_name, canonical_name) for data_name, canonical_name, _ in tensor_targets
-        )
+        spatial_targets = tuple((data_name, canonical_name) for data_name, canonical_name, _ in tensor_targets)
 
         tensor_image_inputs = tuple(
             (canonical_name, value)
             for _, canonical_name, value in tensor_targets
             if canonical_name not in TENSOR_ANNOTATION_TARGETS
         )
-        self._tensor_requires_numpy_bridge = not self._tensor_pipeline_supports_cpu_inputs(
-            self.transforms,
-            tensor_image_inputs,
+        return _TensorCallState(
+            annotation_targets=tuple(annotation_targets),
+            spatial_targets=spatial_targets,
+            requires_numpy_bridge=not self._tensor_pipeline_supports_cpu_inputs(
+                self.transforms,
+                tensor_image_inputs,
+            ),
         )
 
     def _tensor_pipeline_supports_cpu_inputs(
@@ -2305,7 +2364,11 @@ class Compose(BaseCompose, HubMixin):
         """
         self._sync_runtime_random_state()
 
-    def preprocess(self, data: Any) -> None:
+    def preprocess(
+        self,
+        data: Any,
+        tensor_call_state: _TensorCallState = _EMPTY_TENSOR_CALL_STATE,
+    ) -> None:
         """Preprocess input data before applying transforms. Validates shapes (if
         is_check_shapes), validates data keys (if strict), ensures contiguous, adds channels.
         """
@@ -2325,25 +2388,33 @@ class Compose(BaseCompose, HubMixin):
 
         # Add channel dimensions first, before processors run
         self._preprocess_arrays(data)
-        self._bridge_tensor_annotations_to_numpy(data)
+        self._bridge_tensor_annotations_to_numpy(data, tensor_call_state)
         self._preprocess_processors(data)
 
-    def _bridge_tensor_annotations_to_numpy(self, data: dict[str, Any]) -> None:
+    def _bridge_tensor_annotations_to_numpy(
+        self,
+        data: dict[str, Any],
+        tensor_call_state: _TensorCallState,
+    ) -> None:
         """Convert accepted Tensor bbox and keypoint matrices once for existing NumPy-only
         processors, keeping all public annotations Tensor at Compose entry and exit.
         """
-        for data_name, canonical_name in self._tensor_annotation_targets:
+        for data_name, canonical_name in tensor_call_state.annotation_targets:
             value = data.get(data_name)
             if isinstance(value, torch.Tensor):
                 data[data_name] = tensor_to_numpy_annotation(value, canonical_name)
 
-    def _bridge_tensor_data_to_numpy(self, data: dict[str, Any]) -> None:
+    def _bridge_tensor_data_to_numpy(
+        self,
+        data: dict[str, Any],
+        tensor_call_state: _TensorCallState,
+    ) -> None:
         """Convert all Tensor spatial targets to NumPy once before a pipeline containing a transform without a direct
         Tensor route.
         """
-        if not self._tensor_requires_numpy_bridge:
+        if not tensor_call_state.requires_numpy_bridge:
             return
-        for data_name, canonical_name in self._tensor_spatial_targets:
+        for data_name, canonical_name in tensor_call_state.spatial_targets:
             value = data.get(data_name)
             if isinstance(value, torch.Tensor):
                 data[data_name] = tensor_to_numpy_spatial(value, canonical_name)
@@ -2554,30 +2625,33 @@ class Compose(BaseCompose, HubMixin):
 
         return data
 
-    def _restore_tensor_annotations(self, data: dict[str, Any]) -> None:
+    def _restore_tensor_annotations(
+        self,
+        data: dict[str, Any],
+        tensor_call_state: _TensorCallState,
+    ) -> None:
         """Restore Tensor bbox and keypoint matrices after NumPy processing so all spatial
         targets in the public Compose result remain Tensors.
         """
-        for data_name, canonical_name in self._tensor_annotation_targets:
+        for data_name, canonical_name in tensor_call_state.annotation_targets:
             value = data.get(data_name)
             if isinstance(value, np.ndarray):
                 data[data_name] = numpy_to_tensor_annotation(value, canonical_name)
 
-    def _restore_tensor_spatial_data(self, data: dict[str, Any]) -> None:
+    def _restore_tensor_spatial_data(
+        self,
+        data: dict[str, Any],
+        tensor_call_state: _TensorCallState,
+    ) -> None:
         """Convert NumPy spatial results back to public Tensor layouts after Compose finishes a pipeline using its
         central representation bridge.
         """
-        if not self._tensor_requires_numpy_bridge:
+        if not tensor_call_state.requires_numpy_bridge:
             return
-        for data_name, canonical_name in self._tensor_spatial_targets:
+        for data_name, canonical_name in tensor_call_state.spatial_targets:
             value = data.get(data_name)
             if isinstance(value, np.ndarray) and canonical_name not in TENSOR_ANNOTATION_TARGETS:
                 data[data_name] = numpy_to_tensor_spatial(value, canonical_name)
-
-    def _clear_tensor_annotation_targets(self) -> None:
-        self._tensor_annotation_targets = ()
-        self._tensor_spatial_targets = ()
-        self._tensor_requires_numpy_bridge = False
 
     def _filter_bound_bboxes_before_postprocess(self, data: dict[str, Any]) -> None:
         """Filter bound bboxes at the final boundary and mirror their keep mask before postprocessing removes internal
@@ -3744,13 +3818,14 @@ class ReplayCompose(Compose):
             dict[str, Any]: Dictionary with transformed data and replay information.
 
         """
-        kwargs[self.save_key] = defaultdict(dict)
-        result = super().__call__(force_apply=force_apply, **kwargs)
-        serialized = self.get_dict_with_id()
-        self.fill_with_params(serialized, result[self.save_key])
-        self.fill_applied(serialized)
-        result[self.save_key] = serialized
-        return result
+        with self._call_lock:
+            kwargs[self.save_key] = defaultdict(dict)
+            result = super().__call__(force_apply=force_apply, **kwargs)
+            serialized = self.get_dict_with_id()
+            self.fill_with_params(serialized, result[self.save_key])
+            self.fill_applied(serialized)
+            result[self.save_key] = serialized
+            return result
 
     def run_with_trace(
         self,
@@ -3763,13 +3838,14 @@ class ReplayCompose(Compose):
         configuration part of the saved augmentation payload.
 
         """
-        data[self.save_key] = defaultdict(dict)
-        trace_result = super().run_with_trace(options=options, force_apply=force_apply, **data)
-        serialized = self.get_dict_with_id()
-        self.fill_with_params(serialized, trace_result.data[self.save_key])
-        self.fill_applied(serialized)
-        trace_result.data[self.save_key] = serialized
-        return trace_result
+        with self._call_lock:
+            data[self.save_key] = defaultdict(dict)
+            trace_result = super().run_with_trace(options=options, force_apply=force_apply, **data)
+            serialized = self.get_dict_with_id()
+            self.fill_with_params(serialized, trace_result.data[self.save_key])
+            self.fill_applied(serialized)
+            trace_result.data[self.save_key] = serialized
+            return trace_result
 
     @staticmethod
     def replay(saved_augmentations: dict[str, Any], **kwargs: Any) -> dict[str, Any]:

--- a/docs/design/compose-serialization-and-tracing.md
+++ b/docs/design/compose-serialization-and-tracing.md
@@ -78,6 +78,22 @@ dictionary. None of these runtime objects is serialized or retained in a DataLoa
 Tracing is off by default. `Compose.__call__` does not allocate a trace context, create records, call a callback, copy
 targets, or read a clock.
 
+## Concurrent invocation contract
+
+One configured `Compose` or `ReplayCompose` instance is reentrant through serialized execution. A process-local
+reentrant lock covers each complete `__call__()` and `run_with_trace()` invocation, including worker RNG
+synchronization, probability and parameter sampling, Tensor route selection, preprocessing, transform dispatch,
+processor work, tracing, restoration, replay finalization, and cleanup. Overlapping callers therefore observe results
+consistent with one serial order and cannot replace another call's grayscale, instance-binding, applied-parameter, or
+representation bookkeeping.
+
+This contract does not provide parallel augmentation from one pipeline object. Lock acquisition order determines
+which overlapping caller receives the next draw from a seeded shared RNG stream. Applications that require parallel
+CPU augmentation should use independent pipeline instances, as normal multi-process `DataLoader` workers do.
+
+The Tensor route plan is call-local rather than serialized policy or mutable pipeline state. Runtime locks are also
+excluded from pickle payloads and recreated after unpickling, so worker processes never share synchronization objects.
+
 ## Trace records and paths
 
 A `TraceRecord` contains:
@@ -127,6 +143,10 @@ include every public constructor field.
 `tests/test_composition_tracing.py` covers nested control flow, repeated selections, skipped nodes, snapshots,
 filtering, timing, observer-only mode, replay, RNG continuation, serialization-stable paths, and
 `save_applied_params` parity.
+
+`tests/test_compose_reentrancy.py` uses explicit thread events to force overlapping call attempts and covers normal
+execution, tracing, replay, Tensor/NumPy restoration, grayscale layout, applied parameters, instance binding, and the
+seeded serial order.
 
 When the relevant core code or either test changes, the scoped `Check Compose policy and tracing contracts`
 pre-commit hook runs both suites before a commit is created.

--- a/docs/design/compose-serialization-and-tracing.md
+++ b/docs/design/compose-serialization-and-tracing.md
@@ -84,7 +84,7 @@ One configured `Compose` or `ReplayCompose` instance is reentrant through serial
 reentrant lock covers each complete `__call__()` and `run_with_trace()` invocation, including worker RNG
 synchronization, probability and parameter sampling, Tensor route selection, preprocessing, transform dispatch,
 processor work, tracing, restoration, replay finalization, and cleanup. Overlapping callers therefore observe results
-consistent with one serial order and cannot replace another call's grayscale, instance-binding, applied-parameter, or
+consistent with one serial order and cannot replace another call's grayscale, instance-binding, applied parameter, or
 representation bookkeeping.
 
 This contract does not provide parallel augmentation from one pipeline object. Lock acquisition order determines

--- a/docs/design/torch-cpu-backend-migration.md
+++ b/docs/design/torch-cpu-backend-migration.md
@@ -149,6 +149,16 @@ The implementation keeps one transform hierarchy. The central bridge converts Te
 and restores Tensor output. The bridge owns conversion, layout, and ownership checks. No transform-specific helper may
 convert an annotation silently.
 
+### Concurrent calls and Tensor route ownership
+
+Tensor route selection is local to one invocation. The supplied spatial and annotation target names and the decision
+to use the whole-pipeline NumPy bridge are never stored as mutable pipeline state.
+
+Overlapping calls to one `Compose` instance execute serially under the public Compose reentrancy contract. This keeps
+Tensor layout restoration, shared transform parameters, processors, tracing, and seeded RNG progress consistent with
+one serial order. It does not claim parallel Tensor augmentation; callers that need parallel CPU work use independent
+pipeline instances.
+
 ### CPU-only boundary
 
 The first stage accepts CPU tensors with `requires_grad=False`.

--- a/tests/test_compose_reentrancy.py
+++ b/tests/test_compose_reentrancy.py
@@ -1,5 +1,6 @@
 """Threaded regression coverage for the public Compose reentrancy contract."""
 
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from threading import Event
 from typing import Any, Literal
@@ -7,6 +8,7 @@ from typing import Any, Literal
 import numpy as np
 import pytest
 import torch
+from typing_extensions import Self
 
 import albumentations as A
 
@@ -14,9 +16,10 @@ import albumentations as A
 class _BlockingAppliedConfigTransform(A.ImageOnlyTransform):
     """Hold one invocation inside transform dispatch while detecting a second invocation."""
 
-    def __init__(self, marker: int = 0, p: float = 1.0):
+    def __init__(self, marker: int = 0, raise_markers: tuple[int, ...] = (), p: float = 1.0):
         super().__init__(p=p)
         self.marker = marker
+        self.raise_markers = raise_markers
         self.first_entered = Event()
         self.second_entered = Event()
         self.release_first = Event()
@@ -39,7 +42,52 @@ class _BlockingAppliedConfigTransform(A.ImageOnlyTransform):
                 raise TimeoutError("First Compose invocation was not released")
         elif marker == 2:
             self.second_entered.set()
+        if marker in self.raise_markers:
+            raise RuntimeError(f"Transform failed for marker {marker}")
         return image
+
+
+class _ObservedRLock:
+    """Expose when another thread reaches a held reentrant lock without relying on scheduler timing."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._state_lock = threading.Lock()
+        self._owner: int | None = None
+        self._depth = 0
+        self.blocked_caller_attempted = Event()
+
+    def acquire(self) -> bool:
+        caller = threading.get_ident()
+        with self._state_lock:
+            if self._owner is not None and self._owner != caller:
+                self.blocked_caller_attempted.set()
+        acquired = self._lock.acquire()
+        with self._state_lock:
+            if self._owner == caller:
+                self._depth += 1
+            else:
+                self._owner = caller
+                self._depth = 1
+        return acquired
+
+    def release(self) -> None:
+        caller = threading.get_ident()
+        with self._state_lock:
+            self._depth -= 1
+            final_release = self._depth == 0
+        self._lock.release()
+        if final_release:
+            with self._state_lock:
+                if self._owner == caller and self._depth == 0:
+                    self._owner = None
+
+    def __enter__(self) -> Self:
+        self.acquire()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.release()
 
 
 def _invoke(
@@ -63,10 +111,10 @@ def _run_overlapping_calls(
     tuple[dict[str, Any], tuple[A.TraceRecord, ...]],
     tuple[dict[str, Any], tuple[A.TraceRecord, ...]],
 ]:
-    second_attempted = Event()
+    observed_lock = _ObservedRLock()
+    pipeline._call_lock = observed_lock
 
     def run_second() -> tuple[dict[str, Any], tuple[A.TraceRecord, ...]]:
-        second_attempted.set()
         return _invoke(pipeline, "call", second_data)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
@@ -76,9 +124,9 @@ def _run_overlapping_calls(
             if not probe.first_entered.wait(timeout=5):
                 raise TimeoutError("First Compose invocation did not reach transform dispatch")
             second_future = executor.submit(run_second)
-            if not second_attempted.wait(timeout=5):
-                raise TimeoutError("Second Compose invocation did not start")
-            second_overlapped = probe.second_entered.wait(timeout=0.25)
+            if not observed_lock.blocked_caller_attempted.wait(timeout=5):
+                raise TimeoutError("Second Compose invocation did not attempt to acquire the held call lock")
+            second_overlapped = probe.second_entered.is_set()
         finally:
             probe.release_first.set()
 
@@ -164,6 +212,21 @@ def test_overlapping_calls_preserve_instance_binding_bookkeeping() -> None:
     np.testing.assert_array_equal(first_result["instances"][0]["mask"], first_instances[0]["mask"])
     for actual, expected in zip(second_result["instances"], second_instances, strict=True):
         np.testing.assert_array_equal(actual["mask"], expected["mask"])
+
+
+def test_call_lock_and_tensor_state_recover_after_transform_exception() -> None:
+    probe = _BlockingAppliedConfigTransform(raise_markers=(1,), p=1.0)
+    probe.release_first.set()
+    pipeline = A.Compose([probe], save_applied_params=True, telemetry=False)
+
+    with pytest.raises(RuntimeError, match="Transform failed for marker 1"):
+        pipeline(image=torch.ones((1, 8, 8), dtype=torch.uint8))
+
+    numpy_image = np.full((8, 8), 2, dtype=np.uint8)
+    result = pipeline(image=numpy_image)
+    assert isinstance(result["image"], np.ndarray)
+    np.testing.assert_array_equal(result["image"], numpy_image)
+    assert result["applied_transforms"][0][1]["marker"] == 2
 
 
 def test_overlapping_seeded_calls_match_lock_acquisition_order() -> None:

--- a/tests/test_compose_reentrancy.py
+++ b/tests/test_compose_reentrancy.py
@@ -1,0 +1,200 @@
+"""Threaded regression coverage for the public Compose reentrancy contract."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from typing import Any, Literal
+
+import numpy as np
+import pytest
+import torch
+
+import albumentations as A
+
+
+class _BlockingAppliedConfigTransform(A.ImageOnlyTransform):
+    """Hold one invocation inside transform dispatch while detecting a second invocation."""
+
+    def __init__(self, marker: int = 0, p: float = 1.0):
+        super().__init__(p=p)
+        self.marker = marker
+        self.first_entered = Event()
+        self.second_entered = Event()
+        self.release_first = Event()
+
+    def get_params_dependent_on_data(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        marker = int(np.asarray(data["image"]).reshape(-1)[0])
+        self.applied_config = {"marker": marker}
+        return {"marker": marker}
+
+    def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
+        if not isinstance(image, np.ndarray):
+            raise TypeError("Compose must bridge Tensor input before NumPy-only dispatch")
+        if marker == 1:
+            self.first_entered.set()
+            if not self.release_first.wait(timeout=10):
+                raise TimeoutError("First Compose invocation was not released")
+        elif marker == 2:
+            self.second_entered.set()
+        return image
+
+
+def _invoke(
+    pipeline: A.Compose,
+    mode: Literal["call", "trace"],
+    data: dict[str, Any],
+) -> tuple[dict[str, Any], tuple[A.TraceRecord, ...]]:
+    if mode == "trace":
+        traced = pipeline.run_with_trace(**data)
+        return traced.data, traced.records
+    return pipeline(**data), ()
+
+
+def _run_overlapping_calls(
+    pipeline: A.Compose,
+    probe: _BlockingAppliedConfigTransform,
+    first_mode: Literal["call", "trace"],
+    first_data: dict[str, Any],
+    second_data: dict[str, Any],
+) -> tuple[
+    tuple[dict[str, Any], tuple[A.TraceRecord, ...]],
+    tuple[dict[str, Any], tuple[A.TraceRecord, ...]],
+]:
+    second_attempted = Event()
+
+    def run_second() -> tuple[dict[str, Any], tuple[A.TraceRecord, ...]]:
+        second_attempted.set()
+        return _invoke(pipeline, "call", second_data)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(_invoke, pipeline, first_mode, first_data)
+        second_future = None
+        try:
+            if not probe.first_entered.wait(timeout=5):
+                raise TimeoutError("First Compose invocation did not reach transform dispatch")
+            second_future = executor.submit(run_second)
+            if not second_attempted.wait(timeout=5):
+                raise TimeoutError("Second Compose invocation did not start")
+            second_overlapped = probe.second_entered.wait(timeout=0.25)
+        finally:
+            probe.release_first.set()
+
+        first_result = first_future.result(timeout=5)
+        if second_future is None:
+            raise RuntimeError("Second Compose invocation was not submitted")
+        second_result = second_future.result(timeout=5)
+
+    assert not second_overlapped, "Calls to one Compose instance must be serialized"
+    return first_result, second_result
+
+
+@pytest.mark.parametrize("compose_type", [A.Compose, A.ReplayCompose])
+@pytest.mark.parametrize("first_mode", ["call", "trace"])
+def test_overlapping_calls_preserve_tensor_grayscale_and_applied_params(
+    compose_type: type[A.Compose],
+    first_mode: Literal["call", "trace"],
+) -> None:
+    probe = _BlockingAppliedConfigTransform(p=1.0)
+    pipeline = compose_type([probe], save_applied_params=True, telemetry=False)
+    tensor_image = torch.ones((1, 8, 8), dtype=torch.uint8)
+    tensor_mask = torch.ones((8, 8), dtype=torch.uint8)
+    numpy_image = np.full((8, 8), 2, dtype=np.uint8)
+
+    (first_result, first_records), (second_result, _) = _run_overlapping_calls(
+        pipeline,
+        probe,
+        first_mode,
+        {"image": tensor_image, "mask": tensor_mask},
+        {"image": numpy_image},
+    )
+
+    assert isinstance(first_result["image"], torch.Tensor)
+    assert isinstance(first_result["mask"], torch.Tensor)
+    assert first_result["image"].shape == tensor_image.shape
+    assert first_result["mask"].shape == tensor_mask.shape
+    torch.testing.assert_close(first_result["image"], tensor_image)
+    torch.testing.assert_close(first_result["mask"], tensor_mask)
+    assert isinstance(second_result["image"], np.ndarray)
+    assert second_result["image"].shape == numpy_image.shape
+    np.testing.assert_array_equal(second_result["image"], numpy_image)
+    assert first_result["applied_transforms"][0][1]["marker"] == 1
+    assert second_result["applied_transforms"][0][1]["marker"] == 2
+    if compose_type is A.ReplayCompose:
+        assert first_result["replay"]["applied"]
+        assert second_result["replay"]["applied"]
+    if first_mode == "trace":
+        leaf_records = [record for record in first_records if record.node_kind == "leaf"]
+        assert leaf_records[0].params is not None
+        assert leaf_records[0].params["marker"] == 1
+
+
+def test_overlapping_calls_preserve_instance_binding_bookkeeping() -> None:
+    probe = _BlockingAppliedConfigTransform(p=1.0)
+    pipeline = A.Compose(
+        [probe],
+        bbox_params=A.BboxParams(coord_format="pascal_voc"),
+        instance_binding=["masks", "bboxes"],
+        telemetry=False,
+    )
+
+    def make_instances(count: int) -> list[dict[str, Any]]:
+        return [
+            {
+                "mask": np.full((16, 16), index + 1, dtype=np.uint8),
+                "bbox": np.array([1, 1, 8, 8], dtype=np.float32),
+            }
+            for index in range(count)
+        ]
+
+    first_instances = make_instances(1)
+    second_instances = make_instances(2)
+    (first_result, _), (second_result, _) = _run_overlapping_calls(
+        pipeline,
+        probe,
+        "call",
+        {"image": np.ones((16, 16, 3), dtype=np.uint8), "instances": first_instances},
+        {"image": np.full((16, 16, 3), 2, dtype=np.uint8), "instances": second_instances},
+    )
+
+    assert len(first_result["instances"]) == 1
+    assert len(second_result["instances"]) == 2
+    np.testing.assert_array_equal(first_result["instances"][0]["mask"], first_instances[0]["mask"])
+    for actual, expected in zip(second_result["instances"], second_instances, strict=True):
+        np.testing.assert_array_equal(actual["mask"], expected["mask"])
+
+
+def test_overlapping_seeded_calls_match_lock_acquisition_order() -> None:
+    first_image = np.full((16, 16, 3), 100, dtype=np.uint8)
+    first_image[0, 0] = 1
+    second_image = np.full((16, 16, 3), 150, dtype=np.uint8)
+    second_image[0, 0] = 2
+
+    concurrent_probe = _BlockingAppliedConfigTransform(p=1.0)
+    concurrent_pipeline = A.Compose(
+        [concurrent_probe, A.RandomBrightnessContrast(p=1.0)],
+        seed=137,
+        telemetry=False,
+    )
+    (first_result, _), (second_result, _) = _run_overlapping_calls(
+        concurrent_pipeline,
+        concurrent_probe,
+        "call",
+        {"image": first_image.copy()},
+        {"image": second_image.copy()},
+    )
+
+    serial_probe = _BlockingAppliedConfigTransform(p=1.0)
+    serial_probe.release_first.set()
+    serial_pipeline = A.Compose(
+        [serial_probe, A.RandomBrightnessContrast(p=1.0)],
+        seed=137,
+        telemetry=False,
+    )
+    expected_first = serial_pipeline(image=first_image.copy())
+    expected_second = serial_pipeline(image=second_image.copy())
+
+    np.testing.assert_array_equal(first_result["image"], expected_first["image"])
+    np.testing.assert_array_equal(second_result["image"], expected_second["image"])


### PR DESCRIPTION
## Summary

Fixes #419.

This implements the serialized concurrent-call contract described in the issue:

- guard each complete `Compose.__call__()` and `run_with_trace()` invocation with a process-local reentrant lock;
- keep Tensor bridge planning in a call-local `_TensorCallState` instead of mutable pipeline fields;
- apply the same invocation boundary to nested traced compositions and `ReplayCompose` finalization;
- exclude the runtime lock from pickle state and recreate it after unpickling; and
- document that overlapping calls are reentrant but serialized, with lock acquisition order determining the seeded RNG sequence.

The implementation does not claim parallel augmentation from one pipeline instance. Callers that need parallel CPU work should use independent `Compose` instances.

## Regression coverage

`tests/test_compose_reentrancy.py` uses `threading.Event` synchronization rather than sleeps to force a second caller to attempt entry while the first is inside transform dispatch. It covers:

- `Compose` and `ReplayCompose`;
- normal and traced execution;
- Tensor fallback with `image + mask` racing a NumPy `image` call;
- grayscale layout and Tensor/NumPy boundary restoration;
- `save_applied_params` and trace parameters;
- `instance_binding`; and
- seeded overlapping calls matching the lock-acquisition serial order.

The original implementation fails the threaded regression because both callers enter transform dispatch concurrently.

## Validation

- `python -m pytest tests/test_compose_reentrancy.py -q`: **7 passed**
- relevant Compose/Tensor/tracing/replay/worker/serialization suites: **1571 passed, 8 skipped**
- `python -m tools.quality_gate fast`: **passed**
  - Ruff format/check: passed
  - mypy: passed
  - Pyrefly: 0 errors (2 configured suppressions)
  - contract suite: **1276 passed**
  - CI matrix/shard, benchmark coverage, performance budget, legal integrity, regression vectors, pre-commit, and Compose smoke: passed
- explicit pre-commit run over all four changed/new files: passed
- `git diff --check`: passed

## Performance evidence

I ran the repository Tensor Compose benchmark before and after the change over the complete 3 sizes × 3 channel counts × 2 dtypes matrix (`repeats=7`, `iterations=128`, CPU, DataLoader skipped for the matrix). Every cell passed correctness.

- `numpy_with_to_tensor`: median cell delta **+1.67%**
- `tensor_direct`: median cell delta **+1.35%**

Because direct `NoOp` calls take only about 11–20 microseconds on this Windows host, some individual percentage deltas were noisy. I investigated every >5% cell with 15 repeats × 512 iterations. All but two reruns fell below 5%; the remaining deltas were +1.29 microseconds for NumPy-to-Tensor and +0.58 microseconds for direct Tensor, while equivalent cells moved in both directions.

A representative 256×256×3 uint8 DataLoader run (`workers=0`, 64 samples, batch size 8, 15 repeats) measured:

- NumPy + `ToTensorV2`: **+3.08%** per sample
- direct Tensor: **-12.49%** per sample

This change adds synchronization and call-local bookkeeping only. It does not add full-array passes, copies, conversions, kernels, LUTs, grouped reductions, or random draws. Vectorization, in-place operation, backend parity, and Albucore migration are therefore not applicable; the lock and invocation policy belong to `Compose`, not an image-processing primitive.

## AI assistance disclosure

OpenAI Codex assisted with the diagnosis, implementation, regression tests, documentation, validation, and benchmark analysis for this pull request. This assistance is explicitly disclosed for maintainer review.

## Summary by Sourcery

Make Compose and ReplayCompose invocations reentrant by serializing concurrent calls under a per-instance lock and making Tensor route planning call-local rather than mutable pipeline state.

New Features:
- Introduce a reentrant, process-local invocation lock on Compose and ReplayCompose to serialize overlapping __call__ and run_with_trace executions while preserving reentrancy.

Enhancements:
- Refactor Tensor/Numpy bridge planning into an immutable per-call _TensorCallState so Tensor route and annotation handling are local to each invocation.
- Align nested traced Compose and ReplayCompose execution with the same invocation boundary to keep tracing, replay finalization, and Tensor restoration consistent across concurrent calls.
- Ensure runtime locks are excluded from Compose pickle state and recreated on unpickling so worker processes do not share synchronization objects.
- Document the concurrent invocation and Tensor route ownership contracts for Compose, including the serialized RNG behavior under overlapping seeded calls.

Tests:
- Add threaded regression tests in tests/test_compose_reentrancy.py to validate serialized concurrent calls across normal execution, tracing, replay, Tensor/NumPy restoration, grayscale layout, applied parameters, instance binding, and seeded RNG ordering.