### PR TITLE
Make Torch installation explicit

### DIFF
--- a/.codex/rules/albumentations-rules.md
+++ b/.codex/rules/albumentations-rules.md
@@ -58,6 +58,10 @@ always_apply: true
   and must also pass the NumPy-Compose-plus-terminal-conversion versus Tensor-Compose model-ready-output benchmark.
   Run `DataLoader`/collation benchmarks for shared Compose, bridge, planner, batching, and milestone changes; do not
   require them in every isolated transform-family pull request.
+- For Torch packaging, dependency-profile, or CI setup work, follow
+  `docs/design/torch-dependency-and-ci-greenfield.md`. Package metadata must not select Torch or TorchVision. CI and
+  documentation jobs that import AlbumentationsX must request the shared CPU-only runtime profile explicitly; static
+  jobs remain Torch-free.
 - After Python or quality-gate config edits, run `uv run python tools/quality_gate.py fast` before marking work
   complete when the environment can support it.
 

--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -1,13 +1,17 @@
 name: Set up purpose-specific CI environment
-description: Install uv, select Python, restore the uv cache, and sync one locked dependency group.
+description: Install uv, select Python, restore the uv cache, and sync one locked tool group with an explicit runtime profile.
 
 inputs:
   python-version:
     description: Python version understood by setup-uv.
     required: true
   dependency-group:
-    description: Locked PEP 735 dependency group to install.
+    description: Locked PEP 735 tool group to install.
     required: true
+  runtime-profile:
+    description: Runtime selected by the job. Use none for static work and torch-cpu for package imports.
+    required: false
+    default: none
 
 runs:
   using: composite
@@ -17,14 +21,37 @@ runs:
       with:
         activate-environment: true
         cache-dependency-glob: uv.lock
-        cache-suffix: ${{ inputs.dependency-group }}
+        cache-suffix: ${{ inputs.dependency-group }}-${{ inputs.runtime-profile }}
         enable-cache: true
         python-version: ${{ inputs.python-version }}
 
-    - name: Sync ${{ inputs.dependency-group }} dependencies
+    - name: Sync ${{ inputs.dependency-group }} with ${{ inputs.runtime-profile }}
       shell: bash
       env:
         CI_DEPENDENCY_GROUP: ${{ inputs.dependency-group }}
-      run: >-
-        uv sync --locked --no-default-groups
-        --group "${CI_DEPENDENCY_GROUP}" --inexact
+        CI_RUNTIME_PROFILE: ${{ inputs.runtime-profile }}
+      run: |
+        case "${CI_DEPENDENCY_GROUP}" in
+          ci-benchmark|ci-package|ci-quality|ci-release|ci-security|ci-test|ci-types) ;;
+          *) echo "Unknown CI dependency group: ${CI_DEPENDENCY_GROUP}" >&2; exit 2 ;;
+        esac
+        case "${CI_RUNTIME_PROFILE}" in
+          none) runtime_group=() ;;
+          torch-cpu) runtime_group=(--group ci-torch-cpu) ;;
+          *) echo "Unknown CI runtime profile: ${CI_RUNTIME_PROFILE}" >&2; exit 2 ;;
+        esac
+        uv sync --locked --no-default-groups --group "${CI_DEPENDENCY_GROUP}" "${runtime_group[@]}" --inexact
+
+    - name: Verify CPU-only Torch runtime
+      if: inputs.runtime-profile == 'torch-cpu'
+      shell: bash
+      run: python tools/torch_runtime.py check --expect cpu
+
+    - name: Record CI environment contract
+      shell: bash
+      env:
+        CI_DEPENDENCY_GROUP: ${{ inputs.dependency-group }}
+        CI_RUNTIME_PROFILE: ${{ inputs.runtime-profile }}
+      run: |
+        echo "ALBU_CI_DEPENDENCY_GROUP=${CI_DEPENDENCY_GROUP}" >> "$GITHUB_ENV"
+        echo "ALBU_CI_RUNTIME_PROFILE=${CI_RUNTIME_PROFILE}" >> "$GITHUB_ENV"

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -29,11 +29,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: actions
           build-mode: none
       - name: Analyze
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:actions"

--- a/.github/workflows/codeql-python.yml
+++ b/.github/workflows/codeql-python.yml
@@ -35,11 +35,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: python
           build-mode: none
       - name: Analyze
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:python"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         dependency-group: ci-test
+        runtime-profile: torch-cpu
     - name: Run complete base suite
       shell: bash
       run: |
@@ -58,9 +59,8 @@ jobs:
       uses: ./.github/actions/setup-ci
       with:
         python-version: "3.12"
-        dependency-group: ci-pytorch
-    - name: Verify CPU-only PyTorch profile
-      run: python -c "import torch; assert torch.version.cuda is None, torch.version.cuda"
+        dependency-group: ci-test
+        runtime-profile: torch-cpu
     - name: Run PyTorch-marked tests
       run: >-
         python -m pytest -n 2 --dist=worksteal -m pytorch
@@ -93,6 +93,8 @@ jobs:
         opencv-python-headless==5.0.0.93
         hypothesis
         pytest
+    - name: Install CPU-only Torch runtime
+      run: python tools/torch_runtime.py install-cpu --python python
     - name: Prepare nightly evidence directory
       run: python -c "from pathlib import Path; Path('nightly-evidence').mkdir(exist_ok=True)"
     - name: Collect lower-bound environment evidence
@@ -133,6 +135,7 @@ jobs:
       with:
         python-version: "3.14"
         dependency-group: ci-test
+        runtime-profile: torch-cpu
     - name: Prepare nightly evidence directory
       run: python -c "from pathlib import Path; Path('nightly-evidence').mkdir(exist_ok=True)"
     - name: Verify golden vectors
@@ -175,9 +178,11 @@ jobs:
       with:
         python-version: "3.14"
         dependency-group: ci-test
+        runtime-profile: torch-cpu
     - name: Install optional extras
       run: >
         uv sync --locked --no-default-groups --group ci-test --inexact
+        --group ci-torch-cpu
         --extra pillow
         --extra text
         --extra hub

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,10 +59,8 @@ jobs:
       with:
         python-version: "3.12"
         dependency-group: ci-pytorch
-    - name: Install CPU-only PyTorch
-      run: >-
-        uv pip install torch==2.13.0+cpu torchvision==0.28.0+cpu
-        --extra-index-url https://download.pytorch.org/whl/cpu
+    - name: Verify CPU-only PyTorch profile
+      run: python -c "import torch; assert torch.version.cuda is None, torch.version.cuda"
     - name: Run PyTorch-marked tests
       run: >-
         python -m pytest -n 2 --dist=worksteal -m pytorch
@@ -91,7 +89,7 @@ jobs:
         numpy==2.2.6
         scipy==1.15.3
         pydantic==2.12.4
-        albucore==0.2.12
+        albucore==0.2.13
         opencv-python-headless==5.0.0.93
         hypothesis
         pytest
@@ -184,8 +182,6 @@ jobs:
         --extra text
         --extra hub
         --extra contrib-headless
-        --no-install-package torch
-        --no-install-package torchvision
     - name: Run optional extras smoke tests
       run: python -m pytest -q tests/test_text.py tests/test_hub_mixin.py
     - name: Collect optional extras environment

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -58,6 +58,7 @@ jobs:
       with:
         python-version: "3.12"
         dependency-group: ci-benchmark
+        runtime-profile: torch-cpu
     - name: Collect benchmark environment evidence
       run: >
         python tools/collect_test_environment.py
@@ -168,6 +169,7 @@ jobs:
       with:
         python-version: "3.12"
         dependency-group: ci-benchmark
+        runtime-profile: torch-cpu
     - name: Collect ASV environment evidence
       run: >
         python tools/collect_test_environment.py

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -168,7 +168,8 @@ jobs:
         uses: ./.github/actions/setup-ci
         with:
           python-version: "3.12"
-          dependency-group: ci-contracts
+          dependency-group: ci-quality
+          runtime-profile: torch-cpu
       - name: Download changed paths
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -260,6 +261,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           dependency-group: ci-test
+          runtime-profile: torch-cpu
       - name: Run duration-balanced base-suite shard
         shell: bash
         run: |
@@ -311,6 +313,7 @@ jobs:
         with:
           python-version: "3.12"
           dependency-group: ci-test
+          runtime-profile: torch-cpu
       - name: Run base suite with branch coverage
         shell: bash
         run: |
@@ -349,6 +352,7 @@ jobs:
         with:
           python-version: "3.12"
           dependency-group: ci-test
+          runtime-profile: torch-cpu
       - name: Run complete base suite
         shell: bash
         run: |
@@ -388,6 +392,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           dependency-group: ci-test
+          runtime-profile: torch-cpu
       - name: Run changed test modules
         env:
           PYTEST_TARGETS: ${{ needs.plan.outputs.pytest_targets }}
@@ -411,9 +416,8 @@ jobs:
         uses: ./.github/actions/setup-ci
         with:
           python-version: "3.12"
-          dependency-group: ci-pytorch
-      - name: Verify CPU-only PyTorch profile
-        run: python -c "import torch; assert torch.version.cuda is None, torch.version.cuda"
+          dependency-group: ci-test
+          runtime-profile: torch-cpu
       - name: Run PyTorch-marked tests
         run: >-
           python -m pytest -n 2 --dist=worksteal -m pytorch
@@ -561,26 +565,9 @@ jobs:
       - name: Build wheel
         run: uv build --wheel --out-dir dist
       - name: Install wheel into a clean environment
-        shell: bash
-        run: |
-          uv venv --python "${{ matrix.python-version }}" "${RUNNER_TEMP}/install-smoke"
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            smoke_python="${RUNNER_TEMP}/install-smoke/Scripts/python.exe"
-          else
-            smoke_python="${RUNNER_TEMP}/install-smoke/bin/python"
-          fi
-          uv pip install --python "${smoke_python}" dist/*.whl "opencv-python-headless>=5.0.0.93"
-          if "${smoke_python}" -I -c "import importlib.util; raise SystemExit(importlib.util.find_spec('torch') is not None)"; then
-            echo "base wheel installation unexpectedly installed PyTorch"
-            exit 1
-          fi
-          if "${smoke_python}" -I -c "import albumentations" 2> import-without-torch.txt; then
-            echo "AlbumentationsX imported without PyTorch"
-            exit 1
-          fi
-          grep -F 'pip install "albumentationsx[headless]"' import-without-torch.txt
-          uv pip install --python "${smoke_python}" "torch>=2.13.0" --index-url https://download.pytorch.org/whl/cpu
-          "${smoke_python}" -I -c "import albumentations; print(albumentations.__version__)"
+        run: >-
+          python tools/torch_runtime.py install-contract
+          --wheel dist/*.whl --python "${{ matrix.python-version }}"
 
   release_preflight:
     name: Release preflight
@@ -601,6 +588,7 @@ jobs:
         with:
           python-version: "3.12"
           dependency-group: ci-release
+          runtime-profile: torch-cpu
       - name: Prepare release bundle
         id: metadata
         run: |
@@ -620,26 +608,9 @@ jobs:
       - name: Check final distribution metadata
         run: twine check "${RUNNER_TEMP}"/release-bundle/dist/*
       - name: Smoke test final wheel
-        shell: bash
-        run: |
-          smoke_venv="${RUNNER_TEMP}/albumentationsx-release-smoke"
-          uv venv --clear --python 3.12 "${smoke_venv}"
-          wheels=("${RUNNER_TEMP}"/release-bundle/dist/*.whl)
-          uv pip install \
-            --python "${smoke_venv}/bin/python" \
-            "${wheels[0]}" "opencv-python-headless>=5.0.0.93"
-          uv pip install \
-            --python "${smoke_venv}/bin/python" \
-            "torch>=2.13.0" --index-url https://download.pytorch.org/whl/cpu
-          cd "${RUNNER_TEMP}"
-          "${smoke_venv}/bin/python" -I - <<'PY'
-          import albumentations
-          import numpy as np
-
-          image = np.zeros((64, 64, 3), dtype=np.uint8)
-          albumentations.HorizontalFlip(p=1)(image=image)
-          print("albumentations release smoke passed:", albumentations.__version__)
-          PY
+        run: >-
+          python tools/torch_runtime.py install-contract
+          --wheel "${RUNNER_TEMP}"/release-bundle/dist/*.whl --python "3.12"
       - name: Verify lock freshness
         run: uv lock --check
       - name: Collect release environment evidence

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -412,10 +412,8 @@ jobs:
         with:
           python-version: "3.12"
           dependency-group: ci-pytorch
-      - name: Install CPU-only PyTorch
-        run: >-
-          uv pip install torch==2.13.0+cpu torchvision==0.28.0+cpu
-          --extra-index-url https://download.pytorch.org/whl/cpu
+      - name: Verify CPU-only PyTorch profile
+        run: python -c "import torch; assert torch.version.cuda is None, torch.version.cuda"
       - name: Run PyTorch-marked tests
         run: >-
           python -m pytest -n 2 --dist=worksteal -m pytorch
@@ -572,6 +570,16 @@ jobs:
             smoke_python="${RUNNER_TEMP}/install-smoke/bin/python"
           fi
           uv pip install --python "${smoke_python}" dist/*.whl "opencv-python-headless>=5.0.0.93"
+          if "${smoke_python}" -I -c "import importlib.util; raise SystemExit(importlib.util.find_spec('torch') is not None)"; then
+            echo "base wheel installation unexpectedly installed PyTorch"
+            exit 1
+          fi
+          if "${smoke_python}" -I -c "import albumentations" 2> import-without-torch.txt; then
+            echo "AlbumentationsX imported without PyTorch"
+            exit 1
+          fi
+          grep -F 'pip install "albumentationsx[headless]"' import-without-torch.txt
+          uv pip install --python "${smoke_python}" "torch>=2.13.0" --index-url https://download.pytorch.org/whl/cpu
           "${smoke_python}" -I -c "import albumentations; print(albumentations.__version__)"
 
   release_preflight:
@@ -620,6 +628,9 @@ jobs:
           uv pip install \
             --python "${smoke_venv}/bin/python" \
             "${wheels[0]}" "opencv-python-headless>=5.0.0.93"
+          uv pip install \
+            --python "${smoke_venv}/bin/python" \
+            "torch>=2.13.0" --index-url https://download.pytorch.org/whl/cpu
           cd "${RUNNER_TEMP}"
           "${smoke_venv}/bin/python" -I - <<'PY'
           import albumentations

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           python-version: "3.12"
           dependency-group: ci-quality
+          runtime-profile: torch-cpu
       - name: Download changed paths
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -168,7 +168,7 @@ jobs:
         uses: ./.github/actions/setup-ci
         with:
           python-version: "3.12"
-          dependency-group: ci-quality
+          dependency-group: ci-contracts
       - name: Download changed paths
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/pytorch-performance.yml
+++ b/.github/workflows/pytorch-performance.yml
@@ -24,6 +24,7 @@ jobs:
       with:
         python-version: "3.12"
         dependency-group: ci-benchmark
+        runtime-profile: torch-cpu
     - name: Collect PyTorch benchmark environment evidence
       run: >
         python tools/collect_test_environment.py

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         dependency-group: ci-test
+        runtime-profile: torch-cpu
     - name: Verify matrix and regression vectors
       if: matrix.operating-system == 'ubuntu-latest' && matrix.python-version == '3.12'
       run: |
@@ -108,9 +109,8 @@ jobs:
       uses: ./.github/actions/setup-ci
       with:
         python-version: "3.12"
-        dependency-group: ci-pytorch
-    - name: Verify CPU-only PyTorch profile
-      run: python -c "import torch; assert torch.version.cuda is None, torch.version.cuda"
+        dependency-group: ci-test
+        runtime-profile: torch-cpu
     - name: Run PyTorch-marked tests
       run: >-
         python -m pytest -n 2 --dist=worksteal -m pytorch
@@ -134,6 +134,7 @@ jobs:
       with:
         python-version: "3.12"
         dependency-group: ci-benchmark
+        runtime-profile: torch-cpu
     - name: Prepare release candidate performance evidence directory
       run: python -c "from pathlib import Path; Path('release-candidate-performance-evidence').mkdir(exist_ok=True)"
     - name: Collect release candidate performance environment

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -109,10 +109,8 @@ jobs:
       with:
         python-version: "3.12"
         dependency-group: ci-pytorch
-    - name: Install CPU-only PyTorch
-      run: >-
-        uv pip install torch==2.13.0+cpu torchvision==0.28.0+cpu
-        --extra-index-url https://download.pytorch.org/whl/cpu
+    - name: Verify CPU-only PyTorch profile
+      run: python -c "import torch; assert torch.version.cuda is None, torch.version.cuda"
     - name: Run PyTorch-marked tests
       run: >-
         python -m pytest -n 2 --dist=worksteal -m pytorch

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ agreement or order form expressly says so. See the [AGPL text](LICENSE),
 ### Quick Start
 
 ```bash
-# Install AlbumentationsX with OpenCV
-pip install albumentationsx[headless]
+# Install the PyTorch build for your platform first. For Linux CPU-only:
+pip install "torch>=2.13.0" --index-url https://download.pytorch.org/whl/cpu
 
-# Or if you already have OpenCV installed
-pip install albumentationsx
+# Then install AlbumentationsX with OpenCV.
+pip install "albumentationsx[headless]"
 ```
 
 ```python
@@ -124,7 +124,17 @@ AlbumentationsX requires Python 3.10 or higher. To install the latest version fr
 
 ### Basic Installation
 
-If you already have OpenCV installed (any variant), simply install AlbumentationsX:
+Install the PyTorch build for your CPU, CUDA, or MPS environment before installing AlbumentationsX. For a Linux
+CPU-only environment:
+
+```bash
+pip install "torch>=2.13.0" --index-url https://download.pytorch.org/whl/cpu
+```
+
+For CUDA or macOS (MPS), use the matching command from the [PyTorch installation selector](https://pytorch.org/get-started/locally/).
+AlbumentationsX does not choose or install a PyTorch accelerator build.
+
+If you already have OpenCV installed (any variant), install AlbumentationsX:
 
 ```bash
 pip install -U albumentationsx
@@ -136,7 +146,7 @@ If you don't have OpenCV installed yet, choose the appropriate variant:
 
 ```bash
 # For servers/Docker (no GUI support, lighter package)
-pip install -U albumentationsx[headless]
+pip install -U "albumentationsx[headless]"
 
 # For local development with GUI support (cv2.imshow, etc.)
 pip install opencv-python && pip install -U albumentationsx
@@ -145,7 +155,7 @@ pip install opencv-python && pip install -U albumentationsx
 pip install opencv-contrib-python && pip install -U albumentationsx
 
 # For contrib + headless
-pip install -U albumentationsx[contrib-headless]
+pip install -U "albumentationsx[contrib-headless]"
 ```
 
 **Note:** AlbumentationsX works with any OpenCV variant:
@@ -156,6 +166,9 @@ pip install -U albumentationsx[contrib-headless]
 - `opencv-contrib-python-headless` (contrib + headless)
 
 Choose the one that fits your needs. The library will detect whichever is installed.
+
+`pip install albumentationsx` installs the base dependency set without PyTorch. It is useful for dependency-only
+consumers such as documentation builds. Importing `albumentations` requires the PyTorch build you selected above.
 
 Other installation options are described in the [documentation](https://albumentations.ai/docs/1-introduction/installation/?utm_source=github&utm_medium=referral&utm_campaign=readme).
 

--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -2,10 +2,14 @@ from albumentations._version import __author__ as __author__
 from albumentations._version import __maintainer__ as __maintainer__
 from albumentations._version import __version__ as __version__
 
-# Check for OpenCV at import time
+# OpenCV is an installation extra and Torch is intentionally absent from package
+# metadata, so docs and dependency-only consumers do not select a CPU, CUDA, or MPS build.
+# The public import graph requires both.
 try:
     import cv2  # noqa: F401
-except ImportError as e:
+except ModuleNotFoundError as e:
+    if e.name != "cv2":
+        raise
     msg = (
         "AlbumentationsX requires OpenCV but it's not installed.\n\n"
         "Install one of the following:\n"
@@ -17,6 +21,22 @@ except ImportError as e:
         "  pip install albumentationsx[headless]     # Installs opencv-python-headless\n"
         "  pip install albumentationsx[gui]          # Installs opencv-python\n"
         "  pip install albumentationsx[contrib]      # Installs opencv-contrib-python"
+    )
+    raise ImportError(msg) from e
+
+try:
+    import torch  # noqa: F401
+except ModuleNotFoundError as e:
+    if e.name != "torch":
+        raise
+    msg = (
+        "AlbumentationsX requires PyTorch when it is imported.\n\n"
+        "Install the PyTorch build for your platform first. For Linux CPU-only:\n"
+        '  pip install "torch>=2.13.0" --index-url https://download.pytorch.org/whl/cpu\n\n'
+        "Then install AlbumentationsX with an OpenCV extra:\n"
+        '  pip install "albumentationsx[headless]"\n\n'
+        "Use PyTorch's platform-specific command for CUDA or MPS, and replace "
+        "headless with gui, contrib, or contrib-headless if needed."
     )
     raise ImportError(msg) from e
 

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -18,7 +18,7 @@ from ._functional_shared import (
     ImageUInt8,
     add_array,
     add_constant,
-    apply_multichannel_lut,
+    apply_uint8_lut,
     clip,
     clipped,
     cv2,
@@ -35,9 +35,7 @@ from ._functional_shared import (
     power,
     preserve_channel_dim,
     reduce_sum,
-    reshape_ndhwc_channel,
     reshape_xhwc_channel,
-    restore_ndhwc_channel,
     restore_xhwc_channel,
     sz_lut,
     uint8_io,
@@ -264,14 +262,16 @@ def _equalize_cv_multichannel_lut(img: ImageType) -> ImageType:
     """Apply OpenCV-style equalization with one multichannel LUT pass for large
     RGB images and multispectral inputs where per-channel assignment is slower.
     """
-    luts = []
-    for channel_idx in range(get_num_channels(img)):
+    num_channels = get_num_channels(img)
+    lut = np.empty((256, 1, num_channels), dtype=np.uint8)
+    identity_lut = np.arange(256, dtype=np.uint8)
+    for channel_idx in range(num_channels):
         channel = img[..., channel_idx]
         histogram = cv2.calcHist([channel], [0], None, [256], (0, 256)).ravel()
-        lut = _create_equalize_cv_lut(histogram)
-        luts.append(np.arange(256, dtype=np.uint8) if lut is None else lut)
+        channel_lut = _create_equalize_cv_lut(histogram)
+        lut[:, 0, channel_idx] = identity_lut if channel_lut is None else channel_lut
 
-    return apply_multichannel_lut(img, np.stack(luts), get_num_channels(img))
+    return apply_uint8_lut(cast("ImageUInt8", img), lut)
 
 
 def _check_preconditions(
@@ -487,15 +487,15 @@ def move_tone_curve(
     if isinstance(low_y, np.ndarray) and isinstance(high_y, np.ndarray):
         if img.dtype == np.float32:
             return _move_tone_curve_float32(cast("ImageFloat32", img), low_y, high_y)
-        luts = cast(
+        lut = cast(
             "ImageUInt8",
             clip(
-                np.rint(evaluate_bez(low_y, high_y).T),
+                np.rint(evaluate_bez(low_y, high_y)),
                 np.dtype(np.uint8),
                 inplace=False,
             ),
         )
-        return apply_multichannel_lut(img, luts, num_channels)
+        return apply_uint8_lut(cast("ImageUInt8", img), lut[:, np.newaxis, :])
 
     raise TypeError(
         f"low_y and high_y must both be of type float or np.ndarray. Got {type(low_y)} and {type(high_y)}",
@@ -508,14 +508,13 @@ def linear_transformation_rgb(
     transformation_matrix: np.ndarray,
 ) -> ImageType:
     """3x3 linear transformation to RGB. transformation_matrix (or batch) multiplies channel
-    vector. Supports (H,W,3), (B,H,W,3), (B,D,H,W,3).
+    vector. Supports (H,W,3) and (B,H,W,3).
 
     This function applies a 3x3 linear transformation matrix (or batch of matrices)
     to the RGB channels of either a single image or a batch of images.
 
     Args:
-        img (ImageType): A single RGB image of shape (H, W, 3), a batch of images (B, H, W, 3),
-            or a five-dimensional tensor (B, D, H, W, 3).
+        img (ImageType): A single RGB image of shape (H, W, 3) or a batch of images (B, H, W, 3).
         transformation_matrix (np.ndarray): A 3x3 matrix
 
     Returns:
@@ -531,11 +530,7 @@ def linear_transformation_rgb(
         transformed, original_shape = reshape_xhwc_channel(img)
         transformed = cast("ImageType", cv2.transform(transformed, transformation_matrix))
         return cast("ImageType", restore_xhwc_channel(transformed, original_shape))
-    if img.ndim == 5:
-        transformed, original_shape = reshape_ndhwc_channel(img)
-        transformed = cast("ImageType", cv2.transform(transformed, transformation_matrix))
-        return cast("ImageType", restore_ndhwc_channel(transformed, original_shape))
-    raise ValueError(f"Expected input shape (H, W, 3), (B, H, W, 3), (B, D, H, W, 3), got {img.shape}")
+    raise ValueError(f"Expected input shape (H, W, 3) or (B, H, W, 3), got {img.shape}")
 
 
 @uint8_io
@@ -919,7 +914,6 @@ def to_gray_weighted_average(img: ImageType) -> ImageType:
             - Single image: (H, W, 3)
             - Batch of images: (N, H, W, 3)
             - Volume: (D, H, W, 3)
-            - Five-dimensional tensor: (N, D, H, W, 3)
 
     Returns:
         ImageType: Grayscale image as a 2D numpy array.
@@ -940,14 +934,6 @@ def to_gray_weighted_average(img: ImageType) -> ImageType:
         new_shape = (*original_shape[:-1], 1)
 
         return cast("ImageType", restore_xhwc_channel(im, new_shape))
-
-    if img.ndim == 5:
-        img, original_shape = reshape_ndhwc_channel(img)
-        img = cast("ImageType", cv2.cvtColor(img, cv2.COLOR_RGB2GRAY))
-
-        new_shape = (*original_shape[:-1], 1)
-
-        return cast("ImageType", restore_ndhwc_channel(img, new_shape))
 
     raise ValueError(f"Unsupported number of dimensions: {img.ndim}")
 
@@ -974,7 +960,6 @@ def to_gray_from_lab(img: ImageType) -> ImageType:
             - Single image: (H, W, 3)
             - Batch of images: (N, H, W, 3)
             - Volume: (D, H, W, 3)
-            - Five-dimensional tensor: (N, D, H, W, 3)
 
             Supported dtypes:
             - np.uint8: Values in range [0, 255]
@@ -985,7 +970,6 @@ def to_gray_from_lab(img: ImageType) -> ImageType:
             - Single image: (H, W)
             - Batch of images: (N, H, W)
             - Volume: (D, H, W)
-            - Five-dimensional tensor: (N, D, H, W)
 
         The output dtype matches the input dtype. For float inputs, the L channel
         is normalized to [0, 1] by dividing by 100.
@@ -1029,14 +1013,6 @@ def to_gray_from_lab(img: ImageType) -> ImageType:
         new_shape = (*original_shape[:-1], 1)
 
         return cast("ImageType", restore_xhwc_channel(im, new_shape))
-
-    if img.ndim == 5:
-        img, original_shape = reshape_ndhwc_channel(img)
-        img = cast("ImageType", cv2.cvtColor(img, cv2.COLOR_RGB2LAB)[..., 0])
-
-        new_shape = (*original_shape[:-1], 1)
-
-        return cast("ImageType", restore_ndhwc_channel(img, new_shape))
 
     raise ValueError(f"Unsupported number of dimensions: {img.ndim}")
 

--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -23,7 +23,7 @@ from ._functional_shared import (
     add,
     add_array,
     add_weighted,
-    apply_multichannel_lut,
+    apply_uint8_lut,
     clip,
     clipped,
     cv2,
@@ -525,14 +525,16 @@ def _auto_contrast_multichannel_lut(
     """Apply per-channel autocontrast LUTs with one OpenCV pass for large RGB
     images and multispectral inputs where split channel assignment is slower.
     """
-    luts = []
-    for channel_idx in range(get_num_channels(img)):
+    num_channels = get_num_channels(img)
+    lut = np.empty((256, 1, num_channels), dtype=np.uint8)
+    identity_lut = np.arange(256, dtype=np.uint8)
+    for channel_idx in range(num_channels):
         channel = img[..., channel_idx]
         hist = cv2.calcHist([channel], [0], None, [256], [0, max_value]).ravel()
-        lut = _create_auto_contrast_lut(hist, cutoff, None, method, max_value)
-        luts.append(np.arange(256, dtype=np.uint8) if lut is None else lut)
+        channel_lut = _create_auto_contrast_lut(hist, cutoff, None, method, max_value)
+        lut[:, 0, channel_idx] = identity_lut if channel_lut is None else channel_lut
 
-    return cast("ImageUInt8", apply_multichannel_lut(img, np.stack(luts), get_num_channels(img)))
+    return apply_uint8_lut(img, lut)
 
 
 def _auto_contrast_multichannel_hist(

--- a/albumentations/augmentations/pixel/_functional_shared.py
+++ b/albumentations/augmentations/pixel/_functional_shared.py
@@ -6,7 +6,7 @@ import math
 import random
 from collections.abc import Sequence
 from functools import lru_cache
-from typing import Any, Literal, cast
+from typing import Any, Literal
 from warnings import warn
 
 import cv2
@@ -18,6 +18,7 @@ from albucore import (
     add_constant,
     add_vector,
     add_weighted,
+    apply_uint8_lut,
     clip,
     clipped,
     float32_io,
@@ -36,9 +37,7 @@ from albucore import (
     preserve_channel_dim,
     reduce_sum,
     remap,
-    reshape_ndhwc_channel,
     reshape_xhwc_channel,
-    restore_ndhwc_channel,
     restore_xhwc_channel,
     std,
     sz_lut,
@@ -64,17 +63,6 @@ MULTICHANNEL_LUT_MEDIUM_IMAGE_PIXELS = 512 * 512
 MULTICHANNEL_LUT_LARGE_IMAGE_PIXELS = 1024 * 1024
 
 
-def apply_multichannel_lut(img: ImageType, luts: np.ndarray, num_channels: int) -> ImageType:
-    """Apply channel-specific uint8 LUTs in one OpenCV pass for images, batches, and volume data while
-    preserving original shape and channel order.
-    """
-    lut = np.ascontiguousarray(luts.T.reshape(256, 1, num_channels))
-    if img.ndim == NUM_MULTI_CHANNEL_DIMENSIONS:
-        return cast("ImageType", cv2.LUT(img, lut))
-
-    return cast("ImageType", cv2.LUT(img.reshape(-1, 1, num_channels), lut).reshape(img.shape))
-
-
 __all__ = [
     "MAX_VALUES_BY_DTYPE",
     "MONO_CHANNEL_DIMENSIONS",
@@ -94,7 +82,7 @@ __all__ = [
     "add_constant",
     "add_vector",
     "add_weighted",
-    "apply_multichannel_lut",
+    "apply_uint8_lut",
     "clip",
     "clipped",
     "cv2",
@@ -120,9 +108,7 @@ __all__ = [
     "random",
     "reduce_sum",
     "remap",
-    "reshape_ndhwc_channel",
     "reshape_xhwc_channel",
-    "restore_ndhwc_channel",
     "restore_xhwc_channel",
     "std",
     "sz_lut",

--- a/benchmark/asv-pytorch.conf.json
+++ b/benchmark/asv-pytorch.conf.json
@@ -4,7 +4,11 @@
   "project_url": "https://github.com/albumentations-team/AlbumentationsX",
   "repo": "..",
   "environment_type": "virtualenv",
-  "install_command": "python -m pip install \"torch>=2.13.0\" --index-url https://download.pytorch.org/whl/cpu && python -m pip install {build_dir}[headless]",
+  "build_command": "python -m pip wheel --no-deps -w {build_cache_dir} {build_dir}",
+  "install_command": [
+    "python -m pip install \"torch>=2.13.0\" --index-url https://download.pytorch.org/whl/cpu",
+    "python -m pip install {wheel_file}[headless] --force-reinstall"
+  ],
   "benchmark_dir": "pytorch_benchmarks",
   "env_dir": ".asv/pytorch-env",
   "results_dir": ".asv/pytorch-results",

--- a/benchmark/asv-pytorch.conf.json
+++ b/benchmark/asv-pytorch.conf.json
@@ -4,7 +4,7 @@
   "project_url": "https://github.com/albumentations-team/AlbumentationsX",
   "repo": "..",
   "environment_type": "virtualenv",
-  "install_command": "python -m pip install {build_dir}[headless]",
+  "install_command": "python -m pip install \"torch>=2.13.0\" --index-url https://download.pytorch.org/whl/cpu && python -m pip install {build_dir}[headless]",
   "benchmark_dir": "pytorch_benchmarks",
   "env_dir": ".asv/pytorch-env",
   "results_dir": ".asv/pytorch-results",

--- a/benchmark/asv.conf.json
+++ b/benchmark/asv.conf.json
@@ -5,7 +5,7 @@
   "repo": "..",
   "environment_type": "virtualenv",
   "build_command": "python -m pip wheel --no-deps -w {build_cache_dir} {build_dir}",
-  "install_command": "in-dir={env_dir} python -m pip install {wheel_file}[headless,text] --force-reinstall",
+  "install_command": "in-dir={env_dir} python -m pip install \"torch>=2.13.0\" --index-url https://download.pytorch.org/whl/cpu && python -m pip install {wheel_file}[headless,text] --force-reinstall",
   "benchmark_dir": "benchmarks",
   "env_dir": ".asv/env",
   "results_dir": ".asv/results",

--- a/benchmark/asv.conf.json
+++ b/benchmark/asv.conf.json
@@ -5,7 +5,10 @@
   "repo": "..",
   "environment_type": "virtualenv",
   "build_command": "python -m pip wheel --no-deps -w {build_cache_dir} {build_dir}",
-  "install_command": "in-dir={env_dir} python -m pip install \"torch>=2.13.0\" --index-url https://download.pytorch.org/whl/cpu && python -m pip install {wheel_file}[headless,text] --force-reinstall",
+  "install_command": [
+    "in-dir={env_dir} python -m pip install \"torch>=2.13.0\" --index-url https://download.pytorch.org/whl/cpu",
+    "in-dir={env_dir} python -m pip install {wheel_file}[headless,text] --force-reinstall"
+  ],
   "benchmark_dir": "benchmarks",
   "env_dir": ".asv/env",
   "results_dir": ".asv/results",

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - numpy>=2.2.6
     - scipy
     - pydantic>=2.9
-    - pytorch>=2.13.0
     - typing_extensions
     - opencv-python-headless
 
@@ -34,15 +33,16 @@ requirements:
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=5.0.0.93
-    - albucore==0.2.12
-    - numkong!=7.7.1
-    - pytorch>=2.13.0
+    - albucore==0.2.13
+    - numkong>=7.8.0
 
 suggests:
   - huggingface-hub
   - pillow
 
 test:
+  requires:
+    - pytorch>=2.13.0
   imports:
     - albumentations
 

--- a/docs/contributing/environment_setup.md
+++ b/docs/contributing/environment_setup.md
@@ -33,7 +33,7 @@ This is the canonical setup path for contributors and coding agents. It installs
 including Ruff, mypy, Pyrefly, pytest, pre-commit, and security tooling.
 
 CI itself uses smaller locked groups so unrelated jobs do not install the full
-toolchain: `ci-test`, `ci-quality`, `ci-types`, `ci-pytorch`, `ci-security`,
+toolchain: `ci-test`, `ci-quality`, `ci-contracts`, `ci-types`, `ci-pytorch`, `ci-security`,
 `ci-package`, `ci-benchmark`, and `ci-release`. Contributors normally should
 keep using `dev`; the purpose-specific groups are useful when reproducing one
 CI leaf, for example:

--- a/docs/contributing/environment_setup.md
+++ b/docs/contributing/environment_setup.md
@@ -26,20 +26,29 @@ cd AlbumentationsX
 Create a local virtual environment and install the project plus development tools:
 
 ```bash
-uv sync --group dev
+uv sync --locked --group dev --inexact
 ```
 
 This is the canonical setup path for contributors and coding agents. It installs the same toolchain used by CI,
-including Ruff, mypy, Pyrefly, pytest, pre-commit, and security tooling.
+including Ruff, mypy, Pyrefly, pytest, pre-commit, and security tooling. It does not choose a Torch build. Install
+the CPU, CUDA, or MPS Torch build required by your development environment before running code that imports
+AlbumentationsX.
 
-CI itself uses smaller locked groups so unrelated jobs do not install the full
-toolchain: `ci-test`, `ci-quality`, `ci-contracts`, `ci-types`, `ci-pytorch`, `ci-security`,
-`ci-package`, `ci-benchmark`, and `ci-release`. Contributors normally should
-keep using `dev`; the purpose-specific groups are useful when reproducing one
-CI leaf, for example:
+To reproduce the CPU-only runtime used by CI, add its explicit profile:
 
 ```bash
-uv sync --locked --no-default-groups --group ci-test
+uv sync --locked --group dev --group ci-torch-cpu --inexact
+```
+
+CI itself uses smaller locked groups so unrelated jobs do not install the full
+toolchain: `ci-test`, `ci-quality`, `ci-types`, `ci-security`, `ci-package`,
+`ci-benchmark`, `ci-release`, and `ci-torch-cpu`. Tool groups never select a
+runtime. Jobs that import AlbumentationsX add `ci-torch-cpu`; static jobs do
+not. Contributors normally should keep using `dev`; the purpose-specific
+groups are useful when reproducing one CI leaf, for example:
+
+```bash
+uv sync --locked --no-default-groups --group ci-test --group ci-torch-cpu --inexact
 ```
 
 #### pip fallback
@@ -53,6 +62,9 @@ source env/bin/activate
 pip install -e .
 pip install -r requirements-dev.txt
 ```
+
+The fallback requirements also leave Torch to you. Install the CPU, CUDA, or
+MPS Torch build before running the test suite.
 
 On Windows, activate the environment with `env\Scripts\activate.bat` for cmd.exe or `env\Scripts\activate.ps1` for
 PowerShell.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -52,7 +52,7 @@ sample-dependent work, with separate branch-free executors for ordinary, observe
 
 ### [Torch CPU Backend and Tensor-Native Compose](torch-cpu-backend-migration.md)
 
-Plan for making Torch a required dependency and routing compatible NumPy/OpenCV/NumKong and Torch segments through
+Plan for making Torch a soft-required runtime dependency and routing compatible NumPy/OpenCV/NumKong and Torch segments through
 the existing `Compose`. The route planner may cross the representation boundary in either direction when the complete
 measured path does not regress.
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -50,6 +50,13 @@ sample-dependent work, with separate branch-free executors for ordinary, observe
 
 ## Active Design Work
 
+### [Greenfield Torch Dependency and CI Architecture](torch-dependency-and-ci-greenfield.md)
+
+Plan for keeping Torch out of package metadata while making every import-capable CI and documentation job request the
+shared CPU-only runtime profile explicitly.
+
+**Status**: Implemented. The repository uses explicit `none` and `torch-cpu` runtime profiles.
+
 ### [Torch CPU Backend and Tensor-Native Compose](torch-cpu-backend-migration.md)
 
 Plan for making Torch a soft-required runtime dependency and routing compatible NumPy/OpenCV/NumKong and Torch segments through

--- a/docs/design/torch-cpu-backend-migration.md
+++ b/docs/design/torch-cpu-backend-migration.md
@@ -2,7 +2,8 @@
 
 **Status:** In progress
 
-**Decision:** `torch` becomes a required dependency. The existing `Compose` accepts both NumPy arrays and CPU
+**Decision:** `torch` becomes a soft-required runtime dependency. Users install a CPU, CUDA, or MPS build before
+installing AlbumentationsX. The existing `Compose` accepts both NumPy arrays and CPU
 `torch.Tensor` values. Every valid Tensor pipeline returns Tensor output. Before transform parameters are sampled,
 `Compose` chooses one representation for the entire pipeline: direct Tensor execution when every selectable child
 supports the supplied Tensor targets, otherwise one Tensor-to-NumPy bridge before the pipeline and one NumPy-to-Tensor
@@ -15,7 +16,7 @@ without rebuilding and timing a complete loader for every matrix cell.
 
 ## Current implementation status
 
-The repository is in the foundation stage. `torch` is now a required dependency. `Compose` accepts every validated CPU
+The repository is in the foundation stage. Public imports require an installed `torch` runtime. `Compose` accepts every validated CPU
 Tensor pipeline and returns Tensor output. If every selectable transform supports the supplied Tensor targets, the
 pipeline runs directly on Tensor values. If any transform lacks that direct route, `Compose` converts every spatial
 target to its established channel-last NumPy layout once before the pipeline and restores Tensor layouts once after
@@ -310,13 +311,13 @@ not an implicit fallback hidden inside a helper.
 
 ### Phase 0 — dependency and baselines
 
-1. Add the validated Torch floor to runtime dependencies. Keep TorchVision optional.
+1. Declare the validated Torch floor only in the CPU-only CI dependency groups; package installation stays independent.
 2. Update lockfile, CI, platform/Python support checks, SBOM/security inputs, and environment reporting.
 3. Measure baseline variance on a stable Linux x86-64 machine. Calibrate a repeatability threshold no larger than 1%.
 4. Add the route-result JSON schema: environment, input representation, transform IDs, selected route, every bridge,
    raw samples, correctness result, memory result, and decision.
 
-Exit: a default install includes Torch, and the benchmark runner can distinguish a real regression from noise.
+Exit: the CPU CI environment includes Torch, and the benchmark runner can distinguish a real regression from noise.
 
 ### Phase 1 — prove the complete Compose Tensor lifecycle once
 
@@ -411,7 +412,7 @@ unrelated migration work.
 
 The CPU program is complete when:
 
-- Torch is a required dependency on supported platforms;
+- public imports require an installed Torch runtime on supported platforms;
 - `Compose` accepts every valid declared CPU Tensor pipeline and returns Tensor output for Tensor input;
 - `Compose` selects either direct Tensor execution or the whole-pipeline NumPy route before parameter sampling;
 - every accepted route has permanent correctness tests and full per-cell performance evidence;

--- a/docs/design/torch-dependency-and-ci-greenfield.md
+++ b/docs/design/torch-dependency-and-ci-greenfield.md
@@ -1,0 +1,183 @@
+# Greenfield Torch dependency and CI architecture
+
+**Status:** Implemented
+
+**Scope:** Packaging, development environments, documentation builds, CI
+dependency profiles, install smoke tests, and release verification. Tensor
+execution and backend routing are outside this dependency architecture.
+
+## Decision
+
+Torch is an externally managed, soft-required runtime:
+
+- `pip install albumentationsx` installs neither Torch, TorchVision, CUDA
+  libraries, nor an accelerator runtime;
+- the user installs the CPU, CUDA, or MPS Torch build needed by the
+  application before importing AlbumentationsX;
+- importing `albumentations` requires Torch and gives an installation error
+  only when the top-level `torch` module is absent;
+- importing AlbumentationsX does not lazily load Torch and does not call CUDA,
+  MPS, device, stream, or autograd APIs; and
+- every CI job that imports AlbumentationsX explicitly selects CPU-only Torch.
+
+The CPU build is a CI runtime choice. It is not package metadata and cannot
+replace a Torch build selected by an application.
+
+## Why CI has separate tool and runtime axes
+
+Package metadata cannot choose the right Torch distribution for every user. A
+generic requirement can pull a large runtime into a documentation build or
+audit that never imports the library, and may select CUDA packages on Linux.
+
+Removing Torch from package metadata creates a complementary rule: a process
+that imports `albumentations` must already have Torch. Pytest imports
+`tests/conftest.py` before applying markers, so `pytest -m "not pytorch"` still
+needs Torch. Markers select tests; they do not change package import behavior.
+
+Every CI job therefore declares two independent inputs:
+
+```mermaid
+flowchart LR
+    Job["CI job"] --> Tools["Tool group<br/>ci-test, ci-quality, ci-package, ..."]
+    Job --> Runtime["Runtime profile"]
+    Runtime --> None["none<br/>no Torch"]
+    Runtime --> CPU["torch-cpu<br/>CPU index only"]
+    Tools --> Sync["one locked uv sync"]
+    None --> Sync
+    CPU --> Sync
+    Sync --> Environment["purpose-specific environment"]
+```
+
+The shared setup action accepts this contract:
+
+```yaml
+with:
+  python-version: "3.12"
+  dependency-group: ci-test
+  runtime-profile: torch-cpu
+```
+
+`runtime-profile` defaults to `none`. `torch-cpu` adds `ci-torch-cpu` to the
+same locked `uv sync`, uses the explicit PyTorch CPU index, checks that
+`torch.version.cuda is None`, rejects installed `cuda*` and `nvidia-*`
+distributions, and records the selected profile in the job environment.
+Cache keys include both axes.
+
+## Package and contributor contracts
+
+`project.dependencies`, optional extras, Conda `run` dependencies, and
+`requirements-dev.txt` do not select Torch or TorchVision. The project does
+not provide an `albumentationsx[torch]` extra: that extra could not know whether
+the user needs CPU, CUDA, or MPS.
+
+The supported installation order is:
+
+1. Install the required Torch build using the platform-specific PyTorch
+   command.
+2. Install AlbumentationsX and the desired OpenCV extra.
+3. Import AlbumentationsX.
+
+The Linux CPU-only command may use the PyTorch CPU index. CUDA and MPS
+instructions point users to the PyTorch selector. AlbumentationsX never chooses
+an accelerator build for them.
+
+`dev` contains contributor tools but no Torch runtime. `uv sync --inexact`
+preserves a developer's existing CPU, CUDA, or MPS installation. A developer
+who wants the CI runtime adds `--group ci-torch-cpu` explicitly.
+
+## CI profiles
+
+| Tool group | Purpose | Torch selected by the group |
+| --- | --- | --- |
+| `ci-test` | pytest, xdist, coverage, Hypothesis, test libraries, headless OpenCV | No |
+| `ci-quality` | Ruff, pre-commit, mypy, and repository contracts | No |
+| `ci-types` | Pyrefly, typing tools, and stubs | No |
+| `ci-security` | dependency and workflow auditors | No |
+| `ci-package` | build, Twine, and artifact checks | No |
+| `ci-benchmark` | ASV and benchmark tooling | No |
+| `ci-release` | release bundle, SBOM, and release evidence tooling | No |
+| `ci-torch-cpu` | validated Torch floor from the CPU index | Yes, CPU only |
+
+| Job class | Tool group | Runtime profile |
+| --- | --- | --- |
+| Markdown, lint, typing, package, audit, legal, and static docs | matching tool group | `none` |
+| Repository contracts | `ci-quality` | `torch-cpu` |
+| Compatibility, coverage, primary, targeted, and Tensor tests | `ci-test` | `torch-cpu` |
+| ASV evidence and timing | `ci-benchmark` | `torch-cpu` |
+| Release correctness | `ci-release` | `torch-cpu` |
+| Lower-bound test environment | explicit lower bounds | CPU runtime tool |
+| Autodoc, doctests, executed examples, and notebooks | docs tool group | `torch-cpu` |
+
+The current repository has no executed documentation workflow. When one is
+added, importing package code requires `torch-cpu`; Markdown and link-only
+builds remain `none`.
+
+## Clean-wheel contract
+
+`tools/torch_runtime.py install-contract` is the one cross-platform clean
+install check used by PR smoke jobs and release preflight. It performs this
+state machine in a temporary virtual environment:
+
+1. Install the built AlbumentationsX wheel and one OpenCV distribution.
+2. Verify that Torch and CUDA/NVIDIA distributions are absent.
+3. Verify that importing AlbumentationsX fails with the documented
+   missing-Torch guidance.
+4. Install the validated Torch floor from the PyTorch CPU index.
+5. Verify the CPU-only runtime contract.
+6. Import AlbumentationsX and run a small NumPy transform.
+
+The tool owns subprocess invocation and assertions. Workflows do not encode
+shell inversions, platform-specific venv paths, or inline Torch installs.
+Nightly lower-bound tests use the same tool to add CPU Torch after their exact
+minimum dependencies are installed. ASV creates its own isolated benchmark
+environment, so its configuration installs the same Torch requirement from the
+same CPU index.
+
+## Permanent verification
+
+`tools/ci_matrix.py` validates the architecture:
+
+- package metadata, extras, and CI tool groups contain neither Torch nor
+  TorchVision, except for `ci-torch-cpu`'s direct Torch declaration;
+- `dev` does not select the CPU profile;
+- the explicit CPU index is the only `uv` source for Torch;
+- each PR, nightly, release-candidate, and ASV job that imports the package
+  declares `runtime-profile: torch-cpu` with its intended tool group;
+- static jobs have no undocumented Torch runtime; and
+- workflows use the shared runtime tool instead of inline Torch installation.
+
+Workflow tests assert these mappings. Unit tests cover missing, CPU, CUDA, and
+NVIDIA-distribution runtime states. Environment evidence includes the selected
+tool group, runtime profile, Torch version, CUDA version, and accelerator
+distribution names.
+
+## Completion conditions
+
+The architecture is correct when all of the following remain true:
+
+- base installation does not install Torch, TorchVision, CUDA, or NVIDIA
+  packages;
+- a user-selected Torch build survives AlbumentationsX installation;
+- importing without Torch gives the documented error, and importing with CPU,
+  CUDA, or MPS Torch does not initialize an accelerator;
+- package-importing CI jobs use CPU Torch and report no CUDA/NVIDIA packages;
+- static CI and static documentation work stay Torch-free;
+- package smoke validates both states from a clean wheel; and
+- the CI matrix validator, workflow tests, install contract, and selected PR
+  checks pass at the same head SHA.
+
+## Non-goals
+
+This architecture does not make Torch optional after public import, add lazy
+loading, choose a user accelerator build, add GPU CI, add TorchVision as a
+convenience dependency, or change Tensor layouts, bridge behavior, or transform
+capabilities.
+
+## Related documents
+
+- [`../maintaining/ci-policy.md`](../maintaining/ci-policy.md) defines required
+  jobs, routing, and wall-time targets.
+- [`../maintaining/support-policy.md`](../maintaining/support-policy.md)
+  defines supported dependency sets and installation policy.
+- [`../contributing/environment_setup.md`](../contributing/environment_setup.md)
+  defines contributor setup commands.

--- a/docs/design/torch-dependency-and-ci-greenfield.md
+++ b/docs/design/torch-dependency-and-ci-greenfield.md
@@ -100,7 +100,7 @@ who wants the CI runtime adds `--group ci-torch-cpu` explicitly.
 
 | Job class | Tool group | Runtime profile |
 | --- | --- | --- |
-| Markdown, lint, typing, package, audit, legal, and static docs | matching tool group | `none` |
+| Link-only Markdown, lint, typing, package, audit, legal, and static docs | matching tool group | `none` |
 | Repository contracts | `ci-quality` | `torch-cpu` |
 | Compatibility, coverage, primary, targeted, and Tensor tests | `ci-test` | `torch-cpu` |
 | ASV evidence and timing | `ci-benchmark` | `torch-cpu` |
@@ -108,9 +108,10 @@ who wants the CI runtime adds `--group ci-torch-cpu` explicitly.
 | Lower-bound test environment | explicit lower bounds | CPU runtime tool |
 | Autodoc, doctests, executed examples, and notebooks | docs tool group | `torch-cpu` |
 
-The current repository has no executed documentation workflow. When one is
-added, importing package code requires `torch-cpu`; Markdown and link-only
-builds remain `none`.
+The PR Markdown job runs the generated transform-table check, which imports
+package code and therefore selects `torch-cpu`. Link-only Markdown and static
+documentation work remain `none`. Any standalone documentation workflow that
+imports package code must likewise select `torch-cpu`.
 
 ## Clean-wheel contract
 
@@ -161,7 +162,7 @@ The architecture is correct when all of the following remain true:
 - importing without Torch gives the documented error, and importing with CPU,
   CUDA, or MPS Torch does not initialize an accelerator;
 - package-importing CI jobs use CPU Torch and report no CUDA/NVIDIA packages;
-- static CI and static documentation work stay Torch-free;
+- non-importing CI and static documentation work stay Torch-free;
 - package smoke validates both states from a clean wheel; and
 - the CI matrix validator, workflow tests, install contract, and selected PR
   checks pass at the same head SHA.

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -41,7 +41,7 @@ relevant checks. These are the normal profiles:
 
 | Changed paths | Required work | Work intentionally skipped |
 | --- | --- | --- |
-| Ordinary Markdown | Changed-file Markdown hooks | pytest, typing, packaging, security audits |
+| Ordinary Markdown | Changed-file Markdown hooks; CPU runtime when the transform-table generator runs | pytest, typing, packaging, security audits |
 | CI policy Markdown | Markdown hooks and repository contracts | product pytest |
 | Runtime source | Ruff, mypy, Pyrefly, contracts, full 3 × 5 compatibility, one coverage lane | package builds and workflow audit |
 | Isolated test module | Changed module on the primary and OS/version boundary lanes | full product matrix |
@@ -114,9 +114,11 @@ records the selected profile in environment evidence.
 
 The contributor-facing `dev` group includes tools but no Torch runtime. CI must
 not sync the broad `dev` group. Package builds, dependency audits, source legal
-checks, Markdown checks, and static documentation work use `none`. A clean-wheel
-install contract first proves the Torch-free error and then installs the shared
-CPU profile before importing AlbumentationsX.
+checks, link-only Markdown checks, and static documentation work use `none`.
+The Markdown leaf selects `torch-cpu` because its transform-table generator
+imports AlbumentationsX. A clean-wheel install contract first proves the
+Torch-free error and then installs the shared CPU profile before importing
+AlbumentationsX.
 
 ## ASV performance evidence
 

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -99,7 +99,8 @@ CI jobs sync one locked dependency group through
 `.github/actions/setup-ci/action.yml`:
 
 - `ci-test`: base pytest suite and optional test libraries, without Torch;
-- `ci-quality`: Ruff, pre-commit, the isolated mypy hook, and repository contracts;
+- `ci-quality`: Ruff, pre-commit, and the isolated mypy hook, without Torch;
+- `ci-contracts`: repository contracts plus the CPU-only Torch profile required for package imports;
 - `ci-types`: Pyrefly and standalone typing tools;
 - `ci-pytorch`: base test dependencies plus the CPU-only Torch profile;
 - `ci-security`: pip-audit and zizmor;

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -66,9 +66,10 @@ Runtime changes retain every supported operating-system and Python pair:
 - Python 3.10, 3.11, 3.12, 3.13, and 3.14;
 - the locked `ci-test` dependency profile.
 
-Compatibility jobs do not collect coverage and do not install PyTorch. Branch
-coverage runs once on Ubuntu and Python 3.12. PyTorch-marked tests run once in a
-dedicated CPU-only environment.
+Compatibility jobs do not collect coverage. Every pytest lane explicitly uses
+the CPU-only Torch runtime because pytest imports `tests/conftest.py` before it
+applies the `not pytorch` marker. Branch coverage runs once on Ubuntu and Python
+3.12. PyTorch-marked tests run once in the same CPU-only runtime profile.
 
 Windows 3.11, 3.12, and 3.13 are split into two duration-balanced test-file
 shards because the measured baseline exceeded two minutes. The committed
@@ -95,22 +96,27 @@ job or a missing required status is not.
 
 ## Purpose-specific environments
 
-CI jobs sync one locked dependency group through
-`.github/actions/setup-ci/action.yml`:
+CI jobs sync one locked tool group and one runtime profile through
+`.github/actions/setup-ci/action.yml`. The default `none` runtime does not
+install Torch. `torch-cpu` adds `ci-torch-cpu` in the same locked sync, verifies
+`torch.version.cuda is None`, rejects installed CUDA/NVIDIA distributions, and
+records the selected profile in environment evidence.
 
-- `ci-test`: base pytest suite and optional test libraries, without Torch;
-- `ci-quality`: Ruff, pre-commit, and the isolated mypy hook, without Torch;
-- `ci-contracts`: repository contracts plus the CPU-only Torch profile required for package imports;
+- `ci-test`: base pytest suite and optional test libraries;
+- `ci-quality`: Ruff, pre-commit, the isolated mypy hook, and repository contracts;
 - `ci-types`: Pyrefly and standalone typing tools;
-- `ci-pytorch`: base test dependencies plus the CPU-only Torch profile;
 - `ci-security`: pip-audit and zizmor;
 - `ci-package`: build, twine, and legal verifier tests;
 - `ci-benchmark`: ASV;
 - `ci-release`: version-bump preflight, final distributions, release evidence,
   and bundle tooling.
+- `ci-torch-cpu`: the one validated CPU-only Torch floor and package index.
 
-The contributor-facing `dev` group includes all of these capabilities, including
-the CPU-only Torch profile. CI must not sync the broad `dev` group.
+The contributor-facing `dev` group includes tools but no Torch runtime. CI must
+not sync the broad `dev` group. Package builds, dependency audits, source legal
+checks, Markdown checks, and static documentation work use `none`. A clean-wheel
+install contract first proves the Torch-free error and then installs the shared
+CPU profile before importing AlbumentationsX.
 
 ## ASV performance evidence
 

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -46,7 +46,7 @@ relevant checks. These are the normal profiles:
 | Runtime source | Ruff, mypy, Pyrefly, contracts, full 3 × 5 compatibility, one coverage lane | package builds and workflow audit |
 | Isolated test module | Changed module on the primary and OS/version boundary lanes | full product matrix |
 | Shared pytest infrastructure | Full 3 × 5 compatibility | unrelated package and workflow policy jobs |
-| PyTorch source or tests | Dedicated CPU-only PyTorch job plus relevant base checks | Torch installation in ordinary compatibility jobs |
+| PyTorch source or tests | Dedicated CPU-only PyTorch job plus relevant base checks | CUDA or MPS Torch installation in CI |
 | Dependency metadata or lockfile | Primary suite, PyTorch, dependency audit, legal/package checks, clean install matrix | ASV timing comparison |
 | Packaging or legal inputs | Source legal verification, wheel/sdist verification, metadata check, clean installs when relevant | product compatibility matrix |
 | `.github/**` | Repository contracts and `zizmor` | product pytest unless the PR workflow/router itself changed |
@@ -98,18 +98,18 @@ job or a missing required status is not.
 CI jobs sync one locked dependency group through
 `.github/actions/setup-ci/action.yml`:
 
-- `ci-test`: base pytest suite and optional test libraries;
+- `ci-test`: base pytest suite and optional test libraries, without Torch;
 - `ci-quality`: Ruff, pre-commit, the isolated mypy hook, and repository contracts;
 - `ci-types`: Pyrefly and standalone typing tools;
-- `ci-pytorch`: base test dependencies before the CPU-only Torch install;
+- `ci-pytorch`: base test dependencies plus the CPU-only Torch profile;
 - `ci-security`: pip-audit and zizmor;
 - `ci-package`: build, twine, and legal verifier tests;
 - `ci-benchmark`: ASV;
 - `ci-release`: version-bump preflight, final distributions, release evidence,
   and bundle tooling.
 
-The contributor-facing `dev` group includes all of these capabilities plus
-normal PyTorch packages. CI must not sync the broad `dev` group.
+The contributor-facing `dev` group includes all of these capabilities, including
+the CPU-only Torch profile. CI must not sync the broad `dev` group.
 
 ## ASV performance evidence
 

--- a/docs/maintaining/support-policy.md
+++ b/docs/maintaining/support-policy.md
@@ -58,9 +58,11 @@ are outside normal Linux CI unless a workflow has a real GUI reason.
 
 The `headless` extra is the default runtime path. The `contrib-headless`,
 `pillow`, `text`, and `hub` extras get targeted import or small functional
-smoke tests. Torch is a required runtime dependency; TorchVision-specific
-coverage remains in the dedicated PyTorch CI lane. The `pyvips` extra is
-scheduled-only when binary availability is stable.
+smoke tests. Torch is a soft-required runtime dependency: the base install does
+not select a CPU, CUDA, or MPS build, while importing `albumentations` requires
+an installed Torch runtime. The dedicated PyTorch test and benchmark profiles
+select the CPU build. The `pyvips` extra is scheduled-only when binary
+availability is stable.
 
 ## Retiring Support
 

--- a/docs/maintaining/support-policy.md
+++ b/docs/maintaining/support-policy.md
@@ -61,8 +61,8 @@ The `headless` extra is the default runtime path. The `contrib-headless`,
 smoke tests. Torch is a soft-required runtime dependency: the base install does
 not select a CPU, CUDA, or MPS build, while importing `albumentations` requires
 an installed Torch runtime. CI jobs that import AlbumentationsX explicitly
-select the CPU-only profile; static, packaging, audit, and static-documentation
-jobs do not select Torch. The `pyvips` extra is scheduled-only when binary
+select the CPU-only profile; link-only static, packaging, audit, and
+static-documentation jobs do not select Torch. The `pyvips` extra is scheduled-only when binary
 availability is stable.
 
 ## Retiring Support

--- a/docs/maintaining/support-policy.md
+++ b/docs/maintaining/support-policy.md
@@ -60,8 +60,9 @@ The `headless` extra is the default runtime path. The `contrib-headless`,
 `pillow`, `text`, and `hub` extras get targeted import or small functional
 smoke tests. Torch is a soft-required runtime dependency: the base install does
 not select a CPU, CUDA, or MPS build, while importing `albumentations` requires
-an installed Torch runtime. The dedicated PyTorch test and benchmark profiles
-select the CPU build. The `pyvips` extra is scheduled-only when binary
+an installed Torch runtime. CI jobs that import AlbumentationsX explicitly
+select the CPU-only profile; static, packaging, audit, and static-documentation
+jobs do not select Torch. The `pyvips` extra is scheduled-only when binary
 availability is stable.
 
 ## Retiring Support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,10 @@ ci-quality = [
   "ruff>=0.16.2",
   "tomli>=2.4.1",
 ]
+ci-contracts = [
+  { include-group = "ci-quality" },
+  "torch>=2.13.0",
+]
 ci-types = [
   "mypy>=2.3.0",
   "opencv-python-headless>=5.0.0.93",
@@ -220,6 +224,7 @@ ci-pytorch = [
 dev = [
   { include-group = "ci-test" },
   { include-group = "ci-quality" },
+  { include-group = "ci-contracts" },
   { include-group = "ci-types" },
   { include-group = "ci-security" },
   { include-group = "ci-package" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,10 +187,6 @@ ci-quality = [
   "ruff>=0.16.2",
   "tomli>=2.4.1",
 ]
-ci-contracts = [
-  { include-group = "ci-quality" },
-  "torch>=2.13.0",
-]
 ci-types = [
   "mypy>=2.3.0",
   "opencv-python-headless>=5.0.0.93",
@@ -209,7 +205,6 @@ ci-package = [
 ci-benchmark = [
   "asv",
   "opencv-python-headless>=5.0.0.93",
-  "torch>=2.13.0",
 ]
 ci-release = [
   { include-group = "ci-test" },
@@ -217,20 +212,17 @@ ci-release = [
   { include-group = "ci-security" },
   "cyclonedx-bom>=7.3.1",
 ]
-ci-pytorch = [
-  { include-group = "ci-test" },
+ci-torch-cpu = [
   "torch>=2.13.0",
 ]
 dev = [
   { include-group = "ci-test" },
   { include-group = "ci-quality" },
-  { include-group = "ci-contracts" },
   { include-group = "ci-types" },
   { include-group = "ci-security" },
   { include-group = "ci-package" },
   { include-group = "ci-benchmark" },
   { include-group = "ci-release" },
-  { include-group = "ci-pytorch" },
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,13 +126,12 @@ classifiers = [
 ]
 
 dependencies = [
-  "albucore==0.2.12",
-  "numkong!=7.7.1",
+  "albucore==0.2.13",
+  "numkong>=7.8.0",
   "numpy>=2.2.6",
   "pydantic>=2.12.4",
   "pyyaml",
   "scipy>=1.15.3",
-  "torch>=2.13.0",
   "typing-extensions>=4.9.0",
 ]
 
@@ -146,14 +145,22 @@ pillow = ["pillow"]
 pyvips = ["pyvips[binary]"]
 text = ["pillow"]
 
+[tool.uv.sources]
+torch = { index = "pytorch-cpu" }
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
 [dependency-groups]
 ci-test = [
   "albu-spec>=0.0.6",
   "deepdiff>=9.1.0",
   "defusedxml>=0.7.1",
   "eval-type-backport>=0.4.0",
-  "huggingface-hub>=1.23.0",
-  "hypothesis>=6.156.6",
+  "huggingface-hub>=1.27.0",
+  "hypothesis>=6.165.5",
   "opencv-python-headless>=5.0.0.93",
   "pillow>=12.3.0",
   "pyvips[binary]>=3.1.1",
@@ -162,7 +169,7 @@ ci-test = [
   "pytest-mock>=3.15.1",
   "pytest-randomly>=4.1.0",
   "pytest-xdist>=3.8.0",
-  "pytz>=2026.2",
+  "pytz>=2026.3.post1",
   "requests>=2.34.2",
   "scikit-image>=0.25.2",
   "scikit-learn>=1.7.2",
@@ -171,25 +178,25 @@ ci-test = [
 ci-quality = [
   "defusedxml>=0.7.1",
   "google-docstring-parser>=0.0.11",
-  "hypothesis>=6.156.6",
+  "hypothesis>=6.165.5",
   "opencv-python-headless>=5.0.0.93",
-  "packaging>=25.0",
+  "packaging>=26.3",
   "pillow>=12.3.0",
-  "pre-commit>=4.6.0",
+  "pre-commit>=4.6.2",
   "pytest>=9.1.1",
-  "ruff>=0.16.0",
+  "ruff>=0.16.2",
   "tomli>=2.4.1",
 ]
 ci-types = [
   "mypy>=2.3.0",
   "opencv-python-headless>=5.0.0.93",
-  "pyrefly>=1.2.0.dev3",
-  "types-PyYAML>=6.0.12.20260518",
-  "types-setuptools>=83.0.0.20260706",
+  "pyrefly>=1.2.0",
+  "types-PyYAML>=6.0.12.20260724",
+  "types-setuptools>=84.0.0.20260812",
 ]
 ci-security = [
   "pip-audit>=2.10.1",
-  "zizmor>=1.27.0",
+  "zizmor>=1.29.0",
 ]
 ci-package = [
   "pytest>=9.1.1",
@@ -198,15 +205,17 @@ ci-package = [
 ci-benchmark = [
   "asv",
   "opencv-python-headless>=5.0.0.93",
+  "torch>=2.13.0",
 ]
 ci-release = [
   { include-group = "ci-test" },
   { include-group = "ci-package" },
   { include-group = "ci-security" },
-  "cyclonedx-bom",
+  "cyclonedx-bom>=7.3.1",
 ]
 ci-pytorch = [
   { include-group = "ci-test" },
+  "torch>=2.13.0",
 ]
 dev = [
   { include-group = "ci-test" },
@@ -217,8 +226,6 @@ dev = [
   { include-group = "ci-benchmark" },
   { include-group = "ci-release" },
   { include-group = "ci-pytorch" },
-  "torch>=2.13.0",
-  "torchvision>=0.28.0",
 ]
 
 [project.urls]
@@ -520,7 +527,6 @@ markers = [
 filterwarnings = [
     "ignore::UserWarning",
     "ignore::DeprecationWarning:torch.*",
-    "ignore::UserWarning:torchvision.*",
     "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,33 +1,34 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
 albu-spec>=0.0.6
 asv
-cyclonedx-bom
+cyclonedx-bom>=7.3.1
 deepdiff>=9.1.0
 defusedxml>=0.7.1
 eval-type-backport>=0.4.0
 google-docstring-parser>=0.0.11
-huggingface-hub>=1.23.0
-hypothesis>=6.156.6
+huggingface-hub>=1.27.0
+hypothesis>=6.165.5
 mypy>=2.3.0
 opencv-python-headless>=5.0.0.93
 pillow>=12.3.0
 pip-audit>=2.10.1
-pre_commit>=4.6.0
-pyrefly>=1.2.0.dev2
+pre_commit>=4.6.2
+pyrefly>=1.2.0
 pytest>=9.1.1
 pytest-randomly>=4.1.0
 pytest-xdist>=3.8.0
 pytest_cov>=7.1.0
 pytest_mock>=3.15.1
-pytz>=2026.2
+pytz>=2026.3.post1
 pyvips[binary]>=3.1.1
 requests>=2.34.2
-ruff>=0.15.21
+ruff>=0.16.2
 scikit-image>=0.25.2
 scikit-learn>=1.7.2
 tomli>=2.4.1
-torch>=2.13.0
-torchvision>=0.28.0
+torch==2.13.0+cpu; sys_platform != "darwin"
+torch==2.13.0; sys_platform == "darwin"
 twine>=7.0.0
-types-PyYAML>=6.0.12.20260518
-types-setuptools>=83.0.0.20260706
-zizmor>=1.27.0
+types-PyYAML>=6.0.12.20260724
+types-setuptools>=84.0.0.20260812
+zizmor>=1.29.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
---extra-index-url https://download.pytorch.org/whl/cpu
 albu-spec>=0.0.6
 asv
 cyclonedx-bom>=7.3.1
@@ -26,8 +25,6 @@ ruff>=0.16.2
 scikit-image>=0.25.2
 scikit-learn>=1.7.2
 tomli>=2.4.1
-torch==2.13.0+cpu; sys_platform != "darwin"
-torch==2.13.0; sys_platform == "darwin"
 twine>=7.0.0
 types-PyYAML>=6.0.12.20260724
 types-setuptools>=84.0.0.20260812

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1017,6 +1017,21 @@ def test_to_gray_from_lab(dtype):
     np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1)
 
 
+@pytest.mark.parametrize(
+    ("function", "kwargs"),
+    [
+        (fpixel.linear_transformation_rgb, {"transformation_matrix": np.eye(3, dtype=np.float32)}),
+        (fpixel.to_gray_weighted_average, {}),
+        (fpixel.to_gray_from_lab, {}),
+    ],
+)
+def test_channel_color_operations_reject_five_dimensional_inputs(function, kwargs):
+    image = np.zeros((2, 3, 5, 7, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError):
+        function(image, **kwargs)
+
+
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 @pytest.mark.parametrize("channels", [3, 4, 5])
 def test_to_gray_desaturation(dtype, channels):
@@ -1375,6 +1390,16 @@ def test_auto_contrast_multichannel_cdf_matches_per_channel():
     )
 
     np.testing.assert_array_equal(fpixel.auto_contrast(img, cutoff=0, ignore=None, method="cdf"), expected)
+
+
+def test_auto_contrast_multichannel_lut_preserves_channel_dimension():
+    rng = np.random.default_rng(137)
+    img = rng.integers(0, 256, (512, 512, 1), dtype=np.uint8)
+
+    result = fpixel.auto_contrast(img, cutoff=0, ignore=None, method="cdf")
+
+    assert result.shape == img.shape
+    assert result.dtype == img.dtype
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ci_runtime_profiles.py
+++ b/tests/test_ci_runtime_profiles.py
@@ -1,0 +1,62 @@
+"""Contracts for the explicit Torch runtime selection in CI."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tools.ci_matrix import TORCH_RUNTIME_JOBS
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SETUP_ACTION = REPO_ROOT / ".github" / "actions" / "setup-ci" / "action.yml"
+
+
+def _jobs(path: Path) -> dict[str, dict[str, Any]]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"]
+
+
+def test_setup_action_composes_tools_with_an_explicit_runtime_profile() -> None:
+    action = yaml.safe_load(SETUP_ACTION.read_text(encoding="utf-8"))
+    text = SETUP_ACTION.read_text(encoding="utf-8")
+
+    assert action["inputs"]["runtime-profile"]["default"] == "none"
+    assert "--group ci-torch-cpu" in text
+    assert "cache-suffix: ${{ inputs.dependency-group }}-${{ inputs.runtime-profile }}" in text
+    assert "tools/torch_runtime.py check --expect cpu" in text
+    assert "CI_DEPENDENCY_GROUP: ${{ inputs.dependency-group }}" in text
+    assert "ALBU_CI_RUNTIME_PROFILE=${CI_RUNTIME_PROFILE}" in text
+
+
+def test_importing_jobs_explicitly_select_the_cpu_torch_profile() -> None:
+    for workflow_path, expected_jobs in TORCH_RUNTIME_JOBS.items():
+        jobs = _jobs(workflow_path)
+        for job_name, dependency_group in expected_jobs.items():
+            setup_step = next(
+                step for step in jobs[job_name]["steps"] if step.get("uses") == "./.github/actions/setup-ci"
+            )
+
+            assert setup_step["with"]["dependency-group"] == dependency_group
+            assert setup_step["with"]["runtime-profile"] == "torch-cpu"
+
+
+def test_workflows_use_only_declared_groups_and_no_inline_torch_installs() -> None:
+    for workflow_path in (REPO_ROOT / ".github" / "workflows").glob("*.yml"):
+        text = workflow_path.read_text(encoding="utf-8")
+        for job in _jobs(workflow_path).values():
+            for step in job.get("steps", []):
+                if step.get("uses") != "./.github/actions/setup-ci":
+                    continue
+                assert step["with"]["dependency-group"] in {
+                    "ci-benchmark",
+                    "ci-package",
+                    "ci-quality",
+                    "ci-release",
+                    "ci-security",
+                    "ci-test",
+                    "ci-types",
+                }
+
+        assert re.search(r"(?:uv |python -m )?pip install[^\n]*torch", text, flags=re.IGNORECASE) is None

--- a/tests/test_collect_test_environment.py
+++ b/tests/test_collect_test_environment.py
@@ -1,0 +1,29 @@
+"""Tests for CI environment evidence collection."""
+
+from __future__ import annotations
+
+from tools import collect_test_environment
+
+
+def test_torch_runtime_records_torch_free_environment(monkeypatch) -> None:
+    monkeypatch.setattr(collect_test_environment.importlib.metadata, "distributions", lambda: ())
+    monkeypatch.setattr(collect_test_environment.importlib.util, "find_spec", lambda _: None)
+
+    assert collect_test_environment._torch_runtime() == {
+        "accelerator_distributions": [],
+        "cuda_version": None,
+        "installed": False,
+    }
+
+
+def test_collect_environment_records_selected_ci_profile(monkeypatch) -> None:
+    monkeypatch.setenv("ALBU_CI_DEPENDENCY_GROUP", "ci-test")
+    monkeypatch.setenv("ALBU_CI_RUNTIME_PROFILE", "torch-cpu")
+
+    environment = collect_test_environment.collect_environment("pytest")
+
+    assert environment["command"] == "pytest"
+    assert environment["ci_environment"] == {
+        "dependency_group": "ci-test",
+        "runtime_profile": "torch-cpu",
+    }

--- a/tests/test_optional_torch.py
+++ b/tests/test_optional_torch.py
@@ -1,0 +1,44 @@
+"""PyTorch packaging and import-contract regression tests."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+
+import albumentations
+
+
+def test_import_without_torch_names_the_installation_extra() -> None:
+    original_import = __import__
+
+    def import_without_torch(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch":
+            raise ModuleNotFoundError("No module named 'torch'", name="torch")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", import_without_torch):
+        with pytest.raises(ImportError) as error:
+            importlib.reload(albumentations)
+
+    importlib.reload(albumentations)
+
+    assert 'pip install "albumentationsx[headless]"' in str(error.value)
+
+
+def test_import_propagates_torch_loader_errors() -> None:
+    original_import = __import__
+
+    def import_with_broken_torch(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch":
+            raise ImportError("simulated Torch loader failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", import_with_broken_torch):
+        with pytest.raises(ImportError, match="simulated Torch loader failure") as error:
+            importlib.reload(albumentations)
+
+    importlib.reload(albumentations)
+
+    assert "Install the PyTorch build" not in str(error.value)

--- a/tests/test_performance_workflow.py
+++ b/tests/test_performance_workflow.py
@@ -55,3 +55,17 @@ def test_asv_install_commands_are_separate_cpu_torch_steps() -> None:
         assert config["build_command"] == "python -m pip wheel --no-deps -w {build_cache_dir} {build_dir}"
         assert "{wheel_file}" in commands[1]
         assert "&&" not in " ".join(commands)
+
+
+def test_every_asv_job_explicitly_uses_the_cpu_torch_runtime() -> None:
+    workflow = yaml.safe_load(PERFORMANCE_WORKFLOW.read_text())
+    for job_name in ("benchmark_evidence", "asv_comparison"):
+        setup_step = next(
+            step for step in workflow["jobs"][job_name]["steps"] if step.get("uses") == "./.github/actions/setup-ci"
+        )
+
+        assert setup_step["with"] == {
+            "python-version": "3.12",
+            "dependency-group": "ci-benchmark",
+            "runtime-profile": "torch-cpu",
+        }

--- a/tests/test_performance_workflow.py
+++ b/tests/test_performance_workflow.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 PERFORMANCE_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "performance.yml"
+REPO_ROOT = PERFORMANCE_WORKFLOW.parents[2]
 
 
 def _performance_jobs() -> dict[str, dict[str, Any]]:
@@ -39,3 +41,17 @@ def test_performance_workflow_keeps_full_asv_timing_opt_in() -> None:
     assert "asv --config asv.conf.json run" in run_text
     assert "benchmark-asv-evidence/changed-files.txt" in run_text
     assert "tools/select_benchmark_filters.py" in run_text
+
+
+def test_asv_install_commands_are_separate_cpu_torch_steps() -> None:
+    for config_name in ("asv.conf.json", "asv-pytorch.conf.json"):
+        config = json.loads((REPO_ROOT / "benchmark" / config_name).read_text())
+        commands = config["install_command"]
+
+        assert isinstance(commands, list)
+        assert len(commands) == 2
+        assert "torch>=2.13.0" in commands[0]
+        assert "https://download.pytorch.org/whl/cpu" in commands[0]
+        assert config["build_command"] == "python -m pip wheel --no-deps -w {build_cache_dir} {build_dir}"
+        assert "{wheel_file}" in commands[1]
+        assert "&&" not in " ".join(commands)

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -94,6 +94,7 @@ def test_coverage_and_pytorch_are_not_duplicated_across_matrix_cells() -> None:
 
 def test_every_importing_pr_job_explicitly_selects_cpu_torch() -> None:
     expected_groups = {
+        "markdown": "ci-quality",
         "contracts": "ci-quality",
         "compatibility": "ci-test",
         "coverage": "ci-test",

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -87,9 +87,10 @@ def test_coverage_and_pytorch_are_not_duplicated_across_matrix_cells() -> None:
     compatibility = text.split("\n  compatibility:\n", maxsplit=1)[1].split("\n  coverage:\n", maxsplit=1)[0]
 
     assert "--cov=albumentations" not in compatibility
-    assert "Install CPU-only PyTorch" not in compatibility
+    assert "Verify CPU-only PyTorch profile" not in compatibility
     assert text.count("--cov=albumentations") == 1
-    assert text.count("Install CPU-only PyTorch") == 1
+    assert text.count("Verify CPU-only PyTorch profile") == 1
+    assert "torch.version.cuda is None" in text
     assert "tests/test_benchmark_coverage.py" in text
     assert "tests/test_serialization.py" in text
 

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -87,19 +87,44 @@ def test_coverage_and_pytorch_are_not_duplicated_across_matrix_cells() -> None:
     compatibility = text.split("\n  compatibility:\n", maxsplit=1)[1].split("\n  coverage:\n", maxsplit=1)[0]
 
     assert "--cov=albumentations" not in compatibility
-    assert "Verify CPU-only PyTorch profile" not in compatibility
     assert text.count("--cov=albumentations") == 1
-    assert text.count("Verify CPU-only PyTorch profile") == 1
-    assert "torch.version.cuda is None" in text
     assert "tests/test_benchmark_coverage.py" in text
     assert "tests/test_serialization.py" in text
 
 
-def test_repository_contracts_use_the_cpu_only_torch_profile() -> None:
-    contracts = _workflow()["jobs"]["contracts"]
-    setup_step = next(step for step in contracts["steps"] if step["name"] == "Set up contract environment")
+def test_every_importing_pr_job_explicitly_selects_cpu_torch() -> None:
+    expected_groups = {
+        "contracts": "ci-quality",
+        "compatibility": "ci-test",
+        "coverage": "ci-test",
+        "primary": "ci-test",
+        "targeted": "ci-test",
+        "pytorch": "ci-test",
+        "release_preflight": "ci-release",
+    }
 
-    assert setup_step["with"]["dependency-group"] == "ci-contracts"
+    for job_name, expected_group in expected_groups.items():
+        job = _workflow()["jobs"][job_name]
+        setup_step = next(step for step in job["steps"] if step.get("uses") == "./.github/actions/setup-ci")
+
+        assert setup_step["with"] == {
+            "python-version": setup_step["with"]["python-version"],
+            "dependency-group": expected_group,
+            "runtime-profile": "torch-cpu",
+        }
+
+
+def test_install_smoke_uses_the_shared_two_phase_torch_contract() -> None:
+    workflow = _workflow()
+    install_smoke = workflow["jobs"]["install_smoke"]
+    release_preflight = workflow["jobs"]["release_preflight"]
+    install_smoke_text = "\n".join(str(step.get("run", "")) for step in install_smoke["steps"])
+    release_smoke_text = "\n".join(str(step.get("run", "")) for step in release_preflight["steps"])
+
+    assert "tools/torch_runtime.py install-contract" in install_smoke_text
+    assert "tools/torch_runtime.py install-contract" in release_smoke_text
+    assert "find_spec('torch')" not in install_smoke_text
+    assert "uv pip install" not in install_smoke_text
 
 
 def test_version_bump_preflight_builds_publishable_bundle_in_core_profile() -> None:

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -95,6 +95,13 @@ def test_coverage_and_pytorch_are_not_duplicated_across_matrix_cells() -> None:
     assert "tests/test_serialization.py" in text
 
 
+def test_repository_contracts_use_the_cpu_only_torch_profile() -> None:
+    contracts = _workflow()["jobs"]["contracts"]
+    setup_step = next(step for step in contracts["steps"] if step["name"] == "Set up contract environment")
+
+    assert setup_step["with"]["dependency-group"] == "ci-contracts"
+
+
 def test_version_bump_preflight_builds_publishable_bundle_in_core_profile() -> None:
     workflow = _workflow()
     job = workflow["jobs"]["release_preflight"]

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -1,9 +1,6 @@
 import numpy as np
 import pytest
 import torch
-from PIL import Image
-from torchvision.transforms import ColorJitter
-from torchvision.transforms.functional import adjust_brightness, adjust_contrast
 
 import albumentations as A
 from tests.conftest import RECTANGULAR_UINT8_IMAGE, SQUARE_UINT8_IMAGE, UINT8_IMAGES
@@ -144,98 +141,6 @@ def test_with_replaycompose() -> None:
     assert res["mask"].dtype == torch.uint8
     assert res2["image"].dtype == torch.uint8
     assert res2["mask"].dtype == torch.uint8
-
-
-@pytest.mark.parametrize(
-    ["brightness", "contrast", "saturation", "hue"],
-    [
-        [1, 1, 1, 0],
-        [0.123, 1, 1, 0],
-        [1.321, 1, 1, 0],
-        [1, 0.234, 1, 0],
-        [1, 1.432, 1, 0],
-        [1, 1, 0.345, 0],
-        [1, 1, 1.543, 0],
-    ],
-)
-def test_color_jitter(brightness, contrast, saturation, hue):
-    img = np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)
-    pil_image = Image.fromarray(img)
-
-    transform = A.Compose(
-        [
-            A.ColorJitter(
-                brightness_range=[brightness, brightness],
-                contrast_range=[contrast, contrast],
-                saturation_range=[saturation, saturation],
-                hue_range=[hue, hue],
-                p=1,
-            ),
-        ],
-        strict=True,
-    )
-
-    pil_transform = ColorJitter(
-        brightness=[brightness, brightness],
-        contrast=[contrast, contrast],
-        saturation=[saturation, saturation],
-        hue=[hue, hue],
-    )
-
-    res1 = transform(image=img)["image"]
-    res2 = np.array(pil_transform(pil_image))
-
-    assert np.abs(res1.astype(np.int16) - res2.astype(np.int16)).max() <= 2
-
-
-def test_random_brightness_contrast_matches_torchvision_brightness_and_contrast():
-    image = np.array(
-        [
-            [[255, 0, 0], [0, 255, 0]],
-            [[0, 0, 255], [100, 120, 140]],
-        ],
-        dtype=np.uint8,
-    )
-    transform = A.RandomBrightnessContrast(
-        brightness_range=(0.2, 0.2),
-        contrast_range=(0.5, 0.5),
-        p=1,
-    )
-
-    result = transform(image=image)["image"]
-    expected = np.asarray(
-        adjust_brightness(
-            adjust_contrast(Image.fromarray(image), 1.5),
-            1.2,
-        ),
-    )
-
-    assert np.abs(result.astype(np.int16) - expected.astype(np.int16)).max() <= 1
-
-
-def test_random_brightness_contrast_preserves_intermediate_uint8_quantization() -> None:
-    image = np.array(
-        [
-            [[17, 23, 35], [47, 7, 10]],
-            [[46, 37, 20], [14, 16, 18]],
-        ],
-        dtype=np.uint8,
-    )
-    transform = A.RandomBrightnessContrast(
-        brightness_range=(9.0, 9.0),
-        contrast_range=(-0.9, -0.9),
-        p=1,
-    )
-
-    result = transform(image=image)["image"]
-    expected = np.asarray(
-        adjust_brightness(
-            adjust_contrast(Image.fromarray(image), 0.1),
-            10.0,
-        ),
-    )
-
-    np.testing.assert_array_equal(result, expected)
 
 
 def test_post_data_check():

--- a/tests/test_random_tone_curve.py
+++ b/tests/test_random_tone_curve.py
@@ -165,6 +165,20 @@ def test_move_tone_curve_uint8_per_channel_golden_vector() -> None:
     np.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.parametrize("shape", [(8, 8, 1), (2, 8, 8, 1)])
+def test_move_tone_curve_uint8_per_channel_preserves_channel_dimension(shape: tuple[int, ...]) -> None:
+    image = np.arange(np.prod(shape), dtype=np.uint8).reshape(shape)
+    low_y = np.array([0.1], dtype=np.float64)
+    high_y = np.array([0.9], dtype=np.float64)
+
+    result = fpixel.move_tone_curve(image, low_y, high_y, num_channels=1)
+    expected = fpixel.move_tone_curve(image, 0.1, 0.9, num_channels=1)
+
+    np.testing.assert_array_equal(result, expected)
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype
+
+
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 @pytest.mark.parametrize(
     ("low_y", "high_y"),

--- a/tests/test_torch_runtime.py
+++ b/tests/test_torch_runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from tools import torch_runtime
 
 
@@ -57,3 +59,18 @@ def test_install_cpu_torch_uses_the_shared_cpu_index(monkeypatch, tmp_path) -> N
         ],
     ]
     assert checked == [(interpreter, "cpu")]
+
+
+def test_resolve_wheel_expands_a_literal_glob_for_windows_shells(tmp_path) -> None:
+    wheel = tmp_path / "albumentationsx-2.4.0-py3-none-any.whl"
+    wheel.touch()
+
+    assert torch_runtime._resolve_wheel(tmp_path / "*.whl") == wheel
+
+
+def test_resolve_wheel_rejects_ambiguous_matches(tmp_path) -> None:
+    (tmp_path / "one.whl").touch()
+    (tmp_path / "two.whl").touch()
+
+    with pytest.raises(RuntimeError, match="Expected exactly one wheel"):
+        torch_runtime._resolve_wheel(tmp_path / "*.whl")

--- a/tests/test_torch_runtime.py
+++ b/tests/test_torch_runtime.py
@@ -1,0 +1,59 @@
+"""Unit tests for the CPU-only Torch runtime contract tool."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tools import torch_runtime
+
+
+def test_runtime_errors_rejects_cuda_and_nvidia_distributions(monkeypatch) -> None:
+    monkeypatch.setattr(torch_runtime.importlib.util, "find_spec", lambda _: object())
+    monkeypatch.setattr(torch_runtime, "_load_torch", lambda: SimpleNamespace(version=SimpleNamespace(cuda="12.8")))
+    monkeypatch.setattr(torch_runtime, "installed_accelerator_distributions", lambda: ("nvidia-cublas-cu12",))
+
+    errors = torch_runtime.runtime_errors("cpu")
+
+    assert "Torch reports CUDA '12.8'; CI requires the CPU-only build." in errors
+    assert "CPU-only Torch runtime contains accelerator distributions: nvidia-cublas-cu12" in errors
+
+
+def test_runtime_errors_accepts_absent_torch_without_accelerator_distributions(monkeypatch) -> None:
+    monkeypatch.setattr(torch_runtime.importlib.util, "find_spec", lambda _: None)
+    monkeypatch.setattr(torch_runtime, "installed_accelerator_distributions", lambda: ())
+
+    assert torch_runtime.runtime_errors("absent") == []
+
+
+def test_runtime_errors_rejects_torch_in_an_absent_runtime(monkeypatch) -> None:
+    monkeypatch.setattr(torch_runtime.importlib.util, "find_spec", lambda _: object())
+    monkeypatch.setattr(torch_runtime, "installed_accelerator_distributions", lambda: ())
+
+    assert torch_runtime.runtime_errors("absent") == ["Torch is installed but the runtime must be Torch-free."]
+
+
+def test_install_cpu_torch_uses_the_shared_cpu_index(monkeypatch, tmp_path) -> None:
+    commands: list[list[str]] = []
+    checked: list[tuple[object, str]] = []
+    interpreter = tmp_path / "python"
+
+    monkeypatch.setattr(torch_runtime, "_run", commands.append)
+    monkeypatch.setattr(
+        torch_runtime, "_check_interpreter_runtime", lambda path, expected: checked.append((path, expected))
+    )
+
+    torch_runtime.install_cpu_torch(interpreter)
+
+    assert commands == [
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(interpreter),
+            "torch>=2.13.0",
+            "--index-url",
+            "https://download.pytorch.org/whl/cpu",
+        ],
+    ]
+    assert checked == [(interpreter, "cpu")]

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -340,8 +340,8 @@ def _check_torch_free_install_surfaces() -> list[str]:
     development_requirements = _read_text(DEVELOPMENT_REQUIREMENTS)
     if re.search(r"(?im)^\s*(?:torch|torchvision)\b", development_requirements):
         issues.append("requirements-dev.txt must not select Torch or TorchVision")
-    if "download.pytorch.org" in development_requirements:
-        issues.append("requirements-dev.txt must not select a PyTorch package index")
+    if re.search(r"(?im)^\s*--(?:extra-)?index-url\b", development_requirements):
+        issues.append("requirements-dev.txt must not select a package index")
 
     conda_metadata = _read_text(CONDA_RECIPE)
     run_dependencies = re.search(r"(?ms)^  run:\s*\n(.*?)(?=^\S|\Z)", conda_metadata)

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -89,6 +89,7 @@ LOWER_BOUND_REQUIREMENTS = (
 )
 CI_DEPENDENCY_GROUPS = {
     "ci-benchmark": {"asv", "opencv-python-headless", "torch"},
+    "ci-contracts": {"torch"},
     "ci-package": {"pytest", "twine"},
     "ci-pytorch": {"torch"},
     "ci-quality": {
@@ -270,7 +271,7 @@ def _check_ci_dependency_groups(dependency_groups: dict[str, Any]) -> list[str]:
             issues.append(f"pyproject.toml group {group!r} is missing {sorted(missing_packages)!r}")
         if "torchvision" in packages:
             issues.append(f"pyproject.toml group {group!r} must not install torchvision")
-        if "torch" in packages and group not in {"ci-benchmark", "ci-pytorch"}:
+        if "torch" in packages and group not in {"ci-benchmark", "ci-contracts", "ci-pytorch"}:
             issues.append(f"pyproject.toml group {group!r} must not install Torch directly")
     return issues
 
@@ -356,6 +357,7 @@ def _check_pr_workflow() -> list[str]:
                 "python -m tools.ci_gate",
                 "dependency-group: ci-test",
                 "dependency-group: ci-quality",
+                "dependency-group: ci-contracts",
                 "dependency-group: ci-types",
                 "dependency-group: ci-security",
                 "dependency-group: ci-package",

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -112,6 +112,7 @@ CI_DEPENDENCY_GROUPS = {
 CI_RUNTIME_PROFILES = frozenset({"none", "torch-cpu"})
 TORCH_RUNTIME_JOBS = {
     PR_WORKFLOW: {
+        "markdown": "ci-quality",
         "contracts": "ci-quality",
         "compatibility": "ci-test",
         "coverage": "ci-test",

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -50,6 +50,9 @@ PYTORCH_PERFORMANCE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pytorch-pe
 RELEASE_CANDIDATE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-candidate.yml"
 SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "upload_to_pypi.yml"
+SETUP_CI_ACTION = REPO_ROOT / ".github" / "actions" / "setup-ci" / "action.yml"
+CONDA_RECIPE = REPO_ROOT / "conda.recipe" / "meta.yaml"
+DEVELOPMENT_REQUIREMENTS = REPO_ROOT / "requirements-dev.txt"
 CODEQL_ACTIONS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "codeql-actions.yml"
 CODEQL_PYTHON_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "codeql-python.yml"
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
@@ -88,10 +91,8 @@ LOWER_BOUND_REQUIREMENTS = (
     "opencv-python-headless==5.0.0.93",
 )
 CI_DEPENDENCY_GROUPS = {
-    "ci-benchmark": {"asv", "opencv-python-headless", "torch"},
-    "ci-contracts": {"torch"},
+    "ci-benchmark": {"asv", "opencv-python-headless"},
     "ci-package": {"pytest", "twine"},
-    "ci-pytorch": {"torch"},
     "ci-quality": {
         "defusedxml",
         "google-docstring-parser",
@@ -105,7 +106,36 @@ CI_DEPENDENCY_GROUPS = {
     "ci-release": {"cyclonedx-bom"},
     "ci-security": {"pip-audit", "zizmor"},
     "ci-test": {"defusedxml", "opencv-python-headless", "pytest", "pytest-cov", "pytest-xdist"},
+    "ci-torch-cpu": {"torch"},
     "ci-types": {"mypy", "opencv-python-headless", "pyrefly"},
+}
+CI_RUNTIME_PROFILES = frozenset({"none", "torch-cpu"})
+TORCH_RUNTIME_JOBS = {
+    PR_WORKFLOW: {
+        "contracts": "ci-quality",
+        "compatibility": "ci-test",
+        "coverage": "ci-test",
+        "primary": "ci-test",
+        "targeted": "ci-test",
+        "pytorch": "ci-test",
+        "release_preflight": "ci-release",
+    },
+    NIGHTLY_WORKFLOW: {
+        "compatibility_matrix": "ci-test",
+        "pytorch": "ci-test",
+        "property_and_regression": "ci-test",
+        "optional_extras": "ci-test",
+    },
+    RELEASE_CANDIDATE_WORKFLOW: {
+        "release_candidate": "ci-test",
+        "release_candidate_pytorch": "ci-test",
+        "release_candidate_performance": "ci-benchmark",
+    },
+    PERFORMANCE_WORKFLOW: {
+        "benchmark_evidence": "ci-benchmark",
+        "asv_comparison": "ci-benchmark",
+    },
+    PYTORCH_PERFORMANCE_WORKFLOW: {"pytorch_tensor_asv": "ci-benchmark"},
 }
 
 SUPPORT_POLICY_TABLE_ROWS = (
@@ -256,23 +286,89 @@ def _ci_operating_systems(workflow: dict[str, Any]) -> set[str]:
     return _workflow_matrix_values(workflow, "operating-system")
 
 
+def _direct_dependency_names(entries: list[Any]) -> set[str]:
+    return {re.split(r"[<>=!~\[]", entry, maxsplit=1)[0].casefold() for entry in entries if isinstance(entry, str)}
+
+
 def _check_ci_dependency_groups(dependency_groups: dict[str, Any]) -> list[str]:
     issues: list[str] = []
+    unexpected_groups = set(dependency_groups) - {*CI_DEPENDENCY_GROUPS, "dev"}
+    if unexpected_groups:
+        issues.append(f"pyproject.toml defines unsupported dependency groups {sorted(unexpected_groups)!r}")
+
     for group, required_packages in sorted(CI_DEPENDENCY_GROUPS.items()):
         entries = dependency_groups.get(group)
         if not isinstance(entries, list):
             issues.append(f"pyproject.toml is missing CI dependency group {group!r}")
             continue
-        packages = {
-            re.split(r"[<>=!~\[]", entry, maxsplit=1)[0].casefold() for entry in entries if isinstance(entry, str)
-        }
+        packages = _direct_dependency_names(entries)
         missing_packages = required_packages - packages
         if missing_packages:
             issues.append(f"pyproject.toml group {group!r} is missing {sorted(missing_packages)!r}")
+    for group, entries in dependency_groups.items():
+        if not isinstance(entries, list):
+            continue
+        packages = _direct_dependency_names(entries)
         if "torchvision" in packages:
             issues.append(f"pyproject.toml group {group!r} must not install torchvision")
-        if "torch" in packages and group not in {"ci-benchmark", "ci-contracts", "ci-pytorch"}:
+        if "torch" in packages and group != "ci-torch-cpu":
             issues.append(f"pyproject.toml group {group!r} must not install Torch directly")
+
+    return issues
+
+
+def _check_project_torch_metadata(project: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    project_dependencies = project.get("dependencies")
+    if not isinstance(project_dependencies, list):
+        issues.append("pyproject.toml project.dependencies must be a list")
+    elif {"torch", "torchvision"} & _direct_dependency_names(project_dependencies):
+        issues.append("pyproject.toml project.dependencies must not select Torch or TorchVision")
+
+    optional_dependencies = project.get("optional-dependencies", {})
+    if not isinstance(optional_dependencies, dict):
+        issues.append("pyproject.toml project.optional-dependencies must be a table")
+    else:
+        for extra, entries in optional_dependencies.items():
+            if isinstance(entries, list) and {"torch", "torchvision"} & _direct_dependency_names(entries):
+                issues.append(f"pyproject.toml extra {extra!r} must not select Torch or TorchVision")
+    return issues
+
+
+def _check_torch_free_install_surfaces() -> list[str]:
+    issues: list[str] = []
+    development_requirements = _read_text(DEVELOPMENT_REQUIREMENTS)
+    if re.search(r"(?im)^\s*(?:torch|torchvision)\b", development_requirements):
+        issues.append("requirements-dev.txt must not select Torch or TorchVision")
+    if "download.pytorch.org" in development_requirements:
+        issues.append("requirements-dev.txt must not select a PyTorch package index")
+
+    conda_metadata = _read_text(CONDA_RECIPE)
+    run_dependencies = re.search(r"(?ms)^  run:\s*\n(.*?)(?=^\S|\Z)", conda_metadata)
+    if run_dependencies is None:
+        issues.append("conda.recipe/meta.yaml must define a run dependency section")
+    elif re.search(r"(?im)^\s*-\s*(?:pytorch|torchvision)\b", run_dependencies.group(1)):
+        issues.append("conda.recipe/meta.yaml run dependencies must not select Torch or TorchVision")
+    return issues
+
+
+def _check_dev_group(dependency_groups: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    dev_entries = dependency_groups.get("dev", [])
+    if not isinstance(dev_entries, list):
+        return ["pyproject.toml dependency group 'dev' must be a list"]
+
+    included_groups = {
+        entry.get("include-group")
+        for entry in dev_entries
+        if isinstance(entry, dict) and isinstance(entry.get("include-group"), str)
+    }
+    expected_dev_groups = set(CI_DEPENDENCY_GROUPS) - {"ci-torch-cpu"}
+    missing_includes = expected_dev_groups - included_groups
+    if missing_includes:
+        issues.append(f"pyproject.toml dev group does not include {sorted(missing_includes)!r}")
+    if "ci-torch-cpu" in included_groups:
+        issues.append("pyproject.toml dev group must not install the CI CPU Torch profile implicitly")
     return issues
 
 
@@ -280,6 +376,9 @@ def _check_pyproject() -> list[str]:
     pyproject = _load_pyproject()
     project = pyproject.get("project", {})
     issues: list[str] = []
+
+    if not isinstance(project, dict):
+        return ["pyproject.toml project must be a table"]
 
     requires_python = project.get("requires-python")
     if requires_python != f">={OLDEST_PYTHON}":
@@ -292,31 +391,145 @@ def _check_pyproject() -> list[str]:
             f"pyproject.toml Python classifiers are {sorted(classifiers)!r}, expected {sorted(expected)!r}",
         )
 
+    issues.extend(_check_project_torch_metadata(project))
+    issues.extend(_check_torch_free_install_surfaces())
+
     dependency_groups = pyproject.get("dependency-groups", {})
     if not isinstance(dependency_groups, dict):
-        issues.append("pyproject.toml dependency-groups must be a table")
-        return issues
+        return [*issues, "pyproject.toml dependency-groups must be a table"]
 
     issues.extend(_check_ci_dependency_groups(dependency_groups))
+    issues.extend(_check_dev_group(dependency_groups))
 
     uv = pyproject.get("tool", {}).get("uv", {})
     if not isinstance(uv, dict) or uv.get("sources", {}).get("torch") != {"index": "pytorch-cpu"}:
         issues.append("pyproject.toml must route Torch through the explicit pytorch-cpu index")
 
-    dev_entries = dependency_groups.get("dev", [])
-    if not isinstance(dev_entries, list):
-        issues.append("pyproject.toml dependency group 'dev' must be a list")
-        return issues
-    included_groups = {
-        entry.get("include-group")
-        for entry in dev_entries
-        if isinstance(entry, dict) and isinstance(entry.get("include-group"), str)
-    }
-    missing_includes = set(CI_DEPENDENCY_GROUPS) - included_groups
-    if missing_includes:
-        issues.append(f"pyproject.toml dev group does not include {sorted(missing_includes)!r}")
-
     return issues
+
+
+def _setup_ci_step(job: dict[str, Any]) -> dict[str, Any] | None:
+    steps = job.get("steps", [])
+    if not isinstance(steps, list):
+        return None
+    for step in steps:
+        if isinstance(step, dict) and step.get("uses") == "./.github/actions/setup-ci":
+            return step
+    return None
+
+
+def _setup_ci_inputs(job: dict[str, Any]) -> dict[str, Any] | None:
+    step = _setup_ci_step(job)
+    if step is None:
+        return None
+    inputs = step.get("with", {})
+    return inputs if isinstance(inputs, dict) else None
+
+
+def _check_setup_ci_action() -> list[str]:
+    action = _load_yaml(SETUP_CI_ACTION)
+    inputs = action.get("inputs", {})
+    runs = action.get("runs", {})
+    issues: list[str] = []
+
+    if not isinstance(inputs, dict):
+        return [f"{SETUP_CI_ACTION} inputs must be a mapping"]
+    runtime_input = inputs.get("runtime-profile")
+    if not isinstance(runtime_input, dict) or runtime_input.get("default") != "none":
+        issues.append(f"{SETUP_CI_ACTION} must define runtime-profile with default 'none'")
+
+    if not isinstance(runs, dict) or not isinstance(runs.get("steps"), list):
+        return [*issues, f"{SETUP_CI_ACTION} runs.steps must be a list"]
+    action_text = _read_text(SETUP_CI_ACTION)
+    required_contracts = (
+        "cache-suffix: ${{ inputs.dependency-group }}-${{ inputs.runtime-profile }}",
+        "ci-benchmark|ci-package|ci-quality|ci-release|ci-security|ci-test|ci-types",
+        "torch-cpu) runtime_group=(--group ci-torch-cpu)",
+        "Unknown CI runtime profile",
+        "tools/torch_runtime.py check --expect cpu",
+        "ALBU_CI_RUNTIME_PROFILE=${CI_RUNTIME_PROFILE}",
+    )
+    issues.extend(
+        f"{SETUP_CI_ACTION} is missing runtime-profile contract: {required}"
+        for required in required_contracts
+        if required not in action_text
+    )
+    return issues
+
+
+def _expected_torch_runtime_jobs() -> dict[tuple[Path, str], str]:
+    return {(path, job_id): group for path, jobs in TORCH_RUNTIME_JOBS.items() for job_id, group in jobs.items()}
+
+
+def _check_expected_torch_runtime_jobs(expected_jobs: dict[tuple[Path, str], str]) -> list[str]:
+    issues: list[str] = []
+    for (path, job_id), expected_group in expected_jobs.items():
+        job = _workflow_jobs(path).get(job_id)
+        if not isinstance(job, dict):
+            issues.append(f"{path} is missing Torch runtime job {job_id!r}")
+            continue
+        inputs = _setup_ci_inputs(job)
+        if inputs is None:
+            issues.append(f"{path} job {job_id!r} must use the shared setup-ci action")
+            continue
+        if inputs.get("dependency-group") != expected_group:
+            issues.append(
+                f"{path} job {job_id!r} must use dependency group {expected_group!r}, "
+                f"found {inputs.get('dependency-group')!r}",
+            )
+        if inputs.get("runtime-profile") != "torch-cpu":
+            issues.append(f"{path} job {job_id!r} must explicitly use runtime-profile 'torch-cpu'")
+    return issues
+
+
+def _check_declared_workflow_runtime_profiles(expected_jobs: dict[tuple[Path, str], str]) -> list[str]:
+    issues: list[str] = []
+    for path in _workflow_files():
+        for job_id, job in _workflow_jobs(path).items():
+            if not isinstance(job, dict):
+                continue
+            inputs = _setup_ci_inputs(job)
+            if inputs is None:
+                continue
+            dependency_group = inputs.get("dependency-group")
+            allowed_groups = set(CI_DEPENDENCY_GROUPS) - {"ci-torch-cpu"}
+            if dependency_group not in allowed_groups:
+                issues.append(f"{path} job {job_id!r} uses unsupported dependency group {dependency_group!r}")
+            runtime_profile = inputs.get("runtime-profile", "none")
+            if runtime_profile not in CI_RUNTIME_PROFILES:
+                issues.append(f"{path} job {job_id!r} uses unknown runtime profile {runtime_profile!r}")
+            if runtime_profile == "torch-cpu" and (path, job_id) not in expected_jobs:
+                issues.append(f"{path} job {job_id!r} requests an undocumented CPU Torch runtime")
+    return issues
+
+
+def _check_lower_bound_torch_runtime() -> list[str]:
+    issues: list[str] = []
+    nightly_lower_bound = _workflow_jobs(NIGHTLY_WORKFLOW).get("lower_bound_dependencies")
+    if not isinstance(nightly_lower_bound, dict):
+        issues.append(f"{NIGHTLY_WORKFLOW} is missing lower_bound_dependencies")
+    elif "tools/torch_runtime.py install-cpu --python python" not in _workflow_job_run_text(nightly_lower_bound):
+        issues.append(f"{NIGHTLY_WORKFLOW} lower_bound_dependencies must install the shared CPU Torch runtime")
+    return issues
+
+
+def _check_workflow_torch_cleanup() -> list[str]:
+    issues: list[str] = []
+    for path in _workflow_files():
+        workflow_text = _read_text(path)
+        if re.search(r"(?:uv |python -m )?pip install[^\n]*torch", workflow_text, flags=re.IGNORECASE):
+            issues.append(f"{path} must use tools/torch_runtime.py instead of installing Torch inline")
+    return issues
+
+
+def _check_torch_runtime_jobs() -> list[str]:
+    expected_jobs = _expected_torch_runtime_jobs()
+    return [
+        *_check_expected_torch_runtime_jobs(expected_jobs),
+        *_check_declared_workflow_runtime_profiles(expected_jobs),
+        *_check_lower_bound_torch_runtime(),
+        *_check_workflow_torch_cleanup(),
+    ]
 
 
 def _check_pr_workflow() -> list[str]:
@@ -357,11 +570,10 @@ def _check_pr_workflow() -> list[str]:
                 "python -m tools.ci_gate",
                 "dependency-group: ci-test",
                 "dependency-group: ci-quality",
-                "dependency-group: ci-contracts",
                 "dependency-group: ci-types",
                 "dependency-group: ci-security",
                 "dependency-group: ci-package",
-                "dependency-group: ci-pytorch",
+                "runtime-profile: torch-cpu",
                 "python -m tools.ci_shard select",
                 "--dist=worksteal",
                 '-m "not pytorch"',
@@ -501,7 +713,8 @@ def _check_nightly_workflow() -> list[str]:
                 "environment-property-regression.json",
                 "environment-optional-extras.json",
                 "dependency-group: ci-test",
-                "dependency-group: ci-pytorch",
+                "runtime-profile: torch-cpu",
+                "tools/torch_runtime.py install-cpu --python python",
                 "python -m tools.ci_shard select",
                 '-m "not pytorch"',
                 "-m pytorch",
@@ -527,8 +740,8 @@ def _check_release_candidate_workflow() -> list[str]:
                 "python -m tools.performance_budget summarize",
                 "benchmark-performance-budget-",
                 "dependency-group: ci-test",
-                "dependency-group: ci-pytorch",
                 "dependency-group: ci-benchmark",
+                "runtime-profile: torch-cpu",
                 "python -m tools.ci_shard select",
                 '-m "not pytorch"',
                 "-m pytorch",
@@ -596,6 +809,7 @@ def _check_pytorch_performance_workflow() -> list[str]:
             "workflow_dispatch:",
             "continue-on-error: true",
             "dependency-group: ci-benchmark",
+            "runtime-profile: torch-cpu",
             "asv --config asv-pytorch.conf.json check --verbose",
             "asv --config asv-pytorch.conf.json run",
             "pytorch-benchmark-evidence/",
@@ -678,6 +892,8 @@ def _check_workflows() -> list[str]:
         *_check_workflow_python_versions(),
         *_check_workflow_job_timeouts(),
         *_check_workflow_push_triggers(),
+        *_check_setup_ci_action(),
+        *_check_torch_runtime_jobs(),
         *_check_pr_workflow(),
         *_check_full_matrix_workflow(RELEASE_CANDIDATE_WORKFLOW),
         *_check_nightly_workflow(),

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -84,13 +84,13 @@ LOWER_BOUND_REQUIREMENTS = (
     "numpy==2.2.6",
     "scipy==1.15.3",
     "pydantic==2.12.4",
-    "albucore==0.2.12",
+    "albucore==0.2.13",
     "opencv-python-headless==5.0.0.93",
 )
 CI_DEPENDENCY_GROUPS = {
-    "ci-benchmark": {"asv", "opencv-python-headless"},
+    "ci-benchmark": {"asv", "opencv-python-headless", "torch"},
     "ci-package": {"pytest", "twine"},
-    "ci-pytorch": set(),
+    "ci-pytorch": {"torch"},
     "ci-quality": {
         "defusedxml",
         "google-docstring-parser",
@@ -255,6 +255,26 @@ def _ci_operating_systems(workflow: dict[str, Any]) -> set[str]:
     return _workflow_matrix_values(workflow, "operating-system")
 
 
+def _check_ci_dependency_groups(dependency_groups: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    for group, required_packages in sorted(CI_DEPENDENCY_GROUPS.items()):
+        entries = dependency_groups.get(group)
+        if not isinstance(entries, list):
+            issues.append(f"pyproject.toml is missing CI dependency group {group!r}")
+            continue
+        packages = {
+            re.split(r"[<>=!~\[]", entry, maxsplit=1)[0].casefold() for entry in entries if isinstance(entry, str)
+        }
+        missing_packages = required_packages - packages
+        if missing_packages:
+            issues.append(f"pyproject.toml group {group!r} is missing {sorted(missing_packages)!r}")
+        if "torchvision" in packages:
+            issues.append(f"pyproject.toml group {group!r} must not install torchvision")
+        if "torch" in packages and group not in {"ci-benchmark", "ci-pytorch"}:
+            issues.append(f"pyproject.toml group {group!r} must not install Torch directly")
+    return issues
+
+
 def _check_pyproject() -> list[str]:
     pyproject = _load_pyproject()
     project = pyproject.get("project", {})
@@ -276,19 +296,11 @@ def _check_pyproject() -> list[str]:
         issues.append("pyproject.toml dependency-groups must be a table")
         return issues
 
-    for group, required_packages in sorted(CI_DEPENDENCY_GROUPS.items()):
-        entries = dependency_groups.get(group)
-        if not isinstance(entries, list):
-            issues.append(f"pyproject.toml is missing CI dependency group {group!r}")
-            continue
-        packages = {
-            re.split(r"[<>=!~\[]", entry, maxsplit=1)[0].casefold() for entry in entries if isinstance(entry, str)
-        }
-        missing_packages = required_packages - packages
-        if missing_packages:
-            issues.append(f"pyproject.toml group {group!r} is missing {sorted(missing_packages)!r}")
-        if packages & {"torch", "torchvision"}:
-            issues.append(f"pyproject.toml group {group!r} must not install PyTorch directly")
+    issues.extend(_check_ci_dependency_groups(dependency_groups))
+
+    uv = pyproject.get("tool", {}).get("uv", {})
+    if not isinstance(uv, dict) or uv.get("sources", {}).get("torch") != {"index": "pytorch-cpu"}:
+        issues.append("pyproject.toml must route Torch through the explicit pytorch-cpu index")
 
     dev_entries = dependency_groups.get("dev", [])
     if not isinstance(dev_entries, list):

--- a/tools/collect_test_environment.py
+++ b/tools/collect_test_environment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import importlib.metadata
+import importlib.util
 import json
 import os
 import platform
@@ -56,6 +57,33 @@ def _albumentations_runtime_version() -> str | None:
     return albumentations.__version__
 
 
+def _torch_runtime() -> dict[str, Any]:
+    accelerator_distributions = sorted(
+        distribution.metadata["Name"]
+        for distribution in importlib.metadata.distributions()
+        if distribution.metadata.get("Name", "").casefold().startswith(("cuda", "nvidia-"))
+    )
+    if importlib.util.find_spec("torch") is None:
+        return {"cuda_version": None, "installed": False, "accelerator_distributions": accelerator_distributions}
+
+    try:
+        import torch
+    except Exception as error:  # noqa: BLE001 - capture the loader error as evidence instead of failing diagnostics.
+        return {
+            "cuda_version": None,
+            "installed": True,
+            "accelerator_distributions": accelerator_distributions,
+            "loader_error": str(error),
+        }
+
+    return {
+        "cuda_version": torch.version.cuda,
+        "installed": True,
+        "accelerator_distributions": accelerator_distributions,
+        "version": torch.__version__,
+    }
+
+
 def _git_commit() -> str | None:
     git_executable = which("git")
     if git_executable is None:
@@ -104,7 +132,12 @@ def collect_environment(command: str | None = None) -> dict[str, Any]:
             "github_runner_image": os.environ.get("IMAGEOS"),
         },
         "packages": package_versions,
+        "ci_environment": {
+            "dependency_group": os.environ.get("ALBU_CI_DEPENDENCY_GROUP"),
+            "runtime_profile": os.environ.get("ALBU_CI_RUNTIME_PROFILE"),
+        },
         "opencv_runtime_version": _opencv_runtime_version(),
+        "torch_runtime": _torch_runtime(),
         "git_commit": _git_commit(),
         "uv_lock_sha256": _file_sha256(REPO_ROOT / "uv.lock"),
         "github": {

--- a/tools/torch_runtime.py
+++ b/tools/torch_runtime.py
@@ -1,0 +1,184 @@
+"""Install and verify the CPU-only Torch runtime used by AlbumentationsX CI."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import importlib.util
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Literal
+
+TORCH_REQUIREMENT = "torch>=2.13.0"
+PYTORCH_CPU_INDEX = "https://download.pytorch.org/whl/cpu"
+DEFAULT_OPENCV_REQUIREMENT = "opencv-python-headless>=5.0.0.93"
+MISSING_TORCH_GUIDANCE = 'pip install "albumentationsx[headless]"'
+
+
+def _normalize_distribution_name(name: str) -> str:
+    return name.casefold().replace("_", "-")
+
+
+def installed_accelerator_distributions() -> tuple[str, ...]:
+    """Return installed CUDA and NVIDIA distribution names in normalized order."""
+    names = {
+        _normalize_distribution_name(distribution.metadata["Name"])
+        for distribution in importlib.metadata.distributions()
+        if distribution.metadata.get("Name")
+    }
+    return tuple(sorted(name for name in names if name.startswith(("cuda", "nvidia-"))))
+
+
+def _load_torch() -> ModuleType:
+    import torch
+
+    return torch
+
+
+def runtime_errors(expected: Literal["absent", "cpu"]) -> list[str]:
+    """Return contract violations for the selected Torch runtime state."""
+    errors: list[str] = []
+    torch_present = importlib.util.find_spec("torch") is not None
+
+    if expected == "absent":
+        if torch_present:
+            errors.append("Torch is installed but the runtime must be Torch-free.")
+    elif not torch_present:
+        errors.append("Torch is not installed but the CPU runtime is required.")
+    else:
+        try:
+            torch = _load_torch()
+        except Exception as error:  # noqa: BLE001 - report the loader failure as runtime evidence.
+            errors.append(f"Torch could not be imported: {error}")
+        else:
+            if torch.version.cuda is not None:
+                errors.append(f"Torch reports CUDA {torch.version.cuda!r}; CI requires the CPU-only build.")
+
+    accelerator_distributions = installed_accelerator_distributions()
+    if accelerator_distributions:
+        errors.append(
+            "CPU-only Torch runtime contains accelerator distributions: " + ", ".join(accelerator_distributions),
+        )
+
+    return errors
+
+
+def check_runtime(expected: Literal["absent", "cpu"]) -> None:
+    """Raise an error when the current interpreter violates the Torch runtime contract."""
+    errors = runtime_errors(expected)
+    if errors:
+        raise RuntimeError("\n".join(errors))
+
+
+def _run(command: list[str]) -> None:
+    print("+", shlex.join(command))
+    subprocess.run(command, check=True)  # noqa: S603 - commands are constructed from fixed CLI arguments.
+
+
+def _interpreter_path(environment: Path) -> Path:
+    return environment / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+
+
+def _check_interpreter_runtime(interpreter: Path, expected: Literal["absent", "cpu"]) -> None:
+    _run([str(interpreter), str(Path(__file__).resolve()), "check", "--expect", expected])
+
+
+def install_cpu_torch(interpreter: Path) -> None:
+    """Install and verify the shared CPU-only Torch profile in one interpreter."""
+    _run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(interpreter),
+            TORCH_REQUIREMENT,
+            "--index-url",
+            PYTORCH_CPU_INDEX,
+        ],
+    )
+    _check_interpreter_runtime(interpreter, "cpu")
+
+
+def _assert_missing_torch_import(interpreter: Path) -> None:
+    result = subprocess.run(  # noqa: S603 - interpreter and command are constructed by this tool.
+        [str(interpreter), "-I", "-c", "import albumentations"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode == 0:
+        msg = "AlbumentationsX imported without Torch."
+        raise RuntimeError(msg)
+    if MISSING_TORCH_GUIDANCE not in result.stderr:
+        msg = "AlbumentationsX did not report the missing-Torch installation guidance."
+        raise RuntimeError(msg)
+
+
+def _run_import_smoke(interpreter: Path) -> None:
+    _run(
+        [
+            str(interpreter),
+            "-I",
+            "-c",
+            (
+                "import albumentations as A; import numpy as np; "
+                "A.HorizontalFlip(p=1)(image=np.zeros((8, 8, 3), dtype=np.uint8)); "
+                "print(A.__version__)"
+            ),
+        ],
+    )
+
+
+def verify_install_contract(wheel: Path, python_version: str, opencv_requirement: str) -> None:
+    """Prove the Torch-free wheel state and the CPU-Torch import state from a clean environment."""
+    with tempfile.TemporaryDirectory(prefix="albumentationsx-install-contract-") as temporary_directory:
+        environment = Path(temporary_directory) / "environment"
+        _run(["uv", "venv", "--python", python_version, str(environment)])
+        interpreter = _interpreter_path(environment)
+        _run(["uv", "pip", "install", "--python", str(interpreter), str(wheel), opencv_requirement])
+        _check_interpreter_runtime(interpreter, "absent")
+        _assert_missing_torch_import(interpreter)
+        install_cpu_torch(interpreter)
+        _run_import_smoke(interpreter)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = commands.add_parser("check", help="Validate a Torch runtime state.")
+    check_parser.add_argument("--expect", choices=("absent", "cpu"), required=True)
+
+    install_parser = commands.add_parser("install-cpu", help="Install the validated CPU-only Torch runtime.")
+    install_parser.add_argument("--python", dest="interpreter", type=Path, required=True)
+
+    contract_parser = commands.add_parser("install-contract", help="Validate a built wheel in a clean environment.")
+    contract_parser.add_argument("--wheel", type=Path, required=True)
+    contract_parser.add_argument("--python", dest="python_version", required=True)
+    contract_parser.add_argument("--opencv", default=DEFAULT_OPENCV_REQUIREMENT)
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "check":
+        check_runtime(args.expect)
+    elif args.command == "install-cpu":
+        install_cpu_torch(args.interpreter)
+    else:
+        verify_install_contract(args.wheel, args.python_version, args.opencv)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/tools/torch_runtime.py
+++ b/tools/torch_runtime.py
@@ -134,8 +134,17 @@ def _run_import_smoke(interpreter: Path) -> None:
     )
 
 
+def _resolve_wheel(wheel: Path) -> Path:
+    wheels = sorted(wheel.parent.glob(wheel.name))
+    if len(wheels) != 1:
+        msg = f"Expected exactly one wheel matching {wheel}, found {len(wheels)}."
+        raise RuntimeError(msg)
+    return wheels[0]
+
+
 def verify_install_contract(wheel: Path, python_version: str, opencv_requirement: str) -> None:
     """Prove the Torch-free wheel state and the CPU-Torch import state from a clean environment."""
+    wheel = _resolve_wheel(wheel)
     with tempfile.TemporaryDirectory(prefix="albumentationsx-install-contract-") as temporary_directory:
         environment = Path(temporary_directory) / "environment"
         _run(["uv", "venv", "--python", python_version, str(environment)])

--- a/uv.lock
+++ b/uv.lock
@@ -91,51 +91,10 @@ text = [
 ci-benchmark = [
     { name = "asv" },
     { name = "opencv-python-headless" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
-]
-ci-contracts = [
-    { name = "defusedxml" },
-    { name = "google-docstring-parser" },
-    { name = "hypothesis" },
-    { name = "opencv-python-headless" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "ruff" },
-    { name = "tomli" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 ci-package = [
     { name = "pytest" },
     { name = "twine" },
-]
-ci-pytorch = [
-    { name = "albu-spec" },
-    { name = "deepdiff" },
-    { name = "defusedxml" },
-    { name = "eval-type-backport" },
-    { name = "huggingface-hub" },
-    { name = "hypothesis" },
-    { name = "opencv-python-headless" },
-    { name = "pillow" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "pytest-randomly" },
-    { name = "pytest-xdist" },
-    { name = "pytz" },
-    { name = "pyvips", extra = ["binary"] },
-    { name = "requests" },
-    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tomli" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 ci-quality = [
     { name = "defusedxml" },
@@ -203,6 +162,10 @@ ci-test = [
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomli" },
 ]
+ci-torch-cpu = [
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+]
 ci-types = [
     { name = "mypy" },
     { name = "opencv-python-headless" },
@@ -241,8 +204,6 @@ dev = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomli" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "twine" },
     { name = "types-pyyaml" },
     { name = "types-setuptools" },
@@ -273,46 +234,10 @@ provides-extras = ["contrib", "contrib-headless", "gui", "headless", "hub", "pil
 ci-benchmark = [
     { name = "asv" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
-    { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
-]
-ci-contracts = [
-    { name = "defusedxml", specifier = ">=0.7.1" },
-    { name = "google-docstring-parser", specifier = ">=0.0.11" },
-    { name = "hypothesis", specifier = ">=6.165.5" },
-    { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
-    { name = "packaging", specifier = ">=26.3" },
-    { name = "pillow", specifier = ">=12.3.0" },
-    { name = "pre-commit", specifier = ">=4.6.2" },
-    { name = "pytest", specifier = ">=9.1.1" },
-    { name = "ruff", specifier = ">=0.16.2" },
-    { name = "tomli", specifier = ">=2.4.1" },
-    { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 ci-package = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "twine", specifier = ">=7.0.0" },
-]
-ci-pytorch = [
-    { name = "albu-spec", specifier = ">=0.0.6" },
-    { name = "deepdiff", specifier = ">=9.1.0" },
-    { name = "defusedxml", specifier = ">=0.7.1" },
-    { name = "eval-type-backport", specifier = ">=0.4.0" },
-    { name = "huggingface-hub", specifier = ">=1.27.0" },
-    { name = "hypothesis", specifier = ">=6.165.5" },
-    { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
-    { name = "pillow", specifier = ">=12.3.0" },
-    { name = "pytest", specifier = ">=9.1.1" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-mock", specifier = ">=3.15.1" },
-    { name = "pytest-randomly", specifier = ">=4.1.0" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "pytz", specifier = ">=2026.3.post1" },
-    { name = "pyvips", extras = ["binary"], specifier = ">=3.1.1" },
-    { name = "requests", specifier = ">=2.34.2" },
-    { name = "scikit-image", specifier = ">=0.25.2" },
-    { name = "scikit-learn", specifier = ">=1.7.2" },
-    { name = "tomli", specifier = ">=2.4.1" },
-    { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 ci-quality = [
     { name = "defusedxml", specifier = ">=0.7.1" },
@@ -376,6 +301,7 @@ ci-test = [
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "tomli", specifier = ">=2.4.1" },
 ]
+ci-torch-cpu = [{ name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" }]
 ci-types = [
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
@@ -412,7 +338,6 @@ dev = [
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "tomli", specifier = ">=2.4.1" },
-    { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "twine", specifier = ">=7.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260724" },
     { name = "types-setuptools", specifier = ">=84.0.0.20260812" },

--- a/uv.lock
+++ b/uv.lock
@@ -94,6 +94,20 @@ ci-benchmark = [
     { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
+ci-contracts = [
+    { name = "defusedxml" },
+    { name = "google-docstring-parser" },
+    { name = "hypothesis" },
+    { name = "opencv-python-headless" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "tomli" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+]
 ci-package = [
     { name = "pytest" },
     { name = "twine" },
@@ -259,6 +273,19 @@ provides-extras = ["contrib", "contrib-headless", "gui", "headless", "hub", "pil
 ci-benchmark = [
     { name = "asv" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
+    { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
+]
+ci-contracts = [
+    { name = "defusedxml", specifier = ">=0.7.1" },
+    { name = "google-docstring-parser", specifier = ">=0.0.11" },
+    { name = "hypothesis", specifier = ">=6.165.5" },
+    { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
+    { name = "packaging", specifier = ">=26.3" },
+    { name = "pillow", specifier = ">=12.3.0" },
+    { name = "pre-commit", specifier = ">=4.6.2" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.16.2" },
+    { name = "tomli", specifier = ">=2.4.1" },
     { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 ci-package = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,9 +3,12 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 
 [[package]]
@@ -26,7 +29,7 @@ wheels = [
 
 [[package]]
 name = "albucore"
-version = "0.2.12"
+version = "0.2.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numkong" },
@@ -34,11 +37,10 @@ dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "stringzilla" },
-    { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/03/0d81c80164397d29f413b81cfeea5c9b989a970ee2b1a43f3f09f461d0f3/albucore-0.2.12.tar.gz", hash = "sha256:314cafc3f1ec3c1ecb87fe4e5168f56694217aa27287bc7e6ffb13aeb61a9e02", size = 254563, upload-time = "2026-08-05T09:31:58.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/7b/a7018a715bda30e37b0a584bd1e7a9c084b8063308a150a490887ab39532/albucore-0.2.13.tar.gz", hash = "sha256:0afb83ea8ad73d799370cb45c8c26e739becccbe1cdf3e3fe11594907c2eb622", size = 196407, upload-time = "2026-08-13T11:36:57.103Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/10/4b6fa19d445fca566e7a6ba1cf67852f527a094a5dcb63ffa82af47efa54/albucore-0.2.12-py3-none-any.whl", hash = "sha256:f516da25592367abf09c3c54b88ce697b6eddeb574a10049067a3b224f484404", size = 58160, upload-time = "2026-08-05T09:31:56.844Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/41/1c6374737bf1033455a351a26bd6d04e6c2cbc8d27353153f6aa3da7e16c/albucore-0.2.13-py3-none-any.whl", hash = "sha256:a2d4d049a4cb1b2f0a52874b9d6ec109947661718112e34923d72cc90a701021", size = 57248, upload-time = "2026-08-13T11:36:55.716Z" },
 ]
 
 [[package]]
@@ -56,7 +58,6 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "torch" },
     { name = "typing-extensions" },
 ]
 
@@ -90,6 +91,8 @@ text = [
 ci-benchmark = [
     { name = "asv" },
     { name = "opencv-python-headless" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 ci-package = [
     { name = "pytest" },
@@ -117,6 +120,8 @@ ci-pytorch = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomli" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 ci-quality = [
     { name = "defusedxml" },
@@ -222,8 +227,8 @@ dev = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomli" },
-    { name = "torch" },
-    { name = "torchvision" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "twine" },
     { name = "types-pyyaml" },
     { name = "types-setuptools" },
@@ -232,9 +237,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "albucore", specifier = "==0.2.12" },
+    { name = "albucore", specifier = "==0.2.13" },
     { name = "huggingface-hub", marker = "extra == 'hub'" },
-    { name = "numkong", specifier = "!=7.7.1" },
+    { name = "numkong", specifier = ">=7.8.0" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "opencv-contrib-python", marker = "extra == 'contrib'", specifier = ">=5.0.0.93" },
     { name = "opencv-contrib-python-headless", marker = "extra == 'contrib-headless'", specifier = ">=5.0.0.93" },
@@ -246,7 +251,6 @@ requires-dist = [
     { name = "pyvips", extras = ["binary"], marker = "extra == 'pyvips'" },
     { name = "pyyaml" },
     { name = "scipy", specifier = ">=1.15.3" },
-    { name = "torch", specifier = ">=2.13.0" },
     { name = "typing-extensions", specifier = ">=4.9.0" },
 ]
 provides-extras = ["contrib", "contrib-headless", "gui", "headless", "hub", "pillow", "pyvips", "text"]
@@ -255,6 +259,7 @@ provides-extras = ["contrib", "contrib-headless", "gui", "headless", "hub", "pil
 ci-benchmark = [
     { name = "asv" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
+    { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 ci-package = [
     { name = "pytest", specifier = ">=9.1.1" },
@@ -265,8 +270,8 @@ ci-pytorch = [
     { name = "deepdiff", specifier = ">=9.1.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "eval-type-backport", specifier = ">=0.4.0" },
-    { name = "huggingface-hub", specifier = ">=1.23.0" },
-    { name = "hypothesis", specifier = ">=6.156.6" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
+    { name = "hypothesis", specifier = ">=6.165.5" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
@@ -274,33 +279,34 @@ ci-pytorch = [
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "pytz", specifier = ">=2026.2" },
+    { name = "pytz", specifier = ">=2026.3.post1" },
     { name = "pyvips", extras = ["binary"], specifier = ">=3.1.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "tomli", specifier = ">=2.4.1" },
+    { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 ci-quality = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "google-docstring-parser", specifier = ">=0.0.11" },
-    { name = "hypothesis", specifier = ">=6.156.6" },
+    { name = "hypothesis", specifier = ">=6.165.5" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
-    { name = "packaging", specifier = ">=25.0" },
+    { name = "packaging", specifier = ">=26.3" },
     { name = "pillow", specifier = ">=12.3.0" },
-    { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pre-commit", specifier = ">=4.6.2" },
     { name = "pytest", specifier = ">=9.1.1" },
-    { name = "ruff", specifier = ">=0.16.0" },
+    { name = "ruff", specifier = ">=0.16.2" },
     { name = "tomli", specifier = ">=2.4.1" },
 ]
 ci-release = [
     { name = "albu-spec", specifier = ">=0.0.6" },
-    { name = "cyclonedx-bom" },
+    { name = "cyclonedx-bom", specifier = ">=7.3.1" },
     { name = "deepdiff", specifier = ">=9.1.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "eval-type-backport", specifier = ">=0.4.0" },
-    { name = "huggingface-hub", specifier = ">=1.23.0" },
-    { name = "hypothesis", specifier = ">=6.156.6" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
+    { name = "hypothesis", specifier = ">=6.165.5" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pip-audit", specifier = ">=2.10.1" },
@@ -309,26 +315,26 @@ ci-release = [
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "pytz", specifier = ">=2026.2" },
+    { name = "pytz", specifier = ">=2026.3.post1" },
     { name = "pyvips", extras = ["binary"], specifier = ">=3.1.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "tomli", specifier = ">=2.4.1" },
     { name = "twine", specifier = ">=7.0.0" },
-    { name = "zizmor", specifier = ">=1.27.0" },
+    { name = "zizmor", specifier = ">=1.29.0" },
 ]
 ci-security = [
     { name = "pip-audit", specifier = ">=2.10.1" },
-    { name = "zizmor", specifier = ">=1.27.0" },
+    { name = "zizmor", specifier = ">=1.29.0" },
 ]
 ci-test = [
     { name = "albu-spec", specifier = ">=0.0.6" },
     { name = "deepdiff", specifier = ">=9.1.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "eval-type-backport", specifier = ">=0.4.0" },
-    { name = "huggingface-hub", specifier = ">=1.23.0" },
-    { name = "hypothesis", specifier = ">=6.156.6" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
+    { name = "hypothesis", specifier = ">=6.165.5" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
@@ -336,7 +342,7 @@ ci-test = [
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "pytz", specifier = ">=2026.2" },
+    { name = "pytz", specifier = ">=2026.3.post1" },
     { name = "pyvips", extras = ["binary"], specifier = ">=3.1.1" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "scikit-image", specifier = ">=0.25.2" },
@@ -346,45 +352,44 @@ ci-test = [
 ci-types = [
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
-    { name = "pyrefly", specifier = ">=1.2.0.dev3" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
-    { name = "types-setuptools", specifier = ">=83.0.0.20260706" },
+    { name = "pyrefly", specifier = ">=1.2.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260724" },
+    { name = "types-setuptools", specifier = ">=84.0.0.20260812" },
 ]
 dev = [
     { name = "albu-spec", specifier = ">=0.0.6" },
     { name = "asv" },
-    { name = "cyclonedx-bom" },
+    { name = "cyclonedx-bom", specifier = ">=7.3.1" },
     { name = "deepdiff", specifier = ">=9.1.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "eval-type-backport", specifier = ">=0.4.0" },
     { name = "google-docstring-parser", specifier = ">=0.0.11" },
-    { name = "huggingface-hub", specifier = ">=1.23.0" },
-    { name = "hypothesis", specifier = ">=6.156.6" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
+    { name = "hypothesis", specifier = ">=6.165.5" },
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "opencv-python-headless", specifier = ">=5.0.0.93" },
-    { name = "packaging", specifier = ">=25.0" },
+    { name = "packaging", specifier = ">=26.3" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pip-audit", specifier = ">=2.10.1" },
-    { name = "pre-commit", specifier = ">=4.6.0" },
-    { name = "pyrefly", specifier = ">=1.2.0.dev3" },
+    { name = "pre-commit", specifier = ">=4.6.2" },
+    { name = "pyrefly", specifier = ">=1.2.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "pytz", specifier = ">=2026.2" },
+    { name = "pytz", specifier = ">=2026.3.post1" },
     { name = "pyvips", extras = ["binary"], specifier = ">=3.1.1" },
     { name = "requests", specifier = ">=2.34.2" },
-    { name = "ruff", specifier = ">=0.16.0" },
+    { name = "ruff", specifier = ">=0.16.2" },
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "tomli", specifier = ">=2.4.1" },
-    { name = "torch", specifier = ">=2.13.0" },
-    { name = "torchvision", specifier = ">=0.28.0" },
+    { name = "torch", specifier = ">=2.13.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "twine", specifier = ">=7.0.0" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
-    { name = "types-setuptools", specifier = ">=83.0.0.20260706" },
-    { name = "zizmor", specifier = ">=1.27.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260724" },
+    { name = "types-setuptools", specifier = ">=84.0.0.20260812" },
+    { name = "zizmor", specifier = ">=1.29.0" },
 ]
 
 [[package]]
@@ -535,7 +540,7 @@ name = "build"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "colorama", marker = "(python_full_version >= '3.15' and os_name == 'nt') or (os_name == 'nt' and sys_platform != 'darwin')" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
@@ -1075,87 +1080,8 @@ wheels = [
 ]
 
 [[package]]
-name = "cuda-bindings"
-version = "13.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-pathfinder" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/1f/5ef51f5fbaa5d4d3201bb3d7555af028ec1aa4416275ccbf73c9e34e3d2d/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9851b0caa8bfd3bc6fa054eaf57bea7c8e9c3a62db2d2621224677f49f3c53d0", size = 6675244, upload-time = "2026-05-29T23:11:38.664Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
-    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
-    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
-    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
-]
-
-[[package]]
-name = "cuda-pathfinder"
-version = "1.5.6"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/53/8fc9b0cdc5b7f62746e6a01b85b6461e5ae27f871010a5fcf8fa6950766d/cuda_pathfinder-1.5.6-py3-none-any.whl", hash = "sha256:7e4c07c117b78ba1fb35dac4c444d21f3677b1b1ff56175c53a8e3025c5b43c0", size = 52972, upload-time = "2026-06-30T00:58:04.34Z" },
-]
-
-[[package]]
-name = "cuda-toolkit"
-version = "13.0.3.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
-]
-
-[package.optional-dependencies]
-cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-]
-
-[[package]]
 name = "cyclonedx-bom"
-version = "7.3.0"
+version = "7.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
@@ -1165,9 +1091,9 @@ dependencies = [
     { name = "pip-requirements-parser" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/e1/700aea05811f8988a60636e045914ffb155ce5318879f14b5c9016a12da5/cyclonedx_bom-7.3.0.tar.gz", hash = "sha256:d54080d65731980945de38e52009a5e5711f4a3c31377a3d13af96eaca5fcf3d", size = 4420319, upload-time = "2026-03-30T12:30:08.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/a2/ab75601071afb20352758ef20fd7983cd290f807cabd672eaa28eed45018/cyclonedx_bom-7.3.1.tar.gz", hash = "sha256:ebd99dc2cf62a7067e327bef2b2ffada99d57ed3fda2db6c4c8f3004e5bfd3cf", size = 4420707, upload-time = "2026-07-23T13:57:30.18Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/f8/285a990b17b44dac4899b14fbeab81a28f3bb828621d4a6c449631249136/cyclonedx_bom-7.3.0-py3-none-any.whl", hash = "sha256:73d7d76b3a28ebadc50eabf424cbcf128785a74b8a59ce7893da2e29cfaab585", size = 60924, upload-time = "2026-03-30T12:30:06.943Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/e464ae953209f1379e50f704fdc86b9695883e7d6f25464796981261bb1f/cyclonedx_bom-7.3.1-py3-none-any.whl", hash = "sha256:8c5adccefd593e89c0500463649c232625cee8e38dae1a433e057dfa495eff08", size = 60945, upload-time = "2026-07-23T13:57:28.463Z" },
 ]
 
 [[package]]
@@ -1322,34 +1248,26 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.5.1"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
-    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
-    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
-    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
-    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
-    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
-    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
-    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
-    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
-    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
-    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+    { url = "https://files.pythonhosted.org/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
 ]
 
 [[package]]
@@ -1382,7 +1300,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.23.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1395,78 +1313,82 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/8f/999e4dda11c6187c78f090eac00895a47e11a0049308f07579bcb7aa3aa2/huggingface_hub-1.23.0.tar.gz", hash = "sha256:c04997fb8bbdace1e57b7703d30ed7678af51f70d00d241819ff411b92ae9a88", size = 919163, upload-time = "2026-07-09T14:49:32.315Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/9b/ddf3d02a8681f1b9ce52fda03d755dad6b74c4f8172304c4c8d2975450f9/huggingface_hub-1.27.0.tar.gz", hash = "sha256:c1fed40ea82a6b41b477f5243546549b792ae0a93abcea608cff66089bf8f8df", size = 942668, upload-time = "2026-08-07T12:48:05.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/ce/13b2ba57838b8db1e6bd033c1b21ce0b9f6153b87d4e4939f77074e41eb0/huggingface_hub-1.23.0-py3-none-any.whl", hash = "sha256:b1d604788f5adc7f0eb246e03e0ec19011ca06e38400218c347dccc3dffa64a2", size = 770336, upload-time = "2026-07-09T14:49:30.597Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/95b735e183957c1f26d94c52977f09d466d55119cbbc1558ea4975e4c216/huggingface_hub-1.27.0-py3-none-any.whl", hash = "sha256:7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d", size = 784926, upload-time = "2026-08-07T12:48:02.905Z" },
 ]
 
 [[package]]
 name = "hypothesis"
-version = "6.156.6"
+version = "6.165.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/83/8dbe89bdb8c6f25a7a52e7898af6d82fe35dfef08e5c702f6e33231ce6c6/hypothesis-6.156.6.tar.gz", hash = "sha256:96de02faefa3ce079873541da96f42595583bb001e8e4219294ed7d4501cc4cc", size = 476304, upload-time = "2026-07-10T20:56:49.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/3a/b840ea8b26e0c4795584dc93c832c5d1a9ff37db1818cc91b2ee8110f757/hypothesis-6.165.5.tar.gz", hash = "sha256:0df7fdefd2e10bbfe7d690eb22c7181a739e8040026907207faa305d86e6e4db", size = 503056, upload-time = "2026-08-12T22:34:58.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/dc/0c2a851f06c91d5ac9ef0f3b9615efc1ed650411d2eee23b6334f491c85e/hypothesis-6.156.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:caf6a93d011c10972da111c38ceb34ced20feaa8581e2b350c0655b022e27875", size = 747998, upload-time = "2026-07-10T20:56:16.311Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/f8/59203ca978ab51595d12d6bc7e7a63300d7373431ab42ca3f1742e45db68/hypothesis-6.156.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:07f2bc9df1aeba80e12029c1618e2ee54abc440068c305d7075ffd6b85251843", size = 743073, upload-time = "2026-07-10T20:55:36.825Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d8/86a0023740434098d1b187a62bd5f99b198f098fb43e7fc58342283a8270/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7baca17f4803ad4aa151732326f3990baf54c3127df44aa872ac5bdf8a98a9a6", size = 1070169, upload-time = "2026-07-10T20:55:49.47Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/82/673453915fd0c67673f35a4876ba88f48c621335f293f3537d77b27d4286/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8083806645f84243aade727f4978185caaa0b7190af4318673999ee15fdbf424", size = 1121760, upload-time = "2026-07-10T20:55:53.502Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/c3/3a5557f52912f2fecc6ed59642dcf80dd8e89d0d9664502b68e23d66bf3d/hypothesis-6.156.6-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a922eedcd8618f9c2e17b79fa7b3f3f0b2df34e201958611cc3f0f46cca33c10", size = 1111440, upload-time = "2026-07-10T20:55:43.054Z" },
-    { url = "https://files.pythonhosted.org/packages/38/a6/ae636d4ca7f996a1ccb4b3d5997d949f1718fba52b01559b3ab53b237b3f/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5291bd33c4704d274d7c214d5c200e77f372a06644f5cbbe96dcbe53cb2fbf10", size = 1244944, upload-time = "2026-07-10T20:55:56.109Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/79/c425d22d734be0268ca60d120c6296299e4220a1783cb1a4cc76232807bb/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55f3ec50161b4a95bae63bff2b5166e45935b493013d3be30ede279bf6192318", size = 1288808, upload-time = "2026-07-10T20:56:06.249Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3a/cc9f479d22cbdd36ddfc55a978378eddadd183b09339ebdb81be33bb18e7/hypothesis-6.156.6-cp310-abi3-win32.whl", hash = "sha256:e96570ca5cdd9a5f2ff9e80a6fb2fd5420ebf33b833d7de5b09b6ebb26a3eb6c", size = 634868, upload-time = "2026-07-10T20:55:37.959Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/89/2008d287289841a936456cb13443ca89d88da6e4527d611d482e9544164d/hypothesis-6.156.6-cp310-abi3-win_amd64.whl", hash = "sha256:32710718c22fe8c5571464e898bb87d282837b02617d6ad68130abf7cb4843cb", size = 640382, upload-time = "2026-07-10T20:55:30.634Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dc/b502504a972af7368b62e712268d310ffbc81d0ebfb31d5a9c60332a5063/hypothesis-6.156.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:afec0631a7a557acb50f665108b5d1d1123c21bc702d156a740db1cc33be4a7d", size = 749319, upload-time = "2026-07-10T20:55:35.708Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/fe/a4867bc2b8b81d9b1648992fb7e4a732b3db480ff2d02df2c7b59189c812/hypothesis-6.156.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583a658162ee7e1a82155e3f146932a3a2269030294f3c83f5cf52fcaa0562c3", size = 743969, upload-time = "2026-07-10T20:55:31.983Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/22/6ece4337e01c634594bb177009c049aa3133c151d9e397edccb6c3938567/hypothesis-6.156.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9600277defbfa769d8a6af264cbdff16294682c210c2d058ef39348fec16c0c", size = 1070874, upload-time = "2026-07-10T20:55:44.277Z" },
-    { url = "https://files.pythonhosted.org/packages/05/00/5820a3b1fe264b23770f77dbb3ac0f6fdadd21b640624791a05950f934da/hypothesis-6.156.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7c3f067166bfc28b67f0042fc5fdcc87b3b58664da0c2f563fe544448b7ab3b", size = 1122191, upload-time = "2026-07-10T20:56:20.721Z" },
-    { url = "https://files.pythonhosted.org/packages/90/f8/0861ed15c96302577229334655e038e8c46e4b5b2a8cae971409a7e176e5/hypothesis-6.156.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f57842c1c5314839bdf4be5cff108589ff435cd7192c035dc48e6f14032915a5", size = 1246060, upload-time = "2026-07-10T20:55:41.834Z" },
-    { url = "https://files.pythonhosted.org/packages/64/5c/63b60c6566eafac0b150f6acae5d1cbe0ed64dc294c863888eb87088a542/hypothesis-6.156.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c4a787c3af0035846034461792f2a62f1c43af850feb970a5b53a629d64b52fb", size = 1289510, upload-time = "2026-07-10T20:55:33.133Z" },
-    { url = "https://files.pythonhosted.org/packages/96/4e/bfe57f182f51784549210903241057ae94784858117b965613089f5f89ad/hypothesis-6.156.6-cp310-cp310-win_amd64.whl", hash = "sha256:02accb187617ebaebb120da931f799a3cb0df7c38706f97f9d022441d4faf533", size = 640384, upload-time = "2026-07-10T20:56:26.939Z" },
-    { url = "https://files.pythonhosted.org/packages/13/64/e4a0796190d8089e85f06731e21fdddd7e8edd3a4e562101527a048e21c4/hypothesis-6.156.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5baec7943a14d106e982121dd4f74cfc5ef45e37c17f94fe49338d3d1377f38c", size = 748988, upload-time = "2026-07-10T20:56:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a2/4a789b286cd2cced31992e1f683036b51dd6909b934ea007ffb43aa3a32f/hypothesis-6.156.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5f519905ddeb10e23b8ba2c254541a5b1a8f146fe0551be94d972f4a77226f4", size = 743754, upload-time = "2026-07-10T20:56:09.113Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f7/3dd36c1c03d24ae3ffc3c5b0eca8cc4ae90c07abc320f76509eceb37019a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c108655960b58ded3ca71b2dc5c69fb2ba7e9c723aeb6106facec3892d09087", size = 1070732, upload-time = "2026-07-10T20:56:28.738Z" },
-    { url = "https://files.pythonhosted.org/packages/57/51/befc4b816b471078034a875eb1ef69e0411ab84bcce582b4be173258785a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c8d37bebb6924729bc0bbf5852689df568842948abe4d93dd0ad3377adf76fa", size = 1121988, upload-time = "2026-07-10T20:56:07.676Z" },
-    { url = "https://files.pythonhosted.org/packages/05/b7/a796f5e3e4b7cb911ff346008d49720296d1f4073490b8bc1cce6b3fbb07/hypothesis-6.156.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:74137bef6d502305c3648b2ed1a9bb4bc05fb1025e96b30a2c092204c40fe097", size = 1245596, upload-time = "2026-07-10T20:55:50.662Z" },
-    { url = "https://files.pythonhosted.org/packages/37/65/849c4cba44a6f6cc888fd931124429b24180234ccc4883abab8cad5fcfcb/hypothesis-6.156.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5e0afdf79cceed20fcf0a9fb80d4064a9b2b53d4d4eecbac0e21208a13f5a31b", size = 1289172, upload-time = "2026-07-10T20:55:58.915Z" },
-    { url = "https://files.pythonhosted.org/packages/13/03/7106a110df29eb631d66776e8aa8128f82f04a9dd2b6b22b612e6025e3a2/hypothesis-6.156.6-cp311-cp311-win_amd64.whl", hash = "sha256:84dc89caaf741a02f904ca7bd02b1af99650c75552868162290208aeecb70858", size = 640222, upload-time = "2026-07-10T20:56:10.396Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/45/9f009005b9c796f4a40424484ac7e70847bc088456fd940a937f96bb4b6d/hypothesis-6.156.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a2a728b514fceb81e3f0464508911d5220fd74dadc3270f859427a686b60c4cf", size = 748844, upload-time = "2026-07-10T20:56:38.036Z" },
-    { url = "https://files.pythonhosted.org/packages/02/2f/4d852bb8a9c73a68b18eca9b5b085285282122166e158f4d2a477639bfee/hypothesis-6.156.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7489b9a8f9df8227edd6c7cd8b9ccfab2483bab24da6a474c175973ca2294f58", size = 741936, upload-time = "2026-07-10T20:55:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/74/89/b9968070ae042f9bf3149bb6ba6399d5f28f452e0fb7f638cafc69ff0b9a/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42760873d6db1069d6edbaa355a61b9078a9950259efcfc72fc695741d7db7cd", size = 1069749, upload-time = "2026-07-10T20:56:43.017Z" },
-    { url = "https://files.pythonhosted.org/packages/00/a9/753806f5292b40aeab1d269e408e3a7e85be3c0d88828fb78ab4a34d6626/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4e66aaa7385538a5d617174d47c198ee807f06de99e282a67c6cb724c69340d", size = 1120983, upload-time = "2026-07-10T20:56:25.424Z" },
-    { url = "https://files.pythonhosted.org/packages/85/88/8386d064d680be27e936eba94f1448bc93ef6fa05473ee5034139f1c4284/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08796b674c0b31a5dd4119b2173823390055921588d13eb77324e861b00fd7f8", size = 1243911, upload-time = "2026-07-10T20:55:54.799Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/8c/7524c1e5279e7728eb47c99f2357cbc5f08ae92e9bce49bf50118b53f9c9/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4ca8cc26ea2d31d22cf7710e92951cfaa921f0f8aa1b6db33a5176335f583a4f", size = 1287806, upload-time = "2026-07-10T20:56:02.176Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/b3/c347ad913e1c5f2988956fe17826c0400b4ce470b973e6c248e97b6a0acf/hypothesis-6.156.6-cp312-cp312-win_amd64.whl", hash = "sha256:c3363d3fb8015594636689572510bb6090602d8e8e838a5693c2d52d3b5b09d8", size = 637679, upload-time = "2026-07-10T20:55:39.056Z" },
-    { url = "https://files.pythonhosted.org/packages/70/5d/9583fe153573523dac27226c89e041a86ad4aeeae08c868160cbb93d39d2/hypothesis-6.156.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:59a8def90d9a5a9b67e1ac529e903a2363ceb6cf873c209da6b4284c5daab671", size = 749264, upload-time = "2026-07-10T20:56:46.118Z" },
-    { url = "https://files.pythonhosted.org/packages/86/35/e4113d06769b544f0fb77ffea9195b598b4c56a298905c21fd47c4eed388/hypothesis-6.156.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c574c3224563d730848bc5d1ef1683c4f83993400c0167899fe328f4bfcd4725", size = 742095, upload-time = "2026-07-10T20:56:41.412Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5c/a47666ede10384e8978722cade7ab96a42df71d2ab577317092d0fed7c8a/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01bb8270c46b3ef53b0c2d23ff613ea506d609d06f936d823ea57c58b66b05f7", size = 1069917, upload-time = "2026-07-10T20:56:04.845Z" },
-    { url = "https://files.pythonhosted.org/packages/79/93/75f6057dadd9dc0134f37c08d5d14d04d3cd7374debbcb0cc4569c6712f1/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4ea6559c13606e13b645927f2e0906e52b5ac5d99b40d3abaaeb2e8c7ceeb75", size = 1121204, upload-time = "2026-07-10T20:55:52.008Z" },
-    { url = "https://files.pythonhosted.org/packages/62/87/308efef08bc60d1e673d035e8ca8e9663f4b6b3ba519c3cdebf6583c2b76/hypothesis-6.156.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2d47054d0230f0dd9b6868fc030126c7a6c25527144272ff376cc4e9c39f7540", size = 1244168, upload-time = "2026-07-10T20:55:40.288Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/66/de8fff5bd9a40a4056dafbe7f904887ef12632282bbbac90f1977c30dd3b/hypothesis-6.156.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:050c8c0815f88d47dd0875a92698d20d61639b7b721ee043a6d687c7f14ff7d8", size = 1288127, upload-time = "2026-07-10T20:56:00.541Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/8d/794fb26e1fd3ff004978f8f18b7aa7e1c2270ba72e1f977b987a812064f8/hypothesis-6.156.6-cp313-cp313-win_amd64.whl", hash = "sha256:f0d73edab7b8a0051b3634f2d04d62b7e7282f8f274963b11188ee4957d672ef", size = 637954, upload-time = "2026-07-10T20:56:33.35Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/be/5b4b27984cb43c60e95f570b069660335dad34cb67f7d226017c5d35d31e/hypothesis-6.156.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:34a70a7b8226e34d658072d8fb81d03f97f0a75ceb536329a321b94ce2232fd6", size = 749312, upload-time = "2026-07-10T20:55:46.902Z" },
-    { url = "https://files.pythonhosted.org/packages/31/11/709cceffc28666c9d4cb75ffc6df5ce30db8c7dd5cc2c8b38a2fd837427f/hypothesis-6.156.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f1969646beead7d8cf6a2537d2765af89d73056e2cb218e7fae92b83802250a3", size = 742332, upload-time = "2026-07-10T20:56:30.254Z" },
-    { url = "https://files.pythonhosted.org/packages/84/52/cfc79b13d8dd3cd6de6b9df921c557efe8528a9c90a3a7cd93b37188d57e/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbc2ec7b7d905e6b6ec1635f6340bfa52aaab718101c59f052bc012a6b486cd8", size = 1070109, upload-time = "2026-07-10T20:55:48.244Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ac/1da4def1f006b5ad01187ff96379e24c37439d659ec10c3e944c03436c0f/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9367ae25dfa6dc1af37904785e43c4f8fe1c4118cafdc2f06514154fbdd90992", size = 1121528, upload-time = "2026-07-10T20:56:39.665Z" },
-    { url = "https://files.pythonhosted.org/packages/68/47/744e4f5e3d635dea20dbedf3fa486e2a6fa5210e0a52a0d5c4da56babd84/hypothesis-6.156.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:455f09107ec07c78f2a83cb8fc19e23879c9d51cdc831de6f9cb6ec4059cb9af", size = 1244690, upload-time = "2026-07-10T20:56:31.854Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8a/42252fcd5e521d140dac532f29c2a13ca8f22908cb545ffdd64b5e225680/hypothesis-6.156.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c76634c45a3ceee4c4fdfed39aebd08b8b822ec8b0c556877ef82846fd777730", size = 1288519, upload-time = "2026-07-10T20:56:03.429Z" },
-    { url = "https://files.pythonhosted.org/packages/44/e7/176df9e47cf583d2b8d234b78c0aac3a47075ad5d147e60b2c21a1338bb1/hypothesis-6.156.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:eb7e9f8343bc6b948937e6ec12e6879ed25a17b53ceccbd2b84adadd3d511698", size = 586452, upload-time = "2026-07-10T20:56:22.285Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/75/2c8a0411bbe76429f3ae738ef9a00107201bf6146d9534350014ce369d98/hypothesis-6.156.6-cp314-cp314-win_amd64.whl", hash = "sha256:f9631cd604ae6032c3edf99160dc1b9e33873f2e52762246b24f07fb758652ae", size = 637774, upload-time = "2026-07-10T20:56:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/22/8115005e9aa72c8d63d90e9db5e0b8425fd8950fbc5d6e332805d4d32c9e/hypothesis-6.156.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:1f81163d36d3763b09ffaef7c3a71e88174ca3e6816201fca9d1d159f448fdb5", size = 747428, upload-time = "2026-07-10T20:56:44.611Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/c2/66bfe9337f4a4b1f7754ee6d01d950280152a81d0d797e6c1d9eb0909750/hypothesis-6.156.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:556b905767e36147918634a64356aa05d8c956576f00aee01eb351678f193908", size = 740889, upload-time = "2026-07-10T20:55:57.656Z" },
-    { url = "https://files.pythonhosted.org/packages/95/3b/69f45af2d4f0950b7d1af3cdbdd800b88a6c2370331481eda79d6171fbe3/hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3f2604b28d16d696aaaf4954d20f907b27e54034df98e64746a20c74c319f03", size = 1069270, upload-time = "2026-07-10T20:56:12.024Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/43/6b2549885da08f5e50ba34fb8e0d0a60b2f190ffd516fac220f8db5b5869/hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe012ad66dbe7b8e8ddef6f6992ab1b36719ea64430c2bf1ff7135521052a15", size = 1120409, upload-time = "2026-07-10T20:55:34.551Z" },
-    { url = "https://files.pythonhosted.org/packages/70/97/745c778c3eb29befa2367b1ded8437eecfbbe6932359d0f831275bc32170/hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5bfa3c7b758f7278081c6bfec5f89b43c4eb075c0c9eb095323f7a9eb019b513", size = 1243111, upload-time = "2026-07-10T20:56:17.83Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/d7/c5ec6a442dc9b822f47064bda4b6d3e739dccdd1c5bf44c9a57fb6136830/hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d0db1f4573800c618773622f03cb6533bb3377430ef938c9476ba10c39d22591", size = 1287262, upload-time = "2026-07-10T20:56:23.749Z" },
-    { url = "https://files.pythonhosted.org/packages/11/0c/c134d61710e14b68b010215dcf6bd57d2ec05cd169dff8bfab8fefc2d410/hypothesis-6.156.6-cp314-cp314t-win_amd64.whl", hash = "sha256:38cd0c4a7b9f809f1e23a4d15adfa9c5d99869b9afc327350a5e563350b78e48", size = 637862, upload-time = "2026-07-10T20:56:13.347Z" },
-    { url = "https://files.pythonhosted.org/packages/59/9c/b94f3a31665527b6181616b72990fcf8d6d5fa82b4187aab104ab5f548f0/hypothesis-6.156.6-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8893b4da90e06828846c1b100c3414a7729d047a020d854c0899ae9339df0e70", size = 749575, upload-time = "2026-07-10T20:55:29.371Z" },
-    { url = "https://files.pythonhosted.org/packages/21/74/dcf695f79f526543ae5d0f8c1325508e9fe990a996c0e0853129a9a5d81d/hypothesis-6.156.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b7fc0b7df9b28d028e4cc295b2ac8fbbbc22e090a23382c92fff5e37696be74f", size = 744351, upload-time = "2026-07-10T20:56:36.46Z" },
-    { url = "https://files.pythonhosted.org/packages/11/d3/5bff4c55c6995a6c43f66ec8e5866b56e34f03837fd0be0e4922f3bab168/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38ed3178526382d392d04ad699ad7a2e53845e521a09d40f1cbbc1e1ff63ba48", size = 1070916, upload-time = "2026-07-10T20:56:19.256Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/af/5ed42117a69221ea118caaff933d8212039a0ac0bc15afa915635f13984c/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ad94e28aabf4db0d479297d43b8a2a01e7caaa9bdfccfdac7a4a3717e05b993", size = 1122625, upload-time = "2026-07-10T20:56:14.758Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/d3/02499badc6e3f3e980941021edf5fd780c895d8d08c9015e78516340ed83/hypothesis-6.156.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:983a5cfd955994bffc7eb02976241f7a1f3c2d94dbc3389430c45858fa5c1ae0", size = 640823, upload-time = "2026-07-10T20:55:45.461Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/46/fba332db906bb26f3c27285d17f5210bee54c3d7e1545e4d1bcae08ec437/hypothesis-6.165.5-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e9ee79ccf2de7b185821ed8364eccfea7300b52b30a8c626f6b7213f3b38e5d5", size = 782500, upload-time = "2026-08-12T22:33:48.567Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/f3cd7814a571ecf58c97a40686c97814c9f6be95dd258d9144d909f0900e/hypothesis-6.165.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b732ea0c758e9c587eea8bb89ea27c985cb7609304e484ff8e5ffdb890f56ae5", size = 778047, upload-time = "2026-08-12T22:33:44.541Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a4/e0825ff8e353bf92b77f9b990c3e0e1160a0f2953feb95647cf2ced0b1a0/hypothesis-6.165.5-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edb08b192ea64a75e82dcc0b49e515f9ca86e4523c678bf8035c993f3bf7323f", size = 1107271, upload-time = "2026-08-12T22:33:31.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/85/1005fece1e0f59f8974c2e4be3fae1d0436a77b9fbee9a6203d7b250536d/hypothesis-6.165.5-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb74178189e0a8451e0b7cde4a236f4c8bee848ce01d42df968623ac11a4671a", size = 1135836, upload-time = "2026-08-12T22:34:06.044Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/8a/6f51cf111f590b883f5fcdb21b54345beeab516ad9c07d4256b731d66ef4/hypothesis-6.165.5-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a970cfb945f31b3115b013ede9fe3f0d68b37ff5b86499cc44ccec3d3fe1eeaa", size = 1156825, upload-time = "2026-08-12T22:34:28.263Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7e/fbf54b49173d118681576259acdec61e045b825d516ca1fd5155f7a14ac1/hypothesis-6.165.5-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:569a7cd8b737019420a5530584ee28fba9dfa3ed877621764a2627f804e983c6", size = 1112117, upload-time = "2026-08-12T22:34:13.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/95/98bd41c67215950f73f8df711b7d13e40f0fad21c1ff61271b676abc4e19/hypothesis-6.165.5-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:61f30a43dc377ba94885e1990be785434686d76a8f37605336dd697c696dad4c", size = 1148864, upload-time = "2026-08-12T22:34:22.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/07/9dac0e757abc9dd0500b173adbfe018b1742af5ab35c46169cea290bbf65/hypothesis-6.165.5-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6a25168ab05d52a084e216f8f033472a8bd18167e0e8fc25a8774722db884be2", size = 1282719, upload-time = "2026-08-12T22:33:55.326Z" },
+    { url = "https://files.pythonhosted.org/packages/62/9a/0dcce83dfa414427c2632be45a2338edb5b80e2b9b1c7d88c70c2478c90d/hypothesis-6.165.5-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:6984a5b7e62b19ddd78643d954dfa90ec8dabbdac4df43a4e63f60fa06514eb2", size = 1409219, upload-time = "2026-08-12T22:33:39.521Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8f/82ed9fe9dae7cb79714c5de9cbccd5c4847348971e4ee61c5ad2013417d9/hypothesis-6.165.5-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:77b57c6c5154357955d724a5ba198aa421f1273a9f88a6ae24d23a1c6d1c91b8", size = 1281995, upload-time = "2026-08-12T22:34:38.42Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/4b/06ca1631cce0a9a9806ef15535b9502967751a066dfd620876ff4b8e1eaf/hypothesis-6.165.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d77557a13f3cfbabc9b96909fc985563e474627208d981689e4925dc4708722f", size = 1324044, upload-time = "2026-08-12T22:33:57.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d7/ac8ae1cf829faa5204a743db0e06880ff71bdd105927592b504e34368391/hypothesis-6.165.5-cp310-abi3-win32.whl", hash = "sha256:7c5fd96d54f63fca065cbc21579be0e9b75190af48ff77d5cb759111fe5edae0", size = 668283, upload-time = "2026-08-12T22:33:32.83Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/62/77acaaea919da21dbf9e76b78a87f9ac66fb44dc2e95afce07dad6da1185/hypothesis-6.165.5-cp310-abi3-win_amd64.whl", hash = "sha256:bcc3f34121b046e6091b35901b77e24dd1c674fc234b6e09b102e5efb03afa11", size = 674433, upload-time = "2026-08-12T22:34:47.75Z" },
+    { url = "https://files.pythonhosted.org/packages/63/3c/166588d56651c6f17762e45fe9ffe71d0660af037e8971672a16f1653fc6/hypothesis-6.165.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:5070e35098c626a63ddc0d54dc7065fd5f40a9857a0e0308b1979c9e9f974753", size = 783194, upload-time = "2026-08-12T22:33:59.142Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/d440a58d8f94f5d1cd5163d51d5b794ed44435b5488da707105d0a60fdae/hypothesis-6.165.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65d4b1f6ef4ee525bd0f68ff3544213d43484f94546612f3984030b747b0e114", size = 778923, upload-time = "2026-08-12T22:34:41.519Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9d/de53a16e59c63a36a2db5f46e2b80b6b667854634a68dcd2692ba0450072/hypothesis-6.165.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e21b6809195079d350131c20bf3b251d0c15bebc5cf8a93c49f83d7851354755", size = 1107795, upload-time = "2026-08-12T22:33:45.691Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/8c82eb01b299334a3f325c8696f6ff3ef581ef73cfc908fd8844e51bb972/hypothesis-6.165.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7c86e788b08236cea3c90696b3f005677428c24e848bd1391c6a69c46c7841c", size = 1157363, upload-time = "2026-08-12T22:34:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e0/d7f9b74e08ca59f3eac9baa4b9cbcf43537b064b47aefca7ac0e09a05cbd/hypothesis-6.165.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ff23220088072be375805bdc33b16ceca9684230400a2f71c715859bd5603dac", size = 1283387, upload-time = "2026-08-12T22:33:49.883Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/cc/a608044524a0d7ce7c30ce9e87c379178cb04556b4f460271208047afd28/hypothesis-6.165.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6d547c8b89f355cb7ff23a0c3a8ceb7b3d3d014d1039ef5c739ca7b538e39e57", size = 1324354, upload-time = "2026-08-12T22:34:09.071Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ff/53416c5eef84dca1b0972c11f30c81704b9a4c6c847a5707ae738f9f0fa7/hypothesis-6.165.5-cp310-cp310-win_amd64.whl", hash = "sha256:e2c1d730a155b0401baea2100b1ff6abc1df5649932580a8616263059cc1df05", size = 674318, upload-time = "2026-08-12T22:34:26.808Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/78/c18ff0f6fa107b601b4a7e2311881a267ca37411ca9b1f7887488afcbdd7/hypothesis-6.165.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:cde1a938e491e73f3cd92d131bc3b9a7eec1f5716539a3ad9e906219faaff725", size = 782959, upload-time = "2026-08-12T22:34:10.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9f/5065cb3f925aa79b844eda8ebc9a80d2ad4476faad09614909f94c83f793/hypothesis-6.165.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3ef3c3d190b3de1115051e567221484f38b5993199baed1e04b42de7087e7b66", size = 778746, upload-time = "2026-08-12T22:34:36.884Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/50/c7a01a8aa69d60ee47278dc67b9ab121d06437f1830d4748ba7b8018fb54/hypothesis-6.165.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9aca13ac370ec5cfe1ad1588ac2314f1f3a0ac1ae23b746d0c55c1ea92cd0344", size = 1107652, upload-time = "2026-08-12T22:34:44.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/4a/2d0990ef13fff11ea2eab1f91dab25b7986927ba7beaf2e8aeca8154f44b/hypothesis-6.165.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9cc191c6be2a6bc14904b74b5716c863d5e4307163f33bf4b7ad59c65b713396", size = 1157100, upload-time = "2026-08-12T22:34:35.395Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b3/61373dc68177900b2b684d8d9d64ffcbe8f2af652deda6996e207b8a1f23/hypothesis-6.165.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4980f0307639508f1db23e1fdf3c32f194c44a7f01f98af0e2f6388d56821019", size = 1282970, upload-time = "2026-08-12T22:34:07.352Z" },
+    { url = "https://files.pythonhosted.org/packages/17/df/06f0806d8fb3733aa5b91e84695fa21d976cf731808af30e79dcdbcc1cec/hypothesis-6.165.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:87137180f7377cf21e8c799c38cd6ff04611cf56b7a017d48733508590eaf149", size = 1324294, upload-time = "2026-08-12T22:33:43.123Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/42/15a30ba67755617802fdd7b7e567d8b07312356e4f232cf2cbc5c932dd45/hypothesis-6.165.5-cp311-cp311-win_amd64.whl", hash = "sha256:64322ecb5ce171ce30ab4c21bdb77891cc71ba9ad7dad0211883bacae2449973", size = 674173, upload-time = "2026-08-12T22:34:01.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d0/176ea6d8480d35a1a4fc2ffb1a61126441b2ac067216737052358581d5a7/hypothesis-6.165.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1f330c91d532810bc2ac849e4d0d44a5a4f72508b4c92f1af91b7f2c90c4379a", size = 784074, upload-time = "2026-08-12T22:34:20.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0c/3d128243dfc0ae059935c6607869f244efdc5676bb6e0006a2795cfebaeb/hypothesis-6.165.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:331e8026a380629c8b3b01850f0504a5191617694fe8703ffbb7de32cfbb370e", size = 775642, upload-time = "2026-08-12T22:34:14.757Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/40/e80bb810b26fe5807f7c8e3c3c5c3c7556d7128a195e0a57f2480b8a78e2/hypothesis-6.165.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4ebe628c589b512a0e20b99aa3799e2331ba2c590dadf411d3bee95f9edb914", size = 1106103, upload-time = "2026-08-12T22:33:53.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/1c/14648fa3d821bfe4f132e5482837320f191bc60f38a4bd2b687096adf6e5/hypothesis-6.165.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:397685c7e74e6c489bab521bf437c7aba366e275e54f8bb03a6f4571df71faa8", size = 1156164, upload-time = "2026-08-12T22:34:04.621Z" },
+    { url = "https://files.pythonhosted.org/packages/59/59/74718a2b859e3b6673589f1591785dd15cdec2ff02b7c8d18f3fc0a42ed2/hypothesis-6.165.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ed071268fb878d206ff3172dfef29681cda4982c2752d57e3ad1cf70aa3d7535", size = 1280047, upload-time = "2026-08-12T22:33:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/72/5f/1de655e95992c4657f302ec0eca0dd2cfb6bfaaa3b698836432daedac992/hypothesis-6.165.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:381bb61f342c47d0bbfed6af7fecc93f1a8d4778e0c12e7415bdfe0f9bdc9121", size = 1323384, upload-time = "2026-08-12T22:34:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e9/1f265bf5f575396e8097010c39b11c2c4dd905064c694a0f53dffff58445/hypothesis-6.165.5-cp312-cp312-win_amd64.whl", hash = "sha256:92f2dfb1417bfaf93fdbe654261c68dbbfd573b74473a570895bf81958c045e7", size = 671570, upload-time = "2026-08-12T22:34:51.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/2c3357cda375d8ba1276dec4d0a7b51404f86cc6855f1541b424cf99d5f7/hypothesis-6.165.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:55b907b33ece350a8b69890a7f09b22b6a93761a8724c3ed12a9cd71b2a03eb1", size = 783966, upload-time = "2026-08-12T22:34:40.078Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/64/71cbfa9e741a0d657570af6b42f5f81ca795fdd0bddca44bc89309b46e16/hypothesis-6.165.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2cf1a6b2ccaf36e0a2b1f95515edec4db6db14a4e7afd9c36ff477552ffc0f11", size = 775594, upload-time = "2026-08-12T22:34:00.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/1f/ccb8f0034c8e17f488bc60d74ac21ac0e8945f507ed0b6e8634b67da925e/hypothesis-6.165.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5faa41aca389826d21f311ae5e59b36eb8bb38933a88bc07ad08bd868af6daae", size = 1106007, upload-time = "2026-08-12T22:34:25.431Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9d/64f7f7e1398fb04286816b9770138a35d730f008ac45b44b6425dcc0dd61/hypothesis-6.165.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a194f401e5d0345ef459f5aa80a50676a64e146c4f57474d70f7ccbe11c886c7", size = 1155990, upload-time = "2026-08-12T22:33:37.139Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e9/4bc808417bac59e9c154cbfb38705613adba4f1f37a815607211ab9ee0ab/hypothesis-6.165.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dd2acd36004b990504125c4e679cf98addf3ca2ce873b38a52f71c66716cc7a6", size = 1280030, upload-time = "2026-08-12T22:34:53.359Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ff/dd0de28497f64ca01c059e32eca7e06a69c39f50ab614969ae636b7ceb3f/hypothesis-6.165.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:709d61590c8cd627479fb4255e085239b91b29a4d386e83f910c5117cfe5b25b", size = 1323111, upload-time = "2026-08-12T22:33:41.959Z" },
+    { url = "https://files.pythonhosted.org/packages/45/45/756e1050f26041f6c3aeae2b7e41b10160b2560de0ec46fd3341f6a3cb52/hypothesis-6.165.5-cp313-cp313-win_amd64.whl", hash = "sha256:de4b6d24a0e6adfdd99b2ee1f8d9f43e6ba6146b3860a643e8bce6b41fcebdc6", size = 671569, upload-time = "2026-08-12T22:34:33.938Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5e/e4178b39d5e7307d3658ec54733f3b7d953df12a38681b91ab1929b740cb/hypothesis-6.165.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f877ace8cb1bc0af9e3c83bf2a63f0a29f54f99ec813d1ecc9c3224b514c036", size = 784066, upload-time = "2026-08-12T22:34:42.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f1/9c338484238ef0169f77ae7fdd28e34d1dacc0501f003cf7b0009f1f1f58/hypothesis-6.165.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f9d0b87ba2fa7ae53c09650e07cb74a117b383d7ab4839415341ac802596d1e5", size = 775741, upload-time = "2026-08-12T22:34:31.002Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/79/4502ccc73f5dbaa29c9cc1f33af0337aa28cc03c86ae289530bb70c0fc73/hypothesis-6.165.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:842481f603ef919c2594784bfbaa600916250a35e9d54cc4260e27d415eacc0a", size = 1106541, upload-time = "2026-08-12T22:34:24.067Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/10575fe56720cc6be25f7bc8cef708ee1b6e6669ca0b7fd16f7dbf460190/hypothesis-6.165.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1ecee1a9241db6c2d51ebbe58aa2575364f4fa21583f5d22ac2a8885bbe9490", size = 1156172, upload-time = "2026-08-12T22:33:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3e/b89e390f580d55b2d65bf726d7602a80f7725cc414bd60526bed0caf507b/hypothesis-6.165.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c108e99e4029318ed85ec5c39f5687c36604606394de3ff4da6e42356a2cceff", size = 1280392, upload-time = "2026-08-12T22:34:18.877Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/b33b5c0aedf35c298011748c679d652839a86b55ea616ca7561b85ac233f/hypothesis-6.165.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a811fe1f763e725692fa730c8b27ee3909f652f9c885dd89ee06f2583fd80944", size = 1323482, upload-time = "2026-08-12T22:34:49.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/8f/0361d9fce27af669ae936f535ad8275c35736cccf7d9ed66275f3eca874d/hypothesis-6.165.5-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:38353c9aaf946f76fd2d7d5e59c1564eac93ad362e98c7d6ffa705aa0e38974d", size = 615638, upload-time = "2026-08-12T22:34:54.979Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fa/f49d197e125db4dd6725f248a838c1a8230e50d91889237fbf21705b6d45/hypothesis-6.165.5-cp314-cp314-win_amd64.whl", hash = "sha256:377af80792d187cc222bb2666e979c7e559ebb0f1b312c5376d7216f9c91bbf1", size = 671380, upload-time = "2026-08-12T22:33:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/28/90/f939079a65499cad6352f566c3c632da5292f80e2253a72cc9bf6684d4bb/hypothesis-6.165.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e2c423f947be24a7a7324962bf4984bc2231d61c01a4ce4d794e5c7e72b918f3", size = 782526, upload-time = "2026-08-12T22:33:33.895Z" },
+    { url = "https://files.pythonhosted.org/packages/51/55/8afa60314542179289b2ef7eb6623cc8d9a6405488d2f3266e7610e003d4/hypothesis-6.165.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:05e7e8288b2f5fbb34a30b45c9df72a5ce9da0d5ce90705c76b28dda75aac984", size = 774157, upload-time = "2026-08-12T22:33:56.544Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/83/93ba4b711c0bfa5a2acc200d60f6fb3c947ea1a4b7f6ef0dacc02ac90de0/hypothesis-6.165.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3837b9e586a78f961aa7c0eedb979fa1cf3dcc8302103ac1e75c2520e943555f", size = 1104748, upload-time = "2026-08-12T22:33:46.901Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b9/c0b04ab66762526855fc97c18ecafe038fb1b428f48b2234e3c17b75b4ad/hypothesis-6.165.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8fac650e976dfe4d48682f902224a70e2e64ec0716a8822818fa958b456053", size = 1154827, upload-time = "2026-08-12T22:34:17.53Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/9b/9368493ef62fba5a3ae8b09164466c3ad166b329ae2df01c897dfc3f3790/hypothesis-6.165.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0a5004c3fe761b642ca556abf4551bc9a94d190320bcf7ce118cf8b792eaf71c", size = 1278417, upload-time = "2026-08-12T22:34:16.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/21/5eef54851cb51f47ebe123312c4c737934cb6469f6af38bd6e052037f89c/hypothesis-6.165.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:df05b18c2dcb1701532044d4d119cecc08b7d91fcf72e78a17b03257053cc6e9", size = 1322104, upload-time = "2026-08-12T22:33:38.255Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4e/9ed7f0b7c6b0a5d0d6aa0e0a5c05420db8ce21de6c96ce17139c0dbd8d2c/hypothesis-6.165.5-cp314-cp314t-win_amd64.whl", hash = "sha256:56f3a5b0b21695cdc6c8ccb7cf8da63f5822de4691cf23b9d95b5931b042af00", size = 671372, upload-time = "2026-08-12T22:34:46.023Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8a/ac187d3df9fd0f729aa0746cbe40b27d483d2672b7e700debe31de50327c/hypothesis-6.165.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:39ef2f43c8cccad78ef9f031e9540d8f78ed21ff27fe00b1da3c17e13940d625", size = 783883, upload-time = "2026-08-12T22:34:56.429Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/14/d09919183c5a874cbeb07779c9251960fc4e0a615b2986dee26cc53a0a9e/hypothesis-6.165.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:a055952e72073e864ee4b89e311e35f925f9191c1234b5ec09b63ddd7ea293d2", size = 779735, upload-time = "2026-08-12T22:33:40.729Z" },
+    { url = "https://files.pythonhosted.org/packages/de/17/8fe466e0ff4a92e95e32e7676f9dcb850c40a39a89b2bdb4353b8a073fa7/hypothesis-6.165.5-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ffa6ac269498825e2cc74f3d751837137c364767c960fd931d5cdb48e90109c", size = 1108612, upload-time = "2026-08-12T22:33:52.53Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/de/310a7be0ed7c96aafe7cbd7642112c6966d308ff1e50c4f88c8179541674/hypothesis-6.165.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5c8c81fa8bc858fec4a8b7033b82c5f9d973a37c6194800fff26600aad77989", size = 1158377, upload-time = "2026-08-12T22:34:11.869Z" },
+    { url = "https://files.pythonhosted.org/packages/00/75/66c0a2a5b04fc213026a6bd5caf002fd9111a29680e50c5b793fa96b1748/hypothesis-6.165.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db7435a82a11d6abef3eb695e3a510551b2273fd4bd610a12c38c7b0c9eed218", size = 675276, upload-time = "2026-08-12T22:34:29.698Z" },
 ]
 
 [[package]]
@@ -2208,7 +2130,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -2221,8 +2144,10 @@ version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -2274,108 +2199,108 @@ wheels = [
 
 [[package]]
 name = "numkong"
-version = "7.7.0"
+version = "7.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/7c/406d20b1e99582b94bc2607c6bc4d5cde8ba911b790fbad5b3a8eb6e9211/numkong-7.7.0.tar.gz", hash = "sha256:a7605738c2ca96e2f85747fdf670625ba5fa10cccef90055e247a1a21b92f920", size = 1188299, upload-time = "2026-05-23T21:08:34.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/04/9dc8fdfeb261c619b3f1b66979368becd3aebbfca299a28ec07fb589b5d9/numkong-7.8.0.tar.gz", hash = "sha256:4c4577c3cb64f9b5fa0d005809ccfa01fb6a52f4f53e6d445a22e63bd59525c9", size = 1196071, upload-time = "2026-08-07T15:20:48.223Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f3/1e017cf6024ee4050407bb84fe9d49e81583c455507e41c9f162cb54a7ee/numkong-7.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3be3c1c082f088464241a946f2cc305bed4c7871e4ae00c2dd9e8156e1982085", size = 1244232, upload-time = "2026-05-23T21:05:09.976Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/bb/9d3a2d9fe6f2283ff1bbb985f9a7b442ddad2b4230dd40b7952b09d5672f/numkong-7.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:60c382660cf938da3a250a98f6073ffafa95a18d3f51512f173124c0f80018d3", size = 1218924, upload-time = "2026-05-23T21:05:12.352Z" },
-    { url = "https://files.pythonhosted.org/packages/93/bc/43be0c7973d8a2638d7c6c4526076e960d50ca827446172d2627397b0481/numkong-7.7.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:6a13e811eec107e27c38dd5fd6f3733eb846bd17c2b511c41d7e1b81d65362d9", size = 2226845, upload-time = "2026-05-23T21:05:14.263Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/bb/dc9945330e7c2e4240486a3fa5378f8a5fdc933fce440be6baa9bb1fe1eb/numkong-7.7.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c43d1dd1fbcf4b3e7931a5cc9cb05cdad8fe13710d341e77f5f2c41c7c433d17", size = 2848720, upload-time = "2026-05-23T21:05:16.223Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f4/fdd32093b850258e6a23afcbe233b1a4bf78569da15a10603c9561475895/numkong-7.7.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b793dd278ca4527edfe79598a1de6ea567b0f810b820b4088204eee51a7ac328", size = 2461658, upload-time = "2026-05-23T21:05:18.42Z" },
-    { url = "https://files.pythonhosted.org/packages/94/15/adf65d763e71a1d4b0d4257a48bfc9d7fc1bfcbaabec8e7e280eb2cd78f6/numkong-7.7.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3ca6bec08fb72debb91ddee3dc3b1bda2c587acdf0ace1a34de66dd74f7666c7", size = 5358257, upload-time = "2026-05-23T21:05:20.411Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a4/f9626c580e8600730a909b02805e69b54d971303eca86cc90dcc3d3ec100/numkong-7.7.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aa70f126c3a1d262b273063d0e78845816c59e2e44c69641553328426bf82c4f", size = 10478607, upload-time = "2026-05-23T21:05:22.392Z" },
-    { url = "https://files.pythonhosted.org/packages/51/e3/a73f1300837bde3e3cfcab68dc4d5e7806d96bfb1dd1e9900ea0791dcb7e/numkong-7.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7cca18390094eedc0e50a600d4491f815205222a438ebcd66c246ff5fc5f998b", size = 5355139, upload-time = "2026-05-23T21:05:25.118Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/0b/5168e4916beca66845bdbdf6999e4c817f37bbea216b13e07dd695ac9080/numkong-7.7.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:bceea3441d85e653beab6df674ee68a286fd508abd21163fc4bbde3eb6e298e2", size = 2284813, upload-time = "2026-05-23T21:05:27.21Z" },
-    { url = "https://files.pythonhosted.org/packages/31/8b/e91fe3673817944d72d60c61a37640e4892082c2703d3ad9c21fd9501b67/numkong-7.7.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7e466a1671ba3526c191614e66dab3ad96564cd0b18930f6922eed21df2c498c", size = 2839261, upload-time = "2026-05-23T21:05:29.284Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/37/38455dacc514cc35c1f3b30213f55c4e6bcf1cb4972c185ab01c75315216/numkong-7.7.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:88a379bb1f4dd112f5ed3a5f3cf3e5eee58f44dd5333557fb581bd4d59cb9938", size = 2347975, upload-time = "2026-05-23T21:05:31.449Z" },
-    { url = "https://files.pythonhosted.org/packages/73/24/3a7e02feb98b8ec6b3afbc81ce67497facd3c5541dbafe4c68357699ca66/numkong-7.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9a92c8db4df4152595bd2cb5171ffa2f12978968a1f7c2f3d66a29bd78357ba6", size = 10329830, upload-time = "2026-05-23T21:05:33.646Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/3c/dc0aa35464e27e38d3ac7d7174d5dc459caafb636a5a210fdf78efd5a326/numkong-7.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:ff4e145678e8c67ac1ebe11908f2514e717c96983f744a524596a57ef1d537f5", size = 487012, upload-time = "2026-05-23T21:05:36.118Z" },
-    { url = "https://files.pythonhosted.org/packages/39/27/3345b098a8a443df5b2d741210d896ae1a5e8ed9a0649904a73c8cff5114/numkong-7.7.0-cp310-cp310-win_arm64.whl", hash = "sha256:508bea346abaab29bf1e348793cece74699f66a5610abc80ed7acf8db5090929", size = 442802, upload-time = "2026-05-23T21:05:38.032Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/8f/362964c65dca7af27fa56218631c01da511ec82ac81dc447ec963aebdc15/numkong-7.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b26e17f9a47dd89632a9d8a03b5c6fe12dab4e4bcef68a13f3ef8648d697956", size = 1243968, upload-time = "2026-05-23T21:05:39.642Z" },
-    { url = "https://files.pythonhosted.org/packages/26/2d/b563617e39265eb6e2d5d08d273967d573cd7524a17ba957052a9f8d1862/numkong-7.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:76e30aff031171256e8128fb28405209d03bbefb699cf4b34195161de613f85a", size = 1218745, upload-time = "2026-05-23T21:05:41.31Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/b4/0f4742816d5877c2edb1760207a68a4c7fdc43b68933be483165dd4e36ac/numkong-7.7.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:19126cfb55f4bd68404e7522931dc6f4b2554432bec46c0f18bd1c3759f80a90", size = 2234920, upload-time = "2026-05-23T21:05:43.584Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/2c/d96612fee9e6ae896e55219d6aa20696421f5d6536d92001af51ffc83ca1/numkong-7.7.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1e0bf61e237215180af500f2028df14e4b9e015745dcb40b521f400ef7027bbb", size = 2858345, upload-time = "2026-05-23T21:05:45.745Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/3f/ab07af16b66ec01a37c5acbc4b3c5908e23da581f459f246dd9c2ecb5c26/numkong-7.7.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:824ab308059ccfa0682d59e0e631ee0c5f9378370bb9ca6597a562c5dfafec6f", size = 2471467, upload-time = "2026-05-23T21:05:47.359Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/a8/09899728312a8751f0237bb172a34e9d1da0887bcf740af97fb8b726640c/numkong-7.7.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f44110f0b56eec3aa91f0e5c0e83ddb8cbf684f53b56b0e23da341bced4765eb", size = 5369192, upload-time = "2026-05-23T21:05:49.258Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/63/fa390d8ac75fce1493e84319ebfd5489c5a304d169e8d27e64790200b53a/numkong-7.7.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:46f4d42c059d9fb1c1b1b3e4d7a01b447eeaa98128a18e36f76685c46e6d7c41", size = 10489306, upload-time = "2026-05-23T21:05:51.69Z" },
-    { url = "https://files.pythonhosted.org/packages/78/ec/017c3eacb021ee46251b99c65d3939501305e0f63c50da577836898bd765/numkong-7.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:501984c54db71ccc0ce0738c91eee0c4d30ee80b1c237eee2a9f283c5533921e", size = 5364848, upload-time = "2026-05-23T21:05:54.507Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/35/c872cb63bb2b7b833434bca61d22c2b37549831cd465f34ab5e31a77465a/numkong-7.7.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df9b8e986bed7312e8a8c368445f4d8b5d884a0ebd787316b90f9c3fdd1d5281", size = 2292597, upload-time = "2026-05-23T21:05:56.352Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/64/b489a4a3ee1ba616788eb65ada77f400760f1ad9d480489d62b267a833dd/numkong-7.7.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b1e5422814ffe83fa8d9cb88e3303dff7cf874c748f26802769d6e9b500b7f4a", size = 2850670, upload-time = "2026-05-23T21:05:58.516Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/22/5ebd2eb4a4564475a334ac27428f4dbcb451e3825582e47a82aa731090a5/numkong-7.7.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9c801d0c4258f02c0eb493288611a8cc48f2048fd6e9a46eac74d2c737e5a892", size = 2358635, upload-time = "2026-05-23T21:06:00.151Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/8e/793772ee6d5aa756b37cadb1026c94e168f372aadb8f97e37b501f87253e/numkong-7.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2e06550762e22c3eedc4787e4b3c22e5ef70695404c23518493a589aba822cc9", size = 10338545, upload-time = "2026-05-23T21:06:02.47Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/5f/3ae86635f0ff869ceb4ecb5a143b71085850d2f83849f6fd32722a2ff718/numkong-7.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:b27feab71e8664f244d7fc972aab10cd4517a41e595c61821c316db018911773", size = 486865, upload-time = "2026-05-23T21:06:04.904Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/31/e4507f8c79380b327f06c5f3651726f818c91e6a1243219d9bcbeeb492d4/numkong-7.7.0-cp311-cp311-win_arm64.whl", hash = "sha256:79562ed23da82b140874a2e5417bd10c630c15ff55f0d2ac0baab517caafe933", size = 442688, upload-time = "2026-05-23T21:06:06.781Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f3/d7317e577e3fff6d6ae7883e89e913a085c070968b3a5067a61a2d40972a/numkong-7.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2fceebfdcf7f744e504f0cfdfb624f61779a5677c9fa08d6fff25592c4ec18a9", size = 1237036, upload-time = "2026-05-23T21:06:08.717Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b4/a4de0badc57f8e894a6f7ff4409bd8b981d3e9d8d22fabc6528e9ae774d3/numkong-7.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9e75cf905b19731f831c47bfdf29233b03883973bdac0b002a94ac141fa07319", size = 1219052, upload-time = "2026-05-23T21:06:10.762Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/f3/b557ddb16b4521f051d520d3c0c6db884c6bbd94504186f60f7b4be71151/numkong-7.7.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:b388d6002cec95fee91deb4808e1310f22d4d713ec40d3119310577c9933f413", size = 2236853, upload-time = "2026-05-23T21:06:12.513Z" },
-    { url = "https://files.pythonhosted.org/packages/93/7f/cb81b9c783d0b211b87d3843c3a05730b6d7ff9560db6f1c4f9e02851cdb/numkong-7.7.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2dd01d6199aa5116d0e08d9f27ba83e82419c8ad071ede041c19e46c11156119", size = 2861362, upload-time = "2026-05-23T21:06:14.532Z" },
-    { url = "https://files.pythonhosted.org/packages/13/3a/3b1380646471a958a1ebcd2c693071a20d5247fff7fa541c9cd6d6d492dd/numkong-7.7.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d5304c1fb01c4ab29722477298f8b995e5bb36477b0228b0b42ad1579a410cf", size = 2474897, upload-time = "2026-05-23T21:06:16.283Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/17/cd2a1eab3402c41999c96544a1bf2fb32415d71f5eec3c921076f4cc88e1/numkong-7.7.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:16cc57a7604442c59b448ad691dd0b1f9532d032b36c8899267edba74855f40a", size = 5371899, upload-time = "2026-05-23T21:06:18.462Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/0d/b577437a158968cc878d4f2054a5815f81db0de9cbd1e79484aae78882e1/numkong-7.7.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:84a04e568c45dd7db351b64d88fcd0653764e0694271d62c6ab721fce6207f2a", size = 10487001, upload-time = "2026-05-23T21:06:20.472Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/d1/d7823e12ef24f02f27626230d119ceffaf7c54d1f0af06e1533008825da6/numkong-7.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3855e3a6dfd912fd089c20593fb1e008888e507f6d13aed6be474844cffe0c70", size = 5367363, upload-time = "2026-05-23T21:06:22.93Z" },
-    { url = "https://files.pythonhosted.org/packages/16/cc/fe7dac0ca2ffc1140a8a86caa6ae947667acde8af8c544beb36cdcc13274/numkong-7.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2af024fa271180ed81606d8ddae619dc8e587da0308d2cdc885a2e024b2d274e", size = 2291703, upload-time = "2026-05-23T21:06:24.818Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/35/845d9d2c0b6e881cd384af6a2070b0e5f7f85d24780353c98bd0bf82ad22/numkong-7.7.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e9971260a855f23dd89690702ad1ed4e478ca643738eee275a4f3a9a85ee03d", size = 2853643, upload-time = "2026-05-23T21:06:26.987Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/f5/c29abb8299d09bb05e5ceef16d21d2db7e0d8e27350ab615353456d3a7b6/numkong-7.7.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:82e002e5bdc51be6b984832ec3304f53302ec6f56deec923425996c412d5f099", size = 2362080, upload-time = "2026-05-23T21:06:28.895Z" },
-    { url = "https://files.pythonhosted.org/packages/89/fb/7a178cfeabf8697f02e995dbd018154619a9dab393e0ec21c594896e4ad7/numkong-7.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ea0beacd90b25cd2db257dc9c353878954a5c75550d984d124b0fe2f3f0e9a6", size = 10337599, upload-time = "2026-05-23T21:06:31.101Z" },
-    { url = "https://files.pythonhosted.org/packages/74/5f/2ee1b7b86aa2b38a40924527dfe1ee636fd77dcfe1a2daff9fb21f28a43f/numkong-7.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:63b4460f24e64bd7468f92034df46370dda43a03b1dca92eaab2beebf0cf3ea2", size = 487365, upload-time = "2026-05-23T21:06:33.718Z" },
-    { url = "https://files.pythonhosted.org/packages/53/f6/0ad01fa04ce1fb13a1447726976aab0309076c3d8f04ebbaf9a0bdd804ce/numkong-7.7.0-cp312-cp312-win_arm64.whl", hash = "sha256:e04c87284d5e9408afec883d71259e6f209fc633ed6ab13a26eadd84d2e0510a", size = 442756, upload-time = "2026-05-23T21:06:35.24Z" },
-    { url = "https://files.pythonhosted.org/packages/db/75/0471f833c2948e4fdb2b1f1dd9179ca797b65c856669bfc6c59369a9a900/numkong-7.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5c7921b7ed05254a94a328de0a6a326da6c6f0258754c320db3d2eac12d6cc2d", size = 1236990, upload-time = "2026-05-23T21:06:36.96Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/70/b8cc344bce62de65a2d1b381c42d6d2894e673b68d47a931fa6a6f362110/numkong-7.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c9df73777b23dceaab4b4d3456e4bcd2ee1083f105375b0264d9181949fead7b", size = 1219051, upload-time = "2026-05-23T21:06:39.274Z" },
-    { url = "https://files.pythonhosted.org/packages/50/0d/b27c9d18dcfdb8d5bb3376de365d593a4a721cecc2d566fc4cc6c7b4ebe4/numkong-7.7.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:ae2157ef6e573621e162c96b2ed137b233e17b5e36dca43770cd559d04584a76", size = 2237128, upload-time = "2026-05-23T21:06:40.973Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/90/ddbb99b91e3267660e63bb4c9371510c2982e4229b44a747c769ef65a020/numkong-7.7.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:605628bb258077d4e81775dfdd6865f6427ebf03631335423efce82ae9e2cbfa", size = 2861641, upload-time = "2026-05-23T21:06:42.651Z" },
-    { url = "https://files.pythonhosted.org/packages/38/11/9b89eadeedc30b3c555a3684cea6e3a8a13d102e50e6374387649a96a63b/numkong-7.7.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3085857cc2155dfc90ae0ee3a52c553954180b94b8136b53ed74fd253ee400e8", size = 2475169, upload-time = "2026-05-23T21:06:45.032Z" },
-    { url = "https://files.pythonhosted.org/packages/95/3f/be2d963b4293316491d9126af6c397ccbb58bb461a3dca034e15f3c29dea/numkong-7.7.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d4bf666d0d57b0c0f6f6be0ff43b4f74e775f7f9a0f028bb83a1ccb8a74acd3c", size = 5372558, upload-time = "2026-05-23T21:06:46.777Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/8e/6985479a85b1099ca0c0e8acbdce5c05c63d7452f07f19060544382573be/numkong-7.7.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8bfc9bafcf72a80f6e77d4dfa53918f19a86e5c44a3d43327c74dead1541614b", size = 10487347, upload-time = "2026-05-23T21:06:48.973Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/e0/902e33a7d2cde392af9e213dee3db8b16aa9cdb1bbfec69d851ca431f66a/numkong-7.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:60ac1bb76452e7f39917c9b51a8166af4780ec87b2fcc4281747f58ccf72cc08", size = 5367377, upload-time = "2026-05-23T21:06:51.942Z" },
-    { url = "https://files.pythonhosted.org/packages/57/9c/ed38d9900c1debb6d09c7b1e7546149691067269478af240f37966c554d5/numkong-7.7.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d7a6e08292fd63c7144b043524d42a31bfa40c35bcbe24558c12509e83036568", size = 2291789, upload-time = "2026-05-23T21:06:54.1Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a4/fe37cf0f080675d4c6e27daeb8bbda6baffcb2793a5c46fefb4d0d01808e/numkong-7.7.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1cb84cc00f2a93cea6187039e92cb51c8490ed0efe7a9ed2f0ba2b20e11b0574", size = 2853795, upload-time = "2026-05-23T21:06:55.838Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/59/29e1d015392535dce61ae506db036206077ca7c3dda626daa834c767ec90/numkong-7.7.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:1a69ba9f37abee695c908db40b1291074cb367baa7de76568c7c968b8df8d795", size = 2362334, upload-time = "2026-05-23T21:06:57.703Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d9/685c4fdc4745cadaf0b80e8e9eb05acb7e387574dcf1232b54f83e626d0e/numkong-7.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:075a0777c3e4c5409d09a2f3265b96474dda025555df590b02412683f9935405", size = 10337771, upload-time = "2026-05-23T21:06:59.952Z" },
-    { url = "https://files.pythonhosted.org/packages/64/92/a02c15fd95aa9bfb9fd0e87dcd7115c59b4a58a8809bc07edbb292007f7f/numkong-7.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:2ca9a65cc812da75466f697d685b4dd02fa346789eeaf344033cb30bbdda5c0f", size = 487359, upload-time = "2026-05-23T21:07:02.296Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/84/d36daa90fa14e7c9914e53a5980888c69906fe7548074e603a166e02b719/numkong-7.7.0-cp313-cp313-win_arm64.whl", hash = "sha256:f5005af348418c6849c9e78fb8e6f2f273c1c8d771a1383eca908a273c1ef09d", size = 442764, upload-time = "2026-05-23T21:07:03.804Z" },
-    { url = "https://files.pythonhosted.org/packages/42/8b/4a09214b1378897a6eaa670bf9baff05413b232c32b6a80ae399761b1091/numkong-7.7.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:aaf8a71b81d64a5cd5764037f53f264c3383afb8b6c8c618c6215f1c80da7f39", size = 1239602, upload-time = "2026-05-23T21:07:05.871Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/36/b8b2d7eaffab15fdef97e3c45a11edfb8076c9a8d575237182eccfbe8a25/numkong-7.7.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d4ac21854b52e48ef7e84a75545a71fb7e73ea2960a5ac0ab69aaf55a54a4ab4", size = 1221504, upload-time = "2026-05-23T21:07:07.579Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/46/db730ecd3666ff2d8c29ecbc4021d3f9a59daaaf4f0d9a4949ebd4450901/numkong-7.7.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:fc210d88ad920cc6f3c9bce06c7867744ddca8f4d9317e3d94e3c0e436a0e603", size = 2259349, upload-time = "2026-05-23T21:07:09.481Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/88/172adb56600a75329428c4cb18943c0a60e76adb066b2c90e9c5227f64cc/numkong-7.7.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d5d2271a73c99d079b6d235ea5e3d26ee572103099d504df8fcad58b96182c9", size = 2893780, upload-time = "2026-05-23T21:07:11.386Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2f/41113a514f4286757be3d1161d6a7fea9fbbc4433a73afa20d5cf6cdc3a3/numkong-7.7.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da087ad802698989ba9685382f8dfaf205d0dbbe1ce613fcc45d6a10718d9d13", size = 2510173, upload-time = "2026-05-23T21:07:13.094Z" },
-    { url = "https://files.pythonhosted.org/packages/83/15/551d98cdba350e2f43495a327586d97bf0df6a40c007da8eef8dafec6c23/numkong-7.7.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:532dfdb0f2f5fa55866ad1f9ea10a33b1e829a2661b5c0de5f6497f3aa1ca932", size = 5404536, upload-time = "2026-05-23T21:07:15.351Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c3/1924f6c052c81c579eabdf14d6388b758211a882fb218eeedf8632ef8acf/numkong-7.7.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:7ae8c8e4cb5fff78a5f6872c8465b26a982f932cef0d1fc29626ec2e32d66f4b", size = 10515358, upload-time = "2026-05-23T21:07:17.865Z" },
-    { url = "https://files.pythonhosted.org/packages/37/4b/b99b385060b3316b63380365361a7bd1b4f726c1cd8be7ae6e2f5659caab/numkong-7.7.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0bc4fbe9150d6dadd3af489bd12732e4708549594d5f21a4c31ec68c4bf152da", size = 5396673, upload-time = "2026-05-23T21:07:20.815Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/c3/b5abd1830f791a96fadb14b6084d3e1f388db2de8166dd2a6396d9a34202/numkong-7.7.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:5d60042fad41f1afb43fcb7d5c347c405427ca2334737a7c33a8acf677fed489", size = 2314597, upload-time = "2026-05-23T21:07:22.805Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/d0/6c2b5d574e77882e4b03c5c7cce40debf0b22920c1cc40db535047f7c043/numkong-7.7.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:7e5f40eb27a2068d34a4509290e3cac718402ac4cbef6ff14ff238dccfdb81d6", size = 2884020, upload-time = "2026-05-23T21:07:24.779Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/82/6ba642eefa77a8de01a46f22e7fc7a13aeb1933b11f1a22966a72713d155/numkong-7.7.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:3d8ed5ad16b55e3ef2906d479d92356f575bbedd83017a78b6f9f0930f1a0c42", size = 2391684, upload-time = "2026-05-23T21:07:26.745Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f8/449e7f3865262004e12ba728c84261dca1756cb82282435e3d9c6b49905b/numkong-7.7.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1cb94ad62a8808a1ebe778a69b6b545092956af0728a464facf2d82d0f67cd64", size = 10365150, upload-time = "2026-05-23T21:07:28.724Z" },
-    { url = "https://files.pythonhosted.org/packages/da/1b/41ad96b6c0a490f92562b650d63b618d98731b06d04c77caa4c68d4d2a5f/numkong-7.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8271398abd01b4ea63372f8357b325c9f7a3da683b67e85d07b7916ed34f7d1e", size = 489944, upload-time = "2026-05-23T21:07:30.985Z" },
-    { url = "https://files.pythonhosted.org/packages/28/bc/d1277b69c80a0bbca4bd5230669fca4d5ca97872b6c4831eee0d54eef9fd/numkong-7.7.0-cp313-cp313t-win_arm64.whl", hash = "sha256:76e532968492a99e939ec68a333917d10e0e38095f125d5de073f1ffd2f2260e", size = 443564, upload-time = "2026-05-23T21:07:32.66Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/51/507dd4c86661a3d603f46a5f0d39b32ce3f12a276008b0e897566980a3ef/numkong-7.7.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:702f254e5cb44124aecb82fcdb7dcad7c4722615ab4bd1d8962ae689343ce330", size = 1237115, upload-time = "2026-05-23T21:07:34.466Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/61/6b8c412164c7963d204bab5216e514cbfd8786b5d838185c6967fe4721cb/numkong-7.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:73aed2e821251fb548676a9d36bc00bcd4134d9310bfcb984e7d92812527ad5f", size = 1219056, upload-time = "2026-05-23T21:07:36.234Z" },
-    { url = "https://files.pythonhosted.org/packages/14/cf/a69c85043ad8a1279d56f38f70e4ae9b4cdf0b7f20d38db81f3abbec68d0/numkong-7.7.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4b7e79cb3c9d59d6fc917536f6fc48f48a05b1b279aa0e69666e0b260c56019b", size = 2238055, upload-time = "2026-05-23T21:07:37.939Z" },
-    { url = "https://files.pythonhosted.org/packages/80/84/38758e4c44441c2c120779a9a5d7bb798672a8893d82112cb9832eb62b89/numkong-7.7.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f429bfe084a67ecb81a00874aca0b2a3ba316e8c033f7c9cd904b0abb49646ec", size = 2862668, upload-time = "2026-05-23T21:07:40.015Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/77/360be8543a09058fe5a65104907b77f267e6031588b2b900e4d999c4aa31/numkong-7.7.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:abf9d8ff0c733ac15ae4c8b14f32ddc5dbcb9861a9fed59c23afc41a22448589", size = 2475931, upload-time = "2026-05-23T21:07:41.778Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/96/0d1918af36a367ab749008b7b54579f141a7aa1620e3f606e830b0f0ba92/numkong-7.7.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1c2a24776864000f9bcfaf4665487af1a1ddcbfd217cdc535a38bc301471f282", size = 5373707, upload-time = "2026-05-23T21:07:43.652Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/82/edf4c207dd573e88196a0e44d2f785954fac8828f0aa0c4672f7df4c3a8f/numkong-7.7.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:a8fd6c4eeb7f76c728e2939d4bc79658683d716017b9edbb70579723133efbdf", size = 10488379, upload-time = "2026-05-23T21:07:46.219Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/06/847d578547971f7228ddc52e51a721831032a4a067510020a8bcab130260/numkong-7.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:88f0b03af52c42ec9cf27fb2b7a3b56a850a91e40d1da21340277c5fd26cda0a", size = 5368158, upload-time = "2026-05-23T21:07:48.746Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ae/1513e41cfc069f5b4a4694724759941a1f3427d6c9ad3ba5def26180a48a/numkong-7.7.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:8405c2580597e8768a21aef20a25849fb06db04b05e4066397a138b3d158ac06", size = 2292602, upload-time = "2026-05-23T21:07:51.265Z" },
-    { url = "https://files.pythonhosted.org/packages/22/34/29f49fa156f4e25c3085228e2c34417b58cba60330a91e4714853b3dad4c/numkong-7.7.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:db098a259115f63f2fbbf7ac6b2de1fc211b94ccb8d3f4977335408fbf1b58dc", size = 2854858, upload-time = "2026-05-23T21:07:53.131Z" },
-    { url = "https://files.pythonhosted.org/packages/22/25/1aaa04be15aef14dbcfac5780f9228c37ebc07a823700247ab12a2dd40c8/numkong-7.7.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:517c519af729b3e4ea440b085c5c55c265109878b9978f3a4909f5815d6db5ca", size = 2362502, upload-time = "2026-05-23T21:07:55.401Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/4b/e8141339859e33905064f7a0f475c94f6e645da7f33061e88703af65aa21/numkong-7.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d5121dbc99de0397223f6269b07c1b17fc24e8abfd57c7070e523abdd7d448b6", size = 10338175, upload-time = "2026-05-23T21:07:57.552Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ac/68ae2405a4904044b232077fccbc721461a9dc20a2809b5fc6eb52bcd838/numkong-7.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:c59d2a7f6535a424b38e20b492d9c6a68f011f528206c4300c641b1502839c05", size = 502237, upload-time = "2026-05-23T21:08:00.843Z" },
-    { url = "https://files.pythonhosted.org/packages/80/70/f87a1b27484d4a7998c4864871be3a470f6eb0f1bfb64d298a46fccba2f9/numkong-7.7.0-cp314-cp314-win_arm64.whl", hash = "sha256:c75a89cd7f95056de27123baa79008f568854b1afe819facd7279c9c3f0cc80e", size = 462876, upload-time = "2026-05-23T21:08:02.513Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/cd/076ab1fdc69f8294ebb560d83066cc923f3545c03801071f390c4f24cb58/numkong-7.7.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:98012bd8d10816ca7cfa15c1e093df1d37c483d166a5c4b18690cfeddf75e842", size = 1239925, upload-time = "2026-05-23T21:08:04.206Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/81/1e4d1e3f362419d3b04f4cd2a41a8f4b514a60f166aa082e9a75505cde70/numkong-7.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0b60f0a95d282464aeae10c754d135a5c89644351eff60541537b9616296ad99", size = 1221527, upload-time = "2026-05-23T21:08:06.394Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/71/5d25649d34eff0ef07ce91f2dcc1871de7fdeff45d381ac9cd8fa4d84a85/numkong-7.7.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:bd47062eee181da424619f93c62ca07ea4c91927bbb64f5fd205bcfd181c565b", size = 2260484, upload-time = "2026-05-23T21:08:08.656Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c1/cc6f78dcc18353d5a57fa626dac019a34b2b7a15318a742b1072ed084a09/numkong-7.7.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d330f50d5cad2dbb6d86c5bf3126b76bb59c217c815e2b8eeafaa11a961ce877", size = 2894520, upload-time = "2026-05-23T21:08:11.012Z" },
-    { url = "https://files.pythonhosted.org/packages/14/dc/bc93682e5babe3dfe232e647fcaf32faeed78a0c95705e0efe46b27de8c2/numkong-7.7.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a62011b84e6a738af780ebe9ebbfb2b4e56a6ed73eb046636f19ca23692c5add", size = 2511325, upload-time = "2026-05-23T21:08:13.242Z" },
-    { url = "https://files.pythonhosted.org/packages/48/4e/98c1836c2aa5d842d7e3063abf9a1ef7566cf0b62b08ca08e1f755760c8a/numkong-7.7.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b15ed9823c386293918cba8c169f5d6880350831caec4b4e6c7673598a66d86b", size = 5406093, upload-time = "2026-05-23T21:08:15.323Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/42/077d1647550ee5f9fc5492dfb4025b0b0a3a309e27345c9ac6815fb00ea5/numkong-7.7.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:286a97e9e18c165e8c5257d9571b8e73816e013a1437f7f660dbe28b6ff96cff", size = 10516334, upload-time = "2026-05-23T21:08:17.432Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/0a/e5e94f3e2bd6ec31370c806e77a43ce0d5110a8fc15c595f3b68e4393039/numkong-7.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:511300d1e754cc781d6f182150b7d6ce0c53e098df8be98c53e37996dd5f080a", size = 5397422, upload-time = "2026-05-23T21:08:20.286Z" },
-    { url = "https://files.pythonhosted.org/packages/61/16/12579552ccfb9b32e608c34cb6788c0a91261269aa1f39a1d5b29db37d29/numkong-7.7.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8dde89dc06bf903a368f489d873bdac16cf54a238b5ae554eb33b6aaef8ffba9", size = 2315367, upload-time = "2026-05-23T21:08:22.672Z" },
-    { url = "https://files.pythonhosted.org/packages/29/74/d2dc95cd4778915c90282c00978395119a9dcbd3aceee2ff52e54857d2e7/numkong-7.7.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0500f486f1d248e44e25905a026c07cde58d0d3c3ba45b5940ffca68dc3d5c36", size = 2885021, upload-time = "2026-05-23T21:08:25.046Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/40/98cb8af36afee4ebe51bc7fe4a3a20c759e34e95894d85ad20618706df3a/numkong-7.7.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8b7ed8532aa30b510c2a6d4d3ed38e5b57a0677bd97554ba5e15c13e008d6c66", size = 2392651, upload-time = "2026-05-23T21:08:26.973Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e1/981b15e13e81fb0bea57df3db6bdad96d2c615d73a93dd3d18624889d995/numkong-7.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c79ed742d9ac7cbe468b49503b36a15c910332d04fcf93964e46f9b20952199b", size = 10366062, upload-time = "2026-05-23T21:08:29.159Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b0/5d51726be98e3783dd423e671b101492bf00e983827a9691a201b4274375/numkong-7.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ea4d904c821eab7a7a901e9dc41bc91327da7173f716ba10dd2e941cbece5970", size = 505277, upload-time = "2026-05-23T21:08:31.422Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f3/9218ec3e282d16ce241d6c7cca7895dfbbd4c4729f47a10133258cd9c4aa/numkong-7.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9598bebe5319144da2c40036b23925c724e822d328071bf976391ea053ec6adb", size = 463944, upload-time = "2026-05-23T21:08:33.139Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3d/b9cee993b169faacee2aa69e2548e7b9a007707e2872a6a22f73af273822/numkong-7.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a5c68f645ce9a3e64ecec5de418e6e531ea6cce8a7d459628490ecfba85c2216", size = 626889, upload-time = "2026-08-07T15:17:43.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e3/5a6bac2089646c774af16f0715b1344ccfdbdce8d4c03f7bdea6c233e44b/numkong-7.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0324f161d38383a8acb72f095ab45ab2aa2550c70160de30a0aad17b6dd907b1", size = 620349, upload-time = "2026-08-07T15:17:45.147Z" },
+    { url = "https://files.pythonhosted.org/packages/97/1e/cb94b5d91ebbb91dd4147a66846568fe4cd10d4523d935e3a0e7d7f979c9/numkong-7.8.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:df685617039d31ba755f5b58bed33974a9a319715f8cc284f68d6df1d5b0f67b", size = 2239100, upload-time = "2026-08-07T15:17:46.71Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/9a633a8d31b8d7e9d6280f4514f92c9c2e3e8cfeb9233a9f97ea886e91e4/numkong-7.8.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a9beaba10cf8a8fb7620a5e75840a4d34344c029dd697c1810b6c73261db179", size = 2862091, upload-time = "2026-08-07T15:17:48.284Z" },
+    { url = "https://files.pythonhosted.org/packages/05/fe/1ca19c91f9b959f00ee001092a063a9a4dfb738419795894a89d32ff6840/numkong-7.8.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0deb94653dfcd4522f19c0561c1b8ccdbc4ff50360d3c7b6dfb60a3f3a22677f", size = 2478631, upload-time = "2026-08-07T15:17:50.054Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c4/02c5689ec256ec95e218b32211275f741a34888750bec0d90035c2be89ca/numkong-7.8.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:8326adef3f33c5afe22ac144848ed776543e4488d04c7618ea6a7f9c23abd523", size = 5375778, upload-time = "2026-08-07T15:17:51.749Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f8/c73c6b7cd406efa3b5730622303a05e6a6e35d6f15b0f7b4956985863c4a/numkong-7.8.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:166696573248b5cb769432faef8e95a1f0fc1723d4f55f15d7356420ff9e4d34", size = 10489438, upload-time = "2026-08-07T15:17:54.071Z" },
+    { url = "https://files.pythonhosted.org/packages/34/63/a85f787d4839a6f153f78d08a7cd0f434760a3fc15f1e4107d38f46e04af/numkong-7.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:537b8708619f075ea533530b20d69de1d7a27db08477630538686fd43e33bb23", size = 5368065, upload-time = "2026-08-07T15:17:56.361Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6d/b5a69873d41782f47a51dd4e774107b458711fdd032d4dcfa34d1ab0d261/numkong-7.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5efafb049dd23fadc74cc613c82d3671e6759e64d130f6e0443c352bb962f001", size = 2291813, upload-time = "2026-08-07T15:17:58.29Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b0/d4bbb9c087125f7e3bb293b00673380a9cb243a9949c763c5291ad3055ac/numkong-7.8.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:22bffaecef20240bde97c1219d1f454e1d0b5fb6534f9e133ba5eb7320ffc3c7", size = 2851392, upload-time = "2026-08-07T15:17:59.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/97/faf59aea61eb5229cf2b523e12194a846eaded6839686fbebcea7ce92d2e/numkong-7.8.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:dad1da5e5f1b797360e6ed4df803dba068e47b31adaa00925fac34dfe117de86", size = 2360233, upload-time = "2026-08-07T15:18:01.454Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/9208adb8431cc8dcab4acd285fa2499fdeacc27707c17f36345a22ceca83/numkong-7.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:14d45cd44996bc36bf7d16270567fa3ef1ed2ec85bda0700b6d485c616294394", size = 10334031, upload-time = "2026-08-07T15:18:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/57/8c/2c077bea2c0239c841d953573dc195053f9cf2355c6c907e88e3c9ea5e21/numkong-7.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:ec19d49671b687721e771e6f1e19283aaed2332b15195e914dd8d65968d37a0a", size = 491838, upload-time = "2026-08-07T15:18:06.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/063a783477d6ba3539ce17a67d226753d7a95e289ae91390cc9b7b8d4d29/numkong-7.8.0-cp310-cp310-win_arm64.whl", hash = "sha256:b2230194314b7e054c382bd8c74dad68117ad2bdf521e8878f78d5abf0c986a0", size = 430757, upload-time = "2026-08-07T15:18:07.776Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/03/be538562ac1054cb6149ddc50d25d5d61195af6f612efb104f62b7f917fc/numkong-7.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b65b55731c07d0def356c44c237ef5901185d7d359793974567ae0e8b5cad11e", size = 626722, upload-time = "2026-08-07T15:18:09.202Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d1/396b8cbd554fa69be81e7d0de38f94befe1e1dcf912c2a321c92f56605df/numkong-7.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3a3c801338de536484107704c3bcd9f3c4ea51f808668c380e9c972fa37d287a", size = 620123, upload-time = "2026-08-07T15:18:10.97Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fc/1d907fe7d66798b58cad3f1ebabc9b1d5fd998ba552601f3fa39a8e0958f/numkong-7.8.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:3dd5afe56bf7ce8383bc6f6022c94d0180ecebc0dcf0c5ffa74a9d8948a6e96b", size = 2250887, upload-time = "2026-08-07T15:18:12.778Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ac/63a1ee221501e0e207076374adcd7a2cf937eef8c9a72e1a02c038329456/numkong-7.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca45301e3c0346ee823ea0871f6ae652e9893148629598537f094236432d7589", size = 2873502, upload-time = "2026-08-07T15:18:14.382Z" },
+    { url = "https://files.pythonhosted.org/packages/62/5a/61d3c23f18b365e23b200f95a1153ff3c9be2d0d560f86e1ca1e005c3098/numkong-7.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7230778fed2f00016449129263486cf4b393ba485078ac5a98078ac094d700fc", size = 2491929, upload-time = "2026-08-07T15:18:15.981Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/0750982ee6f249bb5d5a8d189582ce27c3bdcdf499d91a9589bcf432d712/numkong-7.8.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:331b23498294a7cb63b775d22dde6df9f520da9fa9dc48f73fc131b75be8ed4f", size = 5385307, upload-time = "2026-08-07T15:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/83/67/ff313cd2447f27e0139a881650497dd66b96c8360195e3f0d608e3bea6c8/numkong-7.8.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7112d42a41b5813c694d93a438820c493ae76030be6f840110e2d50587a3e7c7", size = 10500664, upload-time = "2026-08-07T15:18:19.994Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/39/c36d6abeb4f78b6a53a2bf09e8abdddc74d1e6dd21982b37f2ded1427cc9/numkong-7.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:602debae751bc21a8bdbee89c30395f33a44e4ac6f32f6164d9093a60e99af77", size = 5378397, upload-time = "2026-08-07T15:18:22.36Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/58/9985fcdb7b76994029823a96781369bf2e7b735e0b548aa1964bcaafd1ca/numkong-7.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:957dbb30d58c3023616e402c7484c2a9e44f9191b7ce3721187923e9427d03dc", size = 2301578, upload-time = "2026-08-07T15:18:24.403Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/73b94848216b5ae0f886898cfca178a9023a0bbe7a3f4e061b98c327be6c/numkong-7.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:29491a080d842d43695e802aadbf391047169be70ab73697d54fe762967b8a2a", size = 2861690, upload-time = "2026-08-07T15:18:26.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/af/2daacb38132c19e746401e6d665d0c6d2c7dded2ab7793de00978e623785/numkong-7.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:eff0ddb98f547ba5159da6208fdea224b2fc1b818c048a47819a5f9a91c92cd5", size = 2370630, upload-time = "2026-08-07T15:18:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/c204f977d4730b513432157b79274a384b88e8f4c7961f0e868a8f6327b4/numkong-7.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7a52905aeb779857b4a608a4debf28a0d33e68dbc1325c3ac7e4446c87531248", size = 10343848, upload-time = "2026-08-07T15:18:30.675Z" },
+    { url = "https://files.pythonhosted.org/packages/88/74/300e4b3e7a0d02ac115b841ea18fc3758fc748e434aa965d55c462c76e17/numkong-7.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:aff5390273a641bc00726b3f5a585cf04f36c2c9e45b257e9e8a1769dab9c6b8", size = 491643, upload-time = "2026-08-07T15:18:33.069Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/73/bdeab85d3f7fb986e8c099245fca264b35db5173623765929d95a4040442/numkong-7.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:6e0c7a33416837a8bcc5ae8ff9b2562aa4eb303f0d3fd95d60ce5947aee13931", size = 430623, upload-time = "2026-08-07T15:18:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a8/6398e0fda343f978fffc6d4bdca05ad0103cd9f2d7155b0193b9a9d501fb/numkong-7.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8be34206618dfb87e1bfcd428797f1073bd884d90eabfa1821df387f106ca56f", size = 627121, upload-time = "2026-08-07T15:18:36.239Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b6/9d6b4d928a62055212f495cd36f29e8cd71cf46c68ff8391238c3e8d992e/numkong-7.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:09994f1052aa55e28de7c964b93bc8219220bdb618be1b9d8667f22ef9c8e303", size = 620445, upload-time = "2026-08-07T15:18:37.714Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3e/f50e495a5f5f6a2d7bbe1a669150b0366a25c7b66cc878c46946ea467624/numkong-7.8.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4aea2c16c1a5cb7548f9ead79f6e4459f3dad8aefd046114d39ad8ce5983d306", size = 2251154, upload-time = "2026-08-07T15:18:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7f/9a8b60fc158289bb4ec799b256c6ba1e03709dc5e5471837fbf5314c9766/numkong-7.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:69219239958dfc7249d74f1c8102b17ccf7cea454426c15797dc6c3cbd7ef980", size = 2877019, upload-time = "2026-08-07T15:18:41.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c7/fe8cf14ef3a159e594364ffe65d8a9be909bf58143f44b2fbf63ee90d4cc/numkong-7.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bebd4cdaaa247de14aad272a3e75fe883c7e0f2e2ba90bf802503692626c69b2", size = 2495167, upload-time = "2026-08-07T15:18:42.974Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/11/34bc73dc480f4a1b86585c4a06f2faf2274e58c9e242aa12bcac3ce760f0/numkong-7.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:183d0cfd7cd95f83195920296066ba1eb56f2bb55646dfe2d57b8b26ffc79e13", size = 5386676, upload-time = "2026-08-07T15:18:44.715Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d9/dd8c9f4ae813b574ef516e58fd7cd418dbacb25336f6691b84736ceca532/numkong-7.8.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c24b27df47f76c728ee91495016dc7cb9468e566255762614b540e045bbd26de", size = 10499144, upload-time = "2026-08-07T15:18:46.813Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/d6a7dc63ab1ebbbc7703e8a0c401247c5796795a9aa80f3e7564baa18988/numkong-7.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4f9e2c0a731b22ee4f0066bc0d5babcbae82a9ca58f255b118224cdafe93e1c8", size = 5379960, upload-time = "2026-08-07T15:18:49.111Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/38/e00d32b786e4251cb47c95a512d309ad8ca5517a31d56eb3c6df26762647/numkong-7.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:1db9d22fa04373cd488fd9685d5d2fa0ea944855d9d8dd5800662551ad5131d7", size = 2302110, upload-time = "2026-08-07T15:18:50.895Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9e/b90997e1389b3fc6d957ca383265e8fc349d535bd0977f674ee28e3034fb/numkong-7.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8d6cd4237fa4e17256eebb531b82adf32fba42947ad97733e6bee8a2c2b9e099", size = 2864591, upload-time = "2026-08-07T15:18:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fa/19c4565c5d7be98d106b091500423e517e7c50f574f49785ae3aa8ecae63/numkong-7.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cdeedcc77eb333a5e679a1b3b462d56a950879c2175f22e7b24eaf347f145bf9", size = 2374630, upload-time = "2026-08-07T15:18:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/7a/e7d41d133edbb55c87b09c48c2729dd4ccfb20174c4b0e9ad75bd7721468/numkong-7.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:203225c2cee687bb0eb727dbfe4a1c169f628ca75456f1b9e764395d09cd2b96", size = 10343435, upload-time = "2026-08-07T15:18:56.217Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/96/83a57b7746278b1ed685cec2fa29413b6733a7bddcd68d155cef8e6bb6e0/numkong-7.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:179eb9b0cce167d4e1943092ab141a60c25e918987b641f70861dd4d90365e8c", size = 492068, upload-time = "2026-08-07T15:18:58.411Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/a29cfb0c36fea4082a9b11574830b4b355f1f368ac4aa2250bd6e8c5b374/numkong-7.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:03e5b39737a71fa2de291bbf75d080a30c5d31cbf7811513c88d6694754ab17c", size = 431130, upload-time = "2026-08-07T15:18:59.824Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e4/c5f4a49e9072fcf0a1e55d95506098b51decc105f0290bcfe47201dc66e9/numkong-7.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:aa13490bc47069053176fa9615b46a9970a510c8c5274f43d7fee054aa4f7097", size = 627106, upload-time = "2026-08-07T15:19:01.316Z" },
+    { url = "https://files.pythonhosted.org/packages/75/50/4086900fb8b3f4100d972c2de6390c17e00f64315401c4668935406fc711/numkong-7.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:007f400337b5c6d4e51d495fcb130e03c078e6d96ff95947f94389ba10ad4db4", size = 620438, upload-time = "2026-08-07T15:19:02.767Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e6/dce947d8f08353b92c327f6bf1aa86320e82bff507a27f9543870301683e/numkong-7.8.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5335ab3c934ecb514da4119d13917e64c362cf303f068b63b7cc1db459867726", size = 2251150, upload-time = "2026-08-07T15:19:04.345Z" },
+    { url = "https://files.pythonhosted.org/packages/17/4e/99be60698445c4026d3318593327c5b76b947ca3cf2b1b282b78e7b7b4af/numkong-7.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5862783b6242d53ca2334127c36404a0a355b8a9966c0da552efd7bfc237d9ab", size = 2877134, upload-time = "2026-08-07T15:19:06.012Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/94/c227cc1a8d155f160fa9286c7846151dee550c8c9a425bb4457e7963e931/numkong-7.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b2a6cda1aa8ccb0b56270899bfde13a8fdc776391c92412b3796e64a3a1fb88e", size = 2495202, upload-time = "2026-08-07T15:19:10.432Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a8/4550942600336f2dbb8611d727fc9e9c1bacd9e361f9a67260d5b14c2344/numkong-7.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b33c0cab0d08c2fb847138ca9751343a236a1f7f020953d40bbf3fddb918d909", size = 5387148, upload-time = "2026-08-07T15:19:12.358Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/aa/5eb14078a3249cdae8f1a3524a79caad646bb26922a2245eceb218162656/numkong-7.8.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb20894b53164577e98e58149067cce423c79abad50e1d00197b5ae8545313f4", size = 10499476, upload-time = "2026-08-07T15:19:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/95/0d0c37b9462a37f1eaf25572804c0ed3a061842c97284f4209d9523cc9f6/numkong-7.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7f446fc35b8f0b8342a96876cb3ea873a8ed0c95e4e2019d2f98f48714fbba7c", size = 5379896, upload-time = "2026-08-07T15:19:17.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/fe/d3cb203aebfe01dbab71c61d9c9a3a3ad2c840b1e9db67ed17af1cbb54fd/numkong-7.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:fd1da707f239a255afbd4a77fb5ed0bd093593d8e24140e69633f85c1cbb179c", size = 2302313, upload-time = "2026-08-07T15:19:18.858Z" },
+    { url = "https://files.pythonhosted.org/packages/42/87/6782f92b5d94a8aeb022efe9b4c5b9f0e3f22f5762d15d3834d07a321c1a/numkong-7.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:40f967a45778665232a24f811e2038003c72c35c5a3334c68695922175ea85f9", size = 2864788, upload-time = "2026-08-07T15:19:20.772Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7d/04287cf4b4f886d5745a47b123a47a6d80536226c064fdc192adac62bacd/numkong-7.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:8b690cfa7f27063a95b48e9eb4dde934d9c7307e88eb3eb327e7ef94f6f3289c", size = 2374798, upload-time = "2026-08-07T15:19:22.519Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e3/c5f30707d68872780b62356771ff47415505be37afcf19b1e35db0a5b673/numkong-7.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c03ed09b93259dc6d39769423cbb17bb92a5263acb3ad6507800835ed058b942", size = 10343650, upload-time = "2026-08-07T15:19:24.379Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6e/9a72788b064ed9f9d773725c41a3f9f4c42c1adac2ab0ab04e97d9968a22/numkong-7.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:fd0dd074ffdaecf3c97f5ffe250dadb27ff65037c30111cdfec5b6964ea4dd61", size = 492077, upload-time = "2026-08-07T15:19:26.548Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/72/4794328c24c4953c9354977da4a38c0e031ad022bafee30a53d4ae953b42/numkong-7.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:2b1171799e0fe93ccfe8c42f5880eb5a18084bad1ae4e7a00ca4ddcebb36201c", size = 431133, upload-time = "2026-08-07T15:19:27.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f0/8fc629edc2d9dcc0487468bb5ce1646967ed5aa18ebc599f6d7f3e83f966/numkong-7.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3fccd2234ad53682c86912e92586554fb312a63f5cf8bb814f79c9ce2f16d183", size = 629158, upload-time = "2026-08-07T15:19:29.407Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0d/c951ba18b3f14cf5d2b6641538e430f4a64ad1509194802117edbebe4a33/numkong-7.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b734bc8283b3eaf4f55e2255fa8751ac516feb90ff733c1fd42086a445624661", size = 622971, upload-time = "2026-08-07T15:19:31.015Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2b/dc50c6a68206289e676746c1f6e56c096eb4083d6355e40c73cc8a384547/numkong-7.8.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f29597b0116c4e2c2eb00515a798c2727ad58ed2a6b536e0364fe206f1ab734e", size = 2276366, upload-time = "2026-08-07T15:19:32.696Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f1/a8b6c6cfdf9370ba3ad12e2e3aa183d0665b1095b72cc4916568447974cb/numkong-7.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56b000d6390d568eda8d35305301835d8daa93204dd71729e96acfc501c9530a", size = 2908374, upload-time = "2026-08-07T15:19:34.415Z" },
+    { url = "https://files.pythonhosted.org/packages/44/87/c98ee1def871ab06ed8ab2e15b3854879d63b4d397830b8ffa324c77312f/numkong-7.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dbca652878ff1c00c71cc0b5211d076c214eb23cddda61d75253fab98d388f89", size = 2529161, upload-time = "2026-08-07T15:19:35.981Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9d/2d6f9f31cce9594355ecd5e938936a19d3eefdc0102ecd459103cc63d7de/numkong-7.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:db40eec7d71f4861f5c656dbf802420e69f97a04a4cdd5a0863b9d56dd53659e", size = 5418607, upload-time = "2026-08-07T15:19:37.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8f/201f2be6a5add4910b45a002e33f71fba84ff6fcb7498a7d978c071e927d/numkong-7.8.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:248f11a020d85dc3bc927e004884b5bf75640e3dc283452221fbafed3bf26b4d", size = 10529789, upload-time = "2026-08-07T15:19:40.085Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/63/bb2d4b048ac3a7220942f61f957ca66cb36e6ee869731d27a21c667dfa6d/numkong-7.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f679cbd1ba2884a1a9cde900ab4c26b82b03b9abe6b7083bdc8da73117e8c38f", size = 5411829, upload-time = "2026-08-07T15:19:42.496Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/cab5336cd971b0c7295c4fb1f9d92cfa2109e626432cbe3db40543b5f1af/numkong-7.8.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:b4769b00f7dc8e3e2064f1c24f9bfc79b77874521d6ca054e0324864b384849d", size = 2326644, upload-time = "2026-08-07T15:19:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cc/3026f1b2cb04dc55701184ddba63f2d88f2ec9a74e6819d0e7aefbf1ceee/numkong-7.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:dc130cd8acb0fea2c7a4b7a927560dc270de8877b7b34c0463a691e74dfb54e9", size = 2895109, upload-time = "2026-08-07T15:19:46.126Z" },
+    { url = "https://files.pythonhosted.org/packages/03/51/0b12cad783e04d4d95165449dfa3cb83cefe60c71640c6dee80615417edb/numkong-7.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:837f2a093eab00533375adf04b89348916d67533c7f0dd25c626566fb38b0794", size = 2405556, upload-time = "2026-08-07T15:19:48.068Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/cb/5c8c83c95566b1acb9c79b4bd141b202b90140641f24ceb131690ad6f254/numkong-7.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:562fb419e39fa404513154722098640042b0d305e476fa6085dfbc5ad73d4d79", size = 10370221, upload-time = "2026-08-07T15:19:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/bac764a7ea501d495ac09c3f901854d50c679bd590e9f1eccff15441a90a/numkong-7.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:16bff56013a84408a1e813b73467b7830863ead2129f89994a861d1521ecc7a4", size = 494343, upload-time = "2026-08-07T15:19:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6f/2f4d0f3e0699d04e2c637c9e46e750e3f1600514d3a6779fdc34fa4232eb/numkong-7.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:5272437aff361f8a0566262158cd2b8022798c3182ac2cd8393a903afd259cec", size = 432532, upload-time = "2026-08-07T15:19:53.915Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/28/830883b97225799829e9bebec744d4c929dd2635b884fc362cc9e0d0dae9/numkong-7.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6ff667465ba96ae03e6a930c2ce378c7611a64a1afb2e42f105b61e6d5151a5", size = 627286, upload-time = "2026-08-07T15:19:55.396Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c9/5e935a8aeb7eb9f8a1b2e861eae0b549acaeca146e49617f019d4b2ce45c/numkong-7.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1f24c2e6d4fe558eea27bab453acf33401e1d6bd7f65fccb1fd2d20c0fcb7681", size = 620571, upload-time = "2026-08-07T15:19:56.918Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/3b/ac9479d139c82c9de2dc775a01afbf8729bc53cc699f0ebc950d0ae4fdb0/numkong-7.8.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:7509ea718bbd0d22c02e2a9292198ad250525c1c89d611f36a329c4803bc40fb", size = 2251579, upload-time = "2026-08-07T15:19:58.482Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a9/4d7314ce2ef3880066b2321c1a7483a4546c8092a2a1cd5e7fe9a3dbc6b8/numkong-7.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d05f82f25cf07256364ff10b0729811aa32e82ce24e32c4931a43e7ea24f9ea", size = 2879074, upload-time = "2026-08-07T15:20:00.146Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/36/2d2ac5e2e9d4bd7736d790cce7a2d244e92e86af6fcf1d4693298ab4dd7d/numkong-7.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:412477a73b2bf944662069172f3ccdebbf06ecc667939a18db3c09f2fe241429", size = 2495579, upload-time = "2026-08-07T15:20:01.813Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6d/44afdd9973d07fdffbb432f916c757ae32c10f57be7b3c844d67e86083b7/numkong-7.8.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e0273da6c392ad693e049e2ce85e60501c26fcf2067c787a94519cc2b4209c20", size = 5387573, upload-time = "2026-08-07T15:20:04.133Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/568de2380b54d29987e7b7d085e797e3e3db5fe224188ef0ada7b14a8103/numkong-7.8.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:6c19e22b1f01185102d9c38a82e6fc1aecf4dbb917d0a74c79d58d92b6b6e4ca", size = 10499913, upload-time = "2026-08-07T15:20:06.222Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c6/8bf5c40fda1442571dfb73a090cc370ebd6effe8e432fddeb02686f2c509/numkong-7.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d5429f332aef41c040835fe1f405422f2c90162d562e9bd26a17ef9e4a86a0cb", size = 5381127, upload-time = "2026-08-07T15:20:08.404Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fd/1ea73f03e477030e0d6dcec1df4678520f70d90a3957d185c889c3a83fa8/numkong-7.8.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:173a3c353f9ad39addd90d1936e09922d2d7a2f93810d931b9eda58bb192d313", size = 2303463, upload-time = "2026-08-07T15:20:10.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/05/b20b4935b482550721df4fb09210bb2eda903727db6aa7951f72778e3878/numkong-7.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5ba09103bec2ccbfacddc561a50c1073f6d4b3961d200d398b698520b1bac796", size = 2866036, upload-time = "2026-08-07T15:20:12.513Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/38/ee7a89c629b67d788585f66fe00250ffd66cdc7dda86f5da412413640f58/numkong-7.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:2da0084ec3df2830e3d63c751dd210de6bc7020982d09bf3d7616a3c98133482", size = 2375204, upload-time = "2026-08-07T15:20:14.493Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6f/5ebaf3e68491b06f8506ba3ae383de5dbc1cd8ec9f6141ebcfae092a4176/numkong-7.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fee54690e61fb17226cbcabd5e511c0e70dc83bf0af9b1b5524708a5500d84bc", size = 10343789, upload-time = "2026-08-07T15:20:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d7/bf97c9bd4890625435acf645753b0eae9daf0c287d72b508d5727078291e/numkong-7.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:f24e89511073cf49369e40f27bab3467338ae674d861d0314e357c4190bce504", size = 506693, upload-time = "2026-08-07T15:20:18.868Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/05498fa9fe7c4870ffaba992f730864c0bcd434bd084b91d7852aa1bd78c/numkong-7.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:1506bd0f3a531f1ff61b9edcc0e4ce446b6c64958954af0b8d68939b1a0cb887", size = 452626, upload-time = "2026-08-07T15:20:20.355Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a5/ead743284d6a58ff81d9b1b69f7f65287c1e1abb420b45658a9a23cdc552/numkong-7.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fa5e4fc0feb429094058ea8dff3279aa290126e04d6fd64f39834ddf5511d1c5", size = 629294, upload-time = "2026-08-07T15:20:21.994Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ec/c5e7f0d6df10fb50031d06b1718210fbae7e25755643b70ec41e1a71d012/numkong-7.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ca9cf8fcfaa25fe8051f9d3ff5d943ebd45e59a2780344be997b931a6ff20678", size = 622974, upload-time = "2026-08-07T15:20:23.423Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/c1f5ead15dc395bc3edf241ab4cf12e349b5132b21511c0cf074e6635cd7/numkong-7.8.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:714cfb9aef8a01afbc2cb9c23968b501f25ce88354598df9729fd311901ff0ce", size = 2276994, upload-time = "2026-08-07T15:20:25.005Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f0/8d4b015ac9585d909a33b58d2bea2a8dd00aab4a7e37ae4cb8c9c0f4b298/numkong-7.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:53d2c5aaa70ae25456fafaabc14c6c473c8929bdecc7d5d61df790b40d1a3a19", size = 2909339, upload-time = "2026-08-07T15:20:26.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/d78c20e31a9a6dc557c7f882942391c9657d6814e7f9953743322f64555e/numkong-7.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:94bccc5bb2ed9b5c15f5f19a69f3f74d63a475f34e05dfd31e82559bc416ad4a", size = 2529932, upload-time = "2026-08-07T15:20:28.516Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/f275d114fa75759a5c8ba2d8b0c13bb81856a913589476674118da538453/numkong-7.8.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:73b7cd682cf56add3b84b670bce187e1060da94057f88ecc5b504f0f0615dcd9", size = 5420010, upload-time = "2026-08-07T15:20:30.386Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/11/fa9cb0da3b58537f3a5d222368b31bd1f979c4fd3a6a955f9399be563069/numkong-7.8.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4adc3de7954e9951da46b98bc45bdfa0a50217032bda703f7b4a48ee3143e98c", size = 10530689, upload-time = "2026-08-07T15:20:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/50/63/d484a1db9d39050b8fffa70b765b704d384dde36da6a4d1d6490acf6e9ff/numkong-7.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:acfdfe89e6554db25bcb3195f49e1d70be4ae48bc8305df39ff3deeb05f155c5", size = 5413015, upload-time = "2026-08-07T15:20:35.171Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/5c13da4e06d0fed5893257ee2d5787a601d05bea35a8882e5ece85e75d7a/numkong-7.8.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:eba7900257d6ac9f78f196486247b84756813a62f7de03be78af0119488b8dba", size = 2327492, upload-time = "2026-08-07T15:20:37.07Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/1d5132e1743a8fc6926b89c113e406ed585e072ce15b0833f3119846afb0/numkong-7.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:e490e6e1966c5d388a8540189784c1728b429b13574d51a324ff4ff1aee26bb1", size = 2896020, upload-time = "2026-08-07T15:20:38.867Z" },
+    { url = "https://files.pythonhosted.org/packages/db/df/682483fb476758addce5adabee7b3bc5930220337c29be671f996e08c524/numkong-7.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:deec0d7b44feea4506aa1430fddb4809800fb855eee64f01b08fb924c2d7ecc3", size = 2406838, upload-time = "2026-08-07T15:20:40.497Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/cb/c395bfc136e5a76f2f2f1405f8904cd6cdf29f777a509e7e531a94bba776/numkong-7.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3719f5d4250f6b5f5fb611ec1f7d867be24d6b0d0cae2f59f629012620ed5c0e", size = 10371353, upload-time = "2026-08-07T15:20:42.475Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bf/79d55955383f32e3138bb337f02f9e2fe7977bebb5fbaf439758619a1e15/numkong-7.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:32ceb77c948145f252bac5f17c36815de78b3b4b41c68aee23292d71a952957c", size = 509319, upload-time = "2026-08-07T15:20:44.747Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/12/c5eedd0ae1e6cce89e0699c26f00ad3e92c2dd3d18a9b05064feb5c20b77/numkong-7.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b645873852493f15a595c9a4b1ebbb5a81e0b7149c9d1d6b2a86e5292e324f5", size = 454099, upload-time = "2026-08-07T15:20:46.635Z" },
 ]
 
 [[package]]
@@ -2383,7 +2308,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -2448,7 +2374,8 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -2531,7 +2458,8 @@ version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
 wheels = [
@@ -2578,158 +2506,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
     { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
     { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
-]
-
-[[package]]
-name = "nvidia-cublas"
-version = "13.1.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti"
-version = "13.0.85"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
-    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc"
-version = "13.0.88"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime"
-version = "13.0.96"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu13"
-version = "9.20.0.48"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
-]
-
-[[package]]
-name = "nvidia-cufft"
-version = "12.0.0.61"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
-]
-
-[[package]]
-name = "nvidia-cufile"
-version = "1.15.1.6"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
-]
-
-[[package]]
-name = "nvidia-curand"
-version = "10.4.0.35"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver"
-version = "12.0.4.66"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
-]
-
-[[package]]
-name = "nvidia-cusparse"
-version = "12.6.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu13"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
-    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu13"
-version = "2.29.7"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
-]
-
-[[package]]
-name = "nvidia-nvjitlink"
-version = "13.3.33"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
-    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
-]
-
-[[package]]
-name = "nvidia-nvshmem-cu13"
-version = "3.4.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
-]
-
-[[package]]
-name = "nvidia-nvtx"
-version = "13.0.85"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -2836,11 +2612,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "26.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]
@@ -3021,7 +2797,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.6.0"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -3030,9 +2806,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
 ]
 
 [[package]]
@@ -3228,21 +3004,21 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "1.2.0.dev3"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/ae/78a02bb1fcb953a37565bd53d1f71014e8316dbc1e4e1bf37889423f72f1/pyrefly-1.2.0.dev3.tar.gz", hash = "sha256:e9bdeb0a1a547e1d165be71aa0853e968a05effccb61c67b42f22c270667165e", size = 6197548, upload-time = "2026-07-24T20:54:07.906Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/01/a86e9f24722b095c3f88e3616132b75a21b0df53804bdc6a45314dd4d93c/pyrefly-1.2.0.tar.gz", hash = "sha256:5485f960fc2481617068c918335c39ab1507ef90b6b5bd35bf57726e60e73185", size = 6243654, upload-time = "2026-08-01T02:56:27.592Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/d3/71ea7545934a2633991ad2c551aac92de8afef4eb24a34a315bb64f71bcf/pyrefly-1.2.0.dev3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe9cf4922c3dbb2c694efa6683aa79b02f2a4f3a3f01252784a2d33b550b815d", size = 13902998, upload-time = "2026-07-24T20:53:36.607Z" },
-    { url = "https://files.pythonhosted.org/packages/78/90/25935e5da71a09f0ca8357a182494bed34efd7d60053b8bf7ec17dbeb1ac/pyrefly-1.2.0.dev3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6d8910e5e56405680b071e0dce065fc2eb0fc111a042fca309982206cee21db6", size = 13358037, upload-time = "2026-07-24T20:53:39.542Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/b1/999e1e4299534eeb2444b0cf18093b5a0cf3cb01244691f836443a0e9770/pyrefly-1.2.0.dev3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35c4c4c9613f60d6f408bd33f142dabd519953f034ace4ec0fd8c4eda70a06dd", size = 13772678, upload-time = "2026-07-24T20:53:42.446Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/81/e21fbc80b28e0ac3203a7427fa197cd93339dcc0263cc1e9be8be3070eb1/pyrefly-1.2.0.dev3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:347a563e427f39f8b4e3b5ff997d7b3b4d9438f1917c0ba543394d08fbcb7bb5", size = 14807454, upload-time = "2026-07-24T20:53:45.12Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/0a/cfa2f8121b3a54d22d1441c52757d73257be466faf71c1eafb34dac48008/pyrefly-1.2.0.dev3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e9e220d60a9f115ce789321cdca11087484572cc3349a330a13e7ff3408995bb", size = 14820987, upload-time = "2026-07-24T20:53:47.983Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ce/ffc6c589544ca1631c16af7d776ebd4010dd1968659b189d70ed7135e3d3/pyrefly-1.2.0.dev3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06d9434c5e475baa6db45c346f9bdcf30c89cb19facb97feb4d4ab311431f25b", size = 14254722, upload-time = "2026-07-24T20:53:50.795Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a1/6c0438993f8fa5ddb60076b3e52eb47cf83036d268a6da1b1aad3692258b/pyrefly-1.2.0.dev3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:465ff2b1a49331ac2a07ae9a1efe8b7b351493333870ad30f111c8a0fb4e22ae", size = 13796734, upload-time = "2026-07-24T20:53:53.813Z" },
-    { url = "https://files.pythonhosted.org/packages/00/91/52a1507687fa84a6b5fbb6af3c9158b522e90436b5cbbec499c6e6abc4c2/pyrefly-1.2.0.dev3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:44a1c896e3206a57d0c60aac7b12c01e6c1d629d557ef2a541a48e079c5c3bf7", size = 14295787, upload-time = "2026-07-24T20:53:57.199Z" },
-    { url = "https://files.pythonhosted.org/packages/14/76/0d8a77e9d2bcaa555a66df13c3ed14111e4180270cfd002282654e55c452/pyrefly-1.2.0.dev3-py3-none-win32.whl", hash = "sha256:946b1c8d5d41139d5931ba16bbb567d02e2f8fe9d35a18c812f782e3cce0df1f", size = 13019850, upload-time = "2026-07-24T20:54:00.058Z" },
-    { url = "https://files.pythonhosted.org/packages/74/d9/3f543aca87864d3e360a3205d6152d84849696c9be134883976e37d1c524/pyrefly-1.2.0.dev3-py3-none-win_amd64.whl", hash = "sha256:de77594256092309a529a7d89a92ad0c4775f82bd4082235de792b96324216eb", size = 13967675, upload-time = "2026-07-24T20:54:02.786Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/27/a52738bfb8e835fb325984e49c4d00362859b6a99b4c244164145b27010f/pyrefly-1.2.0.dev3-py3-none-win_arm64.whl", hash = "sha256:a407c6a0c9374cf7a1bdb9e0769ce88fbbfb1ee1d88a056bebc7c7e1c6bbbdbc", size = 13326689, upload-time = "2026-07-24T20:54:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/9d/3c0ef1d4843987b22f996ed381ec9cf5a3b1273e29804db276252e4c95eb/pyrefly-1.2.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7f46d983ac49ddd2b043694960a01dc6a19a5cfd8eec609d6bd9c42866f91b4e", size = 14026305, upload-time = "2026-08-01T02:56:02.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/06/03bbb78fbea54cdc65b626619f3597d5611aca4fdef11e72a4e8360e7e63/pyrefly-1.2.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:756f669b5555090f5c1a4fef30db1785fabe657764f7e4e6dc88994dfb8ca82d", size = 13463880, upload-time = "2026-08-01T02:56:04.93Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/7d8bc00a38e93bbc9c3e7bd14d305f7948717e667c9bcddeab9dd42fd255/pyrefly-1.2.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3465812ce5ef4781fb592edbf2724547296f0a3124be115d73c7e8b2401862d", size = 13907329, upload-time = "2026-08-01T02:56:07.104Z" },
+    { url = "https://files.pythonhosted.org/packages/be/94/9e08b4bf799d0b8f36b55a2783c7ba5f51730cf0632a85a67b5b5ed876cd/pyrefly-1.2.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5de7b2ad2bba5c8055181681a84b74143eac2234a48ba5d1b7ed7e7a722b02bd", size = 15039020, upload-time = "2026-08-01T02:56:09.208Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/bd/bca5fd0c80f4daf8ee6903a29df9f3de1feb05ff0946b8f35ec8c5096b13/pyrefly-1.2.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25822ea9505f589ea8a725e4268b475132fb89e038fbf092e446510443ac142a", size = 14986199, upload-time = "2026-08-01T02:56:11.924Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/f07087f3d185ad2eced0c56cef89ca5474dfb4ff25f146cd50a861c97553/pyrefly-1.2.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90efe75e17491ef5d636e10469e9278d7d0256b3b4c5e1f4750069bf3ae0f5d1", size = 14393715, upload-time = "2026-08-01T02:56:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/70/0d142c320e284b9e3ce35e9b1e58b8ce2ee1f578f2a7234bc30e5022b94f/pyrefly-1.2.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:368aaf7eee4f511ddc0f8e564cf14e01ab2f10b0db9105c6d5b153bf498d07bf", size = 13933008, upload-time = "2026-08-01T02:56:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e8/e84f11b6e1f63fd453ad3654213b9a0f6f4de8cef6b58038eef2d0d5955d/pyrefly-1.2.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d52d5da7bc65fb7675fbaa80eda879d4f8787c494f04cac21603330d3abbdbbe", size = 14431827, upload-time = "2026-08-01T02:56:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/06/810d31380f66c75e1c0779a408d3b16117b1b368b57894f6aa66bef21686/pyrefly-1.2.0-py3-none-win32.whl", hash = "sha256:8c90751de8506d938e8f802659c74cf35bd7a0036510ee6c634a38eebb280bfa", size = 13229447, upload-time = "2026-08-01T02:56:20.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/98/4dafa3c7a1caed2dc8cc708dde09ba27963c7736508f55b626fff3024113/pyrefly-1.2.0-py3-none-win_amd64.whl", hash = "sha256:8a8964c224ccc4882730130955815de21ff443c1ac3f0b90685b19bf63848170", size = 14087387, upload-time = "2026-08-01T02:56:23.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1c/df3cb0a2e5591660ded7a1836cd2f29dc48c91adb1c0a3a700a96f6d09e1/pyrefly-1.2.0-py3-none-win_arm64.whl", hash = "sha256:3a90bb8df39dfbac74b1f3b2e9d7c526b8f80568884c3944d955023a73ebf61e", size = 13430873, upload-time = "2026-08-01T02:56:25.425Z" },
 ]
 
 [[package]]
@@ -3341,11 +3117,11 @@ wheels = [
 
 [[package]]
 name = "pytz"
-version = "2026.2"
+version = "2026.3.post1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
 ]
 
 [[package]]
@@ -3597,7 +3373,8 @@ name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
@@ -3723,8 +3500,10 @@ version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
 wheels = [
@@ -3847,27 +3626,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.0"
+version = "0.16.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
-    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
-    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
-    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
 ]
 
 [[package]]
@@ -3875,7 +3654,8 @@ name = "scikit-image"
 version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "imageio" },
@@ -3918,8 +3698,10 @@ version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "imageio" },
@@ -3991,7 +3773,8 @@ name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "joblib" },
@@ -4039,8 +3822,10 @@ version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "joblib" },
@@ -4090,7 +3875,8 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
@@ -4149,7 +3935,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
@@ -4224,7 +4011,8 @@ version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
@@ -4315,91 +4103,101 @@ wheels = [
 
 [[package]]
 name = "stringzilla"
-version = "4.6.2"
+version = "5.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/b5/40951e5eaef033aa377c111f4a18a62dbce6d6211eff754f88c73aeebe49/stringzilla-4.6.2.tar.gz", hash = "sha256:f30fb35d84578236723aaf9442e9281ae29c8ad5255eb118173c9370af4c0e71", size = 646294, upload-time = "2026-06-05T17:07:09.163Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/21/42eb0353de11b272e67f96b4be906c3d04f9c9911270c0de8d50bce3fd27/stringzilla-5.1.2.tar.gz", hash = "sha256:7c2a952d6305df23bd4e592c28c27786e0d77982949233df20029370cd0096ad", size = 1991371, upload-time = "2026-08-12T02:05:22.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/1b/c57c344ee4846225df15dd8b1092e3deea3d0007c85af430384dafd97955/stringzilla-4.6.2-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:05692b0e808371848afeef774792df8019ae3b3721ba24ecbdaff059ff5116e1", size = 211458, upload-time = "2026-06-05T17:05:07.573Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a4/520efe0720db1be83549c79b0411af980b1e39516a5c37689d33e1fa1781/stringzilla-4.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d9f5d7856a0f9c6371a6db104996aded2a0f23327101e4a5ce34d0ae22a7c81d", size = 198967, upload-time = "2026-06-05T17:05:09.791Z" },
-    { url = "https://files.pythonhosted.org/packages/87/03/89fc5e21d063b1991a75b8506aadf712e72a945c9a0ad1c879a61d0e1cf3/stringzilla-4.6.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ef9c472362458e8e0bd138d43018d55720fec26c22a46c8ad7a3cce6947e199c", size = 575694, upload-time = "2026-06-05T17:05:11.308Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ec/63e2e1557ce60e579858a22492b4077ddce3f23e2fc88c7e4e1f2c03b97f/stringzilla-4.6.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f9c90d4f7f6bca00cc6fe613f6450fdbe9be7e522990cfc309adb50e95fec4c", size = 640499, upload-time = "2026-06-05T17:05:12.782Z" },
-    { url = "https://files.pythonhosted.org/packages/69/5b/cf96fd6b6863314820998184c8396f2834e3086b822c747617c21972dfc4/stringzilla-4.6.2-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53fb72393d920c700f93547f5dba8f7aca6ebe2a586e200a1e9ba365a6a0af2e", size = 639984, upload-time = "2026-06-05T17:05:14.669Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/e8/4411217539c15a41ebbe816e6c6a3df7b6fd18817e12fccd6f848e130af6/stringzilla-4.6.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a52dc2307c8136553db2bdd62eab70f7feaf9a8010dc52fd2612f63679d4210f", size = 586553, upload-time = "2026-06-05T17:05:16.131Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/bb/54f86db591a9e71b4fed4f7c7d0fba0bd4c030b0f47f6d0d027370c23a20/stringzilla-4.6.2-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:43cf9adc320ced59ed79ce43735173f2df1fdc8a7387e19d5e9e14d810d633d8", size = 593205, upload-time = "2026-06-05T17:05:17.549Z" },
-    { url = "https://files.pythonhosted.org/packages/82/d9/20f561d072ad6c242af8b426c306bd49df33494e550e53160486fd5364d8/stringzilla-4.6.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:133cf8ff87f4f5db54a12cf9c97b79c186e2b979cb97131a321720f13123a049", size = 1848736, upload-time = "2026-06-05T17:05:18.819Z" },
-    { url = "https://files.pythonhosted.org/packages/62/70/d709c62ca69d310399d1a1cf61a049ffa3d2901eb03922a1430a08bcb691/stringzilla-4.6.2-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f2377d628a08115342973b432c36ec121358748705b6fa726043a88f8e5bbc2", size = 606973, upload-time = "2026-06-05T17:05:20.338Z" },
-    { url = "https://files.pythonhosted.org/packages/13/56/0063591f24abc6f9e69abde70b051ba589685dd51974028d093e3161d48b/stringzilla-4.6.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f8b5ab3fb6dc5abcd78fbbac8d3be6f5c96d94c7c1983d279f9fedccbdda8571", size = 655746, upload-time = "2026-06-05T17:05:21.926Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/4e/ad74bd7107530c3ac989ac1163e5fc5547e4b46a1ec5453277a73526774c/stringzilla-4.6.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:0bef1c6c7e755b2ada69383e051abfbeceae22b87817ab4d73cf5ade73e8a9dd", size = 587711, upload-time = "2026-06-05T17:05:23.488Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/8b/a7d3d4c8bca156a5791e145428a072440096d58b4a98b1c55c7e5f1db1fe/stringzilla-4.6.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4a7901ba376efd0a43d353193fe64d55324d5c68407f16f17ab50ef80004c10e", size = 606967, upload-time = "2026-06-05T17:05:24.752Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/64/3001c758b6cd74b4f55328b76b275bcb47c6a5fb79441e290b7d24da607a/stringzilla-4.6.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:eaa6b10fa206e2eafc1f9ca7e95c96b917f31f694497138e84e09eb6d2d813a1", size = 605921, upload-time = "2026-06-05T17:05:26.239Z" },
-    { url = "https://files.pythonhosted.org/packages/01/34/d50a53251cc5f07f30a3ad32dac9c6abb6e279939a2767564e7b8fb61052/stringzilla-4.6.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:25cb1fc08837c555fe927228fef1b1217e45f703eb1b9785331c0192a2ea6629", size = 598770, upload-time = "2026-06-05T17:05:27.546Z" },
-    { url = "https://files.pythonhosted.org/packages/90/a0/59cd1122b3bdce491656bd330cabc189d514defc69a11a428008476c55dd/stringzilla-4.6.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6af8df7d4d35c5b816e460841a4ca0e1e086e7acab0aa5b939de915b0112e43c", size = 624696, upload-time = "2026-06-05T17:05:29.146Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/42/1fb69af5552d373d1e790dfd58031004bfaba406c8222b006d6d2229c0c6/stringzilla-4.6.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:25be2a763cc43b35be6d5717d239be4e9a8f05ed4e5a9fb907896f95ba8cb27c", size = 1975187, upload-time = "2026-06-05T17:05:30.449Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/b2/21e2e5546d3a679bcf2440f1cb5d96fcfaac128bc459bab9d3916f6868e8/stringzilla-4.6.2-cp310-cp310-win32.whl", hash = "sha256:d8e47dc8acc0f0d8d031a8f69e9f798545465e200c2122d970181e741b8f8911", size = 114411, upload-time = "2026-06-05T17:05:31.982Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/6f/069902e9679f17908ee49d5418e36b2a6dc6ac4f8caa33013fb679581e53/stringzilla-4.6.2-cp310-cp310-win_amd64.whl", hash = "sha256:2d1eaf16aef37c86d0910fff169eb1af4e7b0fb3b80fa2ac88f70eb3fecd5f39", size = 162307, upload-time = "2026-06-05T17:05:33.17Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/e6/b39ee8b58fcd376219afd2e390e0447299a56e26be038e0875555f56576b/stringzilla-4.6.2-cp310-cp310-win_arm64.whl", hash = "sha256:fe6f9562d88ef8d812ab7ead2f5da59b5903ce5ef318e718ca96bedcb7492625", size = 122948, upload-time = "2026-06-05T17:05:34.654Z" },
-    { url = "https://files.pythonhosted.org/packages/04/f3/193fa3a4fd79e2ff4bf1622f908c30088daf9b65c1b7344b090b7b86a6b9/stringzilla-4.6.2-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:56e8a999ee954a34fbe729523ddf8f3f1024180b444090c42d10d71db50449c4", size = 211456, upload-time = "2026-06-05T17:05:35.713Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c4/33fd6afac7ffb6953b4cf86dbf91dfe8d5a110adb7b42eb59e6a16d74f55/stringzilla-4.6.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0381e4e9d1081eb9de6242a9a98e14b884651e6cf9d0bd50eac30927699a5b72", size = 198918, upload-time = "2026-06-05T17:05:36.959Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/12/1e4fb2fe9993e11ccbdbf887489439b02dff3f8e63ae13c0bcb87b662dee/stringzilla-4.6.2-cp311-cp311-win32.whl", hash = "sha256:445b2fbe485fe4743725e6ff189ada43a73f73d9ea94bf4cfafb68b4ecbb5141", size = 114431, upload-time = "2026-06-05T17:05:38.18Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/4a/fde3ecc52dcb0f949087b6efeaa1ba636b19a9bc54d2e7c9167902b263f7/stringzilla-4.6.2-cp311-cp311-win_amd64.whl", hash = "sha256:795371c6d00e21e037bd338ed29a633fc22ff992b3385a359c55f597f9c4e4f8", size = 162222, upload-time = "2026-06-05T17:05:39.447Z" },
-    { url = "https://files.pythonhosted.org/packages/86/4c/8a33d0d924351419d4a9a909102373d73bdb2c1b12c179fddecaadbd8644/stringzilla-4.6.2-cp311-cp311-win_arm64.whl", hash = "sha256:283ad47988be6f594f1d37be1b6031b5ad987b162e33115c2e9711d051b894bb", size = 122938, upload-time = "2026-06-05T17:05:40.758Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/2c/71021ff18092efeef3bd9e9f75c04b2f5b648c66aa88f80981f12f1777f0/stringzilla-4.6.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4fd0728a45baa861927abf37d365c656695c89b13a671108f34b7bdc88653c20", size = 212166, upload-time = "2026-06-05T17:05:41.951Z" },
-    { url = "https://files.pythonhosted.org/packages/88/2b/62dd1a69ee3bb55ac507da01f4312ecba338e77e158e8b03c01eb79884fe/stringzilla-4.6.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dae0ce637947ab3bfbca8e26236de1149e2a181a7b7286a174936a986b370689", size = 199218, upload-time = "2026-06-05T17:05:43.182Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c2/b7764bb3dfb08f221f0b96267b2b72715489a165c89973bbce2edc2d8f97/stringzilla-4.6.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b54e6be715a19faf407837bccf302082866134b09673d470c162cbbffb7b1570", size = 582298, upload-time = "2026-06-05T17:05:44.883Z" },
-    { url = "https://files.pythonhosted.org/packages/25/4f/80eda1295021033ad67b775ef7e4933b3b52f6f715fb464676cd0330bbdf/stringzilla-4.6.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5737b993627d8994654dc8780b858ed610bd4ed6a9c1ed6bd9972c33b258b06", size = 647665, upload-time = "2026-06-05T17:05:46.529Z" },
-    { url = "https://files.pythonhosted.org/packages/73/83/946c776fd76af08a20f21c4671bbc4cc5a8a0e9b3ba578b67e724a5639b1/stringzilla-4.6.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3c60de67871c87a4aebcdca3f120d87252446cc4cd344156ae5391d17147bed2", size = 651211, upload-time = "2026-06-05T17:05:48.034Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/f8/869e728e232645c93817c4bdd794bcd75bc895334b110011e46c5cbd90e9/stringzilla-4.6.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02a9979e6992ed6975ab6bc24d19148839a8cfad88ee828608296cef9002a141", size = 595069, upload-time = "2026-06-05T17:05:49.586Z" },
-    { url = "https://files.pythonhosted.org/packages/44/8d/08a810a6b9a13f15a5885f290fb14ea6d75e783b95852c95c5a938016f25/stringzilla-4.6.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b307cd338cf719137db7efaa1cb3da3421d50ea26c61059424bac97ddd5138d5", size = 600468, upload-time = "2026-06-05T17:05:51.02Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/65df9199a334066cf9d8ead48573f80b6c3bc2cb7d2a0a0fce09f31b2860/stringzilla-4.6.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83bc6f26f02628c831ddfc547f1077c69a6fd7902231fea2aee8f93e9da8bd46", size = 1857818, upload-time = "2026-06-05T17:05:52.762Z" },
-    { url = "https://files.pythonhosted.org/packages/48/b3/8a7ca75ee56f82e0d120932e6d4ed96c304b82f28d8e4c63f040f279b04e/stringzilla-4.6.2-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da84c50cb0eb3d5b6f03de83b791bf891b1f49a296e3dac0301a27cf2a827d0c", size = 611350, upload-time = "2026-06-05T17:05:54.549Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/9c/8b1e21c13c94a7b405c36a84fe12aa746a19215a1eaf4610233356188c78/stringzilla-4.6.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bbbeea11ddd1553a63650c1abb720710989879d94d151a43600f10af1d8a39a5", size = 661628, upload-time = "2026-06-05T17:05:55.98Z" },
-    { url = "https://files.pythonhosted.org/packages/78/52/0f784920c1a4e5f2241772f961c4b72d2444d066ef588c34edb5490c7995/stringzilla-4.6.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:cadbc0ac8474cdfa85084f797f080b797c1eb951cd7aa0c73881616d1ddf0639", size = 597510, upload-time = "2026-06-05T17:05:57.21Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/47/0ca2d6131b65e925e8d5498d32f72b0353de58bd49346ccc0d193d79fc5d/stringzilla-4.6.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4ca9adcadc1fe1564e31d4bda14d76f5d7614c616c10c16d7bccc48ee486b0eb", size = 616539, upload-time = "2026-06-05T17:05:58.704Z" },
-    { url = "https://files.pythonhosted.org/packages/59/05/48bbe7225e55f0ff5c7c4bc00296733ab88e09135dcb6a39f614fcaf0c4b/stringzilla-4.6.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a321e1b909378769f7c05697468fe88ea65089148785be50b65f26f591350204", size = 613551, upload-time = "2026-06-05T17:06:00.247Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5e/84af0d65bc2f661b5df0a5e9202f722a746a67a77649fc5d1634d5b22455/stringzilla-4.6.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9248aa322f24f28a888991f38d23a75d4dd27587becd029b00e94a1f155f9276", size = 602450, upload-time = "2026-06-05T17:06:01.853Z" },
-    { url = "https://files.pythonhosted.org/packages/85/62/03a153b149edcf433d87672e3b62917423c53ca2e30df8ac1cbb08fbaf72/stringzilla-4.6.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:50d61f06b66a9b4d737f9ed3611da41a53e9cb8aa3c25d9c3d34dbb67f272e6c", size = 632715, upload-time = "2026-06-05T17:06:03.209Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/6f/52211a7b7871497547ea71c93ac4a9e6911f99e6c412102792c29889dcb6/stringzilla-4.6.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:215d9e5ea1f3caeeebaac1b6cf18579a8f7e519a16afba036954230bae17d12c", size = 1976332, upload-time = "2026-06-05T17:06:04.689Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/3a/40848f18b3801019af4f0efd8a317f7953f8287560f32ff3c4cb4c38cea2/stringzilla-4.6.2-cp312-cp312-win32.whl", hash = "sha256:0638c6bdbcc45de73ab9c85eab622712174993ef91b5b0463f333a11e9a2bbfb", size = 114688, upload-time = "2026-06-05T17:06:06.43Z" },
-    { url = "https://files.pythonhosted.org/packages/20/0f/14df6be0e23b3cdd7e28732eb7f93437ce57d20510ba43875e3d98be02d8/stringzilla-4.6.2-cp312-cp312-win_amd64.whl", hash = "sha256:42dc9bf6379edb174607b7061cb2c234d3f8a57f701fee31755cbcb5fd55e93a", size = 162453, upload-time = "2026-06-05T17:06:07.838Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/01/cb7608daeb23f427e0da01ecb4cb211b7f860055b2d94578845f5ac4f1a4/stringzilla-4.6.2-cp312-cp312-win_arm64.whl", hash = "sha256:ec028b7db898a2131a10fcebced14cc0dad5af0d45ad05f27e20ca0feb226446", size = 123179, upload-time = "2026-06-05T17:06:09.249Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d8/d92cc16d4e7b7e8b05f4f78d5546bfdd635d42ae5e39bcf80198d50f7d0c/stringzilla-4.6.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00a791addb965cc3268e1e983d933f7aa81f19ea1a5bfed78ed3c319623597f9", size = 212166, upload-time = "2026-06-05T17:06:10.556Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/9f626134a7e7a40e9cfc875aed379b123df2a5fd8484234914431840712e/stringzilla-4.6.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b2bbea488adb0320fd317cf07f35486fcb7d8e487aa5b23e60b55b36a6e9faa9", size = 199217, upload-time = "2026-06-05T17:06:11.864Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/24/47ac8d851ab53a8ee3178755a74eaf5987bb4b01b5a9b748bf2120d26022/stringzilla-4.6.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:23a2ebe9e8cceff2d0c2c0a664a72417ae7d6a9b10a5d9049c95bd152ec70b3e", size = 582265, upload-time = "2026-06-05T17:06:13.236Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/fb/b7f9f5f5068c47378017eb2747df52d3fc77f43bd4764b5719a30ed1cc9a/stringzilla-4.6.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0d7149226d0455caf1aa2eec2b425fa276f1e2a61ba3760ff492f6b9f25cc23", size = 647712, upload-time = "2026-06-05T17:06:14.643Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/00/ed9bad99ef5e9c002634c61822585b792b22c19d66f40954e4efad694a72/stringzilla-4.6.2-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6a01e629f2677522abae4e9e65ada2f983ead838266d3a9b99bb512c731f325c", size = 651073, upload-time = "2026-06-05T17:06:16.045Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d3/72119c2e900be6451114d1d1c5947e00c79dc725c0e15a7cb34c185f55bd/stringzilla-4.6.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:53b7dbc30c3c22fb5761e90c4854213ab62bf153fe3b25011348b312bb49df03", size = 595114, upload-time = "2026-06-05T17:06:17.534Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/14/ff3e14615132504806a467819999ba5840a181cc4e907044987fece7eabb/stringzilla-4.6.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c2e30dfd179206e9bfced4c4e91d3f8af9eae7d6fce5ba5e5f4e66aa9215be7", size = 600463, upload-time = "2026-06-05T17:06:18.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ae/c97a1689dc0cc466f71c2f958adca6ae1a8e6bf5bdbe33164c213a77525c/stringzilla-4.6.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09a67387037c66d167819cfa8d4234c713fbc6df90131a6f61dc3cd84ab19fd4", size = 1857863, upload-time = "2026-06-05T17:06:20.373Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c2/33ace5325d88229b565ee144a350d77bdded7a3103e2e326de8acc961d3c/stringzilla-4.6.2-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcb95e147f7709527fa4e3eddc16b9a4e033ca48cba85cc20deda62270c85e0c", size = 611309, upload-time = "2026-06-05T17:06:22.074Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/9a/98d567f8633449e1cf659cd6ce7682688168403ca8195417fc41bb15e217/stringzilla-4.6.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:716c4120bfed0d0b75a16ff2c99b644de1c5c41d68c57543439ffdc0caf8bd05", size = 661656, upload-time = "2026-06-05T17:06:23.557Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/94/b7c71735aae038a5a74323f41691d581855fe906ba4090c63de733e2316e/stringzilla-4.6.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8e8e831ce10fd629d4573a11d86bf6bf851ef456e4b757a3bb239b3ea30e5013", size = 597568, upload-time = "2026-06-05T17:06:25.038Z" },
-    { url = "https://files.pythonhosted.org/packages/37/8b/9822536bd67d4c86e4919010e0b0cf397af9a9786f2bb04363df873ec718/stringzilla-4.6.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:24dbf7a571da484d1efb4f1674cc2f9fab8ebed4c1eb3c647833098b7cbc4b46", size = 616597, upload-time = "2026-06-05T17:06:26.599Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/b1/5a9ee7e66e320d13cc2a451c8fdc0ff186973754a12b227b0431b74bf9ca/stringzilla-4.6.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2016e170f08bf956ba6f19cdf2eed6850e93a60cef7c4d481c32468ae877f340", size = 613611, upload-time = "2026-06-05T17:06:28.111Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/e6/cfe4bb910a4b806089bf920dc3a875c98318a5acde034f63087f728f52d9/stringzilla-4.6.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f0436f1f2f2f659335bcd132ce79b970703f63b2ae478547e4f3fe83032e04d2", size = 602475, upload-time = "2026-06-05T17:06:29.68Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/65/9dad1d7a415e8fd893f3106f787d499f2bd00e12ed0023a85960ecd68b22/stringzilla-4.6.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:9d7d3d89c903ff519111eb5f9614324e7640c912ce55975eb240de662d7196c9", size = 632736, upload-time = "2026-06-05T17:06:31.056Z" },
-    { url = "https://files.pythonhosted.org/packages/03/c3/f4299a496892111aa200b92ac3e3a4295ab44f21238afeb23f0bff6d70a6/stringzilla-4.6.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4c8c09a22da4bf6dd054a36b8eeed40760f4b5318b9f001145fa1159844475ab", size = 1976337, upload-time = "2026-06-05T17:06:32.538Z" },
-    { url = "https://files.pythonhosted.org/packages/83/1f/e36f84703db11b568489cf950634ff55ba20b780476989992a4fb35497b3/stringzilla-4.6.2-cp313-cp313-win32.whl", hash = "sha256:66dace3fa65ebdbdac3644e513348678f75e94e59b7234f614eae33535be1bdc", size = 114686, upload-time = "2026-06-05T17:06:34.069Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/21/41039cf8b99f21a17709beeea7b63aef9fe8b627a1a843990e2af075af3c/stringzilla-4.6.2-cp313-cp313-win_amd64.whl", hash = "sha256:1bdd87d0a92a83bc013a817afe69bc906b55476370c210791f3e132457dd461a", size = 162456, upload-time = "2026-06-05T17:06:35.393Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/73/a052bc96a5166181c413c49ade7c8bd4bd6ea7bbb92f0791066c5b899053/stringzilla-4.6.2-cp313-cp313-win_arm64.whl", hash = "sha256:9c182254bd7943e4c61ce83c58e6096a180905fadbd2d8b4de8b57fc5cb7c9cc", size = 123186, upload-time = "2026-06-05T17:06:36.934Z" },
-    { url = "https://files.pythonhosted.org/packages/04/43/73302749e84315461722068a89fcbc892ce35ee5204d4fb112d0c1aa00d4/stringzilla-4.6.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbf773dd128460ae44b3839c3a85f2587e42869f1004ea327b11950d1d4a1c11", size = 212195, upload-time = "2026-06-05T17:06:38.379Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/c1/b248df98ce0f25e795a1f5bee5e0cff9b337af3fc0c12f7e7040695e27e6/stringzilla-4.6.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f4e50aaddb4aae588b988925c6e5664db08fe31555a57c649fdfa217b0b88113", size = 199248, upload-time = "2026-06-05T17:06:39.986Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/61/afeb2ac52b6541e91562f89fa126d9b0380e02b0a4ca169cce4e6910a614/stringzilla-4.6.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1a612afc970c67bc9c5de0b1ae11ac2ad61bd80cb1c7f80fa68c16402ab4f656", size = 582391, upload-time = "2026-06-05T17:06:41.379Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/90/d09b435ef6dc56090f1b03a99d49cb16c0d4e7dd315320291f82137d7f6a/stringzilla-4.6.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3afa1595ddede82fff17df64d162ae8498ee61b35aa6c730a55419558cdc7663", size = 647818, upload-time = "2026-06-05T17:06:42.925Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/94/f67c9b02a495e45ecc7eab586b0dece8b7fdaded82a23fb132187192b488/stringzilla-4.6.2-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ca51a91d4606649789aef673e30f78b0381b915ca4963fffea18c0ca6e5bb9d", size = 650412, upload-time = "2026-06-05T17:06:44.618Z" },
-    { url = "https://files.pythonhosted.org/packages/30/11/278fa91c272368e816929ac927172371d4629299b9afbf8be84c6b159ac8/stringzilla-4.6.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1ff91faf487f5cef54ce23375691d70562f7134dee485b0cb7bee215a0cd82c9", size = 595271, upload-time = "2026-06-05T17:06:46.406Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/09/4d8c852ab4d55ad7321672cddfc9ad5629293964b92b978afe8b4cfd363a/stringzilla-4.6.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9862fab01ccd8007b676c30e92c9c4978201954260340f962eb4a89d5af482cb", size = 600405, upload-time = "2026-06-05T17:06:48.222Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/d4/56be7c6ed92a96eb261a6f90cefbbea6f4f2e390ac587aa821c65c9b9a9e/stringzilla-4.6.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbd0df9824f32f3fc113d9348dfdcc976d4df2ac2118c53074126abb56351bd0", size = 1857367, upload-time = "2026-06-05T17:06:49.772Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/28/11e549e5fada3a92b62ca3d750e88043a47f75c835ba08bc792409050024/stringzilla-4.6.2-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8475647325b1cb923aebdc3b22dad2a8805eb77c3cc300d27960a4a12293f9c", size = 611547, upload-time = "2026-06-05T17:06:51.535Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/7a/eece4bb72d24cdb08ac4acf5d73aec0ccf8b970508b6f4d1633aef2513e7/stringzilla-4.6.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aba0640812f13520380318930ff716fa5a434393a70d8e7db57ced637ecd0705", size = 661977, upload-time = "2026-06-05T17:06:53.146Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/1f/3ed79edbbf6212e0f813f85aafb15f57b60508c862c73b470002a0bf24d1/stringzilla-4.6.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0a57f406cad5225ae266f1dbfa9f07a8468a33921bd18cd03797871aa334db5e", size = 595870, upload-time = "2026-06-05T17:06:54.69Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ad/1890f124a9ff99c620d032ad637191ab7bcdd06c0881e90133d0bfe81298/stringzilla-4.6.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:573abfc3eca6d903e0aab4ab6a8de841a0e437a93536fd2f75a6c9e70db29729", size = 616634, upload-time = "2026-06-05T17:06:56.308Z" },
-    { url = "https://files.pythonhosted.org/packages/88/1f/eeaa1a37a7feb7369642d17d001a8bb1c5f28ecfbd26088ed06af63b00f2/stringzilla-4.6.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4666e0b76da6e54a5a4d81561905ce09743adc8ea03ca59cbd306305095607cd", size = 613845, upload-time = "2026-06-05T17:06:57.846Z" },
-    { url = "https://files.pythonhosted.org/packages/93/d8/64879da8fba98bed4c4645524c57579bbc13b4c4687152d22458d0ad71f4/stringzilla-4.6.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e6f4d02db0efb228b724d69cb7dbf0126b534ebf87dc47469057aabe591a91f6", size = 602664, upload-time = "2026-06-05T17:06:59.34Z" },
-    { url = "https://files.pythonhosted.org/packages/29/17/5e2377010f92d34f3bfe4f811be6710fc495705e14901a24829a78847b51/stringzilla-4.6.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:64c10e42b88e84fa1cf36f42dc8ba97421f8700d1c11873bab8de13cb5723dc1", size = 632179, upload-time = "2026-06-05T17:07:01.024Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/64/65ea631fc3c6b1c836156041c2895aae4874efa03ac829355224bd60c31d/stringzilla-4.6.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1a4895a105fd3de40fc82ef96f0e8a1030645e10fa13b9b6d15efeaf02e52efc", size = 1976008, upload-time = "2026-06-05T17:07:02.653Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ce/a3bfb84c0da5ca9347ec7f1774a821664763827bb8e854f38fc814ac24e2/stringzilla-4.6.2-cp314-cp314-win32.whl", hash = "sha256:8cad620429de33881cca0e78032bba301176342e987705ddefb827403bc8caf3", size = 117985, upload-time = "2026-06-05T17:07:04.44Z" },
-    { url = "https://files.pythonhosted.org/packages/62/34/e13e520393cd35e9e2cd0c4b9392781a2e30c76888d997523c549829faaa/stringzilla-4.6.2-cp314-cp314-win_amd64.whl", hash = "sha256:34e3c30bd65bba91ccb6b73258e4899fa025e9e21fbb1c028ab32974fd51e377", size = 167485, upload-time = "2026-06-05T17:07:05.873Z" },
-    { url = "https://files.pythonhosted.org/packages/66/12/37808d822c5c2ff188eff46f0ee2637530e0ce781b9aac0b147bb9713c67/stringzilla-4.6.2-cp314-cp314-win_arm64.whl", hash = "sha256:005b4450a5d1f5e199cd4fc28c60a67695555a034981dfc4a8b0fa0b0989f0f1", size = 127917, upload-time = "2026-06-05T17:07:07.544Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/2e31ed089a51964a5ca97b9aa51aed465164470ac65a0c3465549264a7dd/stringzilla-5.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b76315ff95d7d11da5c2574cf3124de62ae4e83a979fe87eb4fc329f029e9012", size = 417158, upload-time = "2026-08-12T02:03:02.58Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6e/47513575aab68f06ec262d0f36dbdcc3226bfa18ea95c3c67ebbffaad64d/stringzilla-5.1.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:f10206f907e1b3742075e9ef3d46db56033e2baec6250d44aa35f7f84733d8a1", size = 443065, upload-time = "2026-08-12T02:03:03.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/6b/c3c1b3962993717da7a1de1f80a4d29a507b14231144a790144659c999f8/stringzilla-5.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad001def970270201da35de9dcd648914a047ebf1550c3ba3fbf28a629b0103f", size = 3483917, upload-time = "2026-08-12T02:03:04.96Z" },
+    { url = "https://files.pythonhosted.org/packages/20/06/a07de5ff010730af3f91abaf1a2956b426ca3edf0ebf06361eb5a2db2872/stringzilla-5.1.2-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:817eb2eb25bbc74874b321c134e3644f9454cd904e90ebdb90b8aa0657eb04ef", size = 2527119, upload-time = "2026-08-12T02:03:06.315Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0d/4af571f1dc3f5ac099ab7d9193c88e8c48caca450b1be44085284b546d0d/stringzilla-5.1.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:090182f83408d2f69413acc92f334a43122b1a6a2496ffd4adf0c3a38fc5cf1f", size = 2700122, upload-time = "2026-08-12T02:03:07.763Z" },
+    { url = "https://files.pythonhosted.org/packages/18/b5/a6f131df123b71d5d764aeac3a85d6e8a440f83fbff0c1338917a6a48ee9/stringzilla-5.1.2-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7214b816455ff1b27d6ede65ed943cd9047c61a06c17c504066aa4de8683e9a9", size = 2537401, upload-time = "2026-08-12T02:03:08.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b2/673d24f8b7efc35944ccffea0dbb5ec514faecfde1cb8e51d8a19d09ac4a/stringzilla-5.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:108c1f8d8a8097abbebac845e41cf2efe02b091aed6d64f98bdf26545696a48b", size = 4318854, upload-time = "2026-08-12T02:03:10.249Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/7e/86b8f2c7fbb4ab095b1e4bca3f02653c84035795ed144a9006293518e0a2/stringzilla-5.1.2-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9aff41b060340980c637a4616bde9b8c4d6170ff7b9d7e04d7e99629de3a0a2f", size = 2521251, upload-time = "2026-08-12T02:03:11.763Z" },
+    { url = "https://files.pythonhosted.org/packages/79/8b/caeb362a3322bc22ce75ed340ea9f2ca61d494240a7d38ed5d57d5490e69/stringzilla-5.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6230823eca9386e022bf3421fbea0d9e9604c22e08295cc524e8902f23522be8", size = 3458426, upload-time = "2026-08-12T02:03:12.924Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/5a/ea49ce7978568892c018b942c35752cef07c07a858641552b00a6acc8382/stringzilla-5.1.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:71dc8e6b7c010687973e7067ff53af70eeb02ade35e433f23baa5d97eabcba6c", size = 2349395, upload-time = "2026-08-12T02:03:14.376Z" },
+    { url = "https://files.pythonhosted.org/packages/78/01/2beaafbdec769a22b9e70de4a37416960d0af87711d05f8b18a6916412ef/stringzilla-5.1.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:22f46fb49248504ec581100ba36059ef71c29aa2749dbf3223cca471698d92bc", size = 2685661, upload-time = "2026-08-12T02:03:15.613Z" },
+    { url = "https://files.pythonhosted.org/packages/39/87/dee46225fcf1129f8519595765e71ab27da2f50179df68fb9c4e11ba7f46/stringzilla-5.1.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:7c2cacc0743c2df30bee32eddd0fd34a229ea19c1585daa86f1252770598e777", size = 2352052, upload-time = "2026-08-12T02:03:17.097Z" },
+    { url = "https://files.pythonhosted.org/packages/84/cc/4e75ae16b743f056f915f81d6a7a5a6051d997832605369b4f790255521e/stringzilla-5.1.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2d9d6850ccf940ed1aa2c66921a6a87ff3e8aa2b270ef78b2a4f771d7c887f2b", size = 2523931, upload-time = "2026-08-12T02:03:18.344Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/28/a57466c586b8236a18213b7502fe69d3f8d468e55c9d42566d5ad2c46d93/stringzilla-5.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:215a474a31cbe3ca06183e0b7e34e7d8fd883b8c23d275ada3fadd866cfd5e9e", size = 4273391, upload-time = "2026-08-12T02:03:19.762Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0d/431102dc4cfd0f54b70968fbef1b1f9d9e262662cc42a6868928525ddd56/stringzilla-5.1.2-cp310-cp310-win32.whl", hash = "sha256:61500ad2d03c90586ac846733dd5fdcb515b8d1e465985d7bd569b18bb33c8e3", size = 309509, upload-time = "2026-08-12T02:03:21.144Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/8082a4c1df1eec94bf8ff93d46f7047b640d226cb97dd1ef93f82bf6da70/stringzilla-5.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:e3e09a14ea3928cee5d0d17ad041069013647a6cff8448cfdd9bbd02c3a9a16f", size = 868190, upload-time = "2026-08-12T02:03:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/fbdfb81167994c21dc4dca17879845fca305670052d04c6e8c83e7d6f31f/stringzilla-5.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7fc4c6b6f808a88e6335870fdaf06af838ac344b871ec6c7f08f6c717189ab03", size = 417165, upload-time = "2026-08-12T02:03:23.738Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d5/eadd09408fca36d338f5b12d6ce15b9dde5ff84b26cfc47671e3471d97a3/stringzilla-5.1.2-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:e30b0fb1dfdb0dc3c73dc97c5dee2da4604829d8bbea5dba6cb12608455c1800", size = 443072, upload-time = "2026-08-12T02:03:24.796Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7a/35a749b45d2df707d6de15557b513249245a83980dc9f8585eda977b06cd/stringzilla-5.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b331d7672bdd5b04507b26d1db41a7a30a11cecd68aef11d2e857c005b30313", size = 3495810, upload-time = "2026-08-12T02:03:26.043Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/93/16ccf77162c2ba95488725d13ddd1a240e69c2967eebc6584d4b3fa4c3c6/stringzilla-5.1.2-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:35a6587c92eeaf5d5a7ad9f8cd68e9f52803cb4223430deeea6997076c04ed41", size = 2544258, upload-time = "2026-08-12T02:03:27.491Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/90/e205630aa0085be7ffced2df89ec446c79ed18162a76cf314b3e635e965c/stringzilla-5.1.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:416a33d281718e8eb37812c30248c6588fb43ce289bccac9d02595f7892a9633", size = 2712356, upload-time = "2026-08-12T02:03:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b3/f5d23a2dcefb22d633edb502dce4ffe11f091b01ff445a674b7eb6c2d39f/stringzilla-5.1.2-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:222a8c10a2493da274e9d6965e534ac8710e0c06a4a73da28c2aa36eb851f23a", size = 2548163, upload-time = "2026-08-12T02:03:30.424Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2b/16b958e8126c5a2be5f22289e3d522549a5f6712da502801f59db923df9a/stringzilla-5.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d899138ac6a9c697cb7f85ca52ebdafc0b8f7ef0fe1cc37a671363d6b33d187", size = 4325423, upload-time = "2026-08-12T02:03:32.802Z" },
+    { url = "https://files.pythonhosted.org/packages/38/61/aecbf150acc4eb947f068d73ba95397e1f73198ec87268d8e82776d1c140/stringzilla-5.1.2-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1af05d3b6aa20bd426b9e502c11b2a215c9b0250f208196d19491c3fc6fd55ad", size = 2530546, upload-time = "2026-08-12T02:03:34.207Z" },
+    { url = "https://files.pythonhosted.org/packages/09/cf/0203004e0681b734dbe0f240e89bb94cc28252fb464896f35fa999ac4840/stringzilla-5.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d05410cc0b72068cc8728848734d280074c83b2883ce5393fbefa8258bb6feaa", size = 3469181, upload-time = "2026-08-12T02:03:35.582Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c6/f357e18d8352ef66c324aece08a287caff6a4bbaa32f45236f55b398434b/stringzilla-5.1.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:1ff72f209c39affe3972e709566f04731668bc11808988e8d8791f659d14d0f4", size = 2358076, upload-time = "2026-08-12T02:03:37.062Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/0f/f713005daa0af4421dc9ad4cd853d1df1b9a6c0b01616472f1791a579ff5/stringzilla-5.1.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0ea9da3de6f445ff387f2c730f8bef3fee585e699b5b36d2ead96a78fe4d0e71", size = 2699087, upload-time = "2026-08-12T02:03:38.609Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f9/f3f97b177dc724c977f0bb25ab3d6a7ea79adefff540465e2c6b0001b3e8/stringzilla-5.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7bb5ff95d6e6f8e338aeca6a80e8ee0cc3707acf38df2301f25fcec4ce1f081b", size = 2361822, upload-time = "2026-08-12T02:03:39.921Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/bc/063d2ec3150874b697699f7d1d4128c96ad7d0ecf818a8304ada4b5cde36/stringzilla-5.1.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:04e3252d08e60a45195703b94d6743a08badc22054ce4554a3a7e319841bc3e9", size = 2532561, upload-time = "2026-08-12T02:03:41.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/a5/f6a62657a87da8bda4463b9cfe80e0eefff27847d57384538ad8a43ff5d2/stringzilla-5.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:eb5f3e095adbbf494933a4a87c37b42167a47a034deeb9622496dbe1a673dbeb", size = 4283222, upload-time = "2026-08-12T02:03:43.061Z" },
+    { url = "https://files.pythonhosted.org/packages/09/4b/9e54fcea2548d404a4257c0e67c6494aaac86b5cf482867cc9cc87d3e132/stringzilla-5.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:e5970d7b80de57eda932d620f76b4a1f00d5a78f5eb1f9ffce562dd83a3cd847", size = 702065, upload-time = "2026-08-12T02:03:44.437Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/2c/9ede1448dbcf880ac11c3673178133e3277e0150b376a978443225d9e1c0/stringzilla-5.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a7b43fe12aa3d1f6101d341e3aabdb5167ea71fc5d88c888b508d2fb81cdc84", size = 417375, upload-time = "2026-08-12T02:03:45.648Z" },
+    { url = "https://files.pythonhosted.org/packages/22/06/54975859943bb28961915a7cc4231dfbe6656b50f49ed9621eee9648edb9/stringzilla-5.1.2-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:5b711f864aacc3aea3d53b72cc2e69159e5ac4ea5ee7ac24d717e365edee7604", size = 443650, upload-time = "2026-08-12T02:03:47.722Z" },
+    { url = "https://files.pythonhosted.org/packages/45/3e/7dcb168368bc2e53920478d3ba9e6e3663e2e538d3fe11ef1cc37859bb94/stringzilla-5.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87e9fe62c9b203e49922cab91389fe97d331083fb9ed7ca71180ba94179bcd0b", size = 3498963, upload-time = "2026-08-12T02:03:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e8/1fd99de75ac32fc8a4ca05b93757a1fcf6b8a0fcce3a8bbdbee12ee691e6/stringzilla-5.1.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3580c2fa1f176de38f68a251fab10adab0355d1d83565024361c7f877f912f8a", size = 2545094, upload-time = "2026-08-12T02:03:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e1/f279cc9f27e5ba329071c74fbd4aca02e7aeb6b9bf3ddb0eccfae5fc9675/stringzilla-5.1.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb8ec524d6c4a691851d77e691b0c254bbca63b4a64e54fe37451c15ba5bb55a", size = 2716685, upload-time = "2026-08-12T02:03:52.495Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/0f/39ec9b7014652ce66eda7f658aeba6b99cf648b5cfd42ca93f77bb7daa53/stringzilla-5.1.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b8292172ab9cac1ade26f9655a7bba64b173a9a56a6f268d2ba4614403bf19a1", size = 2553673, upload-time = "2026-08-12T02:03:54.07Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e8/5c880ffd8d4bb9df4cdf75ab8b44fc8f7011b6cb629b3e6242f3d5944b4f/stringzilla-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7780f3ac20a90b6a33a0719c2e2ce7506a09a3dabd3d4f1b7c3fdd7594df4b25", size = 4332482, upload-time = "2026-08-12T02:03:55.656Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/41/2ff5c6d42c1788e8a461e47bdfa4ae473b7ef4e3aee9be7c220d4e107207/stringzilla-5.1.2-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:04f40b43fde775f61bbd12dd6e2fcc19e60b4147f723a8718b83b4b78489be0a", size = 2533723, upload-time = "2026-08-12T02:03:57.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2f/6433a8705e04610440c9b5a8031b8a681358c8b2fa42605de4ad015509cb/stringzilla-5.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:40b4c8488cee4df637828e094e8c2e82905fc17002c87c33b122f61706a9496d", size = 3470914, upload-time = "2026-08-12T02:03:58.562Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ec/d96da6546428cbe5d30384e13d9edbbd8f7dfa5a34e263139ac176f54275/stringzilla-5.1.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:018dd044a9596be35bc667274317d900f278ff6800d59c3c15be9d80a00ca58e", size = 2363057, upload-time = "2026-08-12T02:03:59.99Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/59/5b9a5cd22cd5c504a200b3835c1820b955272931823bbbda5cb2d8dfed8a/stringzilla-5.1.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d7b1a40f7e82f97577bd79a86eaded1caa3431a09a6165b08b21c7186fec05a0", size = 2704042, upload-time = "2026-08-12T02:04:01.625Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/bc/1d82a71a6bfa9489864f376b9a54735c81335b6e6d82558df6741bc10cbf/stringzilla-5.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4ea6152e915a3a12b150bd7d972eeaf5b9e635de81f7cebdabcc53b3fdb2bdef", size = 2364754, upload-time = "2026-08-12T02:04:03.279Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/01/3b11f482f3c933d63a15761888739f38936d5537bb27d5be36a8ae0b3370/stringzilla-5.1.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:c5dc430efc0c7b66a1189ae029ee068cf75a6b097ce70b30e9579aa26cb10cd2", size = 2539186, upload-time = "2026-08-12T02:04:04.968Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a9/d59224b25e50bfbe5d0a3ede57391b785bc5ef7df586540a6e3ec6184a5d/stringzilla-5.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8969f4b27d461f12c94108adbcc3c20406daf17a3053fedd48acf0e353775c7", size = 4286063, upload-time = "2026-08-12T02:04:06.669Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/57/0cdf5c2f0930c6b263006327135e4165ae5f842899de9a7cbe75d3189bc3/stringzilla-5.1.2-cp312-cp312-win32.whl", hash = "sha256:125fcba11357de66c24228a9888530466214f1babe5141b57b53c9dbd027ffa8", size = 309798, upload-time = "2026-08-12T02:04:08.004Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a5/0d87bb0d286123c63be69de9226cd0c8f7b990f396d3a5d08aab0ac3d040/stringzilla-5.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:78ddfe6cbc1a6900a7d098739fb276a7956bb77341f3637e7aa55e4daaad4eb6", size = 868358, upload-time = "2026-08-12T02:04:09.523Z" },
+    { url = "https://files.pythonhosted.org/packages/56/01/8b0a64f0f8f5658837930b81dae65d549becf2a3356cf36c57aba4b4fad3/stringzilla-5.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:1819ad4cec1c9597ed7520e97f3a10f85d635fb510ebc56fd6410bf86de1f577", size = 702081, upload-time = "2026-08-12T02:04:11.02Z" },
+    { url = "https://files.pythonhosted.org/packages/39/09/c1ef92506fd1edd58fcca507070146d56bd950a1912d861558628fb03cef/stringzilla-5.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b4c9f1ecb87469da0d4ac9a99cf5af48b062fa4b5e52ef4af15e90fa47e24ba", size = 417386, upload-time = "2026-08-12T02:04:12.721Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/89/69666fca88fd0cc86e900ed903e3714be0a1f36092f6a424149a9636a995/stringzilla-5.1.2-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:2420e27441d2536fdd4099cae946f32a0a0df75bfba785d52adfd72804d221e9", size = 443659, upload-time = "2026-08-12T02:04:14.225Z" },
+    { url = "https://files.pythonhosted.org/packages/80/66/b62f24b45d48f7c50a1adc8c692183d36d03b7a73f1abab791066f7c8d44/stringzilla-5.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:988d1cdb3bb25ddb3b04438f69aa4210ccaa23454d99714cf60d0dc9578ffb48", size = 3499108, upload-time = "2026-08-12T02:04:15.58Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e8/8cec708ae9ad98af1fce96581f18bfbb401baf9f3d4df56fb892f39c7790/stringzilla-5.1.2-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:86ad149d5ebd71e2fc94ee7508f5d5555066eef56e9589973cab50abd873b33a", size = 2529155, upload-time = "2026-08-12T02:04:17.39Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4f/88cd5686e3e2804947b43d3bbcc3f8bea90bcb8ee02189e087a5b78a9460/stringzilla-5.1.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a76163e2efc65f890b0f2f7eee0e4b4285cb28d3ee140f72c40f297f7285344c", size = 2716921, upload-time = "2026-08-12T02:04:19.253Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/91d8360b074aa62053fed782e9c037148c57ffb7f88ae6a4f919e7c78700/stringzilla-5.1.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b7042bc73db929fd53826acb62d5049f5f3e9e860d87f5a6892acd0fef22258", size = 2553776, upload-time = "2026-08-12T02:04:20.688Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/5116d83b04fc4d243f578e31a3c9100c335d9e1976f000ffda58c0a7c46d/stringzilla-5.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a9b7ae9091bb5a54fbdd5ea4d484b544fec4c9d6405a5d68c2e578ecf15a47e", size = 4333103, upload-time = "2026-08-12T02:04:22.271Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9b/170036a7952fb2ee89b06aacff11d349c751abd475a1d42dc04ab7024297/stringzilla-5.1.2-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:50d307c5bec4fe6036c21d4a6c3a402805958220cf2f84fc0304317e373dfd26", size = 2533815, upload-time = "2026-08-12T02:04:23.915Z" },
+    { url = "https://files.pythonhosted.org/packages/02/27/e5a801e729444a66897d50ebf194facc95632fc143e8fe5be1f9a8c4d3ec/stringzilla-5.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ebe51031edae64827ac39b65aafff7ddbf46616b6aab647df086b7deec9a04e9", size = 3471298, upload-time = "2026-08-12T02:04:25.695Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c2/35ed56c67668601a4208300c7c6d30ffe3bace1eca0764aa01f71bb73499/stringzilla-5.1.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:185633f5f2c8c334d4d874cb1e8428ba9e65172894777b54e771da31ea636e0d", size = 2363211, upload-time = "2026-08-12T02:04:27.205Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/93/78db97ac13a2d369055236f8c0aa7c4b5cef44b16b8cdffd23a15529b5ef/stringzilla-5.1.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:431ba35e4bc4e76d306f6977b618a4acc4db09f5d16d66585a97735aa25bd105", size = 2704494, upload-time = "2026-08-12T02:04:28.807Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/c570432f829198e363914eb5d41c1ebcd49722fefe1aa66ca789c70cded2/stringzilla-5.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb64438e92f8878e0cf91a88ec804658c8cf30b95bfc2371cd361628b2365011", size = 2364989, upload-time = "2026-08-12T02:04:30.303Z" },
+    { url = "https://files.pythonhosted.org/packages/86/db/a38dbb9716f625e510a83a73c7d0b49bbc2c62a482c7c0db930d0ea71253/stringzilla-5.1.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:36616d20d4fc73ddb775405ef8caa18091d3df7e7becfe7feaecf56f60707e7c", size = 2539372, upload-time = "2026-08-12T02:04:32.017Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/85/fed6c6fd8eb8e9e98546ff02841c4400bb11a5c6fb7371b66b4f1decf0d2/stringzilla-5.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d12b95cc138b066812c38ac5c0ef4ea2cb5056ed5abc47a40ea49d1e54a4baee", size = 4285919, upload-time = "2026-08-12T02:04:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f6/cc6bdbdcc14998bdfc958f02f082f19cf224e42e5a538bdc5d2c8d37628b/stringzilla-5.1.2-cp313-cp313-win32.whl", hash = "sha256:686306a3ecce25e835337efce1495b66c0b33f9f590a92016f0a4e36fb344b19", size = 309801, upload-time = "2026-08-12T02:04:35.33Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/f256c3f26a494d77f4fa7f7edd3ef6a9d89fb13a5f774ad5c97e23eaaa30/stringzilla-5.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:45acf43fdba69b6eaeec567d87367ef7e0b65ee9ae01f2bba15064936e62725b", size = 868148, upload-time = "2026-08-12T02:04:36.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/b2/99c21e16091d14d0d5509b22af3bcfc1e19cdde0365da0371b2c73bc67b0/stringzilla-5.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:1ad6d13abab2b86de565b1c5ac2cd44bd3a1561c1217ea981b35f7067c4f3854", size = 702099, upload-time = "2026-08-12T02:04:38.09Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c2/c0930f69228a738c9992d6c30d8a69ce068d3a69a657ca2c7773ae16ae1b/stringzilla-5.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:65b179d7fe8bee6755d6716792854795ab864e0eba73c2ffacafbe8f5708fd0b", size = 417399, upload-time = "2026-08-12T02:04:39.432Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ce/f1ddd07ea455963715365fe3b0912772016c75bf6279bce63eae9b56e93e/stringzilla-5.1.2-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:1a83aa574a5be171a376dcaa3ffe57e983a8a1ec0ca2d95424d27e65a8784fdd", size = 443699, upload-time = "2026-08-12T02:04:40.907Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/43/3410ead66aa43bc1ea08b338d29c8260a8a592934d35ffc8829197ca9dbd/stringzilla-5.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82acb2f987ee6a31cc6c99abd34ba2bd42744151e3e145908f389d39ccdb61a1", size = 3499711, upload-time = "2026-08-12T02:04:42.281Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f4/884c1a82752da714bd80ddcf9365ec29add73d9cbf5904af1bd331479b8e/stringzilla-5.1.2-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2752accd6b871d55a9f488c83210cbbe04a24c772c49696d4357da311890b049", size = 2528818, upload-time = "2026-08-12T02:04:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/21/81/3b90435f265873416ed9c1e56b24cb860f063c0d78864926229295f409e9/stringzilla-5.1.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aa526909d4f2ee754b1d68bcbf2b9a7f36f99a3abce41eb2e357a9e2aaf0acd4", size = 2718436, upload-time = "2026-08-12T02:04:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/b8/75599a8588eb330cead98a64550c5381f06980a0969d1b5ac64b44eee0f5/stringzilla-5.1.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:304fb79faa74e5bf4468cfafb0dcdbbc9e1de47f44dfdf99e25683eb43189b6c", size = 2554773, upload-time = "2026-08-12T02:04:48.29Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ab/5d48e2ce894861ef0baadcaf10c7f063c22a8fee42a44226c2d47de3cc7a/stringzilla-5.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf66a8ad32adb1390f3a1a7f1af3b45db80b66f6c319a65e59cff3eacf5ebe43", size = 4333189, upload-time = "2026-08-12T02:04:49.941Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/18/fa004508aa59699def7568f43757abd96b5979c296d509576394f637037c/stringzilla-5.1.2-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:187d4fafddea97e769d1de1f8489f6b56761d0c0ff9e3fd285bf4893523af266", size = 2534578, upload-time = "2026-08-12T02:04:51.527Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5a/f992bfc2cb8f6ec03bd576db602152812362d50f4cbeb6b611d9edfff01d/stringzilla-5.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd3ef43fc6ba3c9e62a1161690b4747f449ae4e2bf6c0acfd1e83aeb7446fe13", size = 3471672, upload-time = "2026-08-12T02:04:53.192Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/62/a1cf9bff9c61023a285e074adfff635e95482a52d84ea622624c8c3f02dc/stringzilla-5.1.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0315b8f3673c2d9b08ef056be2649533ab073452c2a240e511ef23b9c39a391f", size = 2362229, upload-time = "2026-08-12T02:04:54.751Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/44/f68f2437cc06bb012ad9af552c9e78c01adca2a6aef2f4caaaca1f06420a/stringzilla-5.1.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb40e2fef1f87157d43047c434a38dc0c8935adee1218690cf40d1ac260d5361", size = 2706538, upload-time = "2026-08-12T02:04:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/82/49/ede4c255c36f60c5e6d87704d6cda10d26437f7ae0d8a43b305fedb8e4cf/stringzilla-5.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0a311ebc4cabd8919484572e1ee35d8458b1b16709163ce3b366eab0b32d13cf", size = 2366278, upload-time = "2026-08-12T02:04:57.942Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/394136a9f8856047e663ed028a15c4e10dbc46bec5d293358a7dfcc9417a/stringzilla-5.1.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:0907407165981c7fc025d75afdd26a808a9a66051298a9c3646a17b2179aabb4", size = 2539688, upload-time = "2026-08-12T02:04:59.542Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/aa/5d4adfdb42b254262e909e0eac2808722e0afe41c11371515ebd817b4de7/stringzilla-5.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:79ac9403b20e494d2f47dcd3464cad440b2c0272717e3b9494c6c742be2f7a46", size = 4285634, upload-time = "2026-08-12T02:05:01.16Z" },
+    { url = "https://files.pythonhosted.org/packages/61/59/c2e92cc84ebbd470f988a614db31071a258409a7ee726c43fa85effb3339/stringzilla-5.1.2-cp314-cp314-win32.whl", hash = "sha256:e5e8af9513e4e869f0d6b794a42b33d9aa1d18c8ec6b1da3aa8aa023ecc67cad", size = 320068, upload-time = "2026-08-12T02:05:02.817Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4a/78dac08e20ac3953821c1422fa4c0838193b9294d5947e7e54829e8079a2/stringzilla-5.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:b3e78c67a02b4393c291a41588bf35faccfd7f701feb68f54e01dd8e5689e278", size = 884748, upload-time = "2026-08-12T02:05:04.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/0d/0aeec0057f0496af51e4e25d55069f19d26f9c5df83e8bb3f48385f142ce/stringzilla-5.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:a0426edb553435507df45b6da45e0b96b4d94498c06a887ebcf6a45354a0839d", size = 720119, upload-time = "2026-08-12T02:05:05.719Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/0c1e9da63b9b3102206017099d46c8934fed955eb51c0b6095cbc9eefd40/stringzilla-5.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b04984fdaefb5a6a5fa881a7a2235960e9def097218602398840dd5a9b97400", size = 419689, upload-time = "2026-08-12T02:05:07.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/84/aa19eab99cafe4194166ce2c87a7ec406051dd0d58646a2d7cfd8b3ff07d/stringzilla-5.1.2-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:19707e152f0543be89908ac2c3b10d59ee84d3cd20a54ac8287aa4e841c65cd0", size = 445299, upload-time = "2026-08-12T02:05:08.775Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7f/55cc08004262482ca3346f4bd2645c61628e6dc1cf520eb233924aad0269/stringzilla-5.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07549270e6c550ce624e3f074434295d1d56408c6659c5b9c3c35542c43a9408", size = 3536939, upload-time = "2026-08-12T02:05:10.289Z" },
+    { url = "https://files.pythonhosted.org/packages/97/17/f51039a68d4264dc39d11aae591fdaaa2d2273eb3991f7e1d01ac84ab7d2/stringzilla-5.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9dfc8f731bdcc48a62e0c77c000c42181275a375d397ab7223be86d8b9eecd", size = 4366457, upload-time = "2026-08-12T02:05:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/22/48/cca29a9ee8c892a746e5c94b36224269fd318f4a387d09b9ea5fb7150cad/stringzilla-5.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e19b67b2effc72a81c64502cf62ea7e4028b4275116dfd10b30f952a419be53", size = 3507912, upload-time = "2026-08-12T02:05:13.915Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c5/5d7e3cebc7ee332a12b57d217076b268817ff10e599c8f6f423340503389/stringzilla-5.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ad88d1910a8e7a6d9a7f40c6cb5a7358cd35e6ccffbff2d30303f19f3b7ad16c", size = 4320285, upload-time = "2026-08-12T02:05:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/9b/be1d0894cd6c502e36e47462b0fae34381a3b8c8da646bdbc5d6e9e9e3ee/stringzilla-5.1.2-cp314-cp314t-win32.whl", hash = "sha256:806511b899fd71d0e11ab4faf5dd3d4d25b23bdd30c4fac301813a358aca8547", size = 322900, upload-time = "2026-08-12T02:05:17.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/c8a5ee87d192fdfbc6e8858182186fd7aca440862502abe9c9016937aa20/stringzilla-5.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:b1de5256a9b627b145a1501fae1ecc274dcea3f6c9b4e024c2648f4de38c656c", size = 887884, upload-time = "2026-08-12T02:05:19.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/60/55de977fca319f2ce687b00be4481f22bdf483333716c86dc08a9b4ff140/stringzilla-5.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f54e19e1a7aa86218d9cfcb67afe3a7c31b91a068b8a198ce1e40809c8bcb9ae", size = 721597, upload-time = "2026-08-12T02:05:21.014Z" },
 ]
 
 [[package]]
@@ -4437,7 +4235,8 @@ name = "tifffile"
 version = "2025.5.10"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
@@ -4452,7 +4251,8 @@ name = "tifffile"
 version = "2026.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
@@ -4468,7 +4268,8 @@ version = "2026.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
@@ -4544,87 +4345,83 @@ wheels = [
 [[package]]
 name = "torch"
 version = "2.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+]
 dependencies = [
-    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.15'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/e7/19894fdb51c7dbaf94f5a79bb0871da0992e8e4241e579cb006da46d2e58/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", size = 111178962, upload-time = "2026-07-08T16:05:49.855Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/5c/b1d5de470c54e339b30a92d96683a71bcebd78f5f2a7fc714cd6dc6bbd68/torch-2.13.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:0ab4b69f3ee03a62a002cfbf77b1ca5e88aceb4ea64cb4388bb28f638ddbb045", size = 427198333, upload-time = "2026-07-08T16:05:36.847Z" },
-    { url = "https://files.pythonhosted.org/packages/50/c0/68a84105e1fcb8970144b388ff3d3e5dc15a3be28c1e247841f7d7247e41/torch-2.13.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c78b7b4d04461855a764cf01bae9a462bb88bc93defcfa11235cbc8fdf3e12c4", size = 526555154, upload-time = "2026-07-08T16:05:06.507Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/c9/0bb9d097b03cbaf96bb75b15e867347b8e41bfcdfe0539452d17d9e63993/torch-2.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:2bd30b6b730d987fa386ce3898933762c5cb8cc82eb0535211d787cc3ce2dfeb", size = 122015602, upload-time = "2026-07-08T16:05:45.25Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/fe/cba54dc58523434919b66f13a667e36e436deddd77ca519e96553617d4ec/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", size = 111187938, upload-time = "2026-07-08T16:05:17.065Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/59/1e3160e18e12aa3038390efab3ce02b36a9d4d6a527ecdd8520dca2e68d8/torch-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:092790c696a760c729fd5722835f50b9d81fd7c8f141571f3f3cf4081a8f664c", size = 427199369, upload-time = "2026-07-08T16:04:51.054Z" },
-    { url = "https://files.pythonhosted.org/packages/01/79/1f2d34ad7034ee1c7ffc1cf8bf0f8213af2a81df6ecdb3997ecec107c09d/torch-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:60fcdcb2f3876e21146cb4524ef06397d727ca9ad5f020818547e25075fe3cb7", size = 526574961, upload-time = "2026-07-08T16:04:07.075Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/fd/0f2ce40f58aefbdb3392f9acce3c8171940943ae2d661f70558bfa73befb/torch-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0d8b11f16a48d60e2015d8213aa0390744cbebb98e58b62b3514dddc656e330", size = 122015870, upload-time = "2026-07-08T16:05:27.59Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
-    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
-    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
-    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
-    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
-    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
-    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", upload-time = "2026-07-08T12:26:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", upload-time = "2026-07-08T12:26:13Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", upload-time = "2026-07-08T12:26:18Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", upload-time = "2026-07-08T12:26:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", upload-time = "2026-07-08T12:26:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", upload-time = "2026-07-08T12:26:33Z" },
 ]
 
 [[package]]
-name = "torchvision"
-version = "0.28.0"
-source = { registry = "https://pypi.org/simple" }
+name = "torch"
+version = "2.13.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pillow" },
-    { name = "torch" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or sys_platform == 'darwin'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/df/1ba039ad6cfe6e69209c36766b9b6e8c6fe92481c6d4e4ca52296f5f699d/torchvision-0.28.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:2a1ef4b6f4bf5828b48cfad97372c8982db906830884b2868ba5c3df937a7d81", size = 1856019, upload-time = "2026-07-08T16:07:59.283Z" },
-    { url = "https://files.pythonhosted.org/packages/88/ea/5c70ecf86f8e95174a85061cea78683a7bb7f422f09c3f3d4f30b7600fa9/torchvision-0.28.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:546fd85345cf8652f6cd099d4f9884b0ca5c2f3fae78689a21dd2f35ea6b622f", size = 7838211, upload-time = "2026-07-08T16:07:27.023Z" },
-    { url = "https://files.pythonhosted.org/packages/46/22/2f7ff1997d793e45d85fafa8374ee25348b7dae9ac521ba8751d7e1c75d5/torchvision-0.28.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6dfb0f45e2b4ceb4e76f158c3fbb5f44387099f3c466e3423a09ab665a194aba", size = 7669419, upload-time = "2026-07-08T16:07:41.648Z" },
-    { url = "https://files.pythonhosted.org/packages/42/d0/2b3c30834ff23acd3854d0ff59bc580711f4b36d725de40105a852ed3719/torchvision-0.28.0-cp310-cp310-win_amd64.whl", hash = "sha256:7fad44dc9582570c7d92c4487d36ac46998f40cc39b438e8b8f5111a935ce4e8", size = 3500355, upload-time = "2026-07-08T16:07:56.865Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/b2/1e010052079e4c577007b789db336ea7075f1a426e84d17121fbc3745516/torchvision-0.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:83fe6c020866a85acd7d97deccc45ff11d66daf42916d04396a4309c66c0ccb8", size = 1856017, upload-time = "2026-07-08T16:07:55.533Z" },
-    { url = "https://files.pythonhosted.org/packages/27/be/1b9c5de9c655ca2df4a74100fa671a7b848532ff787e077ccde14a7dea2a/torchvision-0.28.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:5a38bc6da3d72621be003400b66f66a2b4c6d644fde05f680c2cb7ca8cf8dd6c", size = 7841822, upload-time = "2026-07-08T16:07:49.207Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/9b/f1e68e861d4462e3e195a642c2b448e7b7d3fad5f209487162b9a2133d9b/torchvision-0.28.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7e80f543b22503d9415e126db5f0ff3917036925e38560ee6b9ae38c571a4002", size = 7670718, upload-time = "2026-07-08T16:07:46.525Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/1494610ff54cbb154beb55033cc2cd50f3de04dac132fa2dd00e4f2b2556/torchvision-0.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:9a45ea67235d965ef52187130d20002a4de20c54ea3d927a24286961d268dc37", size = 3814319, upload-time = "2026-07-08T16:07:37.153Z" },
-    { url = "https://files.pythonhosted.org/packages/15/49/c1cab1ecbb3ff1a380a3f99283db1dee61b8afe354f6352c643b65937130/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", size = 1856020, upload-time = "2026-07-08T16:07:52.182Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/4c/95233776e2def960e5abb7a07931230a545f43717a56a1e1140162033598/torchvision-0.28.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5cf78ebc401ce64ae19b8c55de866bb836797d559a4de9c25ccbe74cfa642d3a", size = 7842127, upload-time = "2026-07-08T16:07:53.446Z" },
-    { url = "https://files.pythonhosted.org/packages/93/e4/e9b2495d0d57b9f60d63c57d0a910410a81b4b073bf70917bef815291119/torchvision-0.28.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:028a3d481b37d785605620d7cdad897064c5a55bae2aa1f2658766333e291940", size = 7675040, upload-time = "2026-07-08T16:07:58.017Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/9c/55ed9cb6dfe3ee9c837df5cd0e758372e5829aa38b8dd71343aa632cc4e2/torchvision-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:87dc16b2df427c1318ad335f1e2be2b3b15b2cf20f7934c83b0505a48425ee5d", size = 4085785, upload-time = "2026-07-08T16:07:50.928Z" },
-    { url = "https://files.pythonhosted.org/packages/20/55/08a726c14c67b37c8aca04b077766909f1c7ed23f76116884fe63b9bd033/torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d483b4aa3f5237569053f749cd1a2b5bb548ca456e40461a5dd087f21149d123", size = 1856021, upload-time = "2026-07-08T16:07:45.386Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8f/40beacd53809194f5259e590d1afaeaa8ad57da15f77c646e6560bcc4616/torchvision-0.28.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bb6dd6918460ed89cc7644adcc2402991474d6933cf1ce92b390641cb233fddf", size = 7797014, upload-time = "2026-07-08T16:07:43.04Z" },
-    { url = "https://files.pythonhosted.org/packages/32/db/062cdb5a84380a60439775311fff34d89229760d2a50680393dc18699956/torchvision-0.28.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad7b3a439265cc3739a4ab5b4c998c0e38ea99c0ee7ca4dea35c5d0b099ec237", size = 7674669, upload-time = "2026-07-08T16:07:38.91Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/a6/b4081e2d04e1541abf82785ac9e5178a494c19330391f551356c8c18b7b3/torchvision-0.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:7e9dd6f60d6e15f8dc27d4f877fdb6002fc70d70272412135f1c2ff9cfa08d3b", size = 4157380, upload-time = "2026-07-08T16:07:40.22Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b9/da40eca5bbe9596c12ae9899ab7abaf887f5e20f29d08b924b4633714821/torchvision-0.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3bd9dba55224a9db4a2d77f6feaa5651770d8c8e86d3d0ddb0fa6bec54c8712b", size = 1856014, upload-time = "2026-07-08T16:07:44.282Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d6/313aafd3df4eaf5f330211bd4e75b7598bddbfee4f55580d3b58536e1b20/torchvision-0.28.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:89f90e29b0966352811b12589f3a3c61943bf2bb9487b9d7bbec10efb1096bb5", size = 7796873, upload-time = "2026-07-08T16:07:30.907Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/41/31f8e959ab8f942600b6357f8999c21d779d5fd3304b0fd204ff4b518239/torchvision-0.28.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:36beb0782976906069ca03d4c9aacaf4b6b838b06ed6c20960ea9c51cce7acdd", size = 7674634, upload-time = "2026-07-08T16:07:29.657Z" },
-    { url = "https://files.pythonhosted.org/packages/15/15/4c5115253fd470672cdac0a1cf139e06b4f3e29d041238a2b255937f63be/torchvision-0.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:3557cc7b539f46dabcda2b6f2b14017ccbeef024de466d4fc5835fc3f287f769", size = 4184005, upload-time = "2026-07-08T16:07:35.805Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/80/822a6163da716f8a78141cf6678d74e26a572285d4ea866ef8aa657bb307/torchvision-0.28.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:09ce8f56e81f19b9c378ae7bb109f83f6659fd8bc3cd14241a48e4af46e9ed49", size = 1856011, upload-time = "2026-07-08T16:07:33.404Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d1/cd3f9463b39a790ec8c0c2f6e6c8061edb1562114d04fcdfa786ed889345/torchvision-0.28.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:62c7d110f86a039245b587e4fae60278c649f3bd42ff79cfbc1178eca4e72542", size = 7796742, upload-time = "2026-07-08T16:07:28.339Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/82/3e0a7ad18e99831e2d7f4713d3be717b7159ff5a920862dd5c23c454aa71/torchvision-0.28.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:904cf89af220f8c6b2ed0296bb5065b474ce43b77558e48b2bf9de8b0ba17204", size = 7675526, upload-time = "2026-07-08T16:07:34.572Z" },
-    { url = "https://files.pythonhosted.org/packages/18/d4/23aea03b28297bc66a4461f55ae4296368a9d85fa9a454bafcb2a5348bd7/torchvision-0.28.0-cp314-cp314t-win_amd64.whl", hash = "sha256:46f581979c010ad6da6bd85ee602aa707e1ff44312670223b7a0ee517ad06d47", size = 4291452, upload-time = "2026-07-08T16:07:32.236Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-linux_s390x.whl", hash = "sha256:0555fde6108ca90247ae33d4e1237cbae475c86a223bb2f0f91d9addf1f611bd", upload-time = "2026-07-08T19:27:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f028e428bddee95cdb86e2470254e95c9af629362488550c200ed4793125a817", upload-time = "2026-07-08T19:27:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f5cbb61180a9793d9e12fe115a2310d2600bd449dfb9a01ec5640e21359fa5ea", upload-time = "2026-07-08T19:27:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:3bbb357161e8db43ba7cdcc7e03561eba0c449392f2f27d3566887198fcb4ead", upload-time = "2026-07-08T19:27:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:6e9817dbdf5ea76789babd46e457eac5bf14ff566cf85f8addbfdff2d56601ce", upload-time = "2026-07-08T19:27:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:84453b69508ec79902f899c5ed9495acb9e2bbe9fda5f1d5d6f19e3c3842e1a7", upload-time = "2026-07-08T19:28:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6746dbcbeb526eb61330b76b41ff1b4eb848951103a892eeb080dfa2b264667b", upload-time = "2026-07-08T19:28:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:10717d8b3b67c45a4788bf7ffc0bab1ea1e5ebbedd24466be6100102d141fac1", upload-time = "2026-07-08T19:28:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:2b3d093abd919ad934c43d47e73ba63ceba7cbd7269fc2e9c1e4fc29e8fe45fa", upload-time = "2026-07-08T19:28:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f307c2c32d764ffc6ff6893b801fad6d4752f3e67966cb8abf1843427c02604", upload-time = "2026-07-08T19:28:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ca4a9394b0c771238a4f73590fdbbc4debad85ed0fa63d026ae1b085da7d6e2", upload-time = "2026-07-08T19:29:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a8b450c1e58e5800e5b4691dac412f8d2d65a1dc3298166f91596603a3531e6f", upload-time = "2026-07-08T19:29:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:fa0762705b933624d59f6823db9ce7ec2e35b3e1e9c319c9db51fbeecfc3e319", upload-time = "2026-07-08T19:29:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:966d020354f465672dc7dd10d3a5c6cd17d7eb48620aa1d265b48a1f78f06898", upload-time = "2026-07-08T19:29:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0b8f7d0423027ae8b90c7977c627f3379f325363a08224dffad9b4b2d684a83d", upload-time = "2026-07-08T19:29:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3fbf9c9d1f3c10c2d59d04aca426dee9ccc6ceb32d255c61e93acc3b4f75fae6", upload-time = "2026-07-08T19:29:54Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:a17ff48608634db245e17e8bb00a9558554a49aeb1e4f5fe6cd039af2a10515b", upload-time = "2026-07-08T19:30:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:ac7aaf322be4777765a53bed7264a214dd81b3a1d276b93150515a3c5f75e4b0", upload-time = "2026-07-08T19:30:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:dec241fef3984c0d1edadd1f58708e218d4eae881ceef7bc10cf9964d41b68b9", upload-time = "2026-07-08T19:30:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ca021f9eb2f8345c83fa03e3a04587308afb8df71bd472670b3ece00df58621c", upload-time = "2026-07-08T19:30:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d20fa53ee744502fa4c69818a720b05ca0d37abd055d4f6e66cae155114bc691", upload-time = "2026-07-08T19:30:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:e2e5134decf00e218da62318f3dc5df156231d367871918e91eba95ab0ad43ab", upload-time = "2026-07-08T19:30:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:991cc14b39e751122c01f017be6448533989868731cb5eecd1006893d26787c2", upload-time = "2026-07-08T19:31:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7b8d26e29bceafbdaa8d63bfe7612f23875b5af2cc07e13f809c3ed890bbe1d8", upload-time = "2026-07-08T19:31:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b222c15a0fc2ce207d1c1a59700b46c8fa6748df1f447ad11e5c870dde0933d9", upload-time = "2026-07-08T19:31:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:a43376bd094124ef626bfdd3d4c2c62eacb0b5ddc99776f4a32d4fd16f1f3420", upload-time = "2026-07-08T19:31:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5002ca81af00ae69b57540f615b58b8ae922b6d4848176b366a52bd2196e6", upload-time = "2026-07-08T19:32:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:1a3a35229fdc13446b4eab50e7fcf9399ff941e89a3b761497786297a5d8dde5", upload-time = "2026-07-08T19:32:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:8e109528e6bab044815daebaf71770fbaace3a66ef1c816cb55c875350f78a60", upload-time = "2026-07-08T19:32:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:222a6681467cc7f6f05cd3068dfbc603def3a1e46d1d4620c1c8cdf6178bd563", upload-time = "2026-07-08T19:32:44Z" },
 ]
 
 [[package]]
@@ -4637,25 +4434,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
-]
-
-[[package]]
-name = "triton"
-version = "3.7.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/ea/629cc37436ca5df93ce98956d09cd2ca1498bfee8ef4972d2fe48b9f958c/triton-3.7.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3daf64305d6cea88d3334c65ebc9bcd0c64c9564a977084366aa768d57cbcf64", size = 184551013, upload-time = "2026-06-17T20:03:37.551Z" },
-    { url = "https://files.pythonhosted.org/packages/15/76/c79c34311625227a288df3e483fc5cdf3d596624cbd4b4758c4cbdc14af3/triton-3.7.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee89fbf782ec2ad50391dd1cf26cbea4f4467154c37f4773026da8fc31c0f58e", size = 197596267, upload-time = "2026-06-17T19:53:06.898Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
-    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
-    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
-    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
-    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
 ]
 
 [[package]]
@@ -4680,20 +4458,20 @@ wheels = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260518"
+version = "6.0.12.20260724"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]
 name = "types-setuptools"
-version = "83.0.0.20260706"
+version = "84.0.0.20260812"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/1d/161cde2b9d56177d04207a67cfdcebaabc881ac9b8f98ef8ca972c630c96/types_setuptools-83.0.0.20260706.tar.gz", hash = "sha256:9e586ac6c1eb504d28b5f06aced1d705e0043839413219ee3c08d16625fbb4ff", size = 45290, upload-time = "2026-07-06T06:16:08.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/cd/3b2a3362a526f91c33f785a291462b2ec448ae531101c62372fc30a21f53/types_setuptools-84.0.0.20260812.tar.gz", hash = "sha256:09bedc248ebbb7a232c9419dfcdca329706e61bf2aa5743e9424d027f1d956b4", size = 46545, upload-time = "2026-08-12T03:52:42.316Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/b0/e070aeec63dc76489261282392c6a3422ed914848365fb9f8481894da520/types_setuptools-83.0.0.20260706-py3-none-any.whl", hash = "sha256:42e5bba1bb7c1dc30c1ef3092f0c224dededbf3ae7db525a854bd1a9c6407241", size = 68747, upload-time = "2026-07-06T06:16:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e5/3a41cab4066465593facd660b2683c017f3d88d3297cdd26db0677b8e479/types_setuptools-84.0.0.20260812-py3-none-any.whl", hash = "sha256:799c08e4bc6a288e8a0b538afb5f5ff320a08927ba8dbedb30c74ee3ba5d867b", size = 70320, upload-time = "2026-08-12T03:52:41.154Z" },
 ]
 
 [[package]]
@@ -4780,18 +4558,18 @@ wheels = [
 
 [[package]]
 name = "zizmor"
-version = "1.27.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/a8/1c0c6619e213e6e1fd8323f09661542197448db2984649d2c34097997859/zizmor-1.27.0.tar.gz", hash = "sha256:ffaf8e1bb39447e643592d669761bfbc2aa636875db9079614f6a6c81cec60c8", size = 548896, upload-time = "2026-07-14T08:16:49.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/f8/f4e3fc0b316d5241b6d6968e8fb702e28446bc7d3c1e2b229f4caa6eacf2/zizmor-1.29.0.tar.gz", hash = "sha256:60e34e83c67064e0036989c7c525d13413e897aa4c4f683f1efb2048cdb28a47", size = 571865, upload-time = "2026-08-01T21:09:19.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/81/ba3dbd48a5e3d56d8a9693ba3dac9484df1b3f83862a453ade9f70ef21ff/zizmor-1.27.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0de272b6c19910f5bc6965ac7d4566af26db31571e983e3b567298389d0c84c7", size = 9090700, upload-time = "2026-07-14T08:16:31.04Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/18/960f032faa67427afb8b3e11877b7e911d1ccff3f3bb8bec0c416d4df42c/zizmor-1.27.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cc94158472428e04298b879ef36cb94360b753ece38fa2303464dd7dae07bc68", size = 8673964, upload-time = "2026-07-14T08:16:33.038Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/2a/034e4d11d1ed81e23fc9e526391616848467f0db6faeaa9e1b88fb8560ec/zizmor-1.27.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:b70697ebe555a28fbd3deaa259936f059f64b9f8531020f5b1f3d99087d4f62a", size = 8777649, upload-time = "2026-07-14T08:16:34.831Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/27/8dce2cd076ee0c39b0d9ac129703400c9c1c21c71f1709da660e3769d628/zizmor-1.27.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:0bba3eff43f919b04b9b6365b4ef17437649e11eafb73f603407873b65ad01dd", size = 8367119, upload-time = "2026-07-14T08:16:36.859Z" },
-    { url = "https://files.pythonhosted.org/packages/21/64/4e21d26a2fc910594aaab19367ac25467a4da6438b7c381f67e90c38945e/zizmor-1.27.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:afb28123882d2b8248f1e480bf6cc6d1af102e0d3fbe22a40f7f795b1aa9d435", size = 9163603, upload-time = "2026-07-14T08:16:38.591Z" },
-    { url = "https://files.pythonhosted.org/packages/92/04/17ffd2884f8d74ce747c6ffe11481de5effb35079fd00a0725fab336e57d/zizmor-1.27.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e1042dd14fb4597a1e3007c7ef3f5a017305ca50cfacf43d603f3ae870c65eb1", size = 8807297, upload-time = "2026-07-14T08:16:40.804Z" },
-    { url = "https://files.pythonhosted.org/packages/60/af/3a347da3007655c7979b4b99d6a4d309ebc344715daa7c1357f17d00d680/zizmor-1.27.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:138e65d560e3875dbbbec50eae56a9e14707f8f4e006112174e4752155c01db9", size = 8333630, upload-time = "2026-07-14T08:16:42.814Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/37/921c74ed022fe8e1f599d7e7353cab63d550dda68e410096ed735b7388db/zizmor-1.27.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:90004342c3c5122d7e4e8e27ac6d3c462b878da0ea3d408ff45fa7d768139a76", size = 9253035, upload-time = "2026-07-14T08:16:44.354Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/01/9cdb03c6c2341cf273c9c34506e5193cea7e73dc50b49ccf5f93a3579bdb/zizmor-1.27.0-py3-none-win32.whl", hash = "sha256:fe8947f635c925b83ef83fcd66de5f89a012b22784bb86fcd7e2a1f4e7648c9d", size = 7538509, upload-time = "2026-07-14T08:16:46.253Z" },
-    { url = "https://files.pythonhosted.org/packages/43/42/b924e569218646684d1e211f299282c0b9a0780d6b15f9e10e4a3fdaac11/zizmor-1.27.0-py3-none-win_amd64.whl", hash = "sha256:debc723721172c170d5922171a40eaebf5787a02ff3e69d30597dafdb66a21ba", size = 8643618, upload-time = "2026-07-14T08:16:47.835Z" },
+    { url = "https://files.pythonhosted.org/packages/23/97/667ef4db0ca9225ee402c1b947b5b6f17fd234d72c15a71db150b7695c62/zizmor-1.29.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ea72f84d610643d57f96430c655a3780d0b874e477d32e14eae8e910f6cce1fd", size = 9037504, upload-time = "2026-08-01T21:08:56.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d4/9fc7deaf75778e7516fa1d6c836377c3cb5d203dedc28899946b6f11ecdb/zizmor-1.29.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5aafe617d7b1e0c0c15d58fdf20495f360f74a791dfa136f76630b4cc06c2a34", size = 8654426, upload-time = "2026-08-01T21:08:59.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/6db714fb0aa08aeec62eb9d6ad6a443a1f4ed50d4c0b789944ae55fb83e4/zizmor-1.29.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:67644ae8d6d0394204b9a488f7d86f0dd66fe562f4ba85fc53e6105a6bfc7b6a", size = 8918927, upload-time = "2026-08-01T21:09:01.46Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/a12edc0c0c0a0101c54dbb9099ff08f8de2fcb35c36cb706db3deb2c2728/zizmor-1.29.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:81e4093fed5c8a41d6ae7bb773085a9d2e6c0b0a0b560d46a9c76d69be0a07ed", size = 8500655, upload-time = "2026-08-01T21:09:03.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f0/dfa67018b76bc4f2f50e265e8cbd1293833d1b1de5f3f02fbbb7487ae9c6/zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:587b99c2e1b34575c6c8565c2bfde415ca8bc0310f5589f19bc948c8dea10a20", size = 9351035, upload-time = "2026-08-01T21:09:06.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1b/93cdd5a06984b394d90001f9778008a21689052904109080a09952626c99/zizmor-1.29.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:061600f23c46f2e400bcdef666c236de7e5c0b07dd6ca046daa001eb1514b909", size = 8941717, upload-time = "2026-08-01T21:09:08.861Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f4/8d9e54405b477bc8e4b56c1a60123fca26c109ea6a762eea104fab32555e/zizmor-1.29.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:332546480be38aca95c149f835e0dcb7679ab5d74618a90c6ccb3fa6b8c7b99d", size = 8468289, upload-time = "2026-08-01T21:09:11.096Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/06d57ca830cc4653369c5aca22cccbf04c8c36ee84a67f351214e556bad8/zizmor-1.29.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a7462b9ab45d72a20ad5ab8193b430df8184c59e2bf46954ddd09496f2f00b45", size = 9446505, upload-time = "2026-08-01T21:09:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/253d9a3538e0ea6f96a3bcd69839c0c5a816a00299620b58a10b5bd1df59/zizmor-1.29.0-py3-none-win32.whl", hash = "sha256:8c759e68cd866375030ca39e19e2de47a056b7be7288c1620e2d5b4c274f631f", size = 7655723, upload-time = "2026-08-01T21:09:15.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2d/7919bc23475273ed8038a031fc24bc3f2005c78e608ce8df96746ef0fb98/zizmor-1.29.0-py3-none-win_amd64.whl", hash = "sha256:0fb85948ba5ffc7a8116eee36fe9cfc10167225c97bd2810e3378e66a9fd27c4", size = 8785519, upload-time = "2026-08-01T21:09:17.513Z" },
 ]


### PR DESCRIPTION
## What changed

- Removes Torch and TorchVision from the published base dependency set. Importing `albumentations` still requires the Torch build selected by the user; a missing Torch installation now gives a direct installation command.
- Routes the dedicated CI and benchmark dependency groups through the PyTorch CPU index, so ordinary CI and documentation/package-only installs do not resolve Torch or CUDA packages.
- Raises Albucore to `0.2.13` and NumKong to `>=7.8.0`; conda metadata and lower-bound CI are aligned.
- Removes the local `apply_multichannel_lut` helper. Equalize and AutoContrast build the final `(256, 1, C)` LUT directly and delegate application to `albucore.apply_uint8_lut`; ToneCurve uses the native `(256, C)` result with a zero-copy axis insertion.
- Updates the dev lock group and declared floors: pre-commit 4.6.2, Ruff 0.16.2, Pyrefly 1.2.0, Zizmor 1.29.0, and related tooling.

## Why

Installing the package for documentation, website builds, or non-runtime checks must not force a Torch/CUDA resolver decision. Users select the CPU, CUDA, or MPS Torch distribution appropriate to their environment; CI intentionally uses only CPU Torch where it is required.

## Validation

- `pre-commit autoupdate` (all configured external hook revisions already current)
- `uv run pytest -q -n auto -m "not slow"` — 13,363 passed, 43 skipped, 9 xfailed, 3 xpassed
- `uv run python tools/quality_gate.py fast`
- `uv run python -m tools.ci_matrix check` and `uv run python -m tools.ci_shard check`
- `uv run pytest -q tests/test_ci_plan.py tests/test_ci_gate.py tests/test_ci_shard.py tests/test_pr_workflow.py` — 57 passed
- `uv run zizmor --format=plain --min-severity=medium --min-confidence=medium .github` — no findings
- Built fresh wheel/sdist; `verify_legal_integrity.py --artifacts` and `twine check` passed.

## LUT benchmark

Exact old/new output equality was checked for direct and Compose routes across uint8 256, 512, and 1024 pixels with C=1/3/5. The direct and Compose matrices stayed within the 5% regression threshold; the change removes temporary `np.stack`/transpose/contiguous-copy allocations.

## Summary by Sourcery

Make PyTorch a soft-required runtime dependency while keeping it out of the base install, and align CI, packaging, and documentation with the new Torch and LUT handling contracts.

New Features:
- Add explicit runtime checks that OpenCV and PyTorch are installed, with a guided PyTorch installation message when missing.
- Document that users must install a CPU, CUDA, or MPS PyTorch build separately and provide concrete installation commands and guidance.
- Introduce tests that enforce the optional/Torch import contracts and five-dimensional input rejection for selected color operations.

Bug Fixes:
- Ensure multichannel equalize, autocontrast, and tone-curve operations preserve the channel dimension and behave consistently across shapes.
- Tighten color functional APIs to reject unsupported five-dimensional inputs instead of silently reshaping them.

Enhancements:
- Replace the local multichannel LUT helper with direct use of albucore.apply_uint8_lut to avoid extra allocations and simplify LUT handling.
- Constrain linear RGB transforms and grayscale conversions to 3D/4D layouts, with clearer error messages for unsupported shapes.
- Raise Albucore and NumKong minimum versions and refresh several tooling floors (pre-commit, Ruff, Pyrefly, Zizmor, types stubs, and related libs).

Build:
- Update pyproject and conda metadata to drop Torch from base dependencies, bump Albucore and NumKong floors, and ensure Torch is only a test dependency in Conda.
- Configure uv to route Torch installation through the explicit pytorch-cpu index and add checks that CI dependency groups only install Torch where expected.

CI:
- Adjust CI dependency groups so only PyTorch and benchmark profiles install Torch, and add a validator enforcing Torch/TorchVision placement and the pytorch-cpu index routing.
- Simplify PyTorch jobs to rely on the ci-pytorch dependency group and verify CPU-only Torch profiles instead of manually installing Torch/TorchVision.
- Extend smoke tests to confirm base wheels do not install Torch, that importing without Torch fails with the documented guidance, and that adding Torch via the CPU index restores imports.
- Update PR workflow tests and policy docs to reflect the new CPU-only Torch profile and separation of Torch from general compatibility jobs.

Documentation:
- Revise README and maintenance/design docs to describe Torch as a soft-required runtime dependency, explain installation flows, and clarify CI/support expectations around Torch builds and extras.

Tests:
- Remove torchvision-based color parity tests and add new tests for channel-dimension preservation, five-dimensional input rejection, and the optional Torch import behavior.
- Update CI matrix, PR workflow, and optional extras smoke tests to align with the new Torch handling and dependency floors.