### PR TITLE
chore: bump minor version to 2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.3.10"
+version = "2.4.0"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ ci-security = [
 ]
 ci-package = [
   "pytest>=9.1.1",
-  "twine",
+  "twine>=7.0.0",
 ]
 ci-benchmark = [
   "asv",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ scikit-learn>=1.7.2
 tomli>=2.4.1
 torch>=2.13.0
 torchvision>=0.28.0
-twine
+twine>=7.0.0
 types-PyYAML>=6.0.12.20260518
 types-setuptools>=83.0.0.20260706
 zizmor>=1.27.0

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.3.10"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },

--- a/uv.lock
+++ b/uv.lock
@@ -258,7 +258,7 @@ ci-benchmark = [
 ]
 ci-package = [
     { name = "pytest", specifier = ">=9.1.1" },
-    { name = "twine" },
+    { name = "twine", specifier = ">=7.0.0" },
 ]
 ci-pytorch = [
     { name = "albu-spec", specifier = ">=0.0.6" },
@@ -315,7 +315,7 @@ ci-release = [
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "tomli", specifier = ">=2.4.1" },
-    { name = "twine" },
+    { name = "twine", specifier = ">=7.0.0" },
     { name = "zizmor", specifier = ">=1.27.0" },
 ]
 ci-security = [
@@ -381,7 +381,7 @@ dev = [
     { name = "tomli", specifier = ">=2.4.1" },
     { name = "torch", specifier = ">=2.13.0" },
     { name = "torchvision", specifier = ">=0.28.0" },
-    { name = "twine" },
+    { name = "twine", specifier = ">=7.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
     { name = "types-setuptools", specifier = ">=83.0.0.20260706" },
     { name = "zizmor", specifier = ">=1.27.0" },
@@ -4660,7 +4660,7 @@ wheels = [
 
 [[package]]
 name = "twine"
-version = "6.2.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "id" },
@@ -4673,9 +4673,9 @@ dependencies = [
     { name = "rich" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/3c/58f808a359700f39a967dffede33efeac809262c03303fa3eec6afff8f49/twine-7.0.0.tar.gz", hash = "sha256:85cdb29c518efef867360ae4acd4b0dfd61c8654a22fca08e6f8539f05022177", size = 215032, upload-time = "2026-07-27T15:59:00.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/ddcdc06225eaad6de0e48e1002b06d919dbde20582d0662c7af51308e5d6/twine-7.0.0-py3-none-any.whl", hash = "sha256:b854164df26db268af05f49aa5c0344b10e27a494343ff05b1e0bad3b135f5a7", size = 43204, upload-time = "2026-07-27T15:58:59.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- bump the package version from `2.3.10` to `2.4.0`
- keep the editable package version in `uv.lock` synchronized

## Validation

- `uv lock --check`
- `./.venv/bin/pytest -q` — 13,402 passed, 43 skipped, 9 xfailed, 3 xpassed
- `./.venv/bin/pre-commit run --all-files`

## Summary by Sourcery

Build:
- Update project version in pyproject.toml to 2.4.0 and synchronize the editable package version in uv.lock.