### PR TITLE
test: enforce public transform docstring contracts

### DIFF
--- a/tests/test_custom_transform_apply.py
+++ b/tests/test_custom_transform_apply.py
@@ -564,15 +564,9 @@ class TestReplayComposeIntegration:
             def apply_to_label(self, label: int, **params: Any) -> int:
                 return label + 100  # obvious change
 
-        transform = A.ReplayCompose([FlipWithLabel(p=0.5)], seed=137)
-        # Run until we get one where transform was NOT applied (label unchanged)
-        for _ in range(20):
-            result = transform(image=uint8_image, label=5)
-            if result["label"] == 5:  # not applied
-                saved = result["replay"]
-                break
-        else:
-            pytest.skip("RNG always applied transform in 20 tries")
+        transform = A.ReplayCompose([FlipWithLabel(p=0.0)], seed=137)
+        result = transform(image=uint8_image, label=5)
+        saved = result["replay"]
         # On replay, recorded applied=False means label should still be passed through unchanged
         replayed = A.ReplayCompose.replay(saved, image=uint8_image, label=5)
         assert replayed["label"] == 5

--- a/tests/test_custom_transform_apply.py
+++ b/tests/test_custom_transform_apply.py
@@ -564,7 +564,7 @@ class TestReplayComposeIntegration:
             def apply_to_label(self, label: int, **params: Any) -> int:
                 return label + 100  # obvious change
 
-        transform = A.ReplayCompose([FlipWithLabel(p=0.0)], seed=137)
+        transform = A.ReplayCompose([FlipWithLabel(p=0.0)])
         result = transform(image=uint8_image, label=5)
         saved = result["replay"]
         # On replay, recorded applied=False means label should still be passed through unchanged

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -3,10 +3,24 @@
 import pytest
 from google_docstring_parser import parse_google_docstring
 
+import albumentations as A
 from albumentations.core.type_definitions import Targets
-from tests.utils import get_primary_public_transform_params
+from tests.utils import get_all_valid_transforms
 
-PUBLIC_TRANSFORM_CLASSES = tuple(transform_cls for transform_cls, _ in get_primary_public_transform_params())
+_TRANSFORM_BASE_CLASSES = frozenset(
+    {
+        A.BasicTransform,
+        A.DualTransform,
+        A.ImageOnlyTransform,
+        A.Transform3D,
+        A.VolumeOnlyTransform,
+    },
+)
+PUBLIC_TRANSFORM_CLASSES = tuple(
+    transform_cls
+    for transform_cls in get_all_valid_transforms()
+    if issubclass(transform_cls, A.BasicTransform) and transform_cls not in _TRANSFORM_BASE_CLASSES
+)
 
 
 def parse_targets_from_docstring(docstring_targets: str) -> set[str]:

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -4,7 +4,9 @@ import pytest
 from google_docstring_parser import parse_google_docstring
 
 from albumentations.core.type_definitions import Targets
-from tests.utils import get_all_valid_transforms
+from tests.utils import get_primary_public_transform_params
+
+PUBLIC_TRANSFORM_CLASSES = tuple(transform_cls for transform_cls, _ in get_primary_public_transform_params())
 
 
 def parse_targets_from_docstring(docstring_targets: str) -> set[str]:
@@ -56,14 +58,13 @@ def get_class_bbox_types(cls) -> set[str]:
     return set()
 
 
-@pytest.mark.parametrize("transform_cls", get_all_valid_transforms())
+@pytest.mark.parametrize("transform_cls", PUBLIC_TRANSFORM_CLASSES)
 def test_docstring_targets_match_class_property(transform_cls):
     """Test that 'Targets:' in docstring matches _targets class property."""
     transform_name = transform_cls.__name__
     docstring = transform_cls.__doc__
 
-    if not docstring:
-        pytest.skip(f"{transform_name} has no docstring")
+    assert docstring, f"{transform_name} has no docstring"
 
     parsed = parse_google_docstring(docstring)
     docstring_targets_str = parsed.get("Targets")
@@ -74,11 +75,8 @@ def test_docstring_targets_match_class_property(transform_cls):
     # Get targets from class property
     class_targets = get_class_targets(transform_cls)
 
-    if not docstring_targets:
-        pytest.skip(f"{transform_name} has no 'Targets:' section in docstring")
-
-    if not class_targets:
-        pytest.skip(f"{transform_name} has no _targets property")
+    assert docstring_targets, f"{transform_name} has no 'Targets:' section in docstring"
+    assert class_targets, f"{transform_name} has no _targets property"
 
     # Check they match
     assert docstring_targets == class_targets, (
@@ -86,14 +84,13 @@ def test_docstring_targets_match_class_property(transform_cls):
     )
 
 
-@pytest.mark.parametrize("transform_cls", get_all_valid_transforms())
+@pytest.mark.parametrize("transform_cls", PUBLIC_TRANSFORM_CLASSES)
 def test_docstring_bbox_types_match_class_property(transform_cls):
     """Test that 'Supported bboxes:' in docstring matches _supported_bbox_types class property."""
     transform_name = transform_cls.__name__
     docstring = transform_cls.__doc__
 
-    if not docstring:
-        pytest.skip(f"{transform_name} has no docstring")
+    assert docstring, f"{transform_name} has no docstring"
 
     parsed = parse_google_docstring(docstring)
     docstring_bbox_types_str = parsed.get("Supported bboxes")


### PR DESCRIPTION
## Summary

- enforce `Targets:` docstring coverage for all concrete public transforms
- remove base and composition classes from this contract check
- make the ReplayCompose custom-target non-application test deterministic instead of skipping on a random outcome

## Why

`tests/test_docstrings.py` previously included infrastructure and composition classes, then skipped missing `Targets:` sections. That allowed concrete public transforms without the section to pass. The test now uses `get_primary_public_transform_params()` and asserts the docstring, `Targets:` section, and `_targets` property for every concrete public transform.

The ReplayCompose test now uses `p=0.0` to exercise the recorded `applied=False` path deterministically.

## Validation

- `pre-commit run --all-files`
- `.venv/bin/pytest -n auto -q` — 13926 passed, 32 skipped, 9 xfailed, 3 xpassed

## Summary by Sourcery

Enforce documentation contracts for concrete public transforms and remove nondeterminism from ReplayCompose coverage.

Bug Fixes:
- Make the ReplayCompose custom-target test deterministic by explicitly exercising the non-applied transform path.

Enhancements:
- Enforce docstring and target metadata contracts for all concrete public transforms while excluding transform base and composition classes.

Tests:
- Strengthen docstring validation to require transform docstrings, `Targets:` sections, and `_targets` properties instead of skipping missing entries.