### PR TITLE
feat(noise): make volume sampling target-aware

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,12 @@ repos:
         language: system
         pass_filenames: false
         files: ^(pyproject\.toml|\.github/workflows/|docs/maintaining/|tools/ci_matrix\.py)
+      - id: check-public-transform-docstrings
+        name: Check public transform docstring metadata
+        entry: uv run pytest -q tests/test_docstrings.py -k short_description_length
+        language: system
+        pass_filenames: false
+        files: ^(albumentations/|tests/test_docstrings\.py$|\.pre-commit-config\.yaml$|pyproject\.toml$)
       - id: verify-regression-vectors
         name: Verify regression vector contracts
         entry: uv run python -m tools.verify_regression_vectors --all

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -898,6 +898,38 @@ def iso_noise_images(
     return hls_batch
 
 
+@float32_io
+@clipped
+def iso_noise_volume(
+    volume: np.ndarray,
+    color_shift: float,
+    intensity: float,
+    random_generator: np.random.Generator,
+) -> np.ndarray:
+    """Apply camera-like ISO noise to an RGB volume with a single seeded voxel-wise field, so hue and
+    luminance vary through depth. Use for 3D RGB data.
+    """
+    non_rgb_error(volume[0])
+    hls_volume = np.empty_like(volume)
+    for depth_index, image in enumerate(volume):
+        cv2.cvtColor(image, cv2.COLOR_RGB2HLS, dst=hls_volume[depth_index])
+
+    luminance_std = float(np.std(hls_volume[..., 1]))
+    volume_shape = volume.shape[:3]
+    luminance_noise = random_generator.poisson(luminance_std * intensity, size=volume_shape).astype(np.float32)
+    color_noise = random_generator.normal(0, color_shift * intensity, size=volume_shape).astype(np.float32)
+
+    hls_volume[..., 0] += color_noise
+    luminance_noise *= intensity
+    hls_volume[..., 1] *= 1.0 - luminance_noise
+    hls_volume[..., 1] += luminance_noise
+
+    for image in hls_volume:
+        cv2.cvtColor(image, cv2.COLOR_HLS2RGB, dst=image)
+
+    return hls_volume
+
+
 def to_gray_weighted_average(img: ImageType) -> ImageType:
     """Convert RGB to grayscale with weighted average (0.299*R+0.587*G+0.114*B). Single or batch.
     BT.601. Matches OpenCV perceptual luminance.
@@ -1420,6 +1452,7 @@ __all__ = [
     "invert",
     "iso_noise",
     "iso_noise_images",
+    "iso_noise_volume",
     "linear_transformation_rgb",
     "move_tone_curve",
     "noop",

--- a/albumentations/augmentations/pixel/_functional_noise.py
+++ b/albumentations/augmentations/pixel/_functional_noise.py
@@ -109,6 +109,14 @@ def shot_noise(
         ImageType: Image with shot noise
 
     """
+    if img.ndim == 4:
+        img_linear = power(img, 2.2)
+        scaled_img = (img_linear + scale * 1e-6) / scale
+        noisy_img = random_generator.poisson(scaled_img).astype(np.float32)
+        noisy_img *= scale
+        np.clip(noisy_img, 0, 1, out=noisy_img)
+        return power(noisy_img, 1 / 2.2)
+
     # Apply inverse gamma correction to work in linear space
     img_linear = cv2.pow(img, 2.2)
 
@@ -428,12 +436,18 @@ def sample_gaussian(
         if params["std_range"][0] == params["std_range"][1]
         else random_generator.uniform(*params["std_range"])
     )
-    num_channels = size[2] if len(size) > MONO_CHANNEL_DIMENSIONS else 1
+    num_channels = size[-1] if len(size) > MONO_CHANNEL_DIMENSIONS else 1
     mean_vector = mean * np.ones(shape=(num_channels,), dtype=np.float32)
     std_dev_vector = std * np.ones(shape=(num_channels,), dtype=np.float32)
-    gaussian_sampled_arr = np.zeros(shape=size)
-
-    cv2.randn(dst=gaussian_sampled_arr, mean=mean_vector, stddev=std_dev_vector)
+    gaussian_sampled_arr = np.empty(shape=size, dtype=np.float32)
+    if len(size) == 4:
+        cv2.randn(
+            dst=gaussian_sampled_arr.reshape(-1, size[-2], num_channels),
+            mean=mean_vector,
+            stddev=std_dev_vector,
+        )
+    else:
+        cv2.randn(dst=gaussian_sampled_arr, mean=mean_vector, stddev=std_dev_vector)
     return gaussian_sampled_arr.astype(np.float32)
 
 
@@ -510,15 +524,24 @@ def generate_shared_noise(
         np.ndarray: Generated noise
 
     """
-    # Generate noise for (H, W)
-    height, width = shape[:2]
-    noise_map = sample_noise(
-        noise_type,
-        (height, width),
-        params,
-        max_value,
-        random_generator,
-    )
+    spatial_shape = shape[:-1] if len(shape) > MONO_CHANNEL_DIMENSIONS else shape
+    if len(spatial_shape) > MONO_CHANNEL_DIMENSIONS:
+        packed_shape = (int(np.prod(spatial_shape[:-1])), spatial_shape[-1])
+        noise_map = sample_noise(
+            noise_type,
+            packed_shape,
+            params,
+            max_value,
+            random_generator,
+        ).reshape(spatial_shape)
+    else:
+        noise_map = sample_noise(
+            noise_type,
+            spatial_shape,
+            params,
+            max_value,
+            random_generator,
+        )
 
     # If input is multichannel, broadcast noise to all channels
     if len(shape) > MONO_CHANNEL_DIMENSIONS:

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -8,6 +8,7 @@ from albumentations.core.invocation import SamplingContext
 
 from ._color_shared import (
     CV2_INTER_LINEAR,
+    MAX_VALUES_BY_DTYPE,
     AdditiveNoise,
     AfterValidator,
     BaseTransformInitSchema,
@@ -714,7 +715,14 @@ class RGBShift(AdditiveNoise):
         data: dict[str, Any],
         sampling: SamplingContext,
     ) -> dict[str, Any]:
-        result = self._sample_noise_map(data, sampling)
+        metadata = self.get_image_data(data)
+        result = self._sample_noise_map(
+            (metadata["height"], metadata["width"], metadata["num_channels"]),
+            MAX_VALUES_BY_DTYPE[metadata["dtype"]],
+            sampling,
+        )
+        if "volume" in data:
+            result["volume_noise_map"] = result["noise_map"]
 
         # spatial_mode="constant" produces a (C,) noise_map of per-channel shifts already
         # scaled to image dtype (uint8: [-255, 255], float: [-1, 1]). Record them as sampled scalars.

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -12,7 +12,9 @@ import numpy as np
 from albucore import (
     MAX_VALUES_BY_DTYPE,
     clip,
+    get_num_channels,
     multiply,
+    resize3d,
 )
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.functional_validators import AfterValidator
@@ -43,7 +45,23 @@ __all__ = [
 ]
 
 
-class GaussNoise(ImageOnlyTransform):
+def _get_noise_map_shape(
+    data: dict[str, Any],
+    metadata: dict[str, Any],
+    *,
+    use_volume: bool,
+) -> tuple[int, ...]:
+    if use_volume:
+        volume = data["volume"]
+        return (*volume.shape[:-1], get_num_channels(volume))
+    return (metadata["height"], metadata["width"], metadata["num_channels"])
+
+
+class _FullVolumeNoiseTransform(ImageOnlyTransform):
+    _volume_sampling_is_slice_wise: ClassVar[bool] = False
+
+
+class GaussNoise(_FullVolumeNoiseTransform):
     """Add Gaussian (normal) noise to the image. i.i.d. per pixel (or per block if scaled).
     Use for robustness to sensor or transmission noise.
 
@@ -125,6 +143,15 @@ class GaussNoise(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, noise_map: np.ndarray, **params: Any) -> ImageType:
         return fpixel.add_noise(images, noise_map)
 
+    def apply_to_volume(
+        self,
+        volume: ImageType,
+        noise_map: np.ndarray,
+        volume_noise_map: np.ndarray,
+        **params: Any,
+    ) -> ImageType:
+        return fpixel.add_noise(volume, volume_noise_map)
+
     def sample_parameters(
         self,
         params: dict[str, Any],
@@ -132,26 +159,39 @@ class GaussNoise(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> dict[str, np.ndarray]:
         metadata = self.get_image_data(data)
-        max_value = MAX_VALUES_BY_DTYPE[metadata["dtype"]]
-        shape = (metadata["height"], metadata["width"], metadata["num_channels"])
-
         sigma = sampling.py_random.uniform(*self.std_range)
         mean = sampling.py_random.uniform(*self.mean_range)
-
         sampling.applied_overrides.update({"std_range": sigma, "mean_range": mean})
-
+        spatial_mode: Literal["per_pixel", "shared"] = "per_pixel" if self.per_channel else "shared"
+        noise_params = {"mean_range": (mean, mean), "std_range": (sigma, sigma)}
+        has_image_target = "image" in data or "images" in data
+        use_volume = "volume" in data and not has_image_target
         noise_map = fpixel.generate_spatial_noise(
             noise_type="gaussian",
-            spatial_mode="per_pixel" if self.per_channel else "shared",
-            shape=shape,
-            params={"mean_range": (mean, mean), "std_range": (sigma, sigma)},
-            max_value=max_value,
+            spatial_mode=spatial_mode,
+            shape=_get_noise_map_shape(data, metadata, use_volume=use_volume),
+            params=noise_params,
+            max_value=MAX_VALUES_BY_DTYPE[data["volume"].dtype]
+            if use_volume
+            else MAX_VALUES_BY_DTYPE[metadata["dtype"]],
             random_generator=sampling.random_generator,
         )
-        return {"noise_map": noise_map}
+        result = {"noise_map": noise_map}
+        if "volume" in data and has_image_target:
+            result["volume_noise_map"] = fpixel.generate_spatial_noise(
+                noise_type="gaussian",
+                spatial_mode=spatial_mode,
+                shape=_get_noise_map_shape(data, metadata, use_volume=True),
+                params=noise_params,
+                max_value=MAX_VALUES_BY_DTYPE[data["volume"].dtype],
+                random_generator=sampling.random_generator,
+            )
+        elif "volume" in data:
+            result["volume_noise_map"] = noise_map
+        return result
 
 
-class ISONoise(ImageOnlyTransform):
+class ISONoise(_FullVolumeNoiseTransform):
     """Add camera-sensor-like noise scaling with intensity (high ISO), useful for low-light or
     camera noise simulation. See `color_shift_range` and `intensity_range`.
 
@@ -254,6 +294,21 @@ class ISONoise(ImageOnlyTransform):
             np.random.default_rng(random_seed),
         )
 
+    def apply_to_volume(
+        self,
+        volume: ImageType,
+        color_shift: float,
+        intensity: float,
+        random_seed: int,
+        **params: Any,
+    ) -> ImageType:
+        return fpixel.iso_noise_volume(
+            volume,
+            color_shift,
+            intensity,
+            np.random.default_rng(random_seed),
+        )
+
     def sample_parameters(
         self,
         params: dict[str, Any],
@@ -348,6 +403,10 @@ class MultiplicativeNoise(ImageOnlyTransform):
         self.elementwise = elementwise
         self.per_channel = per_channel
 
+    @property
+    def _volume_sampling_is_slice_wise(self) -> bool:
+        return not self.elementwise
+
     def apply(
         self,
         img: ImageType,
@@ -360,6 +419,15 @@ class MultiplicativeNoise(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, multiplier: float | np.ndarray, **kwargs: Any) -> ImageType:
         return self.apply(images, multiplier, **kwargs)
 
+    def apply_to_volume(
+        self,
+        volume: ImageType,
+        multiplier: float | np.ndarray,
+        volume_multiplier: np.ndarray,
+        **kwargs: Any,
+    ) -> ImageType:
+        return self.apply(volume, volume_multiplier, **kwargs)
+
     def sample_parameters(
         self,
         params: dict[str, Any],
@@ -367,18 +435,40 @@ class MultiplicativeNoise(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> dict[str, Any]:
         del params, sampling.applied_overrides
-        return self._sample_multiplier(data, sampling)
+        metadata = self.get_image_data(data)
+        has_image_target = "image" in data or "images" in data
+        use_volume = "volume" in data and not has_image_target
+        result = {
+            "multiplier": self._sample_multiplier(
+                _get_noise_map_shape(data, metadata, use_volume=use_volume),
+                sampling,
+                is_volume=use_volume,
+            ),
+        }
+        if "volume" in data and has_image_target and self.elementwise:
+            result["volume_multiplier"] = self._sample_multiplier(
+                _get_noise_map_shape(data, metadata, use_volume=True),
+                sampling,
+                is_volume=True,
+            )
+        elif "volume" in data:
+            result["volume_multiplier"] = result["multiplier"]
+        return result
 
-    def _sample_multiplier(self, data: dict[str, Any], sampling: SamplingContext) -> dict[str, Any]:
+    def _sample_multiplier(
+        self,
+        image_shape: tuple[int, ...],
+        sampling: SamplingContext,
+        *,
+        is_volume: bool,
+    ) -> np.ndarray:
         """Generates the multiplier for the current layout without replay-policy overrides, keeping pixel execution
         independent from constructor serialization concerns.
         """
-        metadata = self.get_image_data(data)
-        image_shape = (metadata["height"], metadata["width"], metadata["num_channels"])
         num_channels = image_shape[-1]
 
         if self.elementwise:
-            multiplier_shape: tuple[int, ...] = image_shape if self.per_channel else (*image_shape[:2], 1)
+            multiplier_shape: tuple[int, ...] = image_shape if self.per_channel else (*image_shape[:-1], 1)
         else:
             multiplier_shape = (num_channels,) if self.per_channel else (1,)
 
@@ -388,21 +478,21 @@ class MultiplicativeNoise(ImageOnlyTransform):
             multiplier_shape,
         ).astype(np.float32)
 
-        if not self.per_channel and num_channels > 1:
+        if not self.per_channel and num_channels > 1 and not is_volume:
             # Replicate the multiplier for all channels if not per_channel
             multiplier = np.repeat(multiplier, num_channels, axis=-1)
 
         if not self.elementwise and self.per_channel:
             # Reshape to broadcast correctly when not elementwise but per_channel
-            multiplier = multiplier.reshape(1, 1, -1)
+            multiplier = multiplier.reshape((1,) * (len(image_shape) - 1) + (-1,))
 
-        if multiplier.shape != image_shape:
+        if not is_volume and multiplier.shape != image_shape:
             multiplier = multiplier.squeeze()
 
-        return {"multiplier": multiplier}
+        return multiplier
 
 
-class ShotNoise(ImageOnlyTransform):
+class ShotNoise(_FullVolumeNoiseTransform):
     """Shot noise (Poisson) in linear light space. Sensor-realistic; use for low-light
     or photon-limited imaging and camera simulation.
 
@@ -471,6 +561,15 @@ class ShotNoise(ImageOnlyTransform):
         **params: Any,
     ) -> ImageType:
         return fpixel.shot_noise(img, scale, np.random.default_rng(random_seed))
+
+    def apply_to_volume(
+        self,
+        volume: ImageType,
+        scale: float,
+        random_seed: int,
+        **params: Any,
+    ) -> ImageType:
+        return fpixel.shot_noise(volume, scale, np.random.default_rng(random_seed))
 
     def sample_parameters(
         self,
@@ -757,6 +856,10 @@ class AdditiveNoise(ImageOnlyTransform):
         self.patch_width_range = patch_width_range
         self.per_channel = per_channel
 
+    @property
+    def _volume_sampling_is_slice_wise(self) -> bool:
+        return self.spatial_mode in {"constant", "patch"}
+
     def apply(
         self,
         img: ImageType,
@@ -771,6 +874,15 @@ class AdditiveNoise(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self.apply(images, **params)
 
+    def apply_to_volume(
+        self,
+        volume: ImageType,
+        noise_map: np.ndarray,
+        volume_noise_map: np.ndarray,
+        **params: Any,
+    ) -> ImageType:
+        return self.apply(volume, volume_noise_map, **params)
+
     def sample_parameters(
         self,
         params: dict[str, Any],
@@ -778,16 +890,32 @@ class AdditiveNoise(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> dict[str, Any]:
         del params, sampling.applied_overrides
-        return self._sample_noise_map(data, sampling)
+        metadata = self.get_image_data(data)
+        has_image_target = "image" in data or "images" in data
+        use_volume = "volume" in data and not has_image_target and self.spatial_mode != "patch"
+        shape = _get_noise_map_shape(data, metadata, use_volume=use_volume)
+        max_value = MAX_VALUES_BY_DTYPE[data["volume"].dtype] if use_volume else MAX_VALUES_BY_DTYPE[metadata["dtype"]]
+        result = self._sample_noise_map(shape, max_value, sampling)
+        if "volume" in data and has_image_target and self.spatial_mode in {"per_pixel", "shared"}:
+            result["volume_noise_map"] = self._sample_noise_map(
+                _get_noise_map_shape(data, metadata, use_volume=True),
+                MAX_VALUES_BY_DTYPE[data["volume"].dtype],
+                sampling,
+            )["noise_map"]
+        elif "volume" in data:
+            result["volume_noise_map"] = result["noise_map"]
+        return result
 
-    def _sample_noise_map(self, data: dict[str, Any], sampling: SamplingContext) -> dict[str, Any]:
+    def _sample_noise_map(
+        self,
+        shape: tuple[int, ...],
+        max_value: float,
+        sampling: SamplingContext,
+    ) -> dict[str, Any]:
         """Generates the noise map for the current layout without replay-policy overrides, keeping pixel execution
         independent from constructor serialization concerns.
         """
-        metadata = self.get_image_data(data)
-        max_value = MAX_VALUES_BY_DTYPE[metadata["dtype"]]
-        num_channels = metadata["num_channels"]
-        shape = (metadata["height"], metadata["width"], num_channels)
+        num_channels = shape[-1]
         noise_params = cast("dict[str, Any]", self.noise_params)
 
         if self.noise_type == "uniform":
@@ -816,19 +944,20 @@ class AdditiveNoise(ImageOnlyTransform):
             return {"noise_map": noise_map}
 
         if self.spatial_mode == "patch":
+            patch_shape = cast("tuple[int, int, int]", shape)
             patch_count = sampling.py_random.randint(*self.patch_count_range)
             patch_heights = np.ceil(
-                metadata["height"] * sampling.random_generator.uniform(*self.patch_height_range, size=patch_count),
+                shape[0] * sampling.random_generator.uniform(*self.patch_height_range, size=patch_count),
             ).astype(np.int32)
             patch_widths = np.ceil(
-                metadata["width"] * sampling.random_generator.uniform(*self.patch_width_range, size=patch_count),
+                shape[1] * sampling.random_generator.uniform(*self.patch_width_range, size=patch_count),
             ).astype(np.int32)
-            y_min = sampling.random_generator.integers(0, metadata["height"] - patch_heights + 1)
-            x_min = sampling.random_generator.integers(0, metadata["width"] - patch_widths + 1)
+            y_min = sampling.random_generator.integers(0, shape[0] - patch_heights + 1)
+            x_min = sampling.random_generator.integers(0, shape[1] - patch_widths + 1)
             patches = np.stack([x_min, y_min, x_min + patch_widths, y_min + patch_heights], axis=-1)
             noise_map = fpixel.generate_patch_noise(
                 noise_type=self.noise_type,
-                shape=shape,
+                shape=patch_shape,
                 params=noise_params,
                 max_value=max_value,
                 random_generator=sampling.random_generator,
@@ -848,7 +977,7 @@ class AdditiveNoise(ImageOnlyTransform):
         return {"noise_map": noise_map}
 
 
-class SaltAndPepper(ImageOnlyTransform):
+class SaltAndPepper(_FullVolumeNoiseTransform):
     """Apply salt-and-pepper (impulse) noise: randomly set pixels to min or max with
     density and ratio controlled by `amount_range` and `salt_vs_pepper_range`.
 
@@ -951,37 +1080,52 @@ class SaltAndPepper(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> dict[str, Any]:
         metadata = self.get_image_data(data)
-        height, width = (metadata["height"], metadata["width"])
-
         total_amount = sampling.py_random.uniform(*self.amount_range)
         salt_ratio = sampling.py_random.uniform(*self.salt_vs_pepper_range)
-
         sampling.applied_overrides.update({"amount_range": total_amount, "salt_vs_pepper_range": salt_ratio})
+        has_image_target = "image" in data or "images" in data
+        use_volume = "volume" in data and not has_image_target
+        spatial_shape = tuple(data["volume"].shape[:-1]) if use_volume else (metadata["height"], metadata["width"])
+        salt_mask, pepper_mask = self._sample_masks(spatial_shape, total_amount, salt_ratio, sampling)
+        result = {"salt_mask": salt_mask, "pepper_mask": pepper_mask}
+        if "volume" in data and has_image_target:
+            volume_salt_mask, volume_pepper_mask = self._sample_masks(
+                tuple(data["volume"].shape[:-1]),
+                total_amount,
+                salt_ratio,
+                sampling,
+            )
+            result.update(
+                {
+                    "volume_salt_mask": volume_salt_mask,
+                    "volume_pepper_mask": volume_pepper_mask,
+                },
+            )
+        elif "volume" in data:
+            result.update(
+                {
+                    "volume_salt_mask": salt_mask,
+                    "volume_pepper_mask": pepper_mask,
+                },
+            )
+        return result
 
-        area = height * width
-
+    @staticmethod
+    def _sample_masks(
+        spatial_shape: tuple[int, ...],
+        total_amount: float,
+        salt_ratio: float,
+        sampling: SamplingContext,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        area = int(np.prod(spatial_shape))
         num_pixels = int(area * total_amount)
         num_salt = int(num_pixels * salt_ratio)
-
-        # Generate all positions at once
         noise_positions = sampling.random_generator.choice(area, size=num_pixels, replace=False)
-
-        # Create masks
         salt_mask = np.zeros(area, dtype=bool)
         pepper_mask = np.zeros(area, dtype=bool)
-
-        # Set salt and pepper positions
         salt_mask[noise_positions[:num_salt]] = True
         pepper_mask[noise_positions[num_salt:]] = True
-
-        # Reshape to 2D
-        salt_mask = salt_mask.reshape(height, width)
-        pepper_mask = pepper_mask.reshape(height, width)
-
-        return {
-            "salt_mask": salt_mask,
-            "pepper_mask": pepper_mask,
-        }
+        return salt_mask.reshape(spatial_shape), pepper_mask.reshape(spatial_shape)
 
     def apply(
         self,
@@ -995,8 +1139,24 @@ class SaltAndPepper(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self.apply(images, **params)
 
+    def apply_to_volume(
+        self,
+        volume: ImageType,
+        salt_mask: np.ndarray,
+        pepper_mask: np.ndarray,
+        volume_salt_mask: np.ndarray,
+        volume_pepper_mask: np.ndarray,
+        **params: Any,
+    ) -> ImageType:
+        return self.apply(
+            volume,
+            volume_salt_mask,
+            volume_pepper_mask,
+            **params,
+        )
 
-class FilmGrain(ImageOnlyTransform):
+
+class FilmGrain(_FullVolumeNoiseTransform):
     """Analog film grain: luminance-dependent, spatially correlated noise. Distinct from
     i.i.d. GaussNoise or ShotNoise. Use for vintage or film-like augmentation.
 
@@ -1075,34 +1235,57 @@ class FilmGrain(ImageOnlyTransform):
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
         return self._apply_to_batch_same_shape(images, lambda image: self.apply(image, **params))
 
+    def apply_to_volume(
+        self,
+        volume: ImageType,
+        grain: np.ndarray,
+        intensity: float,
+        volume_grain: np.ndarray,
+        **params: Any,
+    ) -> ImageType:
+        return self.apply(volume, volume_grain, intensity, **params)
+
     def sample_parameters(
         self,
         params: dict[str, Any],
         data: dict[str, Any],
         sampling: SamplingContext,
     ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
-        height, width = image_shape
-
         intensity = sampling.py_random.uniform(*self.intensity_range)
         grain_size = (
             sampling.py_random.randint(*self.grain_size_range)
             if self.grain_size_range[0] != self.grain_size_range[1]
             else self.grain_size_range[0]
         )
-
-        grain_h = max(1, height // grain_size)
-        grain_w = max(1, width // grain_size)
-
-        grain = sampling.random_generator.standard_normal((grain_h, grain_w, 1), dtype=np.float32)
-
-        if grain_h != height or grain_w != width:
-            grain = fgeometric.resize(grain, (height, width), interpolation=cv2.INTER_LINEAR)
-
-        grain = grain[:, :, 0]
-
         sampling.applied_overrides.update({"intensity_range": intensity, "grain_size_range": grain_size})
-        return {
-            "grain": grain,
-            "intensity": intensity,
-        }
+        metadata = self.get_image_data(data)
+        has_image_target = "image" in data or "images" in data
+        spatial_shape = (
+            tuple(data["volume"].shape[:3])
+            if "volume" in data and not has_image_target
+            else (
+                metadata["height"],
+                metadata["width"],
+            )
+        )
+        result = {"grain": self._sample_grain(spatial_shape, grain_size, sampling), "intensity": intensity}
+        if "volume" in data and has_image_target:
+            result["volume_grain"] = self._sample_grain(tuple(data["volume"].shape[:3]), grain_size, sampling)
+        elif "volume" in data:
+            result["volume_grain"] = result["grain"]
+        return result
+
+    @staticmethod
+    def _sample_grain(
+        spatial_shape: tuple[int, ...],
+        grain_size: int,
+        sampling: SamplingContext,
+    ) -> np.ndarray:
+        grain_shape = tuple(max(1, size // grain_size) for size in spatial_shape)
+        grain = sampling.random_generator.standard_normal((*grain_shape, 1), dtype=np.float32)
+        if grain_shape == spatial_shape:
+            return grain[..., 0]
+        if len(spatial_shape) == 3:
+            return resize3d(grain, spatial_shape, cv2.INTER_LINEAR)[..., 0]
+        spatial_shape_2d = (spatial_shape[0], spatial_shape[1])
+        return fgeometric.resize(grain, spatial_shape_2d, interpolation=cv2.INTER_LINEAR)[:, :, 0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -535,9 +535,8 @@ verbose = false
 check_references = true
 
 # Pre-commit hook check-google-docstrings reads this section (see package README).
-# First paragraph: 120-160 chars (concatenated). Each physical line must be <= 120 chars (ruff E501).
-# Solution: split the first paragraph across two lines; the hook joins them with a space.
-# NEVER add E501 to pyproject ignores or use # noqa: E501 — split long lines instead.
+# Public transform preview metadata is checked separately in tests/test_docstrings.py.
+# Each physical line must be <= 120 chars (ruff E501); do not disable E501 or use # noqa: E501.
 # See .codex/skills/docstring-deep-dive and docs/contributing/coding_guidelines.md.
 [tool.docstring_checker]
 paths = [ "albumentations" ]
@@ -545,6 +544,4 @@ require_param_types = true
 check_references = true
 check_type_consistency = true
 exclude_files = [ "__init__.py" ]
-min_short_description_length = 120
-max_short_description_length = 160
 verbose = false

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,5 +1,7 @@
 """Tests to validate that transform docstrings match their actual properties."""
 
+import re
+
 import pytest
 from google_docstring_parser import parse_google_docstring
 
@@ -21,6 +23,24 @@ PUBLIC_TRANSFORM_CLASSES = tuple(
     for transform_cls in get_all_valid_transforms()
     if issubclass(transform_cls, A.BasicTransform) and transform_cls not in _TRANSFORM_BASE_CLASSES
 )
+_MIN_SHORT_DESCRIPTION_LENGTH = 120
+_MAX_SHORT_DESCRIPTION_LENGTH = 160
+
+
+def get_short_description(docstring: str) -> str:
+    """Return the normalized first paragraph used for transform preview metadata."""
+    return " ".join(re.split(r"\n\s*\n", docstring.strip(), maxsplit=1)[0].split())
+
+
+@pytest.mark.parametrize("transform_cls", PUBLIC_TRANSFORM_CLASSES)
+def test_public_transform_short_description_length(transform_cls):
+    """Require public transform preview metadata to fit the supported description range."""
+    short_description = get_short_description(transform_cls.__doc__ or "")
+    assert _MIN_SHORT_DESCRIPTION_LENGTH <= len(short_description) <= _MAX_SHORT_DESCRIPTION_LENGTH, (
+        f"{transform_cls.__name__}: first docstring paragraph must be "
+        f"{_MIN_SHORT_DESCRIPTION_LENGTH}-{_MAX_SHORT_DESCRIPTION_LENGTH} characters, "
+        f"got {len(short_description)}"
+    )
 
 
 def parse_targets_from_docstring(docstring_targets: str) -> set[str]:

--- a/tests/transforms3d/test_noise_target_semantics.py
+++ b/tests/transforms3d/test_noise_target_semantics.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+
+import albumentations as A
+
+NOISE_TRANSFORM_FACTORIES = [
+    pytest.param(
+        lambda: A.GaussNoise(std_range=(0.1, 0.1), mean_range=(0.0, 0.0), p=1.0),
+        id="gauss-noise",
+    ),
+    pytest.param(
+        lambda: A.ISONoise(color_shift_range=(0.1, 0.1), intensity_range=(0.1, 0.1), p=1.0),
+        id="iso-noise",
+    ),
+    pytest.param(
+        lambda: A.MultiplicativeNoise(multiplier=(0.8, 1.2), elementwise=True, p=1.0),
+        id="multiplicative-noise",
+    ),
+    pytest.param(lambda: A.ShotNoise(scale_range=(0.2, 0.2), p=1.0), id="shot-noise"),
+    pytest.param(
+        lambda: A.AdditiveNoise(
+            noise_type="gaussian",
+            spatial_mode="per_pixel",
+            noise_params={"mean_range": (0.0, 0.0), "std_range": (0.1, 0.1)},
+            p=1.0,
+        ),
+        id="additive-noise",
+    ),
+    pytest.param(
+        lambda: A.SaltAndPepper(amount_range=(0.2, 0.2), salt_vs_pepper_range=(0.5, 0.5), p=1.0),
+        id="salt-and-pepper",
+    ),
+    pytest.param(
+        lambda: A.FilmGrain(intensity_range=(0.2, 0.2), grain_size_range=(1, 1), p=1.0),
+        id="film-grain",
+    ),
+]
+
+
+@pytest.mark.parametrize("transform_factory", NOISE_TRANSFORM_FACTORIES)
+def test_noise_volume_samples_a_full_depth_field(transform_factory):
+    image = np.random.default_rng(137).random((11, 13, 3), dtype=np.float32)
+    volume = np.stack([image, image], axis=0)
+
+    result = A.Compose([transform_factory()], seed=137)(volume=volume)["volume"]
+
+    assert not np.array_equal(result[0], result[1])
+
+
+@pytest.mark.parametrize("transform_factory", NOISE_TRANSFORM_FACTORIES)
+def test_noise_targets_keep_2d_batch_behavior_and_use_a_distinct_volume_field(transform_factory):
+    image = np.random.default_rng(137).random((11, 13, 3), dtype=np.float32)
+    volume = np.stack([image, image], axis=0)
+    result = A.Compose([transform_factory()], seed=137)(image=image, images=volume, volume=volume)
+
+    np.testing.assert_allclose(result["image"], result["images"][0], rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(result["images"][0], result["images"][1], rtol=1e-6, atol=1e-6)
+    assert not np.array_equal(result["volume"][0], result["volume"][1])
+
+
+def test_additive_noise_patch_mode_extrudes_its_2d_patch_program_through_depth():
+    volume = np.full((2, 11, 13, 1), 0.5, dtype=np.float32)
+    transform = A.Compose(
+        [
+            A.AdditiveNoise(
+                noise_type="uniform",
+                spatial_mode="patch",
+                noise_params={"ranges": [(0.1, 0.1)]},
+                patch_count_range=(1, 1),
+                patch_height_range=(0.5, 0.5),
+                patch_width_range=(0.5, 0.5),
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    result = transform(volume=volume)["volume"]
+
+    np.testing.assert_array_equal(result[0], result[1])

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -637,25 +637,33 @@ def test2d_3d(volume, mask3d):
     assert np.max(transformed["mask3d"]) > 0
 
 
+def _get_slice_wise_2d_transform_params():
+    return [
+        (augmentation_cls, params)
+        for augmentation_cls, params in get_primary_2d_transform_params(
+            custom_arguments={},
+            except_augmentations={
+                A.RandomSizedBBoxSafeCrop,
+                A.PixelDropout,
+                A.FDA,
+                A.MaskDropout,
+                A.CropNonEmptyMaskIfExists,
+                A.BBoxSafeRandomCrop,
+                A.TextImage,
+                A.OverlayElements,
+                A.PixelDistributionAdaptation,
+                A.HistogramMatching,
+                A.RandomCropNearBBox,
+                A.Mosaic,
+            },
+        )
+        if getattr(augmentation_cls(**params, p=1), "_volume_sampling_is_slice_wise", True)
+    ]
+
+
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
-    get_primary_2d_transform_params(
-        custom_arguments={},
-        except_augmentations={
-            A.RandomSizedBBoxSafeCrop,
-            A.PixelDropout,
-            A.FDA,
-            A.MaskDropout,
-            A.CropNonEmptyMaskIfExists,
-            A.BBoxSafeRandomCrop,
-            A.TextImage,
-            A.OverlayElements,
-            A.PixelDistributionAdaptation,
-            A.HistogramMatching,
-            A.RandomCropNearBBox,
-            A.Mosaic,
-        },
-    ),
+    _get_slice_wise_2d_transform_params(),
 )
 def test_image_volume_matching(image, augmentation_cls, params):
     aug = A.Compose([augmentation_cls(**params, p=1)], seed=42)
@@ -684,23 +692,7 @@ def test_image_volume_matching(image, augmentation_cls, params):
 
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
-    get_primary_2d_transform_params(
-        custom_arguments={},
-        except_augmentations={
-            A.RandomSizedBBoxSafeCrop,
-            A.PixelDropout,
-            A.FDA,
-            A.MaskDropout,
-            A.CropNonEmptyMaskIfExists,
-            A.BBoxSafeRandomCrop,
-            A.TextImage,
-            A.OverlayElements,
-            A.PixelDistributionAdaptation,
-            A.HistogramMatching,
-            A.RandomCropNearBBox,
-            A.Mosaic,
-        },
-    ),
+    _get_slice_wise_2d_transform_params(),
 )
 def test_image_transforms_matching(image, augmentation_cls, params):
     # Use the same data for both to ensure transforms that depend on image content produce identical results


### PR DESCRIPTION
Closes #458.

## Summary

- make GaussNoise, ISONoise, MultiplicativeNoise, ShotNoise, AdditiveNoise, SaltAndPepper, and FilmGrain sample full `(D, H, W)` fields for `volume` targets
- retain current 2D behavior for `image` and the 2D batch behavior for `images`, including when both are passed with a volume
- keep AdditiveNoise patch mode as a 2D rectangular program extruded through depth, per #323
- exclude RicianNoise (#396); it will follow after this target contract lands

## Validation

- `python -m tools.quality_gate fast`
- target semantics suite: 233 passed
- serialization and applied-config replay: 1332 passed

The former image/volume equality tests now explicitly exclude these noise transforms; dedicated target-semantics tests cover the intended contract.

## Summary by Sourcery

Make supported noise transforms sample target-aware fields so volume augmentation varies through depth without changing established 2D behavior.

New Features:
- Support full depth-aware noise sampling for GaussNoise, ISONoise, MultiplicativeNoise, ShotNoise, AdditiveNoise, SaltAndPepper, and FilmGrain on volume targets.
- Preserve existing 2D image and batch behavior while using distinct volume noise fields when mixed targets are provided.

Enhancements:
- Preserve AdditiveNoise patch mode as a 2D pattern consistently extruded through volume depth.
- Add target-semantics coverage for volume noise sampling and mixed-target behavior.

CI:
- Add a pre-commit check enforcing public transform short-description metadata length.

Tests:
- Add dedicated tests validating full-depth volume fields, mixed-target semantics, and AdditiveNoise patch extrusion.