### PR TITLE
chore(release): bump version to 2.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.4.1"
+version = "2.4.2"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.4.1"
+version = "2.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## Summary

- Bump the package version from `2.4.1` to `2.4.2` in `pyproject.toml`.
- Keep the editable package metadata in `uv.lock` aligned with the project version.

This prepares the patch release after the merged CubicSymmetry semantic-label fix in #433.

## Validation

- `uv lock --check`
- `uv run python tools/quality_gate.py fast`
  - 1,276 contract tests passed
  - Ruff, mypy, Pyrefly, CI/release consistency checks, legal checks, and pre-commit passed
- Commit hooks passed for the staged version files.

## Summary by Sourcery

Build:
- Bump project version from 2.4.1 to 2.4.2 in pyproject.toml and align uv.lock metadata with the new release version.