### PR TITLE
ci: minimize version-only release checks

### DIFF
--- a/.codex/skills/validate-and-fix/SKILL.md
+++ b/.codex/skills/validate-and-fix/SKILL.md
@@ -5,17 +5,30 @@ description: After completing code changes, runs tests and pre-commit, then iter
 
 # Validate and Fix
 
+## Necessity Rule
+
+Every code path, test, and CI job must justify itself with a specific decision it protects and a failure it can expose.
+Do not add or run work because an adjacent file changed, because a broad command is convenient, or because a check ran in a
+previous pull request. Remove duplicate coverage instead of accumulating it.
+
+For validation, state the changed contract and select the smallest command set that can falsify it. Add a broader suite only
+when the changed contract can affect its route. A version-only release uses the release preflight; a dependency or packaging
+change beyond the version uses the corresponding dependency, artifact, and install checks.
+
 ## Workflow
 
-1. **Run tests**: `uv run pytest -m "not slow"`
-2. **Run the canonical quality gate**: `uv run python -m tools.quality_gate fast`
-3. **Run pre-commit**: `pre-commit run --all-files`
-4. **If any command fails**: Fix the issues, then repeat from step 1. Do not stop until all pass.
+1. **Name the decision and failure mode**: identify the changed contract and the smallest test, check, or artifact that can
+   reject it.
+2. **Run that focused validation**: use the matching test or quality-gate subcommand.
+3. **Add only required adjacent checks**: code that can affect multiple routes, a workflow/router change, or a release protocol
+   may require a broader command. Record why.
+4. **If a selected command fails**: fix the issue, then repeat that command. Do not expand the validation scope unless the
+   failure proves that the initial scope was incomplete.
 
 ## Rules
 
 - Iterate until clean. Do not report errors and stop—fix them.
-- Exclude slow tests during iteration; run full suite once at the end if desired: `uv run pytest`
+- Do not run the full suite merely by habit. Run it when the changed contract, release protocol, or a focused failure requires it.
 - For CI, workflow, support-policy, or dependency-profile changes, also run:
   - `uv run python -m tools.ci_matrix check`
   - `uv run python -m tools.ci_shard check`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,6 +59,8 @@ jobs:
           git diff --name-only -z "${BASE_SHA}" "${HEAD_SHA}" -- > ci-plan/changed-files.z
           git show "${BASE_SHA}:pyproject.toml" > ci-plan/base-pyproject.toml
           cp pyproject.toml ci-plan/head-pyproject.toml
+          git show "${BASE_SHA}:uv.lock" > ci-plan/base-uv.lock
+          cp uv.lock ci-plan/head-uv.lock
 
       - name: Select pull-request checks
         id: plan
@@ -70,6 +72,8 @@ jobs:
           --paths-file ci-plan/changed-files.z --null
           --base-pyproject ci-plan/base-pyproject.toml
           --head-pyproject ci-plan/head-pyproject.toml
+          --base-lock ci-plan/base-uv.lock
+          --head-lock ci-plan/head-uv.lock
           --draft "${DRAFT}" --force-full "${FORCE_FULL}"
           --github-output "${GITHUB_OUTPUT}"
           --summary "${GITHUB_STEP_SUMMARY}"

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -3,7 +3,8 @@
 AlbumentationsX pull-request CI optimizes for merge-ready wall time while
 preserving the supported compatibility guarantee. The workflow always starts,
 classifies the changed paths, and runs only the checks that can produce useful
-signal for those paths. Unknown paths fail closed to the complete profile.
+signal for those paths. Every selected job must name a concrete failure it can
+expose. Unknown paths fail closed to the complete profile.
 
 The implementation lives in `.github/workflows/pr.yml`. Routing is owned by
 `tools/ci_plan.py`; stable gate aggregation is owned by `tools/ci_gate.py`.
@@ -49,6 +50,7 @@ relevant checks. These are the normal profiles:
 | PyTorch source or tests | Dedicated CPU-only PyTorch job plus relevant base checks | CUDA or MPS Torch installation in CI |
 | Dependency metadata or lockfile | Primary suite, PyTorch, dependency audit, legal/package checks, clean install matrix | ASV timing comparison |
 | Packaging or legal inputs | Source legal verification, wheel/sdist verification, metadata check, clean installs when relevant | product compatibility matrix |
+| Version-only release (`pyproject.toml` and `uv.lock`) | Release preflight | Ruff, mypy, Pyrefly, contracts, product tests, standalone audit, package, legal, and install jobs |
 | `.github/**` | Repository contracts and `zizmor` | product pytest unless the PR workflow/router itself changed |
 | Benchmark source or tooling | Benchmark contracts and advisory ASV evidence | product pytest |
 | Unknown path | Complete conservative profile | Nothing |
@@ -143,10 +145,13 @@ leaf globally required.
 
 The pull-request workflow routes dependency audit, workflow audit, source legal
 verification, artifact verification, and clean install smoke tests by path.
-Any valid `project.version` increase also selects the complete profile and the
-release preflight that creates the final publishable bundle. The later
-`release: published` workflow only verifies and delivers that bundle; it does
-not repeat the release checks.
+A version-only release changes exactly `[project].version` and the matching
+editable-package version in `uv.lock`; the router compares the base and head
+metadata to prove that condition. It selects only release preflight, which
+creates and verifies the publishable bundle. A version bump that also changes
+metadata or locked dependencies selects the complete profile. The later
+`release: published` workflow verifies and delivers that bundle without
+repeating the release checks.
 The scheduled Security workflow still runs dependency audit, `zizmor`, and
 OpenSSF Scorecard evidence independently of pull-request routing.
 

--- a/tests/test_ci_plan.py
+++ b/tests/test_ci_plan.py
@@ -190,6 +190,60 @@ def test_version_increase_selects_complete_release_preflight() -> None:
     assert "release-preflight" in plan.gates["policy"]
 
 
+@pytest.mark.parametrize(
+    ("head_dependency", "version_only"),
+    [("numpy>=2", True), ("numpy>=3", False)],
+)
+def test_version_bump_selects_minimal_release_only_when_metadata_is_unchanged(
+    tmp_path: Path,
+    head_dependency: str,
+    *,
+    version_only: bool,
+) -> None:
+    base_pyproject = tmp_path / "base-pyproject.toml"
+    base_pyproject.write_text(
+        '[project]\nname = "albumentationsx"\nversion = "2.3.2"\ndependencies = ["numpy>=2"]\n',
+        encoding="utf-8",
+    )
+    head_pyproject = tmp_path / "head-pyproject.toml"
+    head_pyproject.write_text(
+        f'[project]\nname = "albumentationsx"\nversion = "2.3.3"\ndependencies = ["{head_dependency}"]\n',
+        encoding="utf-8",
+    )
+    base_lock = tmp_path / "base-uv.lock"
+    base_lock.write_text(
+        'version = 1\n[[package]]\nname = "albumentationsx"\nversion = "2.3.2"\nsource = { editable = "." }\n',
+        encoding="utf-8",
+    )
+    head_lock = tmp_path / "head-uv.lock"
+    head_lock.write_text(
+        'version = 1\n[[package]]\nname = "albumentationsx"\nversion = "2.3.3"\nsource = { editable = "." }\n',
+        encoding="utf-8",
+    )
+
+    plan = build_plan(
+        ["pyproject.toml", "uv.lock"],
+        base_version="2.3.2",
+        head_version="2.3.3",
+        base_pyproject=base_pyproject,
+        head_pyproject=head_pyproject,
+        base_lock=base_lock,
+        head_lock=head_lock,
+    )
+
+    if version_only:
+        assert {name for name, selected in plan.checks.items() if selected} == {"release_preflight"}
+        assert plan.gates["fast"] == ()
+        assert plan.gates["correctness"] == ()
+        assert plan.gates["policy"] == ("release-preflight",)
+    else:
+        assert plan.checks["compatibility"]
+        assert plan.checks["mypy"]
+        assert plan.checks["pytorch"]
+        assert plan.checks["dependency_audit"]
+        assert plan.checks["release_preflight"]
+
+
 def test_prerelease_version_increase_selects_release_preflight() -> None:
     plan = build_plan(["pyproject.toml"], base_version="2.3.2", head_version="2.3.3rc1")
 

--- a/tests/test_ci_plan.py
+++ b/tests/test_ci_plan.py
@@ -191,12 +191,17 @@ def test_version_increase_selects_complete_release_preflight() -> None:
 
 
 @pytest.mark.parametrize(
-    ("head_dependency", "version_only"),
-    [("numpy>=2", True), ("numpy>=3", False)],
+    ("head_dependency", "lock_source", "version_only"),
+    [
+        ("numpy>=2", '{ editable = "." }', True),
+        ("numpy>=3", '{ editable = "." }', False),
+        ("numpy>=2", '{ registry = "https://example.invalid" }', False),
+    ],
 )
 def test_version_bump_selects_minimal_release_only_when_metadata_is_unchanged(
     tmp_path: Path,
     head_dependency: str,
+    lock_source: str,
     *,
     version_only: bool,
 ) -> None:
@@ -212,12 +217,12 @@ def test_version_bump_selects_minimal_release_only_when_metadata_is_unchanged(
     )
     base_lock = tmp_path / "base-uv.lock"
     base_lock.write_text(
-        'version = 1\n[[package]]\nname = "albumentationsx"\nversion = "2.3.2"\nsource = { editable = "." }\n',
+        f'version = 1\n[[package]]\nname = "albumentationsx"\nversion = "2.3.2"\nsource = {lock_source}\n',
         encoding="utf-8",
     )
     head_lock = tmp_path / "head-uv.lock"
     head_lock.write_text(
-        'version = 1\n[[package]]\nname = "albumentationsx"\nversion = "2.3.3"\nsource = { editable = "." }\n',
+        f'version = 1\n[[package]]\nname = "albumentationsx"\nversion = "2.3.3"\nsource = {lock_source}\n',
         encoding="utf-8",
     )
 

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -41,8 +41,11 @@ def test_pr_plan_compares_base_and_head_project_versions() -> None:
     assert plan["outputs"]["release_preflight"] == "${{ steps.plan.outputs.release_preflight }}"
     assert plan["outputs"]["version_change"] == "${{ steps.plan.outputs.version_change }}"
     assert 'git show "${BASE_SHA}:pyproject.toml"' in text
+    assert 'git show "${BASE_SHA}:uv.lock"' in text
     assert "--base-pyproject ci-plan/base-pyproject.toml" in text
     assert "--head-pyproject ci-plan/head-pyproject.toml" in text
+    assert "--base-lock ci-plan/base-uv.lock" in text
+    assert "--head-lock ci-plan/head-uv.lock" in text
 
 
 def test_runtime_compatibility_covers_every_supported_os_python_pair() -> None:

--- a/tools/ci_plan.py
+++ b/tools/ci_plan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import sys
 from dataclasses import asdict, dataclass
@@ -328,6 +329,65 @@ def _version_change(base_version: str | None, head_version: str | None) -> str:
     return "unchanged"
 
 
+def _without_project_version(path: Path) -> dict[str, Any] | None:
+    with path.open("rb") as pyproject_file:
+        data = tomllib.load(pyproject_file)
+    project = data.get("project")
+    if not isinstance(project, dict) or not isinstance(project.get("version"), str):
+        return None
+
+    normalized = copy.deepcopy(data)
+    normalized["project"].pop("version")
+    return normalized
+
+
+def _without_editable_package_version(path: Path, expected_version: str) -> dict[str, Any] | None:
+    with path.open("rb") as lock_file:
+        data = tomllib.load(lock_file)
+    packages = data.get("package")
+    if not isinstance(packages, list):
+        return None
+
+    editable_package_indexes = [
+        index
+        for index, package in enumerate(packages)
+        if isinstance(package, dict)
+        and package.get("name") == "albumentationsx"
+        and package.get("source") == {"editable": "."}
+    ]
+    if len(editable_package_indexes) != 1:
+        return None
+
+    normalized = copy.deepcopy(data)
+    editable_package = normalized["package"][editable_package_indexes[0]]
+    if editable_package.get("version") != expected_version:
+        return None
+    editable_package.pop("version")
+    return normalized
+
+
+def _is_version_only_release(
+    changed_files: tuple[str, ...],
+    *,
+    base_version: str | None,
+    head_version: str | None,
+    base_pyproject: Path | None,
+    head_pyproject: Path | None,
+    base_lock: Path | None,
+    head_lock: Path | None,
+) -> bool:
+    if changed_files != ("pyproject.toml", "uv.lock") or base_version is None or head_version is None:
+        return False
+    if base_pyproject is None or head_pyproject is None or base_lock is None or head_lock is None:
+        return False
+
+    return _without_project_version(base_pyproject) == _without_project_version(
+        head_pyproject
+    ) and _without_editable_package_version(base_lock, base_version) == _without_editable_package_version(
+        head_lock, head_version
+    )
+
+
 def build_plan(
     paths: list[str] | tuple[str, ...],
     *,
@@ -335,6 +395,10 @@ def build_plan(
     force_full: bool = False,
     base_version: str | None = None,
     head_version: str | None = None,
+    base_pyproject: Path | None = None,
+    head_pyproject: Path | None = None,
+    base_lock: Path | None = None,
+    head_lock: Path | None = None,
 ) -> CIPlan:
     """Build the final CI plan for the supplied changed paths."""
     changed_files = tuple(sorted({_normalise_path(path) or "<invalid-path>" for path in paths}))
@@ -342,12 +406,23 @@ def build_plan(
     domains = set().union(*classified) if classified else {"unknown"}
     checks = _new_checks()
     version_change = _version_change(base_version, head_version)
+    version_only_release = version_change == "increase" and _is_version_only_release(
+        changed_files,
+        base_version=base_version,
+        head_version=head_version,
+        base_pyproject=base_pyproject,
+        head_pyproject=head_pyproject,
+        base_lock=base_lock,
+        head_lock=head_lock,
+    )
 
     _select_fast_checks(checks, domains)
     _select_correctness_checks(checks, domains, changed_files)
     _select_policy_checks(checks, domains, changed_files)
-    if force_full or "unknown" in domains or version_change == "increase":
+    if force_full or "unknown" in domains or (version_change == "increase" and not version_only_release):
         _select_everything(checks)
+    elif version_only_release:
+        checks = _new_checks()
     checks["release_preflight"] = version_change == "increase"
     if draft and not force_full:
         _disable_heavy_checks(checks)
@@ -363,7 +438,7 @@ def build_plan(
         "policy": _gate_jobs(checks, POLICY_CHECKS),
     }
     advisory_asv = not draft and bool(domains & {"runtime", "benchmarks", "unknown"})
-    reasons = (
+    reasons = [
         f"Classified {len(changed_files)} changed path(s).",
         f"Selected domains: {', '.join(sorted(domains))}.",
         f"Project version change: {version_change}.",
@@ -372,7 +447,9 @@ def build_plan(
             if "unknown" in domains
             else "All paths matched known domains."
         ),
-    )
+    ]
+    if version_only_release:
+        reasons.append("Version-only release bump selects release preflight without product, type, or audit lanes.")
 
     return CIPlan(
         schema_version=SCHEMA_VERSION,
@@ -387,7 +464,7 @@ def build_plan(
         advisory_asv=advisory_asv,
         draft=draft,
         forced_full=force_full,
-        reasons=reasons,
+        reasons=tuple(reasons),
     )
 
 
@@ -470,6 +547,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--force-full", type=_parse_bool, default=False, help="Select the complete CI profile.")
     parser.add_argument("--base-pyproject", type=Path, help="Base revision pyproject.toml.")
     parser.add_argument("--head-pyproject", type=Path, help="Head revision pyproject.toml.")
+    parser.add_argument("--base-lock", type=Path, help="Base revision uv.lock.")
+    parser.add_argument("--head-lock", type=Path, help="Head revision uv.lock.")
     parser.add_argument("--github-output", type=Path, help="Append scalar outputs for GitHub Actions.")
     parser.add_argument("--summary", type=Path, help="Write a human-readable job summary.")
     return parser.parse_args()
@@ -505,6 +584,10 @@ def main() -> int:
             force_full=args.force_full,
             base_version=base_version,
             head_version=head_version,
+            base_pyproject=args.base_pyproject,
+            head_pyproject=args.head_pyproject,
+            base_lock=args.base_lock,
+            head_lock=args.head_lock,
         )
     except (OSError, TypeError, ValueError) as error:
         print(f"CI plan failed: {error}", file=sys.stderr)

--- a/tools/ci_plan.py
+++ b/tools/ci_plan.py
@@ -381,11 +381,13 @@ def _is_version_only_release(
     if base_pyproject is None or head_pyproject is None or base_lock is None or head_lock is None:
         return False
 
-    return _without_project_version(base_pyproject) == _without_project_version(
-        head_pyproject
-    ) and _without_editable_package_version(base_lock, base_version) == _without_editable_package_version(
-        head_lock, head_version
-    )
+    base_project = _without_project_version(base_pyproject)
+    head_project = _without_project_version(head_pyproject)
+    base_lockfile = _without_editable_package_version(base_lock, base_version)
+    head_lockfile = _without_editable_package_version(head_lock, head_version)
+    if base_project is None or head_project is None or base_lockfile is None or head_lockfile is None:
+        return False
+    return base_project == head_project and base_lockfile == head_lockfile
 
 
 def build_plan(


### PR DESCRIPTION
## What changed

Routes a proven version-only release to `release-preflight` only. The router compares base and head `pyproject.toml` and `uv.lock`, allowing the narrow route only when the changed files are exactly those two and their only semantic changes are the package version.

## Why

A release PR that changes only version metadata cannot produce signal from mypy, Pyrefly, contracts, the product test matrix, or standalone audit/package/install jobs. The old `project.version` rule selected all of them.

## Safety boundary

A version bump with any other metadata or dependency-graph change keeps the complete profile. `release-preflight` still builds and verifies the publishable bundle.

## Policy

The local validation skill and CI policy now require every code path, test, and CI job to name the decision and failure it protects.

## Validation

- `uv run pytest -q tests/test_ci_plan.py tests/test_pr_workflow.py` — 50 passed
- `uv run python -m tools.ci_matrix check`
- `uv run zizmor --format=plain --min-severity=medium --min-confidence=medium .github`
- `uv run mypy tools/ci_plan.py`
- `uv run pyrefly check tools/ci_plan.py --output-format=github --error unnecessary-type-conversion --error implicit-import --error redundant-cast`
- `pre-commit run --files …` for the six changed files

## Summary by Sourcery

Constrain CI routing so that proven version-only release pull requests run only the release preflight job instead of the full profile, while preserving full checks for any metadata or dependency changes.

New Features:
- Detect version-only releases by comparing base and head pyproject and uv.lock contents with project and editable-package versions removed, and route them to a minimal release-preflight-only CI plan.

Enhancements:
- Extend the CI plan builder and CLI to accept base and head uv.lock paths and pass them through the GitHub Actions workflow.
- Refine CI plan reasoning output to explain when a version-only release bump selects only release preflight.
- Document the necessity rule that each test and CI job must be justified by the decision and failure it protects, and update CI policy docs to describe version-only release routing.

Tests:
- Add unit tests to verify that version-only releases select only release-preflight checks while any metadata or dependency change selects the full CI profile, and to ensure the PR workflow passes uv.lock paths to the planner.