### PR TITLE
fix: enforce public image value ranges

### DIFF
--- a/.codex/skills/performance-optimization/SKILL.md
+++ b/.codex/skills/performance-optimization/SKILL.md
@@ -67,6 +67,14 @@ Propose an Albucore primitive when an operation:
 Do not create a local helper merely to avoid coordinating an Albucore change when the operation satisfies these
 conditions.
 
+If investigation identifies an Albucore defect, pause AlbumentationsX changes and open an Albucore Issue and PR
+before resuming.
+
+Do not add a forwarding wrapper around a one-line call merely to attach a decorator. Use `@clipped` when every route
+of an image operation can leave the public range; branch and call `albucore.clip(..., inplace=True)` when only a known
+float32 mode (such as cubic interpolation) can. A separate function is justified only when it owns a real image
+operation and keeps that image policy distinct from masks or annotations.
+
 ## Required Handoff
 
 Report:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -199,7 +199,7 @@ repos:
         pass_filenames: false
         files: ^(README\.md|albumentations/).*$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.2
+    rev: v0.16.3
     hooks:
       - id: ruff
         exclude: '__pycache__/'
@@ -228,7 +228,7 @@ repos:
       - id: codespell
         additional_dependencies: ["tomli>=2.4.1"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.0
+    rev: v2.3.1
     hooks:
       - id: mypy
         files: ^albumentations/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,12 @@ repos:
         entry: python tools/check_internal_workspace.py
         language: python
         files: ^_internal/
+      - id: check-quality-suppressions
+        name: Reject suppression of mandatory complexity checks
+        entry: python tools/check_quality_suppressions.py
+        language: python
+        types_or: [python, toml]
+        files: ^(albumentations/|tools/|pyproject\.toml$)
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
         name: Reject suppression of mandatory complexity checks
         entry: python tools/check_quality_suppressions.py
         language: python
+        additional_dependencies: [tomli>=2.4.1]
         types_or: [python, toml]
         files: ^(albumentations/|tools/|pyproject\.toml$)
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,9 @@ We've organized our contribution guidelines into focused documents:
 1. **Find an Issue**: Look for open issues or propose a new one. For newcomers, look for issues labeled "good first issue"
 2. **Fork & Set Up**: Fork the repository and follow our [Environment Setup Guide](docs/contributing/environment_setup.md)
 3. **Create a Branch**: In your fork, create a new branch: `git checkout -b feature/my-new-feature`
-4. **Make Changes**: Write code following our [Coding Guidelines](docs/contributing/coding_guidelines.md)
+4. **Make Changes**: Write code following our [Coding Guidelines](docs/contributing/coding_guidelines.md). Image
+   operations must preserve their dtype range; clip the operation itself, never through a forwarding wrapper added
+   only to attach a decorator.
 5. **Test**: Add tests and ensure all tests pass
 6. **Submit**: Open a Pull Request from your fork with a clear description of your changes
 

--- a/albumentations/augmentations/crops/base.py
+++ b/albumentations/augmentations/crops/base.py
@@ -2,6 +2,8 @@
 
 from typing import Annotated, Any, ClassVar, Literal, cast
 
+from albucore import clip
+
 from albumentations.core.invocation import SamplingContext
 
 from ._transforms_shared import (
@@ -32,6 +34,9 @@ class CropSizeError(Exception):
 
     Used by crop transforms to fail early before generating invalid crop coordinates.
     """
+
+
+RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 
 
 class BaseCrop(DualTransform):
@@ -743,7 +748,10 @@ class _BaseRandomSizedCrop(DualTransform):
     ) -> ImageType:
         crop = fcrops.crop(img, *crop_coords)
         interpolation = self._get_interpolation_for_resize(cast("tuple[int, int]", crop.shape[:2]), "image")
-        return fgeometric.resize(crop, self.size, interpolation)
+        result = fgeometric.resize(crop, self.size, interpolation)
+        if img.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask(
         self,
@@ -799,6 +807,8 @@ class _BaseRandomSizedCrop(DualTransform):
         result = np.empty((images.shape[0], self.size[0], self.size[1], crop.shape[-1]), dtype=crop.dtype)
         for i in range(images.shape[0]):
             result[i] = fgeometric.resize(crop[i], self.size, interpolation)
+        if images.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(cast("ImageType", result), images.dtype, inplace=True)
         return cast("ImageType", result)
 
     def apply_to_mask3d(

--- a/albumentations/augmentations/crops/base.py
+++ b/albumentations/augmentations/crops/base.py
@@ -2,8 +2,6 @@
 
 from typing import Annotated, Any, ClassVar, Literal, cast
 
-from albucore import clip
-
 from albumentations.core.invocation import SamplingContext
 
 from ._transforms_shared import (
@@ -34,9 +32,6 @@ class CropSizeError(Exception):
 
     Used by crop transforms to fail early before generating invalid crop coordinates.
     """
-
-
-RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 
 
 class BaseCrop(DualTransform):
@@ -749,9 +744,7 @@ class _BaseRandomSizedCrop(DualTransform):
         crop = fcrops.crop(img, *crop_coords)
         interpolation = self._get_interpolation_for_resize(cast("tuple[int, int]", crop.shape[:2]), "image")
         result = fgeometric.resize(crop, self.size, interpolation)
-        if img.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, interpolation)
 
     def apply_to_mask(
         self,
@@ -807,9 +800,7 @@ class _BaseRandomSizedCrop(DualTransform):
         result = np.empty((images.shape[0], self.size[0], self.size[1], crop.shape[-1]), dtype=crop.dtype)
         for i in range(images.shape[0]):
             result[i] = fgeometric.resize(crop[i], self.size, interpolation)
-        if images.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(cast("ImageType", result), images.dtype, inplace=True)
-        return cast("ImageType", result)
+        return fgeometric.clip_if_interpolation_can_overshoot(cast("ImageType", result), interpolation)
 
     def apply_to_mask3d(
         self,

--- a/albumentations/augmentations/crops/basic.py
+++ b/albumentations/augmentations/crops/basic.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 from typing import Annotated, Any, Literal, cast
 
+from albucore import clip
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
@@ -27,6 +28,7 @@ from ._transforms_shared import (
     np,
 )
 from .base import (
+    RANGE_OVERSHOOT_INTERPOLATIONS,
     BaseCropAndPad,
     CropSizeError,
 )
@@ -836,7 +838,7 @@ class CropAndPad(DualTransform):
         fill: tuple[float, ...] | float,
         **params: Any,
     ) -> ImageType:
-        return fcrops.crop_and_pad(
+        result = fcrops.crop_and_pad(
             img,
             crop_params,
             pad_params,
@@ -846,6 +848,9 @@ class CropAndPad(DualTransform):
             self.border_mode,
             self.keep_size,
         )
+        if img.dtype == np.float32 and self.keep_size and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask(
         self,

--- a/albumentations/augmentations/crops/basic.py
+++ b/albumentations/augmentations/crops/basic.py
@@ -3,7 +3,6 @@
 from collections.abc import Sequence
 from typing import Annotated, Any, Literal, cast
 
-from albucore import clip
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
@@ -28,7 +27,6 @@ from ._transforms_shared import (
     np,
 )
 from .base import (
-    RANGE_OVERSHOOT_INTERPOLATIONS,
     BaseCropAndPad,
     CropSizeError,
 )
@@ -848,8 +846,8 @@ class CropAndPad(DualTransform):
             self.border_mode,
             self.keep_size,
         )
-        if img.dtype == np.float32 and self.keep_size and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
+        if self.keep_size:
+            return fgeometric.clip_if_interpolation_can_overshoot(result, self.interpolation)
         return result
 
     def apply_to_mask(

--- a/albumentations/augmentations/crops/bbox_safe.py
+++ b/albumentations/augmentations/crops/bbox_safe.py
@@ -2,8 +2,6 @@
 
 from typing import Annotated, Any, ClassVar
 
-from albucore import clip
-
 from albumentations.core.invocation import SamplingContext
 
 from ._transforms_shared import (
@@ -21,7 +19,6 @@ from ._transforms_shared import (
     union_of_bboxes,
 )
 from .base import (
-    RANGE_OVERSHOOT_INTERPOLATIONS,
     BaseCrop,
     CropSizeError,
 )
@@ -372,9 +369,7 @@ class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
     ) -> ImageType:
         crop = fcrops.crop(img, *crop_coords)
         result = fgeometric.resize(crop, (self.height, self.width), self.interpolation)
-        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, self.interpolation)
 
     def apply_to_mask(
         self,

--- a/albumentations/augmentations/crops/bbox_safe.py
+++ b/albumentations/augmentations/crops/bbox_safe.py
@@ -2,6 +2,8 @@
 
 from typing import Annotated, Any, ClassVar
 
+from albucore import clip
+
 from albumentations.core.invocation import SamplingContext
 
 from ._transforms_shared import (
@@ -19,6 +21,7 @@ from ._transforms_shared import (
     union_of_bboxes,
 )
 from .base import (
+    RANGE_OVERSHOOT_INTERPOLATIONS,
     BaseCrop,
     CropSizeError,
 )
@@ -368,7 +371,10 @@ class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
         **params: Any,
     ) -> ImageType:
         crop = fcrops.crop(img, *crop_coords)
-        return fgeometric.resize(crop, (self.height, self.width), self.interpolation)
+        result = fgeometric.resize(crop, (self.height, self.width), self.interpolation)
+        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask(
         self,

--- a/albumentations/augmentations/geometric/_functional_shared.py
+++ b/albumentations/augmentations/geometric/_functional_shared.py
@@ -13,9 +13,7 @@ from warnings import warn
 import cv2
 import numpy as np
 from albucore import (
-    copy_make_border as albucore_copy_make_border,
-)
-from albucore import (
+    clip,
     from_float,
     hflip,
     preserve_channel_dim,
@@ -24,6 +22,9 @@ from albucore import (
     to_float,
     vflip,
     warp_perspective,
+)
+from albucore import (
+    copy_make_border as albucore_copy_make_border,
 )
 from albucore import (
     resize as albucore_resize,
@@ -66,6 +67,7 @@ __all__ = [
     "bboxes_from_masks",
     "bboxes_to_mask",
     "cast",
+    "clip_if_interpolation_can_overshoot",
     "cv2",
     "defaultdict",
     "denormalize_bboxes",
@@ -89,3 +91,15 @@ __all__ = [
     "warn",
     "warp_perspective",
 ]
+
+
+_RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
+
+
+def clip_if_interpolation_can_overshoot(image: ImageType, interpolation: int) -> ImageType:
+    """Restore the public float32 range after cubic or Lanczos interpolation, whose kernels can overshoot it.
+    Use it for images, not masks.
+    """
+    if image.dtype == np.float32 and interpolation in _RANGE_OVERSHOOT_INTERPOLATIONS:
+        return clip(image, image.dtype, inplace=True)
+    return image

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -27,8 +27,9 @@ target types.
 
 from typing import Annotated, Any, Literal
 
+import cv2
 import numpy as np
-from albucore import remap
+from albucore import clip, remap
 from pydantic import (
     AfterValidator,
     Field,
@@ -74,6 +75,8 @@ __all__ = [
     "ThinPlateSpline",
     "WaterRefraction",
 ]
+
+RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 
 
 class BaseDistortion(DualTransform):
@@ -260,7 +263,7 @@ class BaseDistortion(DualTransform):
         map_y: np.ndarray,
         **params: Any,
     ) -> ImageType:
-        return remap(
+        result = remap(
             img,
             map_x,
             map_y,
@@ -268,6 +271,9 @@ class BaseDistortion(DualTransform):
             border_mode=self.border_mode,
             border_value=self.fill,
         )
+        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
         return self._apply_to_batch_same_shape(mask3d, lambda mask: self.apply_to_mask(mask, **params))

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -27,9 +27,8 @@ target types.
 
 from typing import Annotated, Any, Literal
 
-import cv2
 import numpy as np
-from albucore import clip, remap
+from albucore import remap
 from pydantic import (
     AfterValidator,
     Field,
@@ -75,8 +74,6 @@ __all__ = [
     "ThinPlateSpline",
     "WaterRefraction",
 ]
-
-RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 
 
 class BaseDistortion(DualTransform):
@@ -271,9 +268,7 @@ class BaseDistortion(DualTransform):
             border_mode=self.border_mode,
             border_value=self.fill,
         )
-        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, self.interpolation)
 
     def apply_to_mask3d(self, mask3d: VolumeType, **params: Any) -> VolumeType:
         return self._apply_to_batch_same_shape(mask3d, lambda mask: self.apply_to_mask(mask, **params))

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -9,7 +9,6 @@ from typing import Any, Literal
 
 import cv2
 import numpy as np
-from albucore import clip
 from pydantic import Field, model_validator
 from typing_extensions import Self
 
@@ -27,8 +26,6 @@ from albumentations.core.type_definitions import (
 from . import functional as fgeometric
 
 __all__ = ["LetterBox", "LongestMaxSize", "RandomScale", "Resize", "SmallestMaxSize"]
-
-RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 
 
 class RandomScale(DualTransform):
@@ -235,9 +232,7 @@ class RandomScale(DualTransform):
             interpolation = cv2.INTER_AREA
 
         result = fgeometric.scale_xy(img, scale_x, scale_y, interpolation)
-        if img.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, interpolation)
 
     def apply_to_mask(
         self,
@@ -430,9 +425,7 @@ class MaxSizeTransform(DualTransform):
             interpolation = cv2.INTER_AREA
 
         result = fgeometric.resize(img, (new_height, new_width), interpolation=interpolation)
-        if img.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, interpolation)
 
     def apply_to_mask(
         self,
@@ -836,9 +829,7 @@ class Resize(DualTransform):
             interpolation = cv2.INTER_AREA
 
         result = fgeometric.resize(img, (self.height, self.width), interpolation=interpolation)
-        if img.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, interpolation)
 
     def apply_to_mask(self, mask: ImageType, **params: Any) -> ImageType:
         height, width = mask.shape[:2]
@@ -980,9 +971,7 @@ class LetterBox(DualTransform):
             border_mode=cv2.BORDER_CONSTANT,
             value=self.fill,
         )
-        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, self.interpolation)
 
     def apply_to_mask(
         self,

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 
 import cv2
 import numpy as np
+from albucore import clip
 from pydantic import Field, model_validator
 from typing_extensions import Self
 
@@ -26,6 +27,8 @@ from albumentations.core.type_definitions import (
 from . import functional as fgeometric
 
 __all__ = ["LetterBox", "LongestMaxSize", "RandomScale", "Resize", "SmallestMaxSize"]
+
+RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 
 
 class RandomScale(DualTransform):
@@ -231,7 +234,10 @@ class RandomScale(DualTransform):
         if self.area_for_downscale in ["image", "image_mask"] and is_downscale:
             interpolation = cv2.INTER_AREA
 
-        return fgeometric.scale_xy(img, scale_x, scale_y, interpolation)
+        result = fgeometric.scale_xy(img, scale_x, scale_y, interpolation)
+        if img.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask(
         self,
@@ -423,7 +429,10 @@ class MaxSizeTransform(DualTransform):
         if self.area_for_downscale in ["image", "image_mask"] and scale < 1.0:
             interpolation = cv2.INTER_AREA
 
-        return fgeometric.resize(img, (new_height, new_width), interpolation=interpolation)
+        result = fgeometric.resize(img, (new_height, new_width), interpolation=interpolation)
+        if img.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask(
         self,
@@ -826,7 +835,10 @@ class Resize(DualTransform):
         if self.area_for_downscale in ["image", "image_mask"] and is_downscale:
             interpolation = cv2.INTER_AREA
 
-        return fgeometric.resize(img, (self.height, self.width), interpolation=interpolation)
+        result = fgeometric.resize(img, (self.height, self.width), interpolation=interpolation)
+        if img.dtype == np.float32 and interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask(self, mask: ImageType, **params: Any) -> ImageType:
         height, width = mask.shape[:2]
@@ -867,7 +879,7 @@ class LetterBox(DualTransform):
         mask_interpolation (OpenCV flag): Interpolation method used when resizing masks.
             Default: `cv2.INTER_NEAREST`.
         fill (tuple[float, ...] | float): Constant pixel value for image padding.
-            Default: `114`.
+            Default: `0`. For YOLO-style padding, use `114` with uint8 images or `114 / 255` with float32 images.
         fill_mask (tuple[float, ...] | float): Constant pixel value for mask padding.
             Default: `0`.
         position (Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"]):
@@ -887,7 +899,7 @@ class LetterBox(DualTransform):
         - The output size is always exactly `(height, width)`.
         - Images smaller than the target are upscaled; images larger are downscaled.
         - Bounding boxes and keypoints are adjusted for both the resize and padding steps.
-        - `fill=114` is the YOLO convention for letterbox padding.
+        - YOLO uses `fill=114` for uint8 images. Use `fill=114 / 255` for normalized float32 images.
 
     Examples:
         >>> import numpy as np
@@ -934,7 +946,7 @@ class LetterBox(DualTransform):
         size: tuple[int, int],
         interpolation: FullInterpolationType = CV2_INTER_LINEAR,
         mask_interpolation: FullInterpolationType = CV2_INTER_NEAREST,
-        fill: tuple[float, ...] | float = 114,
+        fill: tuple[float, ...] | float = 0,
         fill_mask: tuple[float, ...] | float = 0,
         position: Literal["center", "top_left", "top_right", "bottom_left", "bottom_right", "random"] = "center",
         p: float = 1.0,
@@ -958,12 +970,8 @@ class LetterBox(DualTransform):
         pad_right: int,
         **params: Any,
     ) -> ImageType:
-        resized = fgeometric.resize(
-            img,
-            (new_height, new_width),
-            interpolation=self.interpolation,
-        )
-        return fgeometric.pad_with_params(
+        resized = fgeometric.resize(img, (new_height, new_width), interpolation=self.interpolation)
+        result = fgeometric.pad_with_params(
             resized,
             pad_top,
             pad_bottom,
@@ -972,6 +980,9 @@ class LetterBox(DualTransform):
             border_mode=cv2.BORDER_CONSTANT,
             value=self.fill,
         )
+        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask(
         self,

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -10,7 +10,7 @@ from typing import Any, Literal
 
 import cv2
 import numpy as np
-from albucore import warp_affine
+from albucore import clip, warp_affine
 from pydantic import model_validator
 from typing_extensions import Self
 
@@ -39,6 +39,7 @@ from . import functional as fgeometric
 __all__ = ["RandomRotate90", "Rotate", "SafeRotate"]
 
 SMALL_NUMBER = 1e-10
+RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 
 
 class RandomRotate90(DualTransform):
@@ -409,7 +410,9 @@ class Rotate(DualTransform):
             border_value=self.fill,
         )
         if self.crop_border:
-            return fcrops.crop(img_out, x_min, y_min, x_max, y_max)
+            img_out = fcrops.crop(img_out, x_min, y_min, x_max, y_max)
+        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(img_out, img.dtype, inplace=True)
         return img_out
 
     def apply_to_mask(

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -10,7 +10,7 @@ from typing import Any, Literal
 
 import cv2
 import numpy as np
-from albucore import clip, warp_affine
+from albucore import warp_affine
 from pydantic import model_validator
 from typing_extensions import Self
 
@@ -39,7 +39,6 @@ from . import functional as fgeometric
 __all__ = ["RandomRotate90", "Rotate", "SafeRotate"]
 
 SMALL_NUMBER = 1e-10
-RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 
 
 class RandomRotate90(DualTransform):
@@ -411,9 +410,7 @@ class Rotate(DualTransform):
         )
         if self.crop_border:
             img_out = fcrops.crop(img_out, x_min, y_min, x_max, y_max)
-        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(img_out, img.dtype, inplace=True)
-        return img_out
+        return fgeometric.clip_if_interpolation_can_overshoot(img_out, self.interpolation)
 
     def apply_to_mask(
         self,

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -11,7 +11,7 @@ from warnings import warn
 
 import cv2
 import numpy as np
-from albucore import batch_transform, is_grayscale_image, is_rgb_image, warp_affine
+from albucore import batch_transform, clip, is_grayscale_image, is_rgb_image, warp_affine
 from pydantic import (
     Field,
     ValidationInfo,
@@ -61,6 +61,7 @@ __all__ = [
 
 NUM_PADS_XY = 2
 NUM_PADS_ALL_SIDES = 4
+RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 RangeValueT = TypeVar("RangeValueT", int, float)
 
 
@@ -204,7 +205,7 @@ class Perspective(DualTransform):
         max_width: int,
         **params: Any,
     ) -> ImageType:
-        return fgeometric.perspective(
+        result = fgeometric.perspective(
             img,
             matrix,
             max_width,
@@ -214,6 +215,9 @@ class Perspective(DualTransform):
             self.keep_size,
             self.interpolation,
         )
+        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_images(
         self,
@@ -223,7 +227,7 @@ class Perspective(DualTransform):
         max_width: int,
         **params: Any,
     ) -> ImageType:
-        return fgeometric.perspective_images(
+        result = fgeometric.perspective_images(
             images,
             matrix,
             max_width,
@@ -233,6 +237,9 @@ class Perspective(DualTransform):
             self.keep_size,
             self.interpolation,
         )
+        if images.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, images.dtype, inplace=True)
+        return result
 
     def apply_to_mask(
         self,
@@ -605,14 +612,17 @@ class Affine(DualTransform):
     ) -> ImageType:
         height, width = output_shape
 
-        return warp_affine(
+        result = warp_affine(
             img,
             matrix,
+            dsize=(width, height),
             flags=self.interpolation,
             border_mode=self.border_mode,
             border_value=self.fill,
-            dsize=(width, height),
         )
+        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_images(
         self,
@@ -627,11 +637,13 @@ class Affine(DualTransform):
             result[i] = warp_affine(
                 image,
                 matrix,
+                dsize=(width, height),
                 flags=self.interpolation,
                 border_mode=self.border_mode,
                 border_value=self.fill,
-                dsize=(width, height),
             )
+        if images.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(cast("ImageType", result), images.dtype, inplace=True)
         return cast("ImageType", result)
 
     def apply_to_mask(
@@ -1176,7 +1188,10 @@ class GridElasticDeform(DualTransform):
     ) -> ImageType:
         if not is_rgb_image(img) and not is_grayscale_image(img):
             raise ValueError("GridElasticDeform transform is only supported for RGB and grayscale images.")
-        return fgeometric.distort_image(img, generated_mesh, self.interpolation)
+        result = fgeometric.distort_image(img, generated_mesh, self.interpolation)
+        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
+            return clip(result, img.dtype, inplace=True)
+        return result
 
     def apply_to_mask(
         self,

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -11,7 +11,7 @@ from warnings import warn
 
 import cv2
 import numpy as np
-from albucore import batch_transform, clip, is_grayscale_image, is_rgb_image, warp_affine
+from albucore import batch_transform, is_grayscale_image, is_rgb_image, warp_affine
 from pydantic import (
     Field,
     ValidationInfo,
@@ -61,7 +61,6 @@ __all__ = [
 
 NUM_PADS_XY = 2
 NUM_PADS_ALL_SIDES = 4
-RANGE_OVERSHOOT_INTERPOLATIONS = frozenset({cv2.INTER_CUBIC, cv2.INTER_LANCZOS4})
 RangeValueT = TypeVar("RangeValueT", int, float)
 
 
@@ -215,9 +214,7 @@ class Perspective(DualTransform):
             self.keep_size,
             self.interpolation,
         )
-        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, self.interpolation)
 
     def apply_to_images(
         self,
@@ -237,9 +234,7 @@ class Perspective(DualTransform):
             self.keep_size,
             self.interpolation,
         )
-        if images.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, images.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, self.interpolation)
 
     def apply_to_mask(
         self,
@@ -620,9 +615,7 @@ class Affine(DualTransform):
             border_mode=self.border_mode,
             border_value=self.fill,
         )
-        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, self.interpolation)
 
     def apply_to_images(
         self,
@@ -642,9 +635,7 @@ class Affine(DualTransform):
                 border_mode=self.border_mode,
                 border_value=self.fill,
             )
-        if images.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(cast("ImageType", result), images.dtype, inplace=True)
-        return cast("ImageType", result)
+        return fgeometric.clip_if_interpolation_can_overshoot(cast("ImageType", result), self.interpolation)
 
     def apply_to_mask(
         self,
@@ -1189,9 +1180,7 @@ class GridElasticDeform(DualTransform):
         if not is_rgb_image(img) and not is_grayscale_image(img):
             raise ValueError("GridElasticDeform transform is only supported for RGB and grayscale images.")
         result = fgeometric.distort_image(img, generated_mesh, self.interpolation)
-        if img.dtype == np.float32 and self.interpolation in RANGE_OVERSHOOT_INTERPOLATIONS:
-            return clip(result, img.dtype, inplace=True)
-        return result
+        return fgeometric.clip_if_interpolation_can_overshoot(result, self.interpolation)
 
     def apply_to_mask(
         self,

--- a/albumentations/augmentations/pixel/_functional_torchvision.py
+++ b/albumentations/augmentations/pixel/_functional_torchvision.py
@@ -252,7 +252,72 @@ def adjust_hue_torchvision(img: ImageType, factor: float) -> ImageType:
     return cast("ImageType", cv2.cvtColor(img, cv2.COLOR_HSV2RGB))
 
 
-def apply_brightness_contrast_torchvision(  # noqa: C901, PLR0912
+def _apply_brightness_only_torchvision(img: ImageType, brightness_factor: float) -> ImageType:
+    if brightness_factor == 0:
+        return np.zeros_like(img)
+    if brightness_factor == 1:
+        return img
+
+    result = multiply(img, brightness_factor, inplace=False)
+    return np.clip(result, 0.0, 1.0, out=result) if result.dtype == np.float32 else result
+
+
+def _apply_contrast_only_torchvision(img: ImageType, contrast_factor: float) -> ImageType:
+    gray_img = img if is_grayscale_image(img) else cast("ImageType", cv2.cvtColor(img, cv2.COLOR_RGB2GRAY))
+    img_mean = float(mean(gray_img))
+    if contrast_factor == 0:
+        if img.dtype != np.float32:
+            img_mean = int(img_mean + 0.5)
+        return cast("ImageType", np.full_like(img, img_mean, dtype=img.dtype))
+
+    result = multiply_add(img, contrast_factor, img_mean * (1 - contrast_factor), inplace=False)
+    return np.clip(result, 0.0, 1.0, out=result) if result.dtype == np.float32 else result
+
+
+def _apply_brightness_contrast_uint8(
+    img: ImageType,
+    brightness_factor: float,
+    contrast_factor: float,
+    mean_at_contrast: float,
+    brightness_first: bool,
+) -> ImageType:
+    lut = np.arange(256, dtype=np.float32)
+    if brightness_first:
+        lut = np.clip(lut * brightness_factor, 0.0, 255.0)
+        lut = np.clip(lut * contrast_factor + mean_at_contrast * 255.0 * (1.0 - contrast_factor), 0.0, 255.0)
+    else:
+        lut = np.clip(lut * contrast_factor + mean_at_contrast * 255.0 * (1.0 - contrast_factor), 0.0, 255.0)
+        # Values are non-negative after clipping, so floor matches the uint8 cast between torchvision operations.
+        np.floor(lut, out=lut)
+        lut = np.clip(lut * brightness_factor, 0.0, 255.0)
+    return sz_lut(img, lut.astype(np.uint8), inplace=False)
+
+
+def _apply_brightness_contrast_float32(
+    img: ImageType,
+    brightness_factor: float,
+    contrast_factor: float,
+    mean_at_contrast: float,
+    brightness_first: bool,
+) -> ImageType:
+    offset = mean_at_contrast * (1.0 - contrast_factor)
+    out = np.empty_like(img)
+    if brightness_first:
+        np.multiply(img, brightness_factor, out=out)
+        np.clip(out, 0.0, 1.0, out=out)
+        np.multiply(out, contrast_factor, out=out)
+        np.add(out, offset, out=out)
+        np.clip(out, 0.0, 1.0, out=out)
+    else:
+        np.multiply(img, contrast_factor, out=out)
+        np.add(out, offset, out=out)
+        np.clip(out, 0.0, 1.0, out=out)
+        np.multiply(out, brightness_factor, out=out)
+        np.clip(out, 0.0, 1.0, out=out)
+    return out
+
+
+def apply_brightness_contrast_torchvision(
     img: ImageType,
     brightness_factor: float,
     contrast_factor: float,
@@ -281,26 +346,10 @@ def apply_brightness_contrast_torchvision(  # noqa: C901, PLR0912
 
     """
     if contrast_factor == 1:
-        if brightness_factor == 0:
-            return np.zeros_like(img)
-        if brightness_factor == 1:
-            return img
-        result = multiply(img, brightness_factor, inplace=False)
-        if result.dtype == np.float32:
-            return np.clip(result, 0.0, 1.0, out=result)
-        return result
+        return _apply_brightness_only_torchvision(img, brightness_factor)
 
     if brightness_factor == 1:
-        gray_img = img if is_grayscale_image(img) else cast("ImageType", cv2.cvtColor(img, cv2.COLOR_RGB2GRAY))
-        img_mean = float(mean(gray_img))
-        if contrast_factor == 0:
-            if img.dtype != np.float32:
-                img_mean = int(img_mean + 0.5)
-            return cast("ImageType", np.full_like(img, img_mean, dtype=img.dtype))
-        result = multiply_add(img, contrast_factor, img_mean * (1 - contrast_factor), inplace=False)
-        if result.dtype == np.float32:
-            return np.clip(result, 0.0, 1.0, out=result)
-        return result
+        return _apply_contrast_only_torchvision(img, contrast_factor)
 
     # Compute original grayscale mean once, normalised to [0, 1].
     # For non-RGB inputs, the global mean is unchanged by first averaging each
@@ -313,33 +362,20 @@ def apply_brightness_contrast_torchvision(  # noqa: C901, PLR0912
     mean_at_contrast = float(np.clip(img_mean * brightness_factor, 0.0, 1.0)) if brightness_first else img_mean
 
     if img.dtype == np.uint8:
-        lut = np.arange(256, dtype=np.float32)
-        if brightness_first:
-            lut = np.clip(lut * brightness_factor, 0.0, 255.0)
-            lut = np.clip(lut * contrast_factor + mean_at_contrast * 255.0 * (1.0 - contrast_factor), 0.0, 255.0)
-        else:
-            lut = np.clip(lut * contrast_factor + mean_at_contrast * 255.0 * (1.0 - contrast_factor), 0.0, 255.0)
-            # Values are non-negative after clipping, so floor matches the uint8 cast between torchvision operations.
-            np.floor(lut, out=lut)
-            lut = np.clip(lut * brightness_factor, 0.0, 255.0)
-        return sz_lut(img, lut.astype(np.uint8), inplace=False)
-
-    # float32: two clipped passes, single buffer, in-place ops
-    offset = mean_at_contrast * (1.0 - contrast_factor)
-    out = np.empty_like(img)
-    if brightness_first:
-        np.multiply(img, brightness_factor, out=out)
-        np.clip(out, 0.0, 1.0, out=out)
-        np.multiply(out, contrast_factor, out=out)
-        np.add(out, offset, out=out)
-        np.clip(out, 0.0, 1.0, out=out)
-    else:
-        np.multiply(img, contrast_factor, out=out)
-        np.add(out, offset, out=out)
-        np.clip(out, 0.0, 1.0, out=out)
-        np.multiply(out, brightness_factor, out=out)
-        np.clip(out, 0.0, 1.0, out=out)
-    return out
+        return _apply_brightness_contrast_uint8(
+            img,
+            brightness_factor,
+            contrast_factor,
+            mean_at_contrast,
+            brightness_first,
+        )
+    return _apply_brightness_contrast_float32(
+        img,
+        brightness_factor,
+        contrast_factor,
+        mean_at_contrast,
+        brightness_first,
+    )
 
 
 @uint8_io

--- a/albumentations/augmentations/pixel/_functional_torchvision.py
+++ b/albumentations/augmentations/pixel/_functional_torchvision.py
@@ -186,60 +186,6 @@ def fancy_pca(img: ImageType, alpha_vector: np.ndarray) -> ImageType:
     return np.clip(img_pca, 0, 1, out=img_pca)
 
 
-@preserve_channel_dim
-def adjust_brightness_torchvision(img: ImageType, factor: float) -> ImageType:
-    """Adjust brightness by multiplying pixels by a scalar factor, matching TorchVision behavior for uint8 and
-    float32 images without changing shape.
-
-    This function adjusts the brightness of an image by multiplying each pixel value by a factor.
-    The brightness is adjusted by multiplying the image by the factor.
-
-    Args:
-        img (ImageType): Input image as a numpy array.
-        factor (float): The factor to adjust the brightness by.
-
-    Returns:
-        ImageType: The adjusted image.
-
-    """
-    if factor == 0:
-        return np.zeros_like(img)
-    if factor == 1:
-        return img
-
-    return multiply(img, factor, inplace=False)
-
-
-@preserve_channel_dim
-def adjust_contrast_torchvision(img: ImageType, factor: float) -> ImageType:
-    """Adjust contrast by multiplying by factor (relative to grayscale mean). Torchvision-compatible;
-    uint8 and float32. factor 0 yields flat gray.
-
-    This function adjusts the contrast of an image by multiplying each pixel value by a factor.
-    The contrast is adjusted by multiplying the image by the factor.
-
-    Args:
-        img (ImageType): Input image as a numpy array.
-        factor (float): The factor to adjust the contrast by.
-
-    Returns:
-        ImageType: The adjusted image.
-
-    """
-    if factor == 1:
-        return img
-
-    gray_img = img if is_grayscale_image(img) else cast("ImageType", cv2.cvtColor(img, cv2.COLOR_RGB2GRAY))
-    img_mean = float(mean(gray_img))
-
-    if factor == 0:
-        if img.dtype != np.float32:
-            img_mean = int(img_mean + 0.5)
-        return cast("ImageType", np.full_like(img, img_mean, dtype=img.dtype))
-
-    return multiply_add(img, factor, img_mean * (1 - factor), inplace=False)
-
-
 @clipped
 @preserve_channel_dim
 def adjust_saturation_torchvision(
@@ -306,7 +252,7 @@ def adjust_hue_torchvision(img: ImageType, factor: float) -> ImageType:
     return cast("ImageType", cv2.cvtColor(img, cv2.COLOR_HSV2RGB))
 
 
-def apply_brightness_contrast_torchvision(
+def apply_brightness_contrast_torchvision(  # noqa: C901, PLR0912
     img: ImageType,
     brightness_factor: float,
     contrast_factor: float,
@@ -334,6 +280,28 @@ def apply_brightness_contrast_torchvision(
         ImageType: Adjusted image with the same dtype as input.
 
     """
+    if contrast_factor == 1:
+        if brightness_factor == 0:
+            return np.zeros_like(img)
+        if brightness_factor == 1:
+            return img
+        result = multiply(img, brightness_factor, inplace=False)
+        if result.dtype == np.float32:
+            return np.clip(result, 0.0, 1.0, out=result)
+        return result
+
+    if brightness_factor == 1:
+        gray_img = img if is_grayscale_image(img) else cast("ImageType", cv2.cvtColor(img, cv2.COLOR_RGB2GRAY))
+        img_mean = float(mean(gray_img))
+        if contrast_factor == 0:
+            if img.dtype != np.float32:
+                img_mean = int(img_mean + 0.5)
+            return cast("ImageType", np.full_like(img, img_mean, dtype=img.dtype))
+        result = multiply_add(img, contrast_factor, img_mean * (1 - contrast_factor), inplace=False)
+        if result.dtype == np.float32:
+            return np.clip(result, 0.0, 1.0, out=result)
+        return result
+
     # Compute original grayscale mean once, normalised to [0, 1].
     # For non-RGB inputs, the global mean is unchanged by first averaging each
     # pixel's channels, so no intermediate grayscale array is needed.
@@ -534,8 +502,6 @@ def slic(
 
 __all__ = [
     "_adjust_hue_torchvision_uint8",
-    "adjust_brightness_torchvision",
-    "adjust_contrast_torchvision",
     "adjust_hue_torchvision",
     "adjust_saturation_torchvision",
     "apply_brightness_contrast_torchvision",

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -205,9 +205,9 @@ class ColorJitter(ImageOnlyTransform):
                     brightness_first=False,
                 )
             elif op == "brightness":
-                img = fpixel.adjust_brightness_torchvision(img, brightness)
+                img = fpixel.apply_brightness_contrast_torchvision(img, brightness, 1.0, brightness_first=True)
             elif op == "contrast":
-                img = fpixel.adjust_contrast_torchvision(img, contrast)
+                img = fpixel.apply_brightness_contrast_torchvision(img, 1.0, contrast, brightness_first=False)
             elif op == "saturation":
                 img = fpixel.adjust_saturation_torchvision(img, saturation)
             elif op == "hue":
@@ -1295,9 +1295,9 @@ class PhotoMetricDistort(ImageOnlyTransform):
                 brightness_first=True,
             )
         if brightness_factor is not None:
-            return fpixel.adjust_brightness_torchvision(img, brightness_factor)
+            return fpixel.apply_brightness_contrast_torchvision(img, brightness_factor, 1.0, brightness_first=True)
         if contrast_factor is not None:
-            return fpixel.adjust_contrast_torchvision(img, contrast_factor)
+            return fpixel.apply_brightness_contrast_torchvision(img, 1.0, contrast_factor, brightness_first=False)
         return img
 
     def apply(
@@ -1322,7 +1322,12 @@ class PhotoMetricDistort(ImageOnlyTransform):
                 contrast_factor,
             )
         elif brightness_factor is not None:
-            img = fpixel.adjust_brightness_torchvision(img, brightness_factor)
+            img = fpixel.apply_brightness_contrast_torchvision(
+                img,
+                brightness_factor,
+                1.0,
+                brightness_first=True,
+            )
 
         if saturation_factor is not None:
             img = fpixel.adjust_saturation_torchvision(img, saturation_factor)
@@ -1330,7 +1335,12 @@ class PhotoMetricDistort(ImageOnlyTransform):
             img = fpixel.adjust_hue_torchvision(img, hue_factor)
 
         if not contrast_before and contrast_factor is not None:
-            img = fpixel.adjust_contrast_torchvision(img, contrast_factor)
+            img = fpixel.apply_brightness_contrast_torchvision(
+                img,
+                1.0,
+                contrast_factor,
+                brightness_first=False,
+            )
 
         if channel_permutation is not None:
             img = fpixel.channel_shuffle(img, channel_permutation)

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -828,7 +828,8 @@ class RandomBrightnessContrast(ImageOnlyTransform):
                 max_value,
             )
 
-        return albucore.multiply_add(img, alpha, beta, inplace=False)
+        result = albucore.multiply_add(img, alpha, beta, inplace=False)
+        return fpixel.clip(result, img.dtype, inplace=True) if img.dtype == np.float32 else result
 
     def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
         if not self.brightness_by_max:

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -140,6 +140,8 @@ class Normalize(ImageOnlyTransform):
 
     """
 
+    _preserves_input_image_range = False
+
     class InitSchema(BaseTransformInitSchema):
         mean: tuple[float, ...] | float | None
         std: tuple[float, ...] | float | None

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -112,6 +112,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         _targets (tuple[Targets, ...] | Targets): Target types this transform can work with.
         _available_keys (set[str]): String representations of valid target keys.
         _key2func (dict[str, Callable[..., Any]]): Mapping between target keys and their processing functions.
+        _preserves_input_image_range (bool): Whether image targets retain the normalized range of their input dtype.
 
     Args:
         interpolation (int): Interpolation method for image transforms.
@@ -152,6 +153,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
     _supports_cpu_tensor: ClassVar[bool] = False
     _cpu_tensor_targets: ClassVar[frozenset[str] | None] = None
     _cpu_tensor_channels: ClassVar[frozenset[int] | None] = None
+    _preserves_input_image_range: ClassVar[bool] = True  # image targets retain the input dtype's normalized range
     _removed_sampling_hooks: ClassVar[frozenset[str]] = frozenset({"get_params", "get_params_dependent_on_data"})
 
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -209,6 +209,15 @@ def apply(self, img: np.ndarray, **params) -> np.ndarray:
     return result
 ```
 
+### Image Value Ranges and `@clipped`
+
+- Image transforms preserve `[0, 255]` for `uint8` and `[0, 1]` for `float32`, unless the transform explicitly sets
+  `_preserves_input_image_range = False`.
+- Use `@clipped` when every route of a functional image operation can leave this range. When only a known float32 mode
+  can overshoot, branch on that mode and call `albucore.clip(..., inplace=True)` there. Do not clip masks or annotations.
+- Do not add a forwarding wrapper around a one-line call merely to attach a decorator. Add a function only when it
+  owns a real image operation and separates image policy from mask or annotation semantics.
+
 ### Channel Flexibility
 
 - Support arbitrary number of channels unless specifically constrained:

--- a/tests/contracts/test_image_range_contract.py
+++ b/tests/contracts/test_image_range_contract.py
@@ -1,0 +1,93 @@
+"""Range invariants for public NumPy image and volume transforms."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, get_args
+
+import cv2
+import numpy as np
+import pytest
+
+import albumentations as A
+from tests.helpers.transform_cases import TRANSFORM_CONTRACT_CASES, TransformContractCase
+
+_IMAGE_TARGETS = ("image", "images", "volume")
+_FLOAT32_FILL_PARAMETERS = frozenset({"fill", "drop_value", "mask_drop_value"})
+
+
+def _range_data(case: TransformContractCase, dtype: np.dtype[Any]) -> dict[str, Any]:
+    data = case.make_data(np.random.default_rng(137))
+    for target in _IMAGE_TARGETS:
+        if target in data:
+            data[target] = _range_extrema(data[target], dtype)
+    for metadata_key in case.metadata_keys:
+        data[metadata_key] = _range_reference_images(data[metadata_key], dtype)
+    return data
+
+
+def _range_extrema(image: np.ndarray, dtype: np.dtype[Any]) -> np.ndarray:
+    result = np.empty_like(image, dtype=dtype)
+    result.fill(0)
+    width_axis = -2 if result.ndim >= 3 else -1
+    edge = [slice(None)] * result.ndim
+    edge[width_axis] = slice(result.shape[width_axis] // 2, None)
+    result[tuple(edge)] = np.iinfo(dtype).max if dtype == np.uint8 else 1.0
+    return result
+
+
+def _range_reference_images(value: Any, dtype: np.dtype[Any]) -> Any:
+    if isinstance(value, np.ndarray):
+        return _range_extrema(value, dtype)
+    if isinstance(value, list):
+        return [_range_reference_images(item, dtype) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_range_reference_images(item, dtype) for item in value)
+    if isinstance(value, dict):
+        return {key: _range_reference_images(item, dtype) if key == "image" else item for key, item in value.items()}
+    return value
+
+
+def _range_init_kwargs(case: TransformContractCase, dtype: np.dtype[Any]) -> dict[str, Any]:
+    init_kwargs = copy.deepcopy(dict(case.init_kwargs))
+    if dtype == np.float32:
+        for parameter_name in _FLOAT32_FILL_PARAMETERS & init_kwargs.keys():
+            init_kwargs[parameter_name] = 0
+    interpolation_field = case.transform_cls.InitSchema.model_fields.get("interpolation")
+    interpolation_values = get_args(interpolation_field.annotation) if interpolation_field is not None else ()
+    if interpolation_field is not None and (not interpolation_values or cv2.INTER_CUBIC in interpolation_values):
+        init_kwargs["interpolation"] = cv2.INTER_CUBIC
+        if "area_for_downscale" in init_kwargs:
+            init_kwargs["area_for_downscale"] = None
+    return init_kwargs
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32], ids=["uint8", "float32"])
+@pytest.mark.parametrize("case", TRANSFORM_CONTRACT_CASES, ids=lambda case: case.case_id)
+def test_range_preserving_transforms_keep_normalized_image_targets_in_range(
+    case: TransformContractCase,
+    dtype: np.dtype[Any],
+) -> None:
+    if not case.transform_cls._preserves_input_image_range:
+        pytest.skip("The transform explicitly changes the image value range.")
+
+    source = _range_data(case, dtype)
+    pipeline = A.Compose(
+        [case.transform_cls(**_range_init_kwargs(case, dtype), p=1.0)],
+        strict=True,
+        telemetry=False,
+        seed=case.seeds[0],
+        **copy.deepcopy(dict(case.primary_compose_kwargs)),
+    )
+
+    result = pipeline(**source)
+
+    for target in _IMAGE_TARGETS:
+        if target not in result:
+            continue
+        image = result[target]
+        max_value = np.iinfo(image.dtype).max if image.dtype == np.uint8 else 1.0
+        assert image.dtype in (np.uint8, np.float32), f"{case.case_id}: {target} returned {image.dtype}"
+        assert np.isfinite(image).all(), f"{case.case_id}: {target} contains non-finite values"
+        assert image.min() >= 0, f"{case.case_id}: {target} has values below zero"
+        assert image.max() <= max_value, f"{case.case_id}: {target} exceeds {max_value}"

--- a/tests/test_pre_commit_hooks.py
+++ b/tests/test_pre_commit_hooks.py
@@ -7,11 +7,26 @@ from pathlib import Path
 from tools import (
     check_internal_workspace,
     check_local_markdown_links,
+    check_no_defaults_in_schemas,
     check_quality_suppressions,
     check_range_parameter_annotations,
     check_removed_sampling_hooks,
     check_transform_init_args_override,
 )
+
+
+def test_schema_default_hook_rejects_default_factory(tmp_path: Path) -> None:
+    source = tmp_path / "schema.py"
+    source.write_text(
+        "from pydantic import BaseModel, Field\n"
+        "class Schema(BaseModel):\n"
+        "    values: list[int] = Field(default_factory=list)\n",
+        encoding="utf-8",
+    )
+
+    assert check_no_defaults_in_schemas.check_file(source) == [
+        (str(source), 3, "Field 'values' in BaseModel class 'Schema' has a default value"),
+    ]
 
 
 def test_quality_suppression_hook_rejects_inline_complexity_suppressions(tmp_path: Path) -> None:

--- a/tests/test_pre_commit_hooks.py
+++ b/tests/test_pre_commit_hooks.py
@@ -7,10 +7,46 @@ from pathlib import Path
 from tools import (
     check_internal_workspace,
     check_local_markdown_links,
+    check_quality_suppressions,
     check_range_parameter_annotations,
     check_removed_sampling_hooks,
     check_transform_init_args_override,
 )
+
+
+def test_quality_suppression_hook_rejects_inline_complexity_suppressions(tmp_path: Path) -> None:
+    source = tmp_path / "example.py"
+    source.write_text("def transform():  # noqa: C901, PLR0912 - temporary\n    pass\n", encoding="utf-8")
+
+    assert check_quality_suppressions.collect_errors((source,)) == [
+        f"{source}:1: do not suppress mandatory complexity checks (C901, PLR0912)",
+    ]
+
+
+def test_quality_suppression_hook_rejects_relaxed_production_limits(tmp_path: Path) -> None:
+    config = tmp_path / "pyproject.toml"
+    config.write_text(
+        '[tool.ruff.lint]\nignore = ["C901"]\n\n'
+        "[tool.ruff.lint.pylint]\nmax-branches = 13\n\n"
+        'lint.per-file-ignores."albumentations/example.py" = ["PLR0912"]\n\n'
+        "[tool.ruff.lint.per-file-ignores]\n"
+        '"albumentations/other.py" = ["C901"]\n',
+        encoding="utf-8",
+    )
+
+    assert check_quality_suppressions.collect_errors((config,)) == [
+        f"{config}: do not ignore mandatory complexity checks (C901)",
+        f"{config}: do not ignore mandatory complexity checks for albumentations/example.py (PLR0912)",
+        f"{config}: do not ignore mandatory complexity checks for albumentations/other.py (C901)",
+        f"{config}:5: max-branches must not exceed 12",
+    ]
+
+
+def test_quality_suppression_hook_keeps_test_complexity_policy(tmp_path: Path) -> None:
+    config = tmp_path / "pyproject.toml"
+    config.write_text('lint.per-file-ignores."tests/*" = ["C901", "PLR0912"]\n', encoding="utf-8")
+
+    assert check_quality_suppressions.collect_errors((config,)) == []
 
 
 def test_internal_workspace_rejects_everything_except_gitkeep() -> None:

--- a/tests/test_pre_commit_hooks.py
+++ b/tests/test_pre_commit_hooks.py
@@ -26,19 +26,16 @@ def test_quality_suppression_hook_rejects_inline_complexity_suppressions(tmp_pat
 def test_quality_suppression_hook_rejects_relaxed_production_limits(tmp_path: Path) -> None:
     config = tmp_path / "pyproject.toml"
     config.write_text(
-        '[tool.ruff.lint]\nignore = ["C901"]\n\n'
-        "[tool.ruff.lint.pylint]\nmax-branches = 13\n\n"
-        'lint.per-file-ignores."albumentations/example.py" = ["PLR0912"]\n\n'
-        "[tool.ruff.lint.per-file-ignores]\n"
-        '"albumentations/other.py" = ["C901"]\n',
+        '[tool.ruff.lint]\nignore = ["C901"]\n'
+        'per-file-ignores = { "albumentations/example.py" = ["PLR0912"] }\n\n'
+        "[tool.ruff.lint.pylint]\nmax-branches = 13\n",
         encoding="utf-8",
     )
 
     assert check_quality_suppressions.collect_errors((config,)) == [
         f"{config}: do not ignore mandatory complexity checks (C901)",
         f"{config}: do not ignore mandatory complexity checks for albumentations/example.py (PLR0912)",
-        f"{config}: do not ignore mandatory complexity checks for albumentations/other.py (C901)",
-        f"{config}:5: max-branches must not exceed 12",
+        f"{config}: max-branches must not exceed 12",
     ]
 
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -830,6 +830,32 @@ def test_random_brightness_contrast_max_mode_preserves_opencv_formula():
     np.testing.assert_array_equal(result, np.full_like(image, 151))
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize(
+    ("target", "shape"),
+    [
+        ("image", (2, 2, 3)),
+        ("images", (2, 2, 2, 3)),
+        ("volume", (2, 2, 2, 3)),
+    ],
+)
+def test_random_brightness_contrast_max_mode_clips_normalized_float_outputs(
+    dtype: type[np.uint8] | type[np.float32],
+    target: str,
+    shape: tuple[int, ...],
+) -> None:
+    transform = A.RandomBrightnessContrast(
+        brightness_range=(-0.15, -0.15),
+        contrast_range=(0, 0),
+        brightness_by_max=True,
+        p=1,
+    )
+
+    result = transform(**{target: np.zeros(shape, dtype=dtype)})[target]
+
+    np.testing.assert_array_equal(result, np.zeros_like(result))
+
+
 @pytest.mark.parametrize(
     "transform_kwargs",
     [
@@ -2542,16 +2568,19 @@ def test_letterbox_positions(position):
     assert result.shape == (200, 200, 3)
 
 
-def test_letterbox_fill_value():
+@pytest.mark.parametrize(
+    ("dtype", "fill_value"),
+    [(np.uint8, 114), (np.float32, 114 / 255)],
+)
+def test_letterbox_fill_value(dtype, fill_value):
     """Padding region should be exactly the fill value."""
-    image = np.zeros((100, 200, 3), dtype=np.uint8)
-    fill_val = 114
+    image = np.zeros((100, 200, 3), dtype=dtype)
     target_size = (200, 200)
-    aug = A.Compose([A.LetterBox(size=target_size, fill=fill_val, position="top_left", p=1.0)])
+    aug = A.Compose([A.LetterBox(size=target_size, fill=fill_value, position="top_left", p=1.0)])
     result = aug(image=image)["image"]
     # wide image (100x200) -> fits width exactly at scale=1, pad_top=50
     pad_bottom = result[150:, :, :]
-    np.testing.assert_array_equal(pad_bottom, fill_val)
+    np.testing.assert_allclose(pad_bottom, fill_value)
 
 
 def test_letterbox_preserves_aspect_ratio():

--- a/tools/check_no_defaults_in_schemas.py
+++ b/tools/check_no_defaults_in_schemas.py
@@ -54,68 +54,47 @@ class DefaultValueChecker(ast.NodeVisitor):
         # Indirect inheritance (recursive check)
         return any(base in self.class_inheritance and self._inherits_from_basemodel(base) for base in bases)
 
-    def _check_class_fields(self, node: ast.ClassDef) -> None:  # noqa: C901, PLR0912
+    def _check_class_fields(self, node: ast.ClassDef) -> None:
         """Check for default values in class field annotations."""
         for item in node.body:
-            if isinstance(item, ast.AnnAssign) and item.value is not None:
-                # This is an annotated assignment with a default value
-                field_name = ast.unparse(item.target) if hasattr(ast, "unparse") else str(item.target)
-
-                # Skip special fields that are allowed to have defaults
-                if self._is_allowed_default_field(field_name):
-                    continue
-
-                # Skip discriminator fields (Literal types used for Pydantic discriminated unions)
-                if self._is_discriminator_field(item):
-                    continue
-
-                # Check if it's a Field() call with default
-                if isinstance(item.value, ast.Call):
-                    if isinstance(item.value.func, ast.Name) and item.value.func.id == "Field":
-                        # Check if Field() has a default parameter or positional arg
-                        has_default = False
-
-                        # Check positional arguments (first arg is default if present)
-                        if item.value.args:
-                            has_default = True
-
-                        # Check keyword arguments for 'default'
-                        for keyword in item.value.keywords:
-                            if keyword.arg == "default":
-                                has_default = True
-                                break
-
-                        if has_default:
-                            self.errors.append(
-                                (
-                                    self.current_file,
-                                    item.lineno,
-                                    f"Field '{field_name}' in BaseModel class '{node.name}' has a default value",
-                                ),
-                            )
-                else:
-                    # Direct assignment (not Field())
-                    self.errors.append(
-                        (
-                            self.current_file,
-                            item.lineno,
-                            f"Field '{field_name}' in BaseModel class '{node.name}' has a default value",
-                        ),
-                    )
-
+            if isinstance(item, ast.AnnAssign):
+                self._check_annotated_field(item, node.name)
             elif isinstance(item, ast.Assign):
-                # Handle regular assignments (var = value)
-                for target in item.targets:
-                    if isinstance(target, ast.Name):
-                        field_name = target.id
-                        if not self._is_allowed_default_field(field_name):
-                            self.errors.append(
-                                (
-                                    self.current_file,
-                                    item.lineno,
-                                    f"Field '{field_name}' in BaseModel class '{node.name}' has a default value",
-                                ),
-                            )
+                self._check_assigned_fields(item, node.name)
+
+    def _check_annotated_field(self, item: ast.AnnAssign, class_name: str) -> None:
+        if item.value is None:
+            return
+
+        field_name = ast.unparse(item.target) if hasattr(ast, "unparse") else str(item.target)
+        if self._is_allowed_default_field(field_name) or self._is_discriminator_field(item):
+            return
+
+        if not self._is_field_without_default(item.value):
+            self._add_error(field_name, class_name, item.lineno)
+
+    def _check_assigned_fields(self, item: ast.Assign, class_name: str) -> None:
+        for target in item.targets:
+            if isinstance(target, ast.Name) and not self._is_allowed_default_field(target.id):
+                self._add_error(target.id, class_name, item.lineno)
+
+    def _is_field_without_default(self, value: ast.expr) -> bool:
+        return (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id == "Field"
+            and not value.args
+            and all(keyword.arg != "default" for keyword in value.keywords)
+        )
+
+    def _add_error(self, field_name: str, class_name: str, line_number: int) -> None:
+        self.errors.append(
+            (
+                self.current_file,
+                line_number,
+                f"Field '{field_name}' in BaseModel class '{class_name}' has a default value",
+            ),
+        )
 
     def _is_allowed_default_field(self, field_name: str) -> bool:
         """Check if a field is allowed to have default values."""

--- a/tools/check_no_defaults_in_schemas.py
+++ b/tools/check_no_defaults_in_schemas.py
@@ -84,7 +84,7 @@ class DefaultValueChecker(ast.NodeVisitor):
             and isinstance(value.func, ast.Name)
             and value.func.id == "Field"
             and not value.args
-            and all(keyword.arg != "default" for keyword in value.keywords)
+            and all(keyword.arg not in {"default", "default_factory"} for keyword in value.keywords)
         )
 
     def _add_error(self, field_name: str, class_name: str, line_number: int) -> None:

--- a/tools/check_quality_suppressions.py
+++ b/tools/check_quality_suppressions.py
@@ -1,0 +1,119 @@
+"""Reject attempts to disable mandatory complexity diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tokenize
+from pathlib import Path
+
+MANDATORY_COMPLEXITY_RULES = {"C901", "PLR0912"}
+NOQA_PATTERN = re.compile(r"#\s*(?:ruff:\s*)?noqa(?:\s*:\s*(?P<codes>[A-Z0-9,\s]+))?", re.IGNORECASE)
+PER_FILE_IGNORES_PATTERN = re.compile(
+    r'^lint\.per-file-ignores\."(?P<target>[^"]+)"\s*=\s*\[(?P<codes>.*?)\]',
+    re.MULTILINE | re.DOTALL,
+)
+PER_FILE_IGNORES_SECTION_PATTERN = re.compile(
+    r"^\[tool\.ruff\.lint\.per-file-ignores\]\s*$\n(?P<rules>.*?)(?=^\[|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+PER_FILE_IGNORE_ENTRY_PATTERN = re.compile(
+    r'^"(?P<target>[^"]+)"\s*=\s*\[(?P<codes>.*?)\]',
+    re.MULTILINE | re.DOTALL,
+)
+GLOBAL_IGNORES_PATTERN = re.compile(
+    r"^\s*(?:lint\.)?(?:extend-)?ignore\s*=\s*\[(?P<codes>.*?)\]",
+    re.MULTILINE | re.DOTALL,
+)
+COMPLEXITY_LIMITS = {"max-complexity": 10, "max-branches": 12}
+
+
+def _is_forbidden_rule(code: str) -> bool:
+    return code.upper() in MANDATORY_COMPLEXITY_RULES
+
+
+def _find_suppressed_rules(comment: str) -> tuple[str, ...]:
+    match = NOQA_PATTERN.search(comment)
+    if match is None:
+        return ()
+
+    codes = match.group("codes")
+    if codes is None:
+        return ("all diagnostics",)
+    return tuple(code for code in re.findall(r"[A-Z]+\d+", codes.upper()) if _is_forbidden_rule(code))
+
+
+def _collect_python_errors(path: Path) -> list[str]:
+    errors: list[str] = []
+    with path.open(encoding="utf-8") as source:
+        tokens = tokenize.generate_tokens(source.readline)
+        for token in tokens:
+            if token.type != tokenize.COMMENT:
+                continue
+            suppressed_rules = _find_suppressed_rules(token.string)
+            if suppressed_rules:
+                rules = ", ".join(suppressed_rules)
+                errors.append(f"{path}:{token.start[0]}: do not suppress mandatory complexity checks ({rules})")
+    return errors
+
+
+def _find_rules(config_value: str) -> tuple[str, ...]:
+    return tuple(rule for rule in re.findall(r'["\']([A-Z]+\d+)["\']', config_value) if _is_forbidden_rule(rule))
+
+
+def _collect_per_file_ignore_errors(path: Path, target: str, config_value: str) -> list[str]:
+    if target.startswith("tests/") or not (rules := _find_rules(config_value)):
+        return []
+    return [f"{path}: do not ignore mandatory complexity checks for {target} ({', '.join(rules)})"]
+
+
+def _collect_toml_errors(path: Path) -> list[str]:
+    source = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    errors.extend(
+        f"{path}: do not ignore mandatory complexity checks ({', '.join(rules)})"
+        for match in GLOBAL_IGNORES_PATTERN.finditer(source)
+        if (rules := _find_rules(match.group("codes")))
+    )
+
+    for match in PER_FILE_IGNORES_PATTERN.finditer(source):
+        errors.extend(_collect_per_file_ignore_errors(path, match.group("target"), match.group("codes")))
+
+    for section in PER_FILE_IGNORES_SECTION_PATTERN.finditer(source):
+        for match in PER_FILE_IGNORE_ENTRY_PATTERN.finditer(section.group("rules")):
+            errors.extend(_collect_per_file_ignore_errors(path, match.group("target"), match.group("codes")))
+
+    for line_number, line in enumerate(source.splitlines(), start=1):
+        for setting, maximum in COMPLEXITY_LIMITS.items():
+            match = re.match(rf"\s*{setting}\s*=\s*(\d+)\b", line)
+            if match and int(match.group(1)) > maximum:
+                errors.append(f"{path}:{line_number}: {setting} must not exceed {maximum}")
+    return errors
+
+
+def collect_errors(filenames: tuple[str | Path, ...]) -> list[str]:
+    """Return mandatory-complexity-check suppressions in staged source or Ruff configuration."""
+    errors: list[str] = []
+    for filename in filenames:
+        path = Path(filename)
+        if path.suffix == ".py":
+            errors.extend(_collect_python_errors(path))
+        elif path.suffix == ".toml":
+            errors.extend(_collect_toml_errors(path))
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Reject suppression of mandatory complexity diagnostics")
+    parser.add_argument("filenames", nargs="*")
+    args = parser.parse_args()
+
+    errors = collect_errors(tuple(args.filenames))
+    for error in errors:
+        print(error)
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_quality_suppressions.py
+++ b/tools/check_quality_suppressions.py
@@ -5,26 +5,17 @@ from __future__ import annotations
 import argparse
 import re
 import tokenize
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 MANDATORY_COMPLEXITY_RULES = {"C901", "PLR0912"}
 NOQA_PATTERN = re.compile(r"#\s*(?:ruff:\s*)?noqa(?:\s*:\s*(?P<codes>[A-Z0-9,\s]+))?", re.IGNORECASE)
-PER_FILE_IGNORES_PATTERN = re.compile(
-    r'^lint\.per-file-ignores\."(?P<target>[^"]+)"\s*=\s*\[(?P<codes>.*?)\]',
-    re.MULTILINE | re.DOTALL,
-)
-PER_FILE_IGNORES_SECTION_PATTERN = re.compile(
-    r"^\[tool\.ruff\.lint\.per-file-ignores\]\s*$\n(?P<rules>.*?)(?=^\[|\Z)",
-    re.MULTILINE | re.DOTALL,
-)
-PER_FILE_IGNORE_ENTRY_PATTERN = re.compile(
-    r'^"(?P<target>[^"]+)"\s*=\s*\[(?P<codes>.*?)\]',
-    re.MULTILINE | re.DOTALL,
-)
-GLOBAL_IGNORES_PATTERN = re.compile(
-    r"^\s*(?:lint\.)?(?:extend-)?ignore\s*=\s*\[(?P<codes>.*?)\]",
-    re.MULTILINE | re.DOTALL,
-)
 COMPLEXITY_LIMITS = {"max-complexity": 10, "max-branches": 12}
 
 
@@ -57,38 +48,43 @@ def _collect_python_errors(path: Path) -> list[str]:
     return errors
 
 
-def _find_rules(config_value: str) -> tuple[str, ...]:
-    return tuple(rule for rule in re.findall(r'["\']([A-Z]+\d+)["\']', config_value) if _is_forbidden_rule(rule))
+def _find_rules(config_value: object) -> tuple[str, ...]:
+    if not isinstance(config_value, list):
+        return ()
+    return tuple(rule for rule in config_value if isinstance(rule, str) and _is_forbidden_rule(rule))
 
 
-def _collect_per_file_ignore_errors(path: Path, target: str, config_value: str) -> list[str]:
+def _collect_per_file_ignore_errors(path: Path, target: str, config_value: object) -> list[str]:
     if target.startswith("tests/") or not (rules := _find_rules(config_value)):
         return []
     return [f"{path}: do not ignore mandatory complexity checks for {target} ({', '.join(rules)})"]
 
 
+def _as_mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
 def _collect_toml_errors(path: Path) -> list[str]:
-    source = path.read_text(encoding="utf-8")
+    config = tomllib.loads(path.read_text(encoding="utf-8"))
+    tool_config = _as_mapping(config.get("tool"))
+    ruff_config = _as_mapping(tool_config.get("ruff"))
+    lint_config = _as_mapping(ruff_config.get("lint"))
     errors: list[str] = []
 
     errors.extend(
         f"{path}: do not ignore mandatory complexity checks ({', '.join(rules)})"
-        for match in GLOBAL_IGNORES_PATTERN.finditer(source)
-        if (rules := _find_rules(match.group("codes")))
+        for setting in ("ignore", "extend-ignore")
+        if (rules := _find_rules(lint_config.get(setting)))
     )
 
-    for match in PER_FILE_IGNORES_PATTERN.finditer(source):
-        errors.extend(_collect_per_file_ignore_errors(path, match.group("target"), match.group("codes")))
+    per_file_ignores = _as_mapping(lint_config.get("per-file-ignores"))
+    for target, rules in per_file_ignores.items():
+        errors.extend(_collect_per_file_ignore_errors(path, target, rules))
 
-    for section in PER_FILE_IGNORES_SECTION_PATTERN.finditer(source):
-        for match in PER_FILE_IGNORE_ENTRY_PATTERN.finditer(section.group("rules")):
-            errors.extend(_collect_per_file_ignore_errors(path, match.group("target"), match.group("codes")))
-
-    for line_number, line in enumerate(source.splitlines(), start=1):
-        for setting, maximum in COMPLEXITY_LIMITS.items():
-            match = re.match(rf"\s*{setting}\s*=\s*(\d+)\b", line)
-            if match and int(match.group(1)) > maximum:
-                errors.append(f"{path}:{line_number}: {setting} must not exceed {maximum}")
+    for section, setting in (("mccabe", "max-complexity"), ("pylint", "max-branches")):
+        limit = _as_mapping(lint_config.get(section)).get(setting)
+        if isinstance(limit, int) and limit > COMPLEXITY_LIMITS[setting]:
+            errors.append(f"{path}: {setting} must not exceed {COMPLEXITY_LIMITS[setting]}")
     return errors
 
 


### PR DESCRIPTION
## Summary

- Add an adversarial public image-range contract test for uint8 and normalized float32 image, images, and volume targets.
- Restore the `[0, 1]` float32 output contract where brightness/contrast and cubic or Lanczos resampling can overshoot.
- Clip only the float32 branches that can leave range; keep uint8 and nearest, linear, and area routes unchanged.
- Remove forwarding TorchVision brightness and contrast helpers; keep their specialized behavior in the fused operation.
- Document the range, clipping, wrapper, and Albucore-escalation policies; refresh pre-commit hook revisions.

## Root cause

`multiply_add` intentionally has raw float semantics. Legacy transform code relied on it as if it clipped. In addition, high-order resampling can overshoot a valid float32 range.

## Validation

- `uv run python tools/quality_gate.py fast` — 1790 passed, 6 skipped.
- `pre-commit run --all-files` after `pre-commit autoupdate`.
- `pre-commit run --files tests/contracts/test_image_range_contract.py`.

## Summary by Sourcery

Enforce image value-range contracts across pixel and geometric transforms while strengthening the associated quality checks and contributor guidance.

Bug Fixes:
- Enforce public image value-range guarantees for uint8 and normalized float32 image, image-batch, and volume targets.
- Prevent brightness/contrast operations and overshooting geometric interpolation from producing out-of-range normalized float32 values.

Enhancements:
- Consolidate TorchVision brightness and contrast handling into the fused operation while preserving dtype-specific behavior.
- Document image range preservation, clipping policies, and normalized float32 padding conventions.

CI:
- Add pre-commit validation that rejects mandatory complexity-check suppressions and relaxations.
- Refresh Ruff and mypy pre-commit hook revisions.

Documentation:
- Update contributor guidance for preserving image value ranges and avoiding forwarding wrappers used solely for clipping decorators.

Tests:
- Add adversarial contract coverage for image-range preservation across image, images, and volume targets.
- Extend hook tests for schema defaults and complexity-suppression policies.

Chores:
- Refactor schema-default validation into smaller checks and reject default factories.