### PR TITLE
docs(ci): clarify Antigravity volume layout

### DIFF
--- a/.github/ci-foundation/antigravity-review.md
+++ b/.github/ci-foundation/antigravity-review.md
@@ -7,13 +7,15 @@ For runtime changes, inspect the public transform contracts, target support, dty
 routes. Performance claims require relevant benchmark evidence. Torch and CI changes must preserve the soft-required
 user runtime and CPU-only automation boundary described in docs/design/torch-dependency-and-ci-greenfield.md.
 
-Within Compose, image targets have channel-last layouts with an explicit channel axis: `image` is `(H, W, C)`,
-`images` is `(N, H, W, C)`, and `volume` is `(D, H, W, C)`. Grayscale images and volumes use `C=1`. `mask3d` is a
-separate target and may omit the channel axis.
+NumPy Compose inputs are channel-last. They may use explicit-channel `(H, W, C)`, `(N, H, W, C)`, and `(D, H, W, C)`
+layouts or channel-less grayscale `(H, W)`, `(N, H, W)`, and `(D, H, W)` layouts. Compose temporarily adds `C=1` to
+channel-less inputs before transform execution and restores their original layouts afterward. Review Compose boundary
+changes against both forms, and assess internal transform execution using the normalized explicit-channel layouts.
+`mask3d` is a separate target and may omit the channel axis.
 
-Do not report missing transform support, compatibility branches, or test coverage for channel-less `(H, W)` images or
-`(D, H, W)` volumes. Those layouts are outside the Compose transform contract. Assess volume changes with explicit,
-channel-last `(D, H, W, C)` inputs.
+Public Tensor inputs remain channel-first: `image` is `(C, H, W)`, `images` is `(C, L, H, W)`, and `volume` is
+`(C, D, H, W)`. Review Tensor routing against these layouts as described in
+docs/design/torch-cpu-backend-migration.md.
 
 For workflow, packaging, and legal changes, inspect the local policy and repository contracts. Do not propose broad
 refactors outside the pull request's scope. Cite changed file paths and line numbers for each actionable finding.

--- a/.github/ci-foundation/antigravity-review.md
+++ b/.github/ci-foundation/antigravity-review.md
@@ -7,5 +7,13 @@ For runtime changes, inspect the public transform contracts, target support, dty
 routes. Performance claims require relevant benchmark evidence. Torch and CI changes must preserve the soft-required
 user runtime and CPU-only automation boundary described in docs/design/torch-dependency-and-ci-greenfield.md.
 
+Within Compose, image targets have channel-last layouts with an explicit channel axis: `image` is `(H, W, C)`,
+`images` is `(N, H, W, C)`, and `volume` is `(D, H, W, C)`. Grayscale images and volumes use `C=1`. `mask3d` is a
+separate target and may omit the channel axis.
+
+Do not report missing transform support, compatibility branches, or test coverage for channel-less `(H, W)` images or
+`(D, H, W)` volumes. Those layouts are outside the Compose transform contract. Assess volume changes with explicit,
+channel-last `(D, H, W, C)` inputs.
+
 For workflow, packaging, and legal changes, inspect the local policy and repository contracts. Do not propose broad
 refactors outside the pull request's scope. Cite changed file paths and line numbers for each actionable finding.


### PR DESCRIPTION
## Summary

Make the Compose volume layout explicit for Antigravity reviews: `volume` uses `(D, H, W, C)`, including grayscale `C=1`; `mask3d` remains a separate target that may omit channels.

The policy directs reviews to assess volume changes with the supported DHWC layout and avoids treating `(D, H, W)` compatibility as a transform requirement.

## Verification

- `pre-commit run --files .github/ci-foundation/antigravity-review.md`

## Summary by Sourcery

Clarify the supported array layouts and channel conventions used when reviewing Compose and Tensor changes.

Enhancements:
- Clarify supported channel-last NumPy Compose layouts, including grayscale normalization and the separate channel handling for `mask3d`.
- Document channel-first Tensor layouts for `image`, `images`, and `volume` to guide Antigravity reviews.

Documentation:
- Update Antigravity review guidance with explicit Compose and Tensor volume layout contracts.