### PR TITLE
test: add removal-deadline contract for announced code retirements

### DIFF
--- a/tests/contracts/test_removal_deadlines.py
+++ b/tests/contracts/test_removal_deadlines.py
@@ -1,0 +1,105 @@
+"""Removal-deadline contracts for code that announces its own retirement.
+
+Several code paths tell users they will disappear in a named release, for
+example the instance-binding permissive fallback in `Compose`. Nothing compares
+those announcements against the package version, so a deadline can pass without
+anyone noticing and the message keeps pointing users at a release that already
+shipped.
+
+This module parses every announcement in the source tree and fails once the
+package reaches the announced version.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import albumentations as A
+
+_ROOT = Path(A.__file__).resolve().parent
+_SUFFIXES = frozenset({".py"})
+_SKIP_PARTS = frozenset({"__pycache__"})
+
+_ANNOUNCEMENT_PATTERNS = (
+    re.compile(r"will be removed in\s+v?(?P<version>\d+\.\d+(?:\.\d+)?)", re.IGNORECASE),
+    re.compile(r"scheduled for removal in\s+v?(?P<version>\d+\.\d+(?:\.\d+)?)", re.IGNORECASE),
+)
+
+# Deadlines that have already passed and are awaiting a maintainer decision:
+# either drop the fallback or restate the deadline. Removing an entry here
+# without addressing the code turns the xfail into an unexpected pass, which
+# fails the suite and prevents the marker from being forgotten.
+_ACCEPTED_OVERDUE = frozenset(
+    {
+        ("core/composition.py", "2.3"),
+    },
+)
+
+
+def _parse_version(raw: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in raw.split("."))
+
+
+def _package_version() -> tuple[int, ...]:
+    return _parse_version(A.__version__)
+
+
+def _iter_announcements() -> list[tuple[str, int, str]]:
+    """Return (relative path, line number, announced version) for every announcement."""
+    announcements: list[tuple[str, int, str]] = []
+    for path in sorted(_ROOT.rglob("*")):
+        if not path.is_file() or path.suffix not in _SUFFIXES:
+            continue
+        if set(path.parts) & _SKIP_PARTS:
+            continue
+        relative = path.relative_to(_ROOT).as_posix()
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for pattern in _ANNOUNCEMENT_PATTERNS:
+                match = pattern.search(line)
+                if match:
+                    announcements.append((relative, number, match.group("version")))
+                    break
+    return announcements
+
+
+_ANNOUNCEMENTS = _iter_announcements()
+
+
+def test_announcements_are_discoverable() -> None:
+    """Guard the parser itself: silent zero matches would make the contract vacuous."""
+    assert _ANNOUNCEMENTS, "no removal announcements found - the parser or the patterns are stale"
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "line_number", "announced_raw"),
+    [
+        pytest.param(
+            relative_path,
+            line_number,
+            announced_raw,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    f"{relative_path} announces removal in {announced_raw}, which has shipped. "
+                    "Drop the code or restate the deadline, then remove this entry from _ACCEPTED_OVERDUE."
+                ),
+            ),
+        )
+        if (relative_path, announced_raw) in _ACCEPTED_OVERDUE
+        else pytest.param(relative_path, line_number, announced_raw)
+        for relative_path, line_number, announced_raw in _ANNOUNCEMENTS
+    ],
+    ids=[f"{relative_path}:{line_number}" for relative_path, line_number, _ in _ANNOUNCEMENTS],
+)
+def test_removal_deadline_has_not_passed(relative_path: str, line_number: int, announced_raw: str) -> None:
+    """A path that announces removal in X.Y must be gone once X.Y ships."""
+    announced = _parse_version(announced_raw)
+    current = _package_version()
+    assert current[:2] < announced[:2], (
+        f"{relative_path}:{line_number} announces removal in {announced_raw}, "
+        f"but the package is at {A.__version__}. Drop the code path or restate the deadline "
+        f"so the message stops pointing users at a release that already shipped."
+    )


### PR DESCRIPTION
Closes #447

## What changed

Adds `tests/contracts/test_removal_deadlines.py`: a contract test that parses
removal announcements ("will be removed in X.Y", "scheduled for removal in X.Y")
out of the package source and fails once the package version reaches the
announced release.

One new test file, no changes to library code.

## Why

Two paths in `core/composition.py` tell users the instance-binding permissive
fallback will be removed in 2.3. That announcement shipped in 2.2.2; the package
is at 2.4.2 and the fallback is still present, so the message points users at a
release that already shipped. Nothing compared announcements against the version,
so the deadline passed unnoticed across fourteen releases.

The test makes the comparison part of the suite, so the next deadline cannot
lapse silently.

## How the two known entries are handled

Both are listed in `_ACCEPTED_OVERDUE` and marked `xfail(strict=True)`, so this
PR does not turn CI red while the fallback's future is undecided. The markers are
self-clearing: once the code is dropped or the deadline restated, the xfail
becomes an unexpected pass and the suite fails until the entry is removed. Any
*new* announcement that lapses fails immediately, with no marker.

This PR deliberately does not decide what happens to the fallback itself — that
is a maintainer call, and #447 sketches a deprecate-in-2.x /
remove-in-3.0 shape for it along with the open questions. I'm happy to prepare
those follow-up PRs once you've picked a direction.

`test_announcements_are_discoverable` guards the parser: if the patterns go
stale and match nothing, the contract would silently pass, so zero matches is
itself a failure.

## Verification

```
python -m pytest tests/contracts/test_removal_deadlines.py -v -p no:randomly
    1 passed, 2 xfailed
    (xfail: core/composition.py:2963, core/composition.py:2982)

python -m pytest tests/ -n auto -q
    14005 passed, 25 skipped, 11 xfailed, 3 xpassed

mypy tests/contracts/test_removal_deadlines.py
    Success: no issues found in 1 source file

pre-commit run --files tests/contracts/test_removal_deadlines.py
    all applicable hooks passed (ruff, ruff format, Pyrefly, pyupgrade,
    numpy-assert-lint, codespell)
```

Environment: Python 3.11.9, Linux (WSL2), editable install, branch cut from
`main` at `7f81ae3`.

## Summary by Sourcery

Enforce announced code-removal deadlines through automated contract tests.

Enhancements:
- Add a contract test that discovers source-code removal announcements and verifies their deadlines against the package version.
- Track currently overdue announcements as strict expected failures while ensuring new expired deadlines fail the test suite.

Tests:
- Add coverage ensuring removal announcements are discoverable so parser drift cannot make the contract pass vacuously.