### PR TITLE
refactor(instance-binding): remove permissive invariant mode

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -1808,10 +1808,8 @@ class Compose(BaseCompose, HubMixin):
         save_applied_params: bool = False,
         telemetry: bool = True,
         instance_binding: Sequence[str] | None = None,
-        strict_instance_invariant: bool = True,
         semantic_mask_label_mappings: dict[str, dict[int, int]] | None = None,
     ):
-        self._strict_instance_invariant = strict_instance_invariant
         super().__init__(
             transforms=transforms,
             p=p,
@@ -2865,8 +2863,7 @@ class Compose(BaseCompose, HubMixin):
         and keypoints (by surviving id). All this method has to do is:
 
         1. Assert that the bound `masks` row count or packed `mask` instance-axis count
-           equals `len(bboxes)` (raises `RuntimeError` in strict mode, `UserWarning` in
-           legacy mode for one minor version's worth of grace).
+           equals `len(bboxes)`.
         2. Translate `_kp_instance_id` from old bbox ids to the new positional ids.
         3. Stamp `_bbox_instance_id = arange(N)` so the next transform sees a dense namespace.
 
@@ -2885,7 +2882,7 @@ class Compose(BaseCompose, HubMixin):
         n = bboxes_arr.shape[0]
         old_ids = bboxes_arr[:, -1].astype(np.int64, copy=True)
 
-        self._validate_bound_mask_alignment(data, binding, n)
+        self._raise_if_bound_mask_alignment_is_invalid(data, binding, n)
 
         if "keypoints" in binding:
             kp_arr = data.get("keypoints")
@@ -2898,7 +2895,7 @@ class Compose(BaseCompose, HubMixin):
                 bbox_id_set = set(old_ids.tolist())
                 orphans = [int(k) for k in kp_ids_col.tolist() if int(k) not in bbox_id_set]
                 if orphans:
-                    self._raise_or_warn_orphan_keypoints(orphans)
+                    self._raise_for_orphan_keypoints(orphans)
                     keep_kp = np.isin(kp_ids_col, old_ids)
                     if not keep_kp.all():
                         kp_arr = kp_arr[keep_kp]
@@ -2913,7 +2910,7 @@ class Compose(BaseCompose, HubMixin):
 
         bboxes_arr[:, -1] = np.arange(n, dtype=bboxes_arr.dtype)
 
-    def _validate_bound_mask_alignment(
+    def _raise_if_bound_mask_alignment_is_invalid(
         self,
         data: dict[str, Any],
         binding: frozenset[str],
@@ -2925,15 +2922,15 @@ class Compose(BaseCompose, HubMixin):
         if "masks" in binding:
             masks = data.get("masks")
             if masks is not None and isinstance(masks, (np.ndarray, torch.Tensor)) and len(masks) != bboxes_len:
-                self._raise_or_warn_invariant_violation(len(masks), bboxes_len)
+                self._raise_for_invariant_violation(len(masks), bboxes_len)
         elif "mask" in binding:
             mask = data.get("mask")
             instance_axis = self._mask_instance_axis(data, mask)
             mask_count = None if mask is None or instance_axis is None else int(mask.shape[instance_axis])
             if mask_count != bboxes_len:
-                self._raise_or_warn_invariant_violation(mask_count, bboxes_len, target_name="mask")
+                self._raise_for_invariant_violation(mask_count, bboxes_len, target_name="mask")
 
-    def _raise_or_warn_invariant_violation(
+    def _raise_for_invariant_violation(
         self,
         mask_count: int | None,
         bboxes_len: int,
@@ -2956,16 +2953,9 @@ class Compose(BaseCompose, HubMixin):
                 "`apply_to_mask` instead of filtering them independently."
             )
         msg = f"Instance-binding invariant violated: {mismatch}. {guidance}"
-        if getattr(self, "_strict_instance_invariant", True):
-            raise RuntimeError(msg)
-        warnings.warn(
-            msg + " Falling back to legacy permissive mode "
-            "(strict_instance_invariant=False); this fallback will be removed in 2.3.",
-            UserWarning,
-            stacklevel=3,
-        )
+        raise RuntimeError(msg)
 
-    def _raise_or_warn_orphan_keypoints(self, orphans: list[int]) -> None:
+    def _raise_for_orphan_keypoints(self, orphans: list[int]) -> None:
         sample = orphans[:5]
         more = "" if len(orphans) <= 5 else f" (+{len(orphans) - 5} more)"
         msg = (
@@ -2974,15 +2964,7 @@ class Compose(BaseCompose, HubMixin):
             "The last transform must drop keypoints whose parent bbox was filtered out, "
             "or `_bbox_filter_with_mirror` must mirror the bbox keep-mask onto keypoints."
         )
-        if getattr(self, "_strict_instance_invariant", True):
-            raise RuntimeError(msg)
-        warnings.warn(
-            msg + " Falling back to legacy permissive mode "
-            "(strict_instance_invariant=False) — orphan keypoints will be dropped silently. "
-            "This fallback will be removed in 2.3.",
-            UserWarning,
-            stacklevel=3,
-        )
+        raise RuntimeError(msg)
 
     def _unpack_instances(self, data: dict[str, Any]) -> None:
         binding = self._instance_binding
@@ -3367,7 +3349,6 @@ class Compose(BaseCompose, HubMixin):
             "save_applied_params": self.save_applied_params,
             "telemetry": self.telemetry,
             "instance_binding": sorted(self._instance_binding) if self._instance_binding else None,
-            "strict_instance_invariant": self._strict_instance_invariant,
         }
 
     def get_dict_with_id(self) -> dict[str, Any]:
@@ -4039,7 +4020,6 @@ class ReplayCompose(Compose):
         mask_interpolation: int | None = None,
         save_applied_params: bool = False,
         telemetry: bool = True,
-        strict_instance_invariant: bool = True,
     ):
         super().__init__(
             transforms,
@@ -4054,7 +4034,6 @@ class ReplayCompose(Compose):
             save_applied_params=save_applied_params,
             telemetry=telemetry,
             instance_binding=instance_binding,
-            strict_instance_invariant=strict_instance_invariant,
             semantic_mask_label_mappings=semantic_mask_label_mappings,
         )
         self.set_deterministic(True, save_key=save_key)

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -2891,16 +2891,11 @@ class Compose(BaseCompose, HubMixin):
                 # Defense in depth: orphan kp ids (no matching bbox) should already be filtered
                 # by `_bbox_filter_with_mirror`/`_prefilter_realign`. If we still see one here,
                 # the upstream chain is broken and silently passing it through corrupts the new
-                # positional namespace, so raise/warn the same as the masks-len breach.
+                # positional namespace, so fail fast.
                 bbox_id_set = set(old_ids.tolist())
                 orphans = [int(k) for k in kp_ids_col.tolist() if int(k) not in bbox_id_set]
                 if orphans:
                     self._raise_for_orphan_keypoints(orphans)
-                    keep_kp = np.isin(kp_ids_col, old_ids)
-                    if not keep_kp.all():
-                        kp_arr = kp_arr[keep_kp]
-                        data["keypoints"] = kp_arr
-                        kp_ids_col = kp_arr[:, -1].astype(np.int64, copy=False)
                 if not np.array_equal(old_ids, np.arange(n, dtype=np.int64)):
                     old_to_new = {int(old): new for new, old in enumerate(old_ids.tolist())}
                     kp_arr[:, -1] = np.array(

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -1194,8 +1194,7 @@ class DualTransform(BasicTransform):
         - The default per-row implementation below preserves alignment for transforms
           whose `apply_to_mask` is total (no row drops).
 
-        Violating this contract surfaces as a `RuntimeError` from `_resync_instance_ids`
-        in strict mode (the default since 2.2.2) or a `UserWarning` in legacy mode.
+        Violating this contract surfaces as a `RuntimeError` from `_resync_instance_ids`.
         """
         if masks.size == 0:
             return masks

--- a/docs/design/compose-serialization-and-tracing.md
+++ b/docs/design/compose-serialization-and-tracing.md
@@ -26,7 +26,7 @@ extends the method only with policy it owns.
 
 | Group | Fields |
 |---|---|
-| Target processing | `bbox_params`, `keypoint_params`, `additional_targets`, `semantic_mask_label_mappings`, `instance_binding`, `strict_instance_invariant` |
+| Target processing | `bbox_params`, `keypoint_params`, `additional_targets`, `semantic_mask_label_mappings`, `instance_binding` |
 | Validation and output | `is_check_shapes`, `strict`, `save_applied_params` |
 | Random and pixel policy | `p`, `seed`, `mask_interpolation` |
 | Operational policy | `telemetry` |

--- a/docs/design/instance_binding.md
+++ b/docs/design/instance_binding.md
@@ -72,8 +72,6 @@ After every bbox-affecting transform has been finalized, the following hold simu
 4. Going into the next transform, `data["bboxes"][:, -1] == arange(N)`.
 
 Violating (1) or (3) raises `RuntimeError` immediately from `_resync_instance_ids`.
-`strict_instance_invariant=False` instead emits a `UserWarning` and continues; new pipelines
-should keep the default, `True`.
 
 #### How the invariant is enforced (one chokepoint, three layers)
 
@@ -201,16 +199,13 @@ A.Compose(
     bbox_params=...,
     keypoint_params=...,
     instance_binding=["masks", "bboxes", "keypoints"],
-    strict_instance_invariant=True,  # default since 2.2.2
 )
 ```
 
 Valid binding targets: `"mask"`, `"masks"`, `"bboxes"`, `"keypoints"`. Minimum 2. `"mask"` and
 `"masks"` are mutually exclusive.
 
-`strict_instance_invariant=True` (default) raises `RuntimeError` from `_resync_instance_ids`
-on contract violations. Setting it to `False` downgrades the error to a `UserWarning`; use it
-only when a caller deliberately defers enforcement while updating a custom transform.
+`_resync_instance_ids` raises `RuntimeError` on contract violations.
 
 ## Preprocessing (Unpack)
 

--- a/tests/contracts/test_composition_serialization_contracts.py
+++ b/tests/contracts/test_composition_serialization_contracts.py
@@ -65,7 +65,6 @@ def _non_default_witness(parameter_name: str) -> object:
         "mask_interpolation": lambda: cv2.INTER_LINEAR,
         "save_applied_params": lambda: True,
         "telemetry": lambda: False,
-        "strict_instance_invariant": lambda: False,
         "n": lambda: 2,
         "replace": lambda: True,
         "channels": lambda: (1,),

--- a/tests/test_instance_binding.py
+++ b/tests/test_instance_binding.py
@@ -3007,15 +3007,3 @@ class TestStructuralInvariantContract:
 
         with pytest.raises(RuntimeError, match=r"packed mask instance count=1 != len\(bboxes\)=2"):
             aug(image=image, instances=instances)
-
-    def test_legacy_mode_warns_instead_of_raising(self) -> None:
-        image, instances = self._instances()
-        aug = A.Compose(
-            [_MaskRowDroppingDualTransform(p=1.0)],
-            bbox_params=A.BboxParams(coord_format="pascal_voc"),
-            instance_binding=["masks", "bboxes"],
-            seed=0,
-            strict_instance_invariant=False,
-        )
-        with pytest.warns(UserWarning, match="Instance-binding invariant violated"), pytest.raises(IndexError):
-            aug(image=image, instances=instances)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -587,7 +587,6 @@ def test_serialization_v2_to_dict() -> None:
         "save_applied_params": False,
         "telemetry": True,
         "instance_binding": None,
-        "strict_instance_invariant": True,
     }
 
 
@@ -607,7 +606,6 @@ def test_compose_roundtrip_preserves_all_behavioral_constructor_state() -> None:
         seed=137,
         save_applied_params=True,
         telemetry=False,
-        strict_instance_invariant=False,
         semantic_mask_label_mappings={"HorizontalFlip": {2: 3, 3: 2}},
     )
 
@@ -621,7 +619,6 @@ def test_compose_roundtrip_preserves_all_behavioral_constructor_state() -> None:
     assert restored.seed == 137
     assert restored.save_applied_params is True
     assert restored.telemetry is False
-    assert restored._strict_instance_invariant is False
     assert restored.additional_targets == {"image2": "image"}
     assert restored.semantic_mask_label_mappings == {"HorizontalFlip": {2: 3, 3: 2}}
     assert restored.processors["bboxes"].params.filter_invalid_bboxes is True
@@ -742,7 +739,6 @@ def test_composition_subclasses_preserve_class_policy_in_roundtrip_and_operators
         mask_interpolation=cv2.INTER_LINEAR,
         save_applied_params=True,
         telemetry=False,
-        strict_instance_invariant=False,
         seed=137,
     )
 
@@ -755,7 +751,6 @@ def test_composition_subclasses_preserve_class_policy_in_roundtrip_and_operators
     assert restored.mask_interpolation == cv2.INTER_LINEAR
     assert restored.save_applied_params is True
     assert restored.telemetry is False
-    assert restored._strict_instance_invariant is False
     assert restored.transforms[0].channels == [1]
     assert restored.transforms[1].n == 2
     assert restored.transforms[1].replace is True


### PR DESCRIPTION
Closes #447. Supersedes #449.\n\nThe permissive instance-binding path was a 2.2.2 migration escape hatch. It warns after masks, bboxes, or keypoints lose their required alignment, but cannot restore a valid result.\n\nThis PR removes strict_instance_invariant from Compose and ReplayCompose, their serialization payloads, documentation, and legacy tests. Instance-bound targets now always fail fast with RuntimeError when the invariant is broken.\n\nBreaking change: old serialized Compose or ReplayCompose payloads containing strict_instance_invariant are unsupported.\n\nValidation:\n- uv run pytest -q tests/test_instance_binding.py tests/test_serialization.py tests/contracts/test_composition_serialization_contracts.py\n- uv run python tools/quality_gate.py fast\n- pre-commit run --files albumentations/core/composition.py albumentations/core/transforms_interface.py docs/design/compose-serialization-and-tracing.md docs/design/instance_binding.md tests/contracts/test_composition_serialization_contracts.py tests/test_instance_binding.py tests/test_serialization.py

## Summary by Sourcery

Remove permissive instance-binding invariant handling so invalid target alignment always raises immediately.

Bug Fixes:
- Make instance-bound target invariant violations consistently fail fast with RuntimeError instead of allowing a warning-based permissive path.

Enhancements:
- Remove the strict_instance_invariant option from Compose and ReplayCompose and from their serialized constructor state.
- Update instance-binding behavior documentation and tests to reflect mandatory invariant enforcement.

Documentation:
- Remove documentation of the retired permissive instance-binding mode and serialization field.

Tests:
- Remove legacy permissive-mode coverage and update serialization contract expectations.