### PR TITLE
chore(release): bump version to 2.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.4.0"
+version = "2.4.1"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## What changed

Bumps AlbumentationsX from `2.4.0` to `2.4.1` and updates the editable-package entry in `uv.lock`.

## Why

The preceding Torch-installation contract change is now ready to be released: base installation no longer selects a Torch distribution, while applications choose their own CPU, CUDA, or MPS runtime before importing AlbumentationsX.

## Validation

- `uv lock --check`
- `uv run python tools/quality_gate.py fast`
- `uv run pytest` (13,460 collected)
- `pre-commit run --all-files`
- `uv build`
- `uv run twine check dist/*`
- `uv run python tools/verify_legal_integrity.py --artifacts dist/*`

## Summary by Sourcery

Bump AlbumentationsX package version to 2.4.1 and refresh the corresponding editable-package entry in the lockfile for release.

Build:
- Update project version metadata to 2.4.1 in pyproject configuration.

Chores:
- Regenerate or adjust uv.lock to align with the new AlbumentationsX release version.