### PR TITLE
fix: drop stale 2.3 removal target from instance-binding fallback warnings

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -2960,7 +2960,8 @@ class Compose(BaseCompose, HubMixin):
             raise RuntimeError(msg)
         warnings.warn(
             msg + " Falling back to legacy permissive mode "
-            "(strict_instance_invariant=False); this fallback will be removed in 2.3.",
+            "(strict_instance_invariant=False); this fallback is deprecated and will be "
+            "removed in a future major release.",
             UserWarning,
             stacklevel=3,
         )
@@ -2979,7 +2980,7 @@ class Compose(BaseCompose, HubMixin):
         warnings.warn(
             msg + " Falling back to legacy permissive mode "
             "(strict_instance_invariant=False) — orphan keypoints will be dropped silently. "
-            "This fallback will be removed in 2.3.",
+            "This fallback is deprecated and will be removed in a future major release.",
             UserWarning,
             stacklevel=3,
         )


### PR DESCRIPTION
Closes #447

Both instance-binding fallback warnings told users the fallback would be removed
in 2.3. That message shipped in 2.2.2 (`4bcd92f`) and the package is at 2.4.2, so
it named a release that had already come and gone.

Reworded both to "deprecated and will be removed in a future major release", so
the messages no longer point at a shipped version. No behaviour change — warning
text only.

Verification:

```
python -m pytest tests/ -n auto -q             14004 passed, 25 skipped, 9 xfailed, 3 xpassed
pre-commit run --files albumentations/core/composition.py    all hooks passed
```

Environment: Python 3.11.9, Linux (WSL2), branch cut from `main` at `7f81ae3`.

## Summary by Sourcery

Bug Fixes:
- Update both instance-binding fallback warnings to avoid referencing the already-released 2.3 version and instead indicate removal in a future major release.