### PR TITLE
chore(tooling): update pre-commit and torch runtime contract

### DIFF
--- a/.codex/skills/performance-optimization/SKILL.md
+++ b/.codex/skills/performance-optimization/SKILL.md
@@ -28,6 +28,13 @@ A mismatch blocks completion.
    seeded-replay contracts unless the change explicitly documents a compatibility break.
 7. Run the project validation workflow after the final implementation.
 
+## Torch Runtime Contract
+
+Torch is already an externally managed, soft-required AlbumentationsX runtime dependency: package metadata does not
+select a CPU, CUDA, or MPS build, but importing `albumentations` requires an installed Torch runtime. Do not reject a
+Torch-backed implementation on the grounds that it would introduce a new runtime dependency. Benchmark the complete
+route, including NumPy/Tensor bridges, layout conversions, allocations, and return conversion.
+
 ## Compose Execution Changes
 
 For `composition.py`, `transforms_interface.py`, or invocation-state work, keep configured graph policy separate from

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -212,7 +212,7 @@ repos:
         pass_filenames: false
         files: ^(README\.md|albumentations/).*$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.3
+    rev: v0.16.4
     hooks:
       - id: ruff
         exclude: '__pycache__/'

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -68,9 +68,9 @@ shared CPU-only runtime profile explicitly.
 
 ### [Torch CPU Backend and Tensor-Native Compose](torch-cpu-backend-migration.md)
 
-Plan for making Torch a soft-required runtime dependency and routing compatible NumPy/OpenCV/NumKong and Torch segments through
-the existing `Compose`. The route planner may cross the representation boundary in either direction when the complete
-measured path does not regress.
+Plan for routing compatible NumPy/OpenCV/NumKong and Torch segments through the existing `Compose`. Torch is already
+an externally managed, soft-required runtime dependency. The route planner may cross the representation boundary in
+either direction when the complete measured path does not regress.
 
 **Status**: In progress. The CPU Tensor boundary is implemented; capability routing and per-family Tensor paths remain
 planned.

--- a/docs/design/torch-cpu-backend-migration.md
+++ b/docs/design/torch-cpu-backend-migration.md
@@ -2,8 +2,8 @@
 
 **Status:** In progress
 
-**Decision:** `torch` becomes a soft-required runtime dependency. Users install a CPU, CUDA, or MPS build before
-installing AlbumentationsX. The existing `Compose` accepts both NumPy arrays and CPU
+**Decision:** `torch` is an externally managed, soft-required runtime dependency. Users install a CPU, CUDA, or MPS
+build before installing AlbumentationsX. The existing `Compose` accepts both NumPy arrays and CPU
 `torch.Tensor` values. Every valid Tensor pipeline returns Tensor output. Before transform parameters are sampled,
 `Compose` chooses one representation for the entire pipeline: direct Tensor execution when every selectable child
 supports the supplied Tensor targets, otherwise one Tensor-to-NumPy bridge before the pipeline and one NumPy-to-Tensor


### PR DESCRIPTION
## Summary

- Update the Ruff pre-commit hook from v0.16.3 to v0.16.4.
- Align the Torch runtime contract in the performance skill and backend migration documentation.

## Validation

- `uv run pytest` — 14,057 passed, 32 skipped, 9 xfailed, 3 xpassed.
- `pre-commit run --all-files` — passed.
- Commit-time pre-commit hooks — passed.

## Summary by Sourcery

Update development tooling and document the established Torch runtime contract consistently.

Enhancements:
- Clarify Torch’s existing externally managed, soft-required runtime contract across performance guidance and backend migration documentation.

Build:
- Update the Ruff pre-commit hook to v0.16.4.

Documentation:
- Align the design documentation with the established Torch runtime dependency model.