### PR TITLE
fix(transforms3d): remap CubicSymmetry labels

### DIFF
--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -26,7 +26,6 @@ from albumentations.core.type_definitions import (
     CV2_BORDER_CONSTANT,
     CV2_INTER_LINEAR,
     CV2_INTER_NEAREST,
-    NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS,
     C4GroupElement,
     Targets,
     VolumeType,
@@ -1844,35 +1843,6 @@ class Flip3D(Transform3D):
         flip_axes = params.get("flip_axes", ())
         return "Flip3D" if len(flip_axes) % 2 else None
 
-    def _apply_label_mapping_to_keypoints(self, keypoints: np.ndarray, **params: Any) -> np.ndarray:
-        """Rename keypoint label values after a realized orientation-reversing reflection while preserving transformed
-        coordinates and input row order.
-        """
-        processor = self.get_processor("keypoints")
-        transform_name = self._get_label_transform_name(**params)
-        if (
-            not isinstance(processor, KeypointsProcessor)
-            or not processor.params.label_fields
-            or keypoints.size == 0
-            or transform_name is None
-        ):
-            return keypoints
-
-        field_mappings = processor.encoded_label_mappings.get(transform_name)
-        if not field_mappings:
-            return keypoints
-
-        result = keypoints.copy()
-        for label_offset, label_field in enumerate(processor.params.label_fields):
-            mapping = field_mappings.get(label_field)
-            column_index = NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS + label_offset
-            if not mapping or column_index >= keypoints.shape[1]:
-                continue
-            source_values = keypoints[:, column_index]
-            for source_label, target_label in mapping.items():
-                result[source_values == source_label, column_index] = target_label
-        return result
-
     def apply_to_volume(
         self,
         volume: VolumeType,
@@ -1959,6 +1929,9 @@ class CubicSymmetry(Transform3D):
         - All transformations preserve the object's chirality (handedness) when using
           pure rotations (indices 0-23) and invert it when using rotoreflections
           (indices 24-47).
+        - A realized rotoreflection emits the `CubicSymmetry` label-mapping event. Configured semantic-mask mappings
+          remap `mask3d` labels and aliases; configured keypoint mappings remap label fields without moving their
+          transformed coordinate rows. Rotations do not emit this event.
 
     Examples:
         >>> import numpy as np

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -2005,6 +2005,13 @@ class CubicSymmetry(Transform3D):
         volume_shape = _get_volume_shape(data)
         return {"index": sampling.py_random.randint(0, 47), "volume_shape": volume_shape}
 
+    def _get_label_transform_name(self, **params: Any) -> str | None:
+        """Return the CubicSymmetry mapping event for a rotoreflection, while pure cube rotations preserve class
+        meanings and must not alter semantic labels.
+        """
+        index = params.get("index")
+        return "CubicSymmetry" if isinstance(index, int) and index >= 24 else None
+
     def apply_to_volume(self, volume: VolumeType, index: int, **params: Any) -> VolumeType:
         return f3d.transform_cube(volume, index)
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -34,7 +34,14 @@ from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.validation import ValidatedTransformMeta
 
 from .serialization import Serializable, SerializableMeta, get_shortest_class_fullname
-from .type_definitions import ALL_TARGETS, ImageType, StackedMasks4D, Targets, VolumeType
+from .type_definitions import (
+    ALL_TARGETS,
+    NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS,
+    ImageType,
+    StackedMasks4D,
+    Targets,
+    VolumeType,
+)
 from .utils import format_args
 from .utils import get_image_data as _get_image_data_impl
 
@@ -1584,6 +1591,35 @@ class Transform3D(DualTransform):
         (D, H, W, C). Output shape unchanged. For VolumeTransform.
         """
         return self.apply_to_volume(mask3d, *args, **params)
+
+    def _apply_label_mapping_to_keypoints(self, keypoints: np.ndarray, **params: Any) -> np.ndarray:
+        """Remap keypoint label fields after 3D geometry while retaining transformed coordinates and row order so each
+        record matches manual annotation.
+        """
+        processor = self.get_processor("keypoints")
+        transform_name = self._get_label_transform_name(**params)
+        if (
+            not isinstance(processor, KeypointsProcessor)
+            or not processor.params.label_fields
+            or keypoints.size == 0
+            or transform_name is None
+        ):
+            return keypoints
+
+        field_mappings = processor.encoded_label_mappings.get(transform_name)
+        if not field_mappings:
+            return keypoints
+
+        result = keypoints.copy()
+        for label_offset, label_field in enumerate(processor.params.label_fields):
+            mapping = field_mappings.get(label_field)
+            column_index = NUM_KEYPOINTS_COLUMNS_IN_ALBUMENTATIONS + label_offset
+            if not mapping or column_index >= keypoints.shape[1]:
+                continue
+            source_values = keypoints[:, column_index]
+            for source_label, target_label in mapping.items():
+                result[source_values == source_label, column_index] = target_label
+        return result
 
     @property
     def targets(self) -> dict[str, Callable[..., Any]]:

--- a/docs/maintaining/correctness-contracts.md
+++ b/docs/maintaining/correctness-contracts.md
@@ -42,6 +42,21 @@ composition/tensor route, or a deliberate golden compatibility contract.
 - Serialization contract: supported transforms round-trip through
   serialization and replay checks.
 
+## 3D Orientation Label Mappings
+
+An orientation-reversing `Transform3D` may emit a transform-name event that activates configured semantic mappings.
+The augmented output must match a manual annotation of the transformed volume:
+
+- `mask3d` and every target aliased to `mask3d` receive the spatial transform, then a simultaneous semantic-label
+  mapping. A swap such as `2: 3, 3: 2` uses the source mask for both assignments.
+- `KeypointParams.label_mapping` remaps configured keypoint label fields in the row that already holds the coordinate
+  transformed by `Transform3D`. It never moves coordinate rows to express a label mapping.
+- Semantic-label remapping does not add, remove, or reorder instance rows. When `instance_binding` is active, masks,
+  bounding boxes, and keypoint groups retain their positional alignment.
+
+`semantic_mask_label_mappings` and `KeypointParams.label_mapping` are independent configuration surfaces. A transform
+event activates each mapping only when the caller configured it for that target type.
+
 ## Stability Modes
 
 Golden regression cases declare one stability mode:

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -116,6 +116,46 @@ def test_semantic_mask_label_mapping_flip3d_ignores_even_reflections(flip_axes: 
     np.testing.assert_array_equal(result["mask3d"], np.flip(mask3d, axis=flip_axes))
 
 
+@pytest.mark.parametrize(("index", "swap_labels"), [(0, False), (24, True)])
+def test_semantic_mask_label_mapping_follows_realized_cubic_symmetry_operation(
+    monkeypatch: pytest.MonkeyPatch,
+    index: int,
+    swap_labels: bool,
+) -> None:
+    """Only rotoreflections rename class IDs after their mask3d geometry is transformed."""
+    volume = np.arange(2 * 4 * 4, dtype=np.float32).reshape(2, 4, 4, 1)
+    mask3d = np.array(
+        [
+            [[2, 0, 3, 4], [4, 3, 0, 2], [2, 4, 3, 0], [0, 2, 4, 3]],
+            [[3, 2, 4, 0], [0, 4, 2, 3], [4, 3, 0, 2], [2, 0, 3, 4]],
+        ],
+        dtype=np.uint8,
+    )
+
+    def fixed_index(
+        self: A.CubicSymmetry,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        sampling: Any,
+    ) -> dict[str, Any]:
+        return {"index": index, "volume_shape": data["volume"].shape}
+
+    monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
+    result = A.Compose(
+        [A.CubicSymmetry(p=1.0)],
+        semantic_mask_label_mappings={"CubicSymmetry": {2: 3, 3: 2}},
+        strict=True,
+        telemetry=False,
+    )(volume=volume, mask3d=mask3d)
+
+    expected = A.CubicSymmetry().apply_to_mask3d(mask3d, index=index)
+    if swap_labels:
+        source_labels = expected.copy()
+        expected[source_labels == 2] = 3
+        expected[source_labels == 3] = 2
+    np.testing.assert_array_equal(result["mask3d"], expected)
+
+
 def test_semantic_mask_label_mapping_preserves_custom_apply_with_params_hook() -> None:
     image = np.zeros((1, 4, 3), dtype=np.uint8)
     mask = np.array([[2, 0, 3, 2]], dtype=np.uint8)

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -143,10 +143,11 @@ def test_semantic_mask_label_mapping_follows_realized_cubic_symmetry_operation(
     monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
     result = A.Compose(
         [A.CubicSymmetry(p=1.0)],
+        additional_targets={"mask3d_alias": "mask3d"},
         semantic_mask_label_mappings={"CubicSymmetry": {2: 3, 3: 2}},
         strict=True,
         telemetry=False,
-    )(volume=volume, mask3d=mask3d)
+    )(volume=volume, mask3d=mask3d, mask3d_alias=mask3d.copy())
 
     expected = A.CubicSymmetry().apply_to_mask3d(mask3d, index=index)
     if swap_labels:
@@ -154,6 +155,7 @@ def test_semantic_mask_label_mapping_follows_realized_cubic_symmetry_operation(
         expected[source_labels == 2] = 3
         expected[source_labels == 3] = 2
     np.testing.assert_array_equal(result["mask3d"], expected)
+    np.testing.assert_array_equal(result["mask3d_alias"], expected)
 
 
 def test_semantic_mask_label_mapping_preserves_custom_apply_with_params_hook() -> None:

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1405,6 +1405,49 @@ def test_flip3d_odd_reflections_remap_keypoint_labels_without_reordering_rows(
 
 
 @pytest.mark.parametrize(
+    ("index", "expected_keypoints", "expected_side"),
+    [
+        (0, np.array([[1, 1, 0], [3, 2, 1]], dtype=np.float32), [2, 3]),
+        (24, np.array([[3, 1, 0], [1, 2, 1]], dtype=np.float32), [3, 2]),
+    ],
+)
+def test_cubic_symmetry_remaps_keypoint_labels_without_reordering_transformed_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    index: int,
+    expected_keypoints: np.ndarray,
+    expected_side: list[int],
+) -> None:
+    """A rotoreflection reassigns 3D semantic labels while every transformed keypoint stays in its own row."""
+    volume = np.zeros((2, 3, 5, 1), dtype=np.float32)
+    keypoints = np.array([[1, 1, 0], [3, 2, 1]], dtype=np.float32)
+    side = [2, 3]
+
+    def fixed_index(
+        self: A.CubicSymmetry,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        sampling: Any,
+    ) -> dict[str, Any]:
+        del self, params, sampling
+        return {"index": index, "volume_shape": data["volume"].shape}
+
+    monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
+    result = A.Compose(
+        [A.CubicSymmetry(p=1.0)],
+        keypoint_params=A.KeypointParams(
+            coord_format="xyz",
+            label_fields=["side"],
+            label_mapping={"CubicSymmetry": {"side": {2: 3, 3: 2}}},
+        ),
+        strict=True,
+        telemetry=False,
+    )(volume=volume, keypoints=keypoints, side=side)
+
+    np.testing.assert_array_equal(result["keypoints"], expected_keypoints)
+    assert result["side"] == expected_side
+
+
+@pytest.mark.parametrize(
     ("label_mapping", "expected_side", "expected_view"),
     [
         ({"Flip3D": {"side": {2: 3, 3: 2}}}, [3, 2], [4, 5]),


### PR DESCRIPTION
Fixes #432.

`CubicSymmetry` emits the `CubicSymmetry` mapping event only for realized rotoreflections (indices `24..47`).
Pure rotations (`0..23`) preserve semantic labels.

For `Transform3D` transforms that emit a mapping event:

- `mask3d` and every `mask3d` alias undergo geometry followed by a simultaneous class-ID remap.
- `KeypointParams.label_mapping` changes label-field values in the same rows that already contain the transformed XYZ
  coordinates. It never swaps complete keypoint rows, preserving a manual annotation and instance alignment.

The keypoint behavior is centralized in `Transform3D`, so `Flip3D` and `CubicSymmetry` share the invariant. The
maintainer correctness-contract documentation records the target, row-order, alias, and instance-binding rules.

Tests and validation:

- `uv run pytest -q tests/transforms3d/test_transforms.py` — 443 passed
- `uv run pytest -q tests/test_semantic_mask_label_mapping.py` — 39 passed
- `uv run pytest -q tests/test_instance_binding.py` — 125 passed
- `uv run python tools/quality_gate.py fast` — passed, including mypy, Pyrefly, 1,276 contract tests, and pre-commit

Public Compose benchmark, forced rotoreflection, `(32, 64, 64, 1)` volume (median microseconds/call; original PR →
this commit):

- unmapped labels: 2 keypoints `78.72 → 78.06`; 1,024 keypoints `175.09 → 177.42`
- mapped labels: 2 keypoints `85.85 → 85.36`; 1,024 keypoints `196.35 → 196.77`
