### PR TITLE
fix(release): support metadata version 2.5

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -148,7 +148,7 @@ jobs:
           name: verified-release-bundle
           path: release-bundle
       - name: Publish distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: release-bundle/dist
           attestations: true


### PR DESCRIPTION
Updates the pinned PyPI publishing action from v1.14.0 to v1.14.2.

The 2.4.0 release failed before upload because the old action bundled a Twine version that rejects Core Metadata 2.5. Upstream v1.14.2 upgrades that dependency to Twine 7 with metadata-2.5 support.

Validation:
- `uv run pytest -m 'not slow'`
- CI matrix and shard checks
- focused CI workflow tests (57 passed)
- `zizmor` workflow audit
- `uv run python -m tools.quality_gate fast`
- `pre-commit run --all-files`

## Summary by Sourcery

Build:
- Bump the pinned pypa/gh-action-pypi-publish GitHub Action from v1.14.0 to v1.14.2 in the upload_to_pypi workflow.