### PR TITLE
fix(core): make target sampling explicit

### DIFF
--- a/.codex/skills/add-transform/SKILL.md
+++ b/.codex/skills/add-transform/SKILL.md
@@ -43,7 +43,7 @@ def my_transform(img: np.ndarray, param1: float, param2: int) -> np.ndarray: ...
 
 - Define sampling and replay behavior at the `sample_parameters` boundary. Implement the greenfield
   `sample_parameters(params, data, targets, sampling) -> SampledParams` contract;
-  return `SampledParams.shared_only(...)` for shared values and use actual-key `TargetParams` entries
+  return `SampledParams(params={...})` for values used by every target and use actual-key `TargetParams` entries
   for representation-dependent values. The coding guidance document describes the complete contract and the hook reports
   mechanical violations.
 - Use relative parameters where users should transfer a policy across image sizes.

--- a/.codex/skills/add-transform/SKILL.md
+++ b/.codex/skills/add-transform/SKILL.md
@@ -42,8 +42,8 @@ def my_transform(img: np.ndarray, param1: float, param2: int) -> np.ndarray: ...
 ## 3. Write the transform class
 
 - Define sampling and replay behavior at the `sample_parameters` boundary. Implement the greenfield
-  `sample_parameters(inputs: TransformSamplingInput, sampling: SamplingContext) -> TransformParameterPlan` contract;
-  return `TransformParameterPlan.shared_only(...)` for shared values and use actual-key `TargetParameterGroup` entries
+  `sample_parameters(params, data, targets, sampling) -> SampledParams` contract;
+  return `SampledParams.shared_only(...)` for shared values and use actual-key `TargetParams` entries
   for representation-dependent values. The coding guidance document describes the complete contract and the hook reports
   mechanical violations.
 - Use relative parameters where users should transfer a policy across image sizes.

--- a/.codex/skills/add-transform/SKILL.md
+++ b/.codex/skills/add-transform/SKILL.md
@@ -28,8 +28,7 @@ kernel.
 Add the pure function in the corresponding `functional.py` file (no class state, no RNG):
 
 ```python
-def my_transform(img: np.ndarray, param1: float, param2: int) -> np.ndarray:
-    ...
+def my_transform(img: np.ndarray, param1: float, param2: int) -> np.ndarray: ...
 ```
 
 - Keep the functional layer deterministic; define stochastic behavior at the transform sampling boundary.
@@ -42,8 +41,11 @@ def my_transform(img: np.ndarray, param1: float, param2: int) -> np.ndarray:
 
 ## 3. Write the transform class
 
-- Define sampling and replay behavior at the `sample_parameters` boundary; the coding guidance document describes the
-  required `SamplingContext` contract and the hook reports mechanical violations.
+- Define sampling and replay behavior at the `sample_parameters` boundary. Implement the greenfield
+  `sample_parameters(inputs: TransformSamplingInput, sampling: SamplingContext) -> TransformParameterPlan` contract;
+  return `TransformParameterPlan.shared_only(...)` for shared values and use actual-key `TargetParameterGroup` entries
+  for representation-dependent values. The coding guidance document describes the complete contract and the hook reports
+  mechanical violations.
 - Use relative parameters where users should transfer a policy across image sizes.
 - Use `ImageType` for image, mask, and volume signatures; reserve `np.ndarray` for bboxes and keypoints.
 - Compose inputs always have a channel dimension: `(H, W, C)`, `(N, H, W, C)`, and `(D, H, W, C)`; grayscale is

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -173,7 +173,7 @@ class Blur(ImageOnlyTransform):
             self.blur_range[1],
         )
         sampling.applied_overrides["blur_range"] = kernel
-        return SampledParams.shared_only({"kernel": kernel})
+        return SampledParams(params={"kernel": kernel})
 
 
 class MotionBlur(Blur):
@@ -454,7 +454,7 @@ class MotionBlur(Blur):
             random_state=sampling.py_random,
         )
 
-        return SampledParams.shared_only({"kernel": kernel.astype(np.float32) / float(reduce_sum(kernel))})
+        return SampledParams(params={"kernel": kernel.astype(np.float32) / float(reduce_sum(kernel))})
 
 
 class MedianBlur(Blur):
@@ -688,7 +688,7 @@ class ModeFilter(ImageOnlyTransform):
             self.kernel_range[1],
         )
         sampling.applied_overrides["kernel_range"] = kernel_size
-        return SampledParams.shared_only({"kernel_size": kernel_size})
+        return SampledParams(params={"kernel_size": kernel_size})
 
 
 class GaussianBlur(ImageOnlyTransform):
@@ -969,8 +969,8 @@ class GaussianBlur(ImageOnlyTransform):
             "pillow_mode": ksize == 0,
         }
         if self.volume_mode == "slice":
-            return SampledParams.shared_only(
-                {
+            return SampledParams(
+                params={
                     **result,
                     "sigma": (sigma, sigma, sigma),
                     "kernel_size": (ksize, ksize, ksize),
@@ -999,7 +999,7 @@ class GaussianBlur(ImageOnlyTransform):
                     requirements={view.name: TargetRequirement() for view in volume_views},
                 ),
             )
-        return SampledParams(shared=result, groups=volume_group)
+        return SampledParams(params=result, target_params=volume_group)
 
 
 class GlassBlur(ImageOnlyTransform):
@@ -1188,7 +1188,7 @@ class GlassBlur(ImageOnlyTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        height, width = targets.require_spatial_shape(2)
+        height, width = targets.require_aligned_spatial_shape(2)
         # generate array containing all necessary values for transformations
         width_pixels = height - self.max_delta * 2
         height_pixels = width - self.max_delta * 2
@@ -1199,7 +1199,7 @@ class GlassBlur(ImageOnlyTransform):
             size=(total_pixels, self.iterations, 2),
         )
 
-        return SampledParams.shared_only({"dxy": dxy})
+        return SampledParams(params={"dxy": dxy})
 
 
 class AdvancedBlur(ImageOnlyTransform):
@@ -1530,7 +1530,7 @@ class AdvancedBlur(ImageOnlyTransform):
 
         # Normalize kernel
         kernel = kernel.astype(np.float32) / reduce_sum(kernel)
-        return SampledParams.shared_only({"kernel": kernel})
+        return SampledParams(params={"kernel": kernel})
 
 
 class Defocus(ImageOnlyTransform):
@@ -1679,7 +1679,7 @@ class Defocus(ImageOnlyTransform):
         radius = sampling.py_random.randint(*self.radius_range)
         alias_blur = sampling.py_random.uniform(*self.alias_blur_range)
         sampling.applied_overrides.update({"radius_range": radius, "alias_blur_range": alias_blur})
-        return SampledParams.shared_only({"radius": radius, "alias_blur": alias_blur})
+        return SampledParams(params={"radius": radius, "alias_blur": alias_blur})
 
 
 class ZoomBlur(ImageOnlyTransform):
@@ -1812,4 +1812,4 @@ class ZoomBlur(ImageOnlyTransform):
         step_factor = sampling.py_random.uniform(*self.step_factor_range)
         max_factor = max(1 + step_factor, sampling.py_random.uniform(*self.max_factor_range))
         sampling.applied_overrides.update({"step_factor_range": step_factor, "max_factor_range": max_factor})
-        return SampledParams.shared_only({"zoom_factors": np.arange(1.0, max_factor, step_factor)})
+        return SampledParams(params={"zoom_factors": np.arange(1.0, max_factor, step_factor)})

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -22,6 +22,12 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TargetRequirement,
+    TransformParameterPlan,
+    TransformSamplingInput,
+)
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
@@ -156,17 +162,16 @@ class Blur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         kernel = fblur.sample_odd_from_range(
             sampling.py_random,
             self.blur_range[0],
             self.blur_range[1],
         )
         sampling.applied_overrides["blur_range"] = kernel
-        return {"kernel": kernel}
+        return TransformParameterPlan.shared_only({"kernel": kernel})
 
 
 class MotionBlur(Blur):
@@ -417,10 +422,9 @@ class MotionBlur(Blur):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         ksize = fblur.sample_odd_from_range(
             sampling.py_random,
             self.blur_range[0],
@@ -446,7 +450,7 @@ class MotionBlur(Blur):
             random_state=sampling.py_random,
         )
 
-        return {"kernel": kernel.astype(np.float32) / float(reduce_sum(kernel))}
+        return TransformParameterPlan.shared_only({"kernel": kernel.astype(np.float32) / float(reduce_sum(kernel))})
 
 
 class MedianBlur(Blur):
@@ -669,17 +673,16 @@ class ModeFilter(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         kernel_size = fblur.sample_odd_from_range(
             sampling.py_random,
             self.kernel_range[0],
             self.kernel_range[1],
         )
         sampling.applied_overrides["kernel_range"] = kernel_size
-        return {"kernel_size": kernel_size}
+        return TransformParameterPlan.shared_only({"kernel_size": kernel_size})
 
 
 class GaussianBlur(ImageOnlyTransform):
@@ -913,15 +916,22 @@ class GaussianBlur(ImageOnlyTransform):
             return fblur.pillow_gaussian_blur(img, kernel)
         return fpixel.separable_convolve(img, kernel=kernel)
 
-    def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
+    def apply_to_volume(
+        self,
+        volume: VolumeType,
+        kernel: np.ndarray,
+        sigma: tuple[float, float, float],
+        kernel_size: tuple[int, int, int],
+        **params: Any,
+    ) -> VolumeType:
         if self.volume_mode == "slice":
-            return super().apply_to_volume(volume, **params)
+            return super().apply_to_volume(volume, kernel=kernel, **params)
         return cast(
             "VolumeType",
             gaussian_blur3d(
                 volume,
-                sigma=params["volume_sigma"],
-                kernel_size=params["volume_kernel_size"],
+                sigma=sigma,
+                kernel_size=kernel_size,
             ),
         )
 
@@ -934,10 +944,9 @@ class GaussianBlur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         sigma = sampling.py_random.uniform(*self.sigma_range)
         ksize = (
             self._sample_3d_kernel_size(self.blur_range, sampling)
@@ -952,7 +961,13 @@ class GaussianBlur(ImageOnlyTransform):
             "pillow_mode": ksize == 0,
         }
         if self.volume_mode == "slice":
-            return result
+            return TransformParameterPlan.shared_only(
+                {
+                    **result,
+                    "sigma": (sigma, sigma, sigma),
+                    "kernel_size": (ksize, ksize, ksize),
+                }
+            )
 
         sigma_z = sigma if self.sigma_z_range is None else sampling.py_random.uniform(*self.sigma_z_range)
         kernel_size_z = ksize if self.blur_z_range is None else self._sample_3d_kernel_size(self.blur_z_range, sampling)
@@ -963,13 +978,20 @@ class GaussianBlur(ImageOnlyTransform):
                 "blur_z_range": kernel_size_z,
             },
         )
-        result.update(
-            {
-                "volume_sigma": (sigma_z, sigma, sigma),
-                "volume_kernel_size": (kernel_size_z, ksize, ksize),
-            },
-        )
-        return result
+        volume_views = inputs.targets.by_canonical_type("volume")
+        volume_group: tuple[TargetParameterGroup, ...] = ()
+        if volume_views:
+            volume_group = (
+                TargetParameterGroup(
+                    targets=tuple(view.name for view in volume_views),
+                    params={
+                        "sigma": (sigma_z, sigma, sigma),
+                        "kernel_size": (kernel_size_z, ksize, ksize),
+                    },
+                    requirements={view.name: TargetRequirement() for view in volume_views},
+                ),
+            )
+        return TransformParameterPlan(shared=result, groups=volume_group)
 
 
 class GlassBlur(ImageOnlyTransform):
@@ -1153,22 +1175,21 @@ class GlassBlur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray]:
-        height, width = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        height, width = inputs.require_spatial_frame().spatial_shape_2d
         # generate array containing all necessary values for transformations
         width_pixels = height - self.max_delta * 2
         height_pixels = width - self.max_delta * 2
-        total_pixels = int(width_pixels * height_pixels)
+        total_pixels = width_pixels * height_pixels
         dxy = sampling.random_generator.integers(
             -self.max_delta,
             self.max_delta,
             size=(total_pixels, self.iterations, 2),
         )
 
-        return {"dxy": dxy}
+        return TransformParameterPlan.shared_only({"dxy": dxy})
 
 
 class AdvancedBlur(ImageOnlyTransform):
@@ -1438,10 +1459,9 @@ class AdvancedBlur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray]:
+    ) -> TransformParameterPlan:
         ksize = fblur.sample_odd_from_range(
             sampling.py_random,
             self.blur_range[0],
@@ -1498,7 +1518,7 @@ class AdvancedBlur(ImageOnlyTransform):
 
         # Normalize kernel
         kernel = kernel.astype(np.float32) / reduce_sum(kernel)
-        return {"kernel": kernel}
+        return TransformParameterPlan.shared_only({"kernel": kernel})
 
 
 class Defocus(ImageOnlyTransform):
@@ -1639,14 +1659,13 @@ class Defocus(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         radius = sampling.py_random.randint(*self.radius_range)
         alias_blur = sampling.py_random.uniform(*self.alias_blur_range)
         sampling.applied_overrides.update({"radius_range": radius, "alias_blur_range": alias_blur})
-        return {"radius": radius, "alias_blur": alias_blur}
+        return TransformParameterPlan.shared_only({"radius": radius, "alias_blur": alias_blur})
 
 
 class ZoomBlur(ImageOnlyTransform):
@@ -1771,11 +1790,10 @@ class ZoomBlur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         step_factor = sampling.py_random.uniform(*self.step_factor_range)
         max_factor = max(1 + step_factor, sampling.py_random.uniform(*self.max_factor_range))
         sampling.applied_overrides.update({"step_factor_range": step_factor, "max_factor_range": max_factor})
-        return {"zoom_factors": np.arange(1.0, max_factor, step_factor)}
+        return TransformParameterPlan.shared_only({"zoom_factors": np.arange(1.0, max_factor, step_factor)})

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -1189,9 +1189,8 @@ class GlassBlur(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         height, width = targets.require_aligned_spatial_shape(2)
-        # generate array containing all necessary values for transformations
-        width_pixels = height - self.max_delta * 2
-        height_pixels = width - self.max_delta * 2
+        height_pixels = height - self.max_delta * 2
+        width_pixels = width - self.max_delta * 2
         total_pixels = width_pixels * height_pixels
         dxy = sampling.random_generator.integers(
             -self.max_delta,

--- a/albumentations/augmentations/blur/transforms.py
+++ b/albumentations/augmentations/blur/transforms.py
@@ -23,10 +23,10 @@ from albumentations.core.pydantic import (
     nondecreasing,
 )
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
+    SampledParams,
+    TargetParams,
     TargetRequirement,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    TargetSet,
 )
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
@@ -162,16 +162,18 @@ class Blur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         kernel = fblur.sample_odd_from_range(
             sampling.py_random,
             self.blur_range[0],
             self.blur_range[1],
         )
         sampling.applied_overrides["blur_range"] = kernel
-        return TransformParameterPlan.shared_only({"kernel": kernel})
+        return SampledParams.shared_only({"kernel": kernel})
 
 
 class MotionBlur(Blur):
@@ -422,9 +424,11 @@ class MotionBlur(Blur):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         ksize = fblur.sample_odd_from_range(
             sampling.py_random,
             self.blur_range[0],
@@ -450,7 +454,7 @@ class MotionBlur(Blur):
             random_state=sampling.py_random,
         )
 
-        return TransformParameterPlan.shared_only({"kernel": kernel.astype(np.float32) / float(reduce_sum(kernel))})
+        return SampledParams.shared_only({"kernel": kernel.astype(np.float32) / float(reduce_sum(kernel))})
 
 
 class MedianBlur(Blur):
@@ -673,16 +677,18 @@ class ModeFilter(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         kernel_size = fblur.sample_odd_from_range(
             sampling.py_random,
             self.kernel_range[0],
             self.kernel_range[1],
         )
         sampling.applied_overrides["kernel_range"] = kernel_size
-        return TransformParameterPlan.shared_only({"kernel_size": kernel_size})
+        return SampledParams.shared_only({"kernel_size": kernel_size})
 
 
 class GaussianBlur(ImageOnlyTransform):
@@ -944,9 +950,11 @@ class GaussianBlur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sigma = sampling.py_random.uniform(*self.sigma_range)
         ksize = (
             self._sample_3d_kernel_size(self.blur_range, sampling)
@@ -961,7 +969,7 @@ class GaussianBlur(ImageOnlyTransform):
             "pillow_mode": ksize == 0,
         }
         if self.volume_mode == "slice":
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {
                     **result,
                     "sigma": (sigma, sigma, sigma),
@@ -978,11 +986,11 @@ class GaussianBlur(ImageOnlyTransform):
                 "blur_z_range": kernel_size_z,
             },
         )
-        volume_views = inputs.targets.by_canonical_type("volume")
-        volume_group: tuple[TargetParameterGroup, ...] = ()
+        volume_views = targets.by_canonical_type("volume")
+        volume_group: tuple[TargetParams, ...] = ()
         if volume_views:
             volume_group = (
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(view.name for view in volume_views),
                     params={
                         "sigma": (sigma_z, sigma, sigma),
@@ -991,7 +999,7 @@ class GaussianBlur(ImageOnlyTransform):
                     requirements={view.name: TargetRequirement() for view in volume_views},
                 ),
             )
-        return TransformParameterPlan(shared=result, groups=volume_group)
+        return SampledParams(shared=result, groups=volume_group)
 
 
 class GlassBlur(ImageOnlyTransform):
@@ -1175,10 +1183,12 @@ class GlassBlur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        height, width = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        height, width = targets.require_spatial_shape(2)
         # generate array containing all necessary values for transformations
         width_pixels = height - self.max_delta * 2
         height_pixels = width - self.max_delta * 2
@@ -1189,7 +1199,7 @@ class GlassBlur(ImageOnlyTransform):
             size=(total_pixels, self.iterations, 2),
         )
 
-        return TransformParameterPlan.shared_only({"dxy": dxy})
+        return SampledParams.shared_only({"dxy": dxy})
 
 
 class AdvancedBlur(ImageOnlyTransform):
@@ -1459,9 +1469,11 @@ class AdvancedBlur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         ksize = fblur.sample_odd_from_range(
             sampling.py_random,
             self.blur_range[0],
@@ -1518,7 +1530,7 @@ class AdvancedBlur(ImageOnlyTransform):
 
         # Normalize kernel
         kernel = kernel.astype(np.float32) / reduce_sum(kernel)
-        return TransformParameterPlan.shared_only({"kernel": kernel})
+        return SampledParams.shared_only({"kernel": kernel})
 
 
 class Defocus(ImageOnlyTransform):
@@ -1659,13 +1671,15 @@ class Defocus(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         radius = sampling.py_random.randint(*self.radius_range)
         alias_blur = sampling.py_random.uniform(*self.alias_blur_range)
         sampling.applied_overrides.update({"radius_range": radius, "alias_blur_range": alias_blur})
-        return TransformParameterPlan.shared_only({"radius": radius, "alias_blur": alias_blur})
+        return SampledParams.shared_only({"radius": radius, "alias_blur": alias_blur})
 
 
 class ZoomBlur(ImageOnlyTransform):
@@ -1790,10 +1804,12 @@ class ZoomBlur(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         step_factor = sampling.py_random.uniform(*self.step_factor_range)
         max_factor = max(1 + step_factor, sampling.py_random.uniform(*self.max_factor_range))
         sampling.applied_overrides.update({"step_factor_range": step_factor, "max_factor_range": max_factor})
-        return TransformParameterPlan.shared_only({"zoom_factors": np.arange(1.0, max_factor, step_factor)})
+        return SampledParams.shared_only({"zoom_factors": np.arange(1.0, max_factor, step_factor)})

--- a/albumentations/augmentations/crops/base.py
+++ b/albumentations/augmentations/crops/base.py
@@ -74,7 +74,7 @@ class BaseCrop(DualTransform):
         ...
         ...     def sample_parameters(self, params, data, targets, sampling):
         ...         '''Calculate crop coordinates based on center of image'''
-        ...         image_height, image_width = targets.require_spatial_shape(2)
+        ...         image_height, image_width = targets.require_aligned_spatial_shape(2)
         ...
         ...         # Calculate center crop coordinates
         ...         x_min = max(0, (image_width - self.crop_width) // 2)
@@ -82,7 +82,7 @@ class BaseCrop(DualTransform):
         ...         x_max = min(image_width, x_min + self.crop_width)
         ...         y_max = min(image_height, y_min + self.crop_height)
         ...
-        ...         return SampledParams.shared_only({"crop_coords": (x_min, y_min, x_max, y_max)})
+        ...         return SampledParams(params={"crop_coords": (x_min, y_min, x_max, y_max)})
         >>>
         >>> # Prepare sample data
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -288,7 +288,7 @@ class BaseCropAndPad(BaseCrop):
         ...
         ...     def sample_parameters(self, params, data, targets, sampling):
         ...         '''Calculate crop coordinates and padding if needed'''
-        ...         image_shape = targets.require_spatial_shape(2)
+        ...         image_shape = targets.require_aligned_spatial_shape(2)
         ...         image_height, image_width = image_shape
         ...
         ...         # Calculate crop coordinates with offsets
@@ -306,7 +306,7 @@ class BaseCropAndPad(BaseCrop):
         ...
         ...         from albumentations.core.transform_params import SampledParams
         ...
-        ...         return SampledParams.shared_only({
+        ...         return SampledParams(params={
         ...             "crop_coords": (x_min, y_min, x_max, y_max),
         ...             "pad_params": pad_params,
         ...         })
@@ -646,7 +646,7 @@ class _BaseRandomSizedCrop(DualTransform):
         ...
         ...     def sample_parameters(self, params, data, targets, sampling):
         ...         # Custom logic to select crop coordinates
-        ...         image_height, image_width = targets.require_spatial_shape(2)
+        ...         image_height, image_width = targets.require_aligned_spatial_shape(2)
         ...
         ...         # Simple example: calculate crop size based on custom_parameter
         ...         crop_height = int(image_height * self.custom_parameter)
@@ -658,7 +658,7 @@ class _BaseRandomSizedCrop(DualTransform):
         ...         y2 = y1 + crop_height
         ...         x2 = x1 + crop_width
         ...
-        ...         return SampledParams.shared_only({"crop_coords": (x1, y1, x2, y2)})
+        ...         return SampledParams(params={"crop_coords": (x1, y1, x2, y2)})
         >>>
         >>> # Prepare sample data
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)

--- a/albumentations/augmentations/crops/base.py
+++ b/albumentations/augmentations/crops/base.py
@@ -72,9 +72,9 @@ class BaseCrop(DualTransform):
         ...         self.crop_height = crop_height
         ...         self.crop_width = crop_width
         ...
-        ...     def sample_parameters(self, params, data, sampling):
+        ...     def sample_parameters(self, inputs, sampling):
         ...         '''Calculate crop coordinates based on center of image'''
-        ...         image_height, image_width = params["shape"][:2]
+        ...         image_height, image_width = inputs.require_spatial_frame().spatial_shape_2d
         ...
         ...         # Calculate center crop coordinates
         ...         x_min = max(0, (image_width - self.crop_width) // 2)
@@ -82,7 +82,7 @@ class BaseCrop(DualTransform):
         ...         x_max = min(image_width, x_min + self.crop_width)
         ...         y_max = min(image_height, y_min + self.crop_height)
         ...
-        ...         return {"crop_coords": (x_min, y_min, x_max, y_max)}
+        ...         return TransformParameterPlan.shared_only({"crop_coords": (x_min, y_min, x_max, y_max)})
         >>>
         >>> # Prepare sample data
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -286,9 +286,9 @@ class BaseCropAndPad(BaseCrop):
         ...         self.offset_x = offset_x
         ...         self.offset_y = offset_y
         ...
-        ...     def sample_parameters(self, params, data, sampling):
+        ...     def sample_parameters(self, inputs, sampling):
         ...         '''Calculate crop coordinates and padding if needed'''
-        ...         image_shape = params["shape"][:2]
+        ...         image_shape = inputs.require_spatial_frame().spatial_shape_2d
         ...         image_height, image_width = image_shape
         ...
         ...         # Calculate crop coordinates with offsets
@@ -304,10 +304,12 @@ class BaseCropAndPad(BaseCrop):
         ...             sampling,
         ...         ) if self.pad_if_needed else None
         ...
-        ...         return {
+        ...         from albumentations.core.transform_params import TransformParameterPlan
+        ...
+        ...         return TransformParameterPlan.shared_only({
         ...             "crop_coords": (x_min, y_min, x_max, y_max),
         ...             "pad_params": pad_params,
-        ...         }
+        ...         })
         >>>
         >>> # Prepare sample data
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -642,9 +644,9 @@ class _BaseRandomSizedCrop(DualTransform):
         ...         )
         ...         self.custom_parameter = custom_parameter
         ...
-        ...     def sample_parameters(self, params, data, sampling):
+        ...     def sample_parameters(self, inputs, sampling):
         ...         # Custom logic to select crop coordinates
-        ...         image_height, image_width = params["shape"][:2]
+        ...         image_height, image_width = inputs.require_spatial_frame().spatial_shape_2d
         ...
         ...         # Simple example: calculate crop size based on custom_parameter
         ...         crop_height = int(image_height * self.custom_parameter)
@@ -656,7 +658,7 @@ class _BaseRandomSizedCrop(DualTransform):
         ...         y2 = y1 + crop_height
         ...         x2 = x1 + crop_width
         ...
-        ...         return {"crop_coords": (x1, y1, x2, y2)}
+        ...         return TransformParameterPlan.shared_only({"crop_coords": (x1, y1, x2, y2)})
         >>>
         >>> # Prepare sample data
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)

--- a/albumentations/augmentations/crops/base.py
+++ b/albumentations/augmentations/crops/base.py
@@ -72,9 +72,9 @@ class BaseCrop(DualTransform):
         ...         self.crop_height = crop_height
         ...         self.crop_width = crop_width
         ...
-        ...     def sample_parameters(self, inputs, sampling):
+        ...     def sample_parameters(self, params, data, targets, sampling):
         ...         '''Calculate crop coordinates based on center of image'''
-        ...         image_height, image_width = inputs.require_spatial_frame().spatial_shape_2d
+        ...         image_height, image_width = targets.require_spatial_shape(2)
         ...
         ...         # Calculate center crop coordinates
         ...         x_min = max(0, (image_width - self.crop_width) // 2)
@@ -82,7 +82,7 @@ class BaseCrop(DualTransform):
         ...         x_max = min(image_width, x_min + self.crop_width)
         ...         y_max = min(image_height, y_min + self.crop_height)
         ...
-        ...         return TransformParameterPlan.shared_only({"crop_coords": (x_min, y_min, x_max, y_max)})
+        ...         return SampledParams.shared_only({"crop_coords": (x_min, y_min, x_max, y_max)})
         >>>
         >>> # Prepare sample data
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -286,9 +286,9 @@ class BaseCropAndPad(BaseCrop):
         ...         self.offset_x = offset_x
         ...         self.offset_y = offset_y
         ...
-        ...     def sample_parameters(self, inputs, sampling):
+        ...     def sample_parameters(self, params, data, targets, sampling):
         ...         '''Calculate crop coordinates and padding if needed'''
-        ...         image_shape = inputs.require_spatial_frame().spatial_shape_2d
+        ...         image_shape = targets.require_spatial_shape(2)
         ...         image_height, image_width = image_shape
         ...
         ...         # Calculate crop coordinates with offsets
@@ -304,9 +304,9 @@ class BaseCropAndPad(BaseCrop):
         ...             sampling,
         ...         ) if self.pad_if_needed else None
         ...
-        ...         from albumentations.core.transform_params import TransformParameterPlan
+        ...         from albumentations.core.transform_params import SampledParams
         ...
-        ...         return TransformParameterPlan.shared_only({
+        ...         return SampledParams.shared_only({
         ...             "crop_coords": (x_min, y_min, x_max, y_max),
         ...             "pad_params": pad_params,
         ...         })
@@ -644,9 +644,9 @@ class _BaseRandomSizedCrop(DualTransform):
         ...         )
         ...         self.custom_parameter = custom_parameter
         ...
-        ...     def sample_parameters(self, inputs, sampling):
+        ...     def sample_parameters(self, params, data, targets, sampling):
         ...         # Custom logic to select crop coordinates
-        ...         image_height, image_width = inputs.require_spatial_frame().spatial_shape_2d
+        ...         image_height, image_width = targets.require_spatial_shape(2)
         ...
         ...         # Simple example: calculate crop size based on custom_parameter
         ...         crop_height = int(image_height * self.custom_parameter)
@@ -658,7 +658,7 @@ class _BaseRandomSizedCrop(DualTransform):
         ...         y2 = y1 + crop_height
         ...         x2 = x1 + crop_width
         ...
-        ...         return TransformParameterPlan.shared_only({"crop_coords": (x1, y1, x2, y2)})
+        ...         return SampledParams.shared_only({"crop_coords": (x1, y1, x2, y2)})
         >>>
         >>> # Prepare sample data
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)

--- a/albumentations/augmentations/crops/basic.py
+++ b/albumentations/augmentations/crops/basic.py
@@ -170,7 +170,7 @@ class RandomCrop(BaseCropAndPad):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         image_height, image_width = image_shape
 
         if not self.pad_if_needed and (self.height > image_height or self.width > image_width):
@@ -203,8 +203,8 @@ class RandomCrop(BaseCropAndPad):
             w_start = sampling.py_random.random()
             crop_coords = fcrops.get_crop_coords(image_shape, (self.height, self.width), h_start, w_start)
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "crop_coords": crop_coords,
                 "pad_params": pad_params,
             }
@@ -350,7 +350,7 @@ class CenterCrop(BaseCropAndPad):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         image_height, image_width = image_shape
 
         if not self.pad_if_needed and (self.height > image_height or self.width > image_width):
@@ -379,8 +379,8 @@ class CenterCrop(BaseCropAndPad):
             # Get crop coordinates based on original dimensions
             crop_coords = fcrops.get_center_crop_coords(image_shape, (self.height, self.width))
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "crop_coords": crop_coords,
                 "pad_params": pad_params,
             }
@@ -603,12 +603,12 @@ class Crop(BaseCropAndPad):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         image_height, image_width = image_shape
 
         if not self.pad_if_needed:
-            return SampledParams.shared_only(
-                {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": None}
+            return SampledParams(
+                params={"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": None}
             )
 
         pad_top, pad_bottom, pad_left, pad_right = self._compute_min_padding(image_height, image_width)
@@ -617,8 +617,8 @@ class Crop(BaseCropAndPad):
         if any([pad_top, pad_bottom, pad_left, pad_right]):
             pad_params = self._compute_adjusted_padding(pad_top, pad_bottom, pad_left, pad_right, sampling)
 
-        return SampledParams.shared_only(
-            {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": pad_params}
+        return SampledParams(
+            params={"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": pad_params}
         )
 
 
@@ -1021,7 +1021,7 @@ class CropAndPad(DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        height, width = targets.require_spatial_shape(2)
+        height, width = targets.require_aligned_spatial_shape(2)
         new_params, percent_params = self._sample_crop_values(height, width, sampling)
 
         pad_params = [max(i, 0) for i in new_params]
@@ -1057,8 +1057,8 @@ class CropAndPad(DualTransform):
             applied_config["fill_mask"] = sampled_fill_mask
         sampling.applied_overrides.update(applied_config)
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "crop_params": tuple(crop_params) if crop_params else None,
                 "pad_params": tuple(pad_params) if pad_params else None,
                 "fill": sampled_fill,

--- a/albumentations/augmentations/crops/basic.py
+++ b/albumentations/augmentations/crops/basic.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Literal, cast
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 from ._transforms_shared import (
     ALL_TARGETS,
@@ -165,10 +165,12 @@ class RandomCrop(BaseCropAndPad):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         image_height, image_width = image_shape
 
         if not self.pad_if_needed and (self.height > image_height or self.width > image_width):
@@ -201,7 +203,7 @@ class RandomCrop(BaseCropAndPad):
             w_start = sampling.py_random.random()
             crop_coords = fcrops.get_crop_coords(image_shape, (self.height, self.width), h_start, w_start)
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "crop_coords": crop_coords,
                 "pad_params": pad_params,
@@ -343,10 +345,12 @@ class CenterCrop(BaseCropAndPad):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         image_height, image_width = image_shape
 
         if not self.pad_if_needed and (self.height > image_height or self.width > image_width):
@@ -375,7 +379,7 @@ class CenterCrop(BaseCropAndPad):
             # Get crop coordinates based on original dimensions
             crop_coords = fcrops.get_center_crop_coords(image_shape, (self.height, self.width))
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "crop_coords": crop_coords,
                 "pad_params": pad_params,
@@ -594,14 +598,16 @@ class Crop(BaseCropAndPad):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         image_height, image_width = image_shape
 
         if not self.pad_if_needed:
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": None}
             )
 
@@ -611,7 +617,7 @@ class Crop(BaseCropAndPad):
         if any([pad_top, pad_bottom, pad_left, pad_right]):
             pad_params = self._compute_adjusted_padding(pad_top, pad_bottom, pad_left, pad_right, sampling)
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": pad_params}
         )
 
@@ -1010,10 +1016,12 @@ class CropAndPad(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        height, width = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        height, width = targets.require_spatial_shape(2)
         new_params, percent_params = self._sample_crop_values(height, width, sampling)
 
         pad_params = [max(i, 0) for i in new_params]
@@ -1049,7 +1057,7 @@ class CropAndPad(DualTransform):
             applied_config["fill_mask"] = sampled_fill_mask
         sampling.applied_overrides.update(applied_config)
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "crop_params": tuple(crop_params) if crop_params else None,
                 "pad_params": tuple(pad_params) if pad_params else None,

--- a/albumentations/augmentations/crops/basic.py
+++ b/albumentations/augmentations/crops/basic.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Literal, cast
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 from ._transforms_shared import (
     ALL_TARGETS,
@@ -164,11 +165,10 @@ class RandomCrop(BaseCropAndPad):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         image_height, image_width = image_shape
 
         if not self.pad_if_needed and (self.height > image_height or self.width > image_width):
@@ -201,10 +201,12 @@ class RandomCrop(BaseCropAndPad):
             w_start = sampling.py_random.random()
             crop_coords = fcrops.get_crop_coords(image_shape, (self.height, self.width), h_start, w_start)
 
-        return {
-            "crop_coords": crop_coords,
-            "pad_params": pad_params,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "crop_coords": crop_coords,
+                "pad_params": pad_params,
+            }
+        )
 
 
 class CenterCrop(BaseCropAndPad):
@@ -341,11 +343,10 @@ class CenterCrop(BaseCropAndPad):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         image_height, image_width = image_shape
 
         if not self.pad_if_needed and (self.height > image_height or self.width > image_width):
@@ -374,10 +375,12 @@ class CenterCrop(BaseCropAndPad):
             # Get crop coordinates based on original dimensions
             crop_coords = fcrops.get_center_crop_coords(image_shape, (self.height, self.width))
 
-        return {
-            "crop_coords": crop_coords,
-            "pad_params": pad_params,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "crop_coords": crop_coords,
+                "pad_params": pad_params,
+            }
+        )
 
 
 class Crop(BaseCropAndPad):
@@ -591,15 +594,16 @@ class Crop(BaseCropAndPad):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         image_height, image_width = image_shape
 
         if not self.pad_if_needed:
-            return {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": None}
+            return TransformParameterPlan.shared_only(
+                {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": None}
+            )
 
         pad_top, pad_bottom, pad_left, pad_right = self._compute_min_padding(image_height, image_width)
         pad_params = None
@@ -607,7 +611,9 @@ class Crop(BaseCropAndPad):
         if any([pad_top, pad_bottom, pad_left, pad_right]):
             pad_params = self._compute_adjusted_padding(pad_top, pad_bottom, pad_left, pad_right, sampling)
 
-        return {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": pad_params}
+        return TransformParameterPlan.shared_only(
+            {"crop_coords": (self.x_min, self.y_min, self.x_max, self.y_max), "pad_params": pad_params}
+        )
 
 
 class CropAndPad(DualTransform):
@@ -1004,11 +1010,10 @@ class CropAndPad(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        height, width = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        height, width = inputs.require_spatial_frame().spatial_shape_2d
         new_params, percent_params = self._sample_crop_values(height, width, sampling)
 
         pad_params = [max(i, 0) for i in new_params]
@@ -1044,13 +1049,15 @@ class CropAndPad(DualTransform):
             applied_config["fill_mask"] = sampled_fill_mask
         sampling.applied_overrides.update(applied_config)
 
-        return {
-            "crop_params": tuple(crop_params) if crop_params else None,
-            "pad_params": tuple(pad_params) if pad_params else None,
-            "fill": sampled_fill,
-            "fill_mask": sampled_fill_mask,
-            "result_shape": (result_rows, result_cols),
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "crop_params": tuple(crop_params) if crop_params else None,
+                "pad_params": tuple(pad_params) if pad_params else None,
+                "fill": sampled_fill,
+                "fill_mask": sampled_fill_mask,
+                "result_shape": (result_rows, result_cols),
+            }
+        )
 
     def _get_px_params(self, sampling: SamplingContext) -> list[int]:
         if self.px is None:

--- a/albumentations/augmentations/crops/bbox_safe.py
+++ b/albumentations/augmentations/crops/bbox_safe.py
@@ -3,7 +3,7 @@
 from typing import Annotated, Any, ClassVar
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 from ._transforms_shared import (
     ALL_TARGETS,
@@ -165,21 +165,22 @@ class BBoxSafeRandomCrop(BaseCrop):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
 
         if len(data["bboxes"]) == 0:  # less likely, this class is for use with bboxes.
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
+            return SampledParams.shared_only({"crop_coords": crop_coords})
 
         bbox_union = union_of_bboxes(bboxes=data["bboxes"], erosion_rate=self.erosion_rate)
 
         if bbox_union is None:
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
+            return SampledParams.shared_only({"crop_coords": crop_coords})
 
         x_min, y_min, x_max, y_max = bbox_union
 
@@ -198,7 +199,7 @@ class BBoxSafeRandomCrop(BaseCrop):
         crop_x_max = int(bbox_xmax * image_width)
         crop_y_max = int(bbox_ymax * image_height)
 
-        return TransformParameterPlan.shared_only({"crop_coords": (crop_x_min, crop_y_min, crop_x_max, crop_y_max)})
+        return SampledParams.shared_only({"crop_coords": (crop_x_min, crop_y_min, crop_x_max, crop_y_max)})
 
 
 class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
@@ -568,15 +569,16 @@ class BBoxSubsetSafeRandomCrop(BBoxSafeRandomCrop):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
 
         if len(data["bboxes"]) == 0:
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
+            return SampledParams.shared_only({"crop_coords": crop_coords})
 
         num_bboxes = len(data["bboxes"])
         min_subset_size = math.ceil(num_bboxes * self.subset_fraction_range[0])
@@ -585,7 +587,7 @@ class BBoxSubsetSafeRandomCrop(BBoxSafeRandomCrop):
         subset_size = sampling.random_generator.integers(min_subset_size, max_subset_size + 1)
         bbox_indices = sampling.random_generator.choice(num_bboxes, size=subset_size, replace=False)
         bbox_union = union_of_bboxes(data["bboxes"][bbox_indices], erosion_rate=self.erosion_rate)
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "crop_coords": self._get_crop_coords(bbox_union, image_shape, sampling),
                 "bbox_indices": tuple(sorted(int(index) for index in bbox_indices)),
@@ -741,11 +743,12 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
-        image_height, image_width = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_height, image_width = targets.require_spatial_shape(2)
         bboxes = data.get("bboxes", [])
 
         if self.height > image_height or self.width > image_width:
@@ -832,7 +835,7 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
         crop_x2 = crop_x1 + self.width
         crop_y2 = crop_y1 + self.height
 
-        return TransformParameterPlan.shared_only({"crop_coords": (crop_x1, crop_y1, crop_x2, crop_y2)})
+        return SampledParams.shared_only({"crop_coords": (crop_x1, crop_y1, crop_x2, crop_y2)})
 
 
 __all__ = [

--- a/albumentations/augmentations/crops/bbox_safe.py
+++ b/albumentations/augmentations/crops/bbox_safe.py
@@ -170,17 +170,17 @@ class BBoxSafeRandomCrop(BaseCrop):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
 
         if len(data["bboxes"]) == 0:  # less likely, this class is for use with bboxes.
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return SampledParams.shared_only({"crop_coords": crop_coords})
+            return SampledParams(params={"crop_coords": crop_coords})
 
         bbox_union = union_of_bboxes(bboxes=data["bboxes"], erosion_rate=self.erosion_rate)
 
         if bbox_union is None:
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return SampledParams.shared_only({"crop_coords": crop_coords})
+            return SampledParams(params={"crop_coords": crop_coords})
 
         x_min, y_min, x_max, y_max = bbox_union
 
@@ -199,7 +199,7 @@ class BBoxSafeRandomCrop(BaseCrop):
         crop_x_max = int(bbox_xmax * image_width)
         crop_y_max = int(bbox_ymax * image_height)
 
-        return SampledParams.shared_only({"crop_coords": (crop_x_min, crop_y_min, crop_x_max, crop_y_max)})
+        return SampledParams(params={"crop_coords": (crop_x_min, crop_y_min, crop_x_max, crop_y_max)})
 
 
 class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
@@ -574,11 +574,11 @@ class BBoxSubsetSafeRandomCrop(BBoxSafeRandomCrop):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
 
         if len(data["bboxes"]) == 0:
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return SampledParams.shared_only({"crop_coords": crop_coords})
+            return SampledParams(params={"crop_coords": crop_coords})
 
         num_bboxes = len(data["bboxes"])
         min_subset_size = math.ceil(num_bboxes * self.subset_fraction_range[0])
@@ -587,8 +587,8 @@ class BBoxSubsetSafeRandomCrop(BBoxSafeRandomCrop):
         subset_size = sampling.random_generator.integers(min_subset_size, max_subset_size + 1)
         bbox_indices = sampling.random_generator.choice(num_bboxes, size=subset_size, replace=False)
         bbox_union = union_of_bboxes(data["bboxes"][bbox_indices], erosion_rate=self.erosion_rate)
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "crop_coords": self._get_crop_coords(bbox_union, image_shape, sampling),
                 "bbox_indices": tuple(sorted(int(index) for index in bbox_indices)),
             }
@@ -748,7 +748,7 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_height, image_width = targets.require_spatial_shape(2)
+        image_height, image_width = targets.require_aligned_spatial_shape(2)
         bboxes = data.get("bboxes", [])
 
         if self.height > image_height or self.width > image_width:
@@ -835,7 +835,7 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
         crop_x2 = crop_x1 + self.width
         crop_y2 = crop_y1 + self.height
 
-        return SampledParams.shared_only({"crop_coords": (crop_x1, crop_y1, crop_x2, crop_y2)})
+        return SampledParams(params={"crop_coords": (crop_x1, crop_y1, crop_x2, crop_y2)})
 
 
 __all__ = [

--- a/albumentations/augmentations/crops/bbox_safe.py
+++ b/albumentations/augmentations/crops/bbox_safe.py
@@ -3,6 +3,7 @@
 from typing import Annotated, Any, ClassVar
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 from ._transforms_shared import (
     ALL_TARGETS,
@@ -164,21 +165,21 @@ class BBoxSafeRandomCrop(BaseCrop):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, tuple[int, int, int, int]]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        data = inputs.data
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
 
         if len(data["bboxes"]) == 0:  # less likely, this class is for use with bboxes.
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return {"crop_coords": crop_coords}
+            return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
 
         bbox_union = union_of_bboxes(bboxes=data["bboxes"], erosion_rate=self.erosion_rate)
 
         if bbox_union is None:
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return {"crop_coords": crop_coords}
+            return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
 
         x_min, y_min, x_max, y_max = bbox_union
 
@@ -197,7 +198,7 @@ class BBoxSafeRandomCrop(BaseCrop):
         crop_x_max = int(bbox_xmax * image_width)
         crop_y_max = int(bbox_ymax * image_height)
 
-        return {"crop_coords": (crop_x_min, crop_y_min, crop_x_max, crop_y_max)}
+        return TransformParameterPlan.shared_only({"crop_coords": (crop_x_min, crop_y_min, crop_x_max, crop_y_max)})
 
 
 class RandomSizedBBoxSafeCrop(BBoxSafeRandomCrop):
@@ -567,15 +568,15 @@ class BBoxSubsetSafeRandomCrop(BBoxSafeRandomCrop):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        data = inputs.data
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
 
         if len(data["bboxes"]) == 0:
             crop_coords = self._get_coords_no_bbox(image_shape, sampling)
-            return {"crop_coords": crop_coords}
+            return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
 
         num_bboxes = len(data["bboxes"])
         min_subset_size = math.ceil(num_bboxes * self.subset_fraction_range[0])
@@ -584,10 +585,12 @@ class BBoxSubsetSafeRandomCrop(BBoxSafeRandomCrop):
         subset_size = sampling.random_generator.integers(min_subset_size, max_subset_size + 1)
         bbox_indices = sampling.random_generator.choice(num_bboxes, size=subset_size, replace=False)
         bbox_union = union_of_bboxes(data["bboxes"][bbox_indices], erosion_rate=self.erosion_rate)
-        return {
-            "crop_coords": self._get_crop_coords(bbox_union, image_shape, sampling),
-            "bbox_indices": tuple(sorted(int(index) for index in bbox_indices)),
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "crop_coords": self._get_crop_coords(bbox_union, image_shape, sampling),
+                "bbox_indices": tuple(sorted(int(index) for index in bbox_indices)),
+            }
+        )
 
 
 class AtLeastOneBBoxRandomCrop(BaseCrop):
@@ -738,11 +741,11 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, tuple[int, int, int, int]]:
-        image_height, image_width = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        data = inputs.data
+        image_height, image_width = inputs.require_spatial_frame().spatial_shape_2d
         bboxes = data.get("bboxes", [])
 
         if self.height > image_height or self.width > image_width:
@@ -829,7 +832,7 @@ class AtLeastOneBBoxRandomCrop(BaseCrop):
         crop_x2 = crop_x1 + self.width
         crop_y2 = crop_y1 + self.height
 
-        return {"crop_coords": (crop_x1, crop_y1, crop_x2, crop_y2)}
+        return TransformParameterPlan.shared_only({"crop_coords": (crop_x1, crop_y1, crop_x2, crop_y2)})
 
 
 __all__ = [

--- a/albumentations/augmentations/crops/sized.py
+++ b/albumentations/augmentations/crops/sized.py
@@ -1,9 +1,9 @@
 """Random sized crop transforms."""
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 from ._transforms_shared import (
     ALL_TARGETS,
@@ -159,10 +159,12 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
 
         crop_height = sampling.py_random.randint(*self.min_max_height)
         crop_width = int(crop_height * self.w2h_ratio)
@@ -176,7 +178,7 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
 
         sampling.applied_overrides["min_max_height"] = (crop_height, crop_height)
 
-        return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
+        return SampledParams.shared_only({"crop_coords": crop_coords})
 
 
 class RandomResizedCrop(_BaseRandomSizedCrop):
@@ -324,10 +326,12 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         image_height, image_width = image_shape
 
         area = image_height * image_width
@@ -356,7 +360,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
                         "ratio": (aspect_ratio, aspect_ratio),
                     },
                 )
-                return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
+                return SampledParams.shared_only({"crop_coords": crop_coords})
 
         # Fallback to central crop - use proper function
         in_ratio = image_width / image_height
@@ -379,7 +383,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
                 "ratio": (fallback_ratio, fallback_ratio),
             },
         )
-        return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
+        return SampledParams.shared_only({"crop_coords": crop_coords})
 
 
 __all__ = [

--- a/albumentations/augmentations/crops/sized.py
+++ b/albumentations/augmentations/crops/sized.py
@@ -1,8 +1,9 @@
 """Random sized crop transforms."""
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Literal
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 from ._transforms_shared import (
     ALL_TARGETS,
@@ -158,11 +159,10 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, tuple[int, int, int, int]]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
 
         crop_height = sampling.py_random.randint(*self.min_max_height)
         crop_width = int(crop_height * self.w2h_ratio)
@@ -176,7 +176,7 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
 
         sampling.applied_overrides["min_max_height"] = (crop_height, crop_height)
 
-        return {"crop_coords": crop_coords}
+        return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
 
 
 class RandomResizedCrop(_BaseRandomSizedCrop):
@@ -324,11 +324,10 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, tuple[int, int, int, int]]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         image_height, image_width = image_shape
 
         area = image_height * image_width
@@ -357,7 +356,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
                         "ratio": (aspect_ratio, aspect_ratio),
                     },
                 )
-                return {"crop_coords": crop_coords}
+                return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
 
         # Fallback to central crop - use proper function
         in_ratio = image_width / image_height
@@ -380,7 +379,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
                 "ratio": (fallback_ratio, fallback_ratio),
             },
         )
-        return {"crop_coords": crop_coords}
+        return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
 
 
 __all__ = [

--- a/albumentations/augmentations/crops/sized.py
+++ b/albumentations/augmentations/crops/sized.py
@@ -164,7 +164,7 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
 
         crop_height = sampling.py_random.randint(*self.min_max_height)
         crop_width = int(crop_height * self.w2h_ratio)
@@ -178,7 +178,7 @@ class RandomSizedCrop(_BaseRandomSizedCrop):
 
         sampling.applied_overrides["min_max_height"] = (crop_height, crop_height)
 
-        return SampledParams.shared_only({"crop_coords": crop_coords})
+        return SampledParams(params={"crop_coords": crop_coords})
 
 
 class RandomResizedCrop(_BaseRandomSizedCrop):
@@ -331,7 +331,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         image_height, image_width = image_shape
 
         area = image_height * image_width
@@ -360,7 +360,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
                         "ratio": (aspect_ratio, aspect_ratio),
                     },
                 )
-                return SampledParams.shared_only({"crop_coords": crop_coords})
+                return SampledParams(params={"crop_coords": crop_coords})
 
         # Fallback to central crop - use proper function
         in_ratio = image_width / image_height
@@ -383,7 +383,7 @@ class RandomResizedCrop(_BaseRandomSizedCrop):
                 "ratio": (fallback_ratio, fallback_ratio),
             },
         )
-        return SampledParams.shared_only({"crop_coords": crop_coords})
+        return SampledParams(params={"crop_coords": crop_coords})
 
 
 __all__ = [

--- a/albumentations/augmentations/crops/special.py
+++ b/albumentations/augmentations/crops/special.py
@@ -221,7 +221,7 @@ class CropNonEmptyMaskIfExists(BaseCrop):
         x_max = x_min + self.width
         y_max = y_min + self.height
 
-        return SampledParams.shared_only({"crop_coords": (x_min, y_min, x_max, y_max)})
+        return SampledParams(params={"crop_coords": (x_min, y_min, x_max, y_max)})
 
 
 class RandomCropNearBBox(BaseCrop):
@@ -279,7 +279,7 @@ class RandomCropNearBBox(BaseCrop):
     ) -> SampledParams:
         bbox = data[self.cropping_bbox_key]
 
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
 
         bbox = self._clip_bbox(bbox, image_shape)
 
@@ -298,7 +298,7 @@ class RandomCropNearBBox(BaseCrop):
             crop_shape = (bbox[3] - bbox[1], bbox[2] - bbox[0])
             crop_coords = fcrops.get_center_crop_coords(image_shape, crop_shape)
 
-        return SampledParams.shared_only({"crop_coords": crop_coords})
+        return SampledParams(params={"crop_coords": crop_coords})
 
     @property
     def targets_as_params(self) -> list[str]:
@@ -443,7 +443,7 @@ class RandomCropFromBorders(BaseCrop):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        height, width = targets.require_spatial_shape(2)
+        height, width = targets.require_aligned_spatial_shape(2)
 
         x_min = sampling.py_random.randint(0, int(self.crop_left * width))
         x_max = sampling.py_random.randint(max(x_min + 1, int((1 - self.crop_right) * width)), width)
@@ -462,7 +462,7 @@ class RandomCropFromBorders(BaseCrop):
             },
         )
 
-        return SampledParams.shared_only({"crop_coords": crop_coords})
+        return SampledParams(params={"crop_coords": crop_coords})
 
 
 __all__ = [

--- a/albumentations/augmentations/crops/special.py
+++ b/albumentations/augmentations/crops/special.py
@@ -1,10 +1,11 @@
 """Specialized crop transforms."""
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 from ._transforms_shared import (
     ALL_TARGETS,
@@ -181,10 +182,10 @@ class CropNonEmptyMaskIfExists(BaseCrop):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         if "mask" in data:
             mask = self._preprocess_mask(data["mask"])
         elif "masks" in data and len(data["masks"]):
@@ -219,7 +220,7 @@ class CropNonEmptyMaskIfExists(BaseCrop):
         x_max = x_min + self.width
         y_max = y_min + self.height
 
-        return {"crop_coords": (x_min, y_min, x_max, y_max)}
+        return TransformParameterPlan.shared_only({"crop_coords": (x_min, y_min, x_max, y_max)})
 
 
 class RandomCropNearBBox(BaseCrop):
@@ -270,13 +271,13 @@ class RandomCropNearBBox(BaseCrop):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, tuple[float, ...]]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         bbox = data[self.cropping_bbox_key]
 
-        image_shape = params["shape"][:2]
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
 
         bbox = self._clip_bbox(bbox, image_shape)
 
@@ -295,7 +296,7 @@ class RandomCropNearBBox(BaseCrop):
             crop_shape = (bbox[3] - bbox[1], bbox[2] - bbox[0])
             crop_coords = fcrops.get_center_crop_coords(image_shape, crop_shape)
 
-        return {"crop_coords": crop_coords}
+        return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
 
     @property
     def targets_as_params(self) -> list[str]:
@@ -435,11 +436,10 @@ class RandomCropFromBorders(BaseCrop):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, tuple[int, int, int, int]]:
-        height, width = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        height, width = inputs.require_spatial_frame().spatial_shape_2d
 
         x_min = sampling.py_random.randint(0, int(self.crop_left * width))
         x_max = sampling.py_random.randint(max(x_min + 1, int((1 - self.crop_right) * width)), width)
@@ -458,7 +458,7 @@ class RandomCropFromBorders(BaseCrop):
             },
         )
 
-        return {"crop_coords": crop_coords}
+        return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
 
 
 __all__ = [

--- a/albumentations/augmentations/crops/special.py
+++ b/albumentations/augmentations/crops/special.py
@@ -1,11 +1,11 @@
 """Specialized crop transforms."""
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 from ._transforms_shared import (
     ALL_TARGETS,
@@ -182,10 +182,11 @@ class CropNonEmptyMaskIfExists(BaseCrop):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         if "mask" in data:
             mask = self._preprocess_mask(data["mask"])
         elif "masks" in data and len(data["masks"]):
@@ -220,7 +221,7 @@ class CropNonEmptyMaskIfExists(BaseCrop):
         x_max = x_min + self.width
         y_max = y_min + self.height
 
-        return TransformParameterPlan.shared_only({"crop_coords": (x_min, y_min, x_max, y_max)})
+        return SampledParams.shared_only({"crop_coords": (x_min, y_min, x_max, y_max)})
 
 
 class RandomCropNearBBox(BaseCrop):
@@ -271,13 +272,14 @@ class RandomCropNearBBox(BaseCrop):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         bbox = data[self.cropping_bbox_key]
 
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+        image_shape = targets.require_spatial_shape(2)
 
         bbox = self._clip_bbox(bbox, image_shape)
 
@@ -296,7 +298,7 @@ class RandomCropNearBBox(BaseCrop):
             crop_shape = (bbox[3] - bbox[1], bbox[2] - bbox[0])
             crop_coords = fcrops.get_center_crop_coords(image_shape, crop_shape)
 
-        return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
+        return SampledParams.shared_only({"crop_coords": crop_coords})
 
     @property
     def targets_as_params(self) -> list[str]:
@@ -436,10 +438,12 @@ class RandomCropFromBorders(BaseCrop):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        height, width = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        height, width = targets.require_spatial_shape(2)
 
         x_min = sampling.py_random.randint(0, int(self.crop_left * width))
         x_max = sampling.py_random.randint(max(x_min + 1, int((1 - self.crop_right) * width)), width)
@@ -458,7 +462,7 @@ class RandomCropFromBorders(BaseCrop):
             },
         )
 
-        return TransformParameterPlan.shared_only({"crop_coords": crop_coords})
+        return SampledParams.shared_only({"crop_coords": crop_coords})
 
 
 __all__ = [

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -115,7 +115,7 @@ class ChannelDropout(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         groups: list[TargetParams] = []
-        for views in targets.group_by(lambda view: view.descriptor.channels):
+        for views in targets.group_image_like_by(lambda view: view.descriptor.channels):
             view = views[0]
             num_channels = view.descriptor.channels or 1
             if num_channels == 1:

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -12,6 +12,12 @@ from pydantic import AfterValidator
 
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -103,22 +109,26 @@ class ChannelDropout(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, tuple[int, ...]]:
-        metadata = self.get_image_data(data)
-        num_channels = metadata["num_channels"]
-        if num_channels == 1:
-            msg = "Images has one channel. ChannelDropout is not defined."
-            raise NotImplementedError(msg)
-
-        if self.channel_drop_range[1] >= num_channels:
-            msg = "Can not drop all channels in ChannelDropout."
-            raise ValueError(msg)
-        num_drop_channels = sampling.py_random.randint(*self.channel_drop_range)
-        channels_to_drop = tuple(sampling.py_random.sample(range(num_channels), k=num_drop_channels))
-
-        sampling.applied_overrides["channel_drop_range"] = num_drop_channels
-
-        return {"channels_to_drop": channels_to_drop}
+    ) -> TransformParameterPlan:
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_by(lambda view: view.descriptor.channels):
+            view = views[0]
+            num_channels = view.descriptor.channels or 1
+            if num_channels == 1:
+                msg = "Images has one channel. ChannelDropout is not defined."
+                raise NotImplementedError(msg)
+            if self.channel_drop_range[1] >= num_channels:
+                msg = "Can not drop all channels in ChannelDropout."
+                raise ValueError(msg)
+            num_drop_channels = sampling.py_random.randint(*self.channel_drop_range)
+            channels_to_drop = tuple(sampling.py_random.sample(range(num_channels), k=num_drop_channels))
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(item.name for item in views),
+                    params={"channels_to_drop": channels_to_drop},
+                    requirements=requirements_for_views(views, channels=True),
+                ),
+            )
+        return TransformParameterPlan(shared={}, groups=tuple(groups))

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -13,9 +13,9 @@ from pydantic import AfterValidator
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    SampledParams,
+    TargetParams,
+    TargetSet,
     requirements_for_views,
 )
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
@@ -109,11 +109,13 @@ class ChannelDropout(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_by(lambda view: view.descriptor.channels):
+    ) -> SampledParams:
+        groups: list[TargetParams] = []
+        for views in targets.group_by(lambda view: view.descriptor.channels):
             view = views[0]
             num_channels = view.descriptor.channels or 1
             if num_channels == 1:
@@ -125,10 +127,10 @@ class ChannelDropout(ImageOnlyTransform):
             num_drop_channels = sampling.py_random.randint(*self.channel_drop_range)
             channels_to_drop = tuple(sampling.py_random.sample(range(num_channels), k=num_drop_channels))
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(item.name for item in views),
                     params={"channels_to_drop": channels_to_drop},
                     requirements=requirements_for_views(views, channels=True),
                 ),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))

--- a/albumentations/augmentations/dropout/channel_dropout.py
+++ b/albumentations/augmentations/dropout/channel_dropout.py
@@ -133,4 +133,4 @@ class ChannelDropout(ImageOnlyTransform):
                     requirements=requirements_for_views(views, channels=True),
                 ),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -18,6 +18,7 @@ from albumentations.augmentations.dropout.transforms import BaseDropout, BaseDro
 from albumentations.core.bbox_utils import denormalize_bboxes
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 __all__ = ["CoarseDropout", "ConstrainedCoarseDropout", "Erasing"]
 
@@ -166,40 +167,34 @@ class CoarseDropout(BaseDropout):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
+            num_holes = sampling.py_random.randint(*self.num_holes_range)
+            hole_heights, hole_widths = self.calculate_hole_dimensions(
+                image_shape,
+                self.hole_height_range,
+                self.hole_width_range,
+                size=num_holes,
+                sampling=sampling,
+            )
+            height, width = image_shape
+            y_min = sampling.random_generator.integers(0, height - hole_heights + 1, size=num_holes)
+            x_min = sampling.random_generator.integers(0, width - hole_widths + 1, size=num_holes)
+            y_max = y_min + hole_heights
+            x_max = x_min + hole_widths
+            holes = np.stack([x_min, y_min, x_max, y_max], axis=-1)
+            sampling.applied_overrides.update(
+                {
+                    "num_holes_range": num_holes,
+                    "hole_height_range": (int(hole_heights.min()), int(hole_heights.max())),
+                    "hole_width_range": (int(hole_widths.min()), int(hole_widths.max())),
+                },
+            )
+            return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        num_holes = sampling.py_random.randint(*self.num_holes_range)
-
-        hole_heights, hole_widths = self.calculate_hole_dimensions(
-            image_shape,
-            self.hole_height_range,
-            self.hole_width_range,
-            size=num_holes,
-            sampling=sampling,
-        )
-
-        height, width = image_shape[:2]
-
-        y_min = sampling.random_generator.integers(0, height - hole_heights + 1, size=num_holes)
-        x_min = sampling.random_generator.integers(0, width - hole_widths + 1, size=num_holes)
-        y_max = y_min + hole_heights
-        x_max = x_min + hole_widths
-
-        holes = np.stack([x_min, y_min, x_max, y_max], axis=-1)
-
-        sampling.applied_overrides.update(
-            {
-                "num_holes_range": num_holes,
-                "hole_height_range": (int(hole_heights.min()), int(hole_heights.max())),
-                "hole_width_range": (int(hole_widths.min()), int(hole_widths.max())),
-            },
-        )
-
-        return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
+        return self._build_spatial_parameter_plan(inputs, materialize)
 
 
 class Erasing(BaseDropout):
@@ -297,10 +292,9 @@ class Erasing(BaseDropout):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         """Calculate erasing parameters (box position and size) from image shape and ratio ranges.
         Direct derivation; used by Erasing sample_parameters.
 
@@ -319,63 +313,55 @@ class Erasing(BaseDropout):
         - h = sqrt(A/r)
         - w = r * sqrt(A/r) = sqrt(A*r)
         """
-        height, width = params["shape"][:2]
-        total_area = height * width
 
-        # Calculate maximum valid area based on dimensions and aspect ratio
-        max_area = total_area * self.scale[1]
-        min_area = total_area * self.scale[0]
+        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
+            height, width = image_shape
+            total_area = height * width
+            max_area = total_area * self.scale[1]
+            min_area = total_area * self.scale[0]
+            r_min, r_max = self.ratio
 
-        # For each aspect ratio r, the maximum area is constrained by:
-        # h = sqrt(A/r) ≤ H and w = sqrt(A*r) ≤ W
-        # Therefore: A ≤ min(r*H², W²/r)
-        r_min, r_max = self.ratio
+            def area_constraint_h(r: float) -> float:
+                return r * height * height
 
-        def area_constraint_h(r: float) -> float:
-            return r * height * height
+            def area_constraint_w(r: float) -> float:
+                return width * width / r
 
-        def area_constraint_w(r: float) -> float:
-            return width * width / r
+            max_area_h = min(area_constraint_h(r_min), area_constraint_h(r_max))
+            max_area_w = min(area_constraint_w(r_min), area_constraint_w(r_max))
+            max_valid_area = min(max_area, max_area_h, max_area_w)
 
-        # Find maximum valid area considering aspect ratio constraints
-        max_area_h = min(area_constraint_h(r_min), area_constraint_h(r_max))
-        max_area_w = min(area_constraint_w(r_min), area_constraint_w(r_max))
-        max_valid_area = min(max_area, max_area_h, max_area_w)
+            if max_valid_area < min_area:
+                return {
+                    "holes": np.empty((0, 4), dtype=np.int32),
+                    "seed": sampling.random_generator.integers(0, 2**32 - 1),
+                }
 
-        if max_valid_area < min_area:
-            return {
-                "holes": np.empty((0, 4), dtype=np.int32),
-                "seed": sampling.random_generator.integers(0, 2**32 - 1),
-            }
+            erase_area = sampling.py_random.uniform(min_area, max_valid_area)
+            max_r = min(r_max, width * width / erase_area)
+            min_r = max(r_min, erase_area / (height * height))
 
-        erase_area = sampling.py_random.uniform(min_area, max_valid_area)
+            if min_r > max_r:
+                return {
+                    "holes": np.empty((0, 4), dtype=np.int32),
+                    "seed": sampling.random_generator.integers(0, 2**32 - 1),
+                }
 
-        max_r = min(r_max, width * width / erase_area)
-        min_r = max(r_min, erase_area / (height * height))
+            aspect_ratio = sampling.py_random.uniform(min_r, max_r)
+            h = round(np.sqrt(erase_area / aspect_ratio))
+            w = round(np.sqrt(erase_area * aspect_ratio))
+            top = sampling.py_random.randint(0, height - h)
+            left = sampling.py_random.randint(0, width - w)
+            holes = np.array([[left, top, left + w, top + h]], dtype=np.int32)
+            sampling.applied_overrides.update(
+                {
+                    "scale": erase_area / total_area,
+                    "ratio": aspect_ratio,
+                },
+            )
+            return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        if min_r > max_r:
-            return {
-                "holes": np.empty((0, 4), dtype=np.int32),
-                "seed": sampling.random_generator.integers(0, 2**32 - 1),
-            }
-
-        aspect_ratio = sampling.py_random.uniform(min_r, max_r)
-
-        h = round(np.sqrt(erase_area / aspect_ratio))
-        w = round(np.sqrt(erase_area * aspect_ratio))
-
-        top = sampling.py_random.randint(0, height - h)
-        left = sampling.py_random.randint(0, width - w)
-
-        holes = np.array([[left, top, left + w, top + h]], dtype=np.int32)
-
-        sampling.applied_overrides.update(
-            {
-                "scale": erase_area / total_area,
-                "ratio": aspect_ratio,
-            },
-        )
-        return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
+        return self._build_spatial_parameter_plan(inputs, materialize)
 
 
 class ConstrainedCoarseDropout(BaseDropout):
@@ -570,10 +556,10 @@ class ConstrainedCoarseDropout(BaseDropout):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         """Get hole parameters from mask indices or bbox labels. Dispatches to get_holes_from_mask or
         get_holes_from_boxes. Returns holes (n, 4) and num_holes.
         """
@@ -593,7 +579,10 @@ class ConstrainedCoarseDropout(BaseDropout):
             if target_boxes is None:
                 holes = np.array([], dtype=np.int32).reshape((0, 4))
             else:
-                target_boxes = denormalize_bboxes(target_boxes, data["image"].shape[:2])
+                image_shape = inputs.targets.primary_image_like().descriptor.spatial_shape
+                if image_shape is None:
+                    raise ValueError("ConstrainedCoarseDropout requires an image-like spatial target")
+                target_boxes = denormalize_bboxes(target_boxes, (image_shape[-2], image_shape[-1]))
                 holes = fdropout.get_holes_from_boxes(
                     target_boxes,
                     num_holes_per_obj,
@@ -613,7 +602,9 @@ class ConstrainedCoarseDropout(BaseDropout):
             },
         )
 
-        return {
-            "holes": holes,
-            "seed": sampling.random_generator.integers(0, 2**32 - 1),
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "holes": holes,
+                "seed": sampling.random_generator.integers(0, 2**32 - 1),
+            }
+        )

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -172,31 +172,29 @@ class CoarseDropout(BaseDropout):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
-            num_holes = sampling.py_random.randint(*self.num_holes_range)
-            hole_heights, hole_widths = self.calculate_hole_dimensions(
-                image_shape,
-                self.hole_height_range,
-                self.hole_width_range,
-                size=num_holes,
-                sampling=sampling,
-            )
-            height, width = image_shape
-            y_min = sampling.random_generator.integers(0, height - hole_heights + 1, size=num_holes)
-            x_min = sampling.random_generator.integers(0, width - hole_widths + 1, size=num_holes)
-            y_max = y_min + hole_heights
-            x_max = x_min + hole_widths
-            holes = np.stack([x_min, y_min, x_max, y_max], axis=-1)
-            sampling.applied_overrides.update(
-                {
-                    "num_holes_range": num_holes,
-                    "hole_height_range": (int(hole_heights.min()), int(hole_heights.max())),
-                    "hole_width_range": (int(hole_widths.min()), int(hole_widths.max())),
-                },
-            )
-            return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
-
-        return self._build_spatial_parameter_plan(targets, materialize)
+        image_shape = targets.require_aligned_spatial_shape(2)
+        num_holes = sampling.py_random.randint(*self.num_holes_range)
+        hole_heights, hole_widths = self.calculate_hole_dimensions(
+            image_shape,
+            self.hole_height_range,
+            self.hole_width_range,
+            size=num_holes,
+            sampling=sampling,
+        )
+        height, width = image_shape
+        y_min = sampling.random_generator.integers(0, height - hole_heights + 1, size=num_holes)
+        x_min = sampling.random_generator.integers(0, width - hole_widths + 1, size=num_holes)
+        y_max = y_min + hole_heights
+        x_max = x_min + hole_widths
+        holes = np.stack([x_min, y_min, x_max, y_max], axis=-1)
+        sampling.applied_overrides.update(
+            {
+                "num_holes_range": num_holes,
+                "hole_height_range": (int(hole_heights.min()), int(hole_heights.max())),
+                "hole_width_range": (int(hole_widths.min()), int(hole_widths.max())),
+            },
+        )
+        return SampledParams(params={"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)})
 
 
 class Erasing(BaseDropout):
@@ -299,73 +297,50 @@ class Erasing(BaseDropout):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        """Calculate erasing parameters (box position and size) from image shape and ratio ranges.
-        Direct derivation; used by Erasing sample_parameters.
+        height, width = targets.require_aligned_spatial_shape(2)
+        total_area = height * width
+        max_area = total_area * self.scale[1]
+        min_area = total_area * self.scale[0]
+        r_min, r_max = self.ratio
 
-        Given:
-        - Image dimensions (H, W)
-        - Target area (A)
-        - Aspect ratio (r = w/h)
+        def area_constraint_h(r: float) -> float:
+            return r * height * height
 
-        We know:
-        - h * w = A (area equation)
-        - w = r * h (aspect ratio equation)
+        def area_constraint_w(r: float) -> float:
+            return width * width / r
 
-        Therefore:
-        - h * (r * h) = A
-        - h² = A/r
-        - h = sqrt(A/r)
-        - w = r * sqrt(A/r) = sqrt(A*r)
-        """
+        max_area_h = min(area_constraint_h(r_min), area_constraint_h(r_max))
+        max_area_w = min(area_constraint_w(r_min), area_constraint_w(r_max))
+        max_valid_area = min(max_area, max_area_h, max_area_w)
 
-        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
-            height, width = image_shape
-            total_area = height * width
-            max_area = total_area * self.scale[1]
-            min_area = total_area * self.scale[0]
-            r_min, r_max = self.ratio
-
-            def area_constraint_h(r: float) -> float:
-                return r * height * height
-
-            def area_constraint_w(r: float) -> float:
-                return width * width / r
-
-            max_area_h = min(area_constraint_h(r_min), area_constraint_h(r_max))
-            max_area_w = min(area_constraint_w(r_min), area_constraint_w(r_max))
-            max_valid_area = min(max_area, max_area_h, max_area_w)
-
-            if max_valid_area < min_area:
-                return {
+        if max_valid_area < min_area:
+            return SampledParams(
+                params={
                     "holes": np.empty((0, 4), dtype=np.int32),
                     "seed": sampling.random_generator.integers(0, 2**32 - 1),
-                }
-
-            erase_area = sampling.py_random.uniform(min_area, max_valid_area)
-            max_r = min(r_max, width * width / erase_area)
-            min_r = max(r_min, erase_area / (height * height))
-
-            if min_r > max_r:
-                return {
-                    "holes": np.empty((0, 4), dtype=np.int32),
-                    "seed": sampling.random_generator.integers(0, 2**32 - 1),
-                }
-
-            aspect_ratio = sampling.py_random.uniform(min_r, max_r)
-            h = round(np.sqrt(erase_area / aspect_ratio))
-            w = round(np.sqrt(erase_area * aspect_ratio))
-            top = sampling.py_random.randint(0, height - h)
-            left = sampling.py_random.randint(0, width - w)
-            holes = np.array([[left, top, left + w, top + h]], dtype=np.int32)
-            sampling.applied_overrides.update(
-                {
-                    "scale": erase_area / total_area,
-                    "ratio": aspect_ratio,
                 },
             )
-            return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        return self._build_spatial_parameter_plan(targets, materialize)
+        erase_area = sampling.py_random.uniform(min_area, max_valid_area)
+        max_r = min(r_max, width * width / erase_area)
+        min_r = max(r_min, erase_area / (height * height))
+
+        if min_r > max_r:
+            return SampledParams(
+                params={
+                    "holes": np.empty((0, 4), dtype=np.int32),
+                    "seed": sampling.random_generator.integers(0, 2**32 - 1),
+                },
+            )
+
+        aspect_ratio = sampling.py_random.uniform(min_r, max_r)
+        h = round(np.sqrt(erase_area / aspect_ratio))
+        w = round(np.sqrt(erase_area * aspect_ratio))
+        top = sampling.py_random.randint(0, height - h)
+        left = sampling.py_random.randint(0, width - w)
+        holes = np.array([[left, top, left + w, top + h]], dtype=np.int32)
+        sampling.applied_overrides.update({"scale": erase_area / total_area, "ratio": aspect_ratio})
+        return SampledParams(params={"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)})
 
 
 class ConstrainedCoarseDropout(BaseDropout):

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -18,7 +18,7 @@ from albumentations.augmentations.dropout.transforms import BaseDropout, BaseDro
 from albumentations.core.bbox_utils import denormalize_bboxes
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 __all__ = ["CoarseDropout", "ConstrainedCoarseDropout", "Erasing"]
 
@@ -167,9 +167,11 @@ class CoarseDropout(BaseDropout):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
             num_holes = sampling.py_random.randint(*self.num_holes_range)
             hole_heights, hole_widths = self.calculate_hole_dimensions(
@@ -194,7 +196,7 @@ class CoarseDropout(BaseDropout):
             )
             return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        return self._build_spatial_parameter_plan(inputs, materialize)
+        return self._build_spatial_parameter_plan(targets, materialize)
 
 
 class Erasing(BaseDropout):
@@ -292,9 +294,11 @@ class Erasing(BaseDropout):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         """Calculate erasing parameters (box position and size) from image shape and ratio ranges.
         Direct derivation; used by Erasing sample_parameters.
 
@@ -361,7 +365,7 @@ class Erasing(BaseDropout):
             )
             return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        return self._build_spatial_parameter_plan(inputs, materialize)
+        return self._build_spatial_parameter_plan(targets, materialize)
 
 
 class ConstrainedCoarseDropout(BaseDropout):
@@ -556,10 +560,11 @@ class ConstrainedCoarseDropout(BaseDropout):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         """Get hole parameters from mask indices or bbox labels. Dispatches to get_holes_from_mask or
         get_holes_from_boxes. Returns holes (n, 4) and num_holes.
         """
@@ -579,7 +584,7 @@ class ConstrainedCoarseDropout(BaseDropout):
             if target_boxes is None:
                 holes = np.array([], dtype=np.int32).reshape((0, 4))
             else:
-                image_shape = inputs.targets.primary_image_like().descriptor.spatial_shape
+                image_shape = targets.primary_image_like().descriptor.spatial_shape
                 if image_shape is None:
                     raise ValueError("ConstrainedCoarseDropout requires an image-like spatial target")
                 target_boxes = denormalize_bboxes(target_boxes, (image_shape[-2], image_shape[-1]))
@@ -602,7 +607,7 @@ class ConstrainedCoarseDropout(BaseDropout):
             },
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "holes": holes,
                 "seed": sampling.random_generator.integers(0, 2**32 - 1),

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -607,8 +607,8 @@ class ConstrainedCoarseDropout(BaseDropout):
             },
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "holes": holes,
                 "seed": sampling.random_generator.integers(0, 2**32 - 1),
             }

--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -144,34 +144,32 @@ class GridDropout(BaseDropout):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
-            if self.holes_number_xy:
-                grid = self.holes_number_xy
-            else:
-                unit_height, unit_width = fdropout.calculate_grid_dimensions(
-                    image_shape,
-                    self.unit_size_range,
-                    self.holes_number_xy,
-                    sampling.random_generator,
-                )
-                grid = (image_shape[0] // unit_height, image_shape[1] // unit_width)
-
-            holes = fdropout.generate_grid_holes(
+        image_shape = targets.require_aligned_spatial_shape(2)
+        if self.holes_number_xy:
+            grid = self.holes_number_xy
+        else:
+            unit_height, unit_width = fdropout.calculate_grid_dimensions(
                 image_shape,
-                grid,
-                self.ratio,
-                self.random_offset,
-                self.shift_xy,
+                self.unit_size_range,
+                self.holes_number_xy,
                 sampling.random_generator,
             )
+            grid = (image_shape[0] // unit_height, image_shape[1] // unit_width)
 
-            sampling.applied_overrides.update(
-                {
-                    "holes_number_xy": grid,
-                    "ratio": self.ratio,
-                    "shift_xy": self.shift_xy,
-                },
-            )
-            return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
+        holes = fdropout.generate_grid_holes(
+            image_shape,
+            grid,
+            self.ratio,
+            self.random_offset,
+            self.shift_xy,
+            sampling.random_generator,
+        )
 
-        return self._build_spatial_parameter_plan(targets, materialize)
+        sampling.applied_overrides.update(
+            {
+                "holes_number_xy": grid,
+                "ratio": self.ratio,
+                "shift_xy": self.shift_xy,
+            },
+        )
+        return SampledParams(params={"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)})

--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -14,7 +14,7 @@ import albumentations.augmentations.dropout.functional as fdropout
 from albumentations.augmentations.dropout.transforms import BaseDropout, BaseDropoutInitSchema, DropoutFillValue
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 __all__ = ["GridDropout"]
 
@@ -139,9 +139,11 @@ class GridDropout(BaseDropout):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
             if self.holes_number_xy:
                 grid = self.holes_number_xy
@@ -172,4 +174,4 @@ class GridDropout(BaseDropout):
             )
             return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        return self._build_spatial_parameter_plan(inputs, materialize)
+        return self._build_spatial_parameter_plan(targets, materialize)

--- a/albumentations/augmentations/dropout/grid_dropout.py
+++ b/albumentations/augmentations/dropout/grid_dropout.py
@@ -14,6 +14,7 @@ import albumentations.augmentations.dropout.functional as fdropout
 from albumentations.augmentations.dropout.transforms import BaseDropout, BaseDropoutInitSchema, DropoutFillValue
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 __all__ = ["GridDropout"]
 
@@ -138,38 +139,37 @@ class GridDropout(BaseDropout):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"]
-        if self.holes_number_xy:
-            grid = self.holes_number_xy
-        else:
-            # Calculate grid based on unit_size_range or default
-            unit_height, unit_width = fdropout.calculate_grid_dimensions(
+    ) -> TransformParameterPlan:
+        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
+            if self.holes_number_xy:
+                grid = self.holes_number_xy
+            else:
+                unit_height, unit_width = fdropout.calculate_grid_dimensions(
+                    image_shape,
+                    self.unit_size_range,
+                    self.holes_number_xy,
+                    sampling.random_generator,
+                )
+                grid = (image_shape[0] // unit_height, image_shape[1] // unit_width)
+
+            holes = fdropout.generate_grid_holes(
                 image_shape,
-                self.unit_size_range,
-                self.holes_number_xy,
+                grid,
+                self.ratio,
+                self.random_offset,
+                self.shift_xy,
                 sampling.random_generator,
             )
-            grid = (image_shape[0] // unit_height, image_shape[1] // unit_width)
 
-        holes = fdropout.generate_grid_holes(
-            image_shape,
-            grid,
-            self.ratio,
-            self.random_offset,
-            self.shift_xy,
-            sampling.random_generator,
-        )
+            sampling.applied_overrides.update(
+                {
+                    "holes_number_xy": grid,
+                    "ratio": self.ratio,
+                    "shift_xy": self.shift_xy,
+                },
+            )
+            return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        sampling.applied_overrides.update(
-            {
-                "holes_number_xy": grid,
-                "ratio": self.ratio,
-                "shift_xy": self.shift_xy,
-            },
-        )
-
-        return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
+        return self._build_spatial_parameter_plan(inputs, materialize)

--- a/albumentations/augmentations/dropout/grid_mask.py
+++ b/albumentations/augmentations/dropout/grid_mask.py
@@ -14,6 +14,7 @@ from albumentations.augmentations.dropout import functional as fdropout
 from albumentations.augmentations.dropout.transforms import BaseDropout, BaseDropoutInitSchema, DropoutFillValue
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 __all__ = ["GridMask"]
 
@@ -96,30 +97,29 @@ class GridMask(BaseDropout):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
+            num_grid = sampling.py_random.randint(*self.num_grid_range)
+            line_width_ratio = sampling.py_random.uniform(*self.line_width_range)
+            rotation = sampling.py_random.uniform(*self.rotation_range)
 
-        num_grid = sampling.py_random.randint(*self.num_grid_range)
-        line_width_ratio = sampling.py_random.uniform(*self.line_width_range)
-        rotation = sampling.py_random.uniform(*self.rotation_range)
+            holes = fdropout.generate_grid_mask_holes(
+                image_shape,
+                num_grid,
+                line_width_ratio,
+                rotation,
+                sampling.random_generator,
+            )
 
-        holes = fdropout.generate_grid_mask_holes(
-            image_shape,
-            num_grid,
-            line_width_ratio,
-            rotation,
-            sampling.random_generator,
-        )
+            sampling.applied_overrides.update(
+                {
+                    "num_grid_range": num_grid,
+                    "line_width_range": line_width_ratio,
+                    "rotation_range": rotation,
+                },
+            )
+            return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        sampling.applied_overrides.update(
-            {
-                "num_grid_range": num_grid,
-                "line_width_range": line_width_ratio,
-                "rotation_range": rotation,
-            },
-        )
-
-        return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
+        return self._build_spatial_parameter_plan(inputs, materialize)

--- a/albumentations/augmentations/dropout/grid_mask.py
+++ b/albumentations/augmentations/dropout/grid_mask.py
@@ -102,26 +102,24 @@ class GridMask(BaseDropout):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
-            num_grid = sampling.py_random.randint(*self.num_grid_range)
-            line_width_ratio = sampling.py_random.uniform(*self.line_width_range)
-            rotation = sampling.py_random.uniform(*self.rotation_range)
+        image_shape = targets.require_aligned_spatial_shape(2)
+        num_grid = sampling.py_random.randint(*self.num_grid_range)
+        line_width_ratio = sampling.py_random.uniform(*self.line_width_range)
+        rotation = sampling.py_random.uniform(*self.rotation_range)
 
-            holes = fdropout.generate_grid_mask_holes(
-                image_shape,
-                num_grid,
-                line_width_ratio,
-                rotation,
-                sampling.random_generator,
-            )
+        holes = fdropout.generate_grid_mask_holes(
+            image_shape,
+            num_grid,
+            line_width_ratio,
+            rotation,
+            sampling.random_generator,
+        )
 
-            sampling.applied_overrides.update(
-                {
-                    "num_grid_range": num_grid,
-                    "line_width_range": line_width_ratio,
-                    "rotation_range": rotation,
-                },
-            )
-            return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
-
-        return self._build_spatial_parameter_plan(targets, materialize)
+        sampling.applied_overrides.update(
+            {
+                "num_grid_range": num_grid,
+                "line_width_range": line_width_ratio,
+                "rotation_range": rotation,
+            },
+        )
+        return SampledParams(params={"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)})

--- a/albumentations/augmentations/dropout/grid_mask.py
+++ b/albumentations/augmentations/dropout/grid_mask.py
@@ -14,7 +14,7 @@ from albumentations.augmentations.dropout import functional as fdropout
 from albumentations.augmentations.dropout.transforms import BaseDropout, BaseDropoutInitSchema, DropoutFillValue
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 __all__ = ["GridMask"]
 
@@ -97,9 +97,11 @@ class GridMask(BaseDropout):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
             num_grid = sampling.py_random.randint(*self.num_grid_range)
             line_width_ratio = sampling.py_random.uniform(*self.line_width_range)
@@ -122,4 +124,4 @@ class GridMask(BaseDropout):
             )
             return {"holes": holes, "seed": sampling.random_generator.integers(0, 2**32 - 1)}
 
-        return self._build_spatial_parameter_plan(inputs, materialize)
+        return self._build_spatial_parameter_plan(targets, materialize)

--- a/albumentations/augmentations/dropout/guided_coarse_dropout.py
+++ b/albumentations/augmentations/dropout/guided_coarse_dropout.py
@@ -11,7 +11,7 @@ from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, no
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.type_definitions import ImageType, Targets
 
 __all__ = ["GuidedCoarseDropout"]
@@ -223,17 +223,18 @@ class GuidedCoarseDropout(BaseDropout):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         height, width = image_shape
         region = self._get_dropout_region(data, image_shape)
         protected_mask = self._build_protected_mask(self._get_protected_bboxes(data, image_shape), image_shape)
         eligible_mask = region & ~protected_mask
         if not eligible_mask.any():
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {"holes": np.empty((0, 4), dtype=np.int32), "dropout_mask": None, "seed": 0}
             )
 
@@ -249,7 +250,7 @@ class GuidedCoarseDropout(BaseDropout):
         )
         holes = self._centers_to_holes(centers, hole_heights, hole_widths, image_shape)
         dropout_mask = self._rasterize_holes(holes, image_shape) & eligible_mask
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "holes": holes,
                 "dropout_mask": dropout_mask if dropout_mask.any() else None,

--- a/albumentations/augmentations/dropout/guided_coarse_dropout.py
+++ b/albumentations/augmentations/dropout/guided_coarse_dropout.py
@@ -11,6 +11,7 @@ from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, no
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.type_definitions import ImageType, Targets
 
 __all__ = ["GuidedCoarseDropout"]
@@ -222,17 +223,19 @@ class GuidedCoarseDropout(BaseDropout):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        data = inputs.data
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         height, width = image_shape
         region = self._get_dropout_region(data, image_shape)
         protected_mask = self._build_protected_mask(self._get_protected_bboxes(data, image_shape), image_shape)
         eligible_mask = region & ~protected_mask
         if not eligible_mask.any():
-            return {"holes": np.empty((0, 4), dtype=np.int32), "dropout_mask": None, "seed": 0}
+            return TransformParameterPlan.shared_only(
+                {"holes": np.empty((0, 4), dtype=np.int32), "dropout_mask": None, "seed": 0}
+            )
 
         num_holes = sampling.py_random.randint(*self.num_holes_range)
         centers = self._sample_centers_uniform(eligible_mask, num_holes, sampling.random_generator)
@@ -246,11 +249,13 @@ class GuidedCoarseDropout(BaseDropout):
         )
         holes = self._centers_to_holes(centers, hole_heights, hole_widths, image_shape)
         dropout_mask = self._rasterize_holes(holes, image_shape) & eligible_mask
-        return {
-            "holes": holes,
-            "dropout_mask": dropout_mask if dropout_mask.any() else None,
-            "seed": int(sampling.random_generator.integers(0, 2**32 - 1)),
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "holes": holes,
+                "dropout_mask": dropout_mask if dropout_mask.any() else None,
+                "seed": int(sampling.random_generator.integers(0, 2**32 - 1)),
+            }
+        )
 
     def apply(
         self,

--- a/albumentations/augmentations/dropout/guided_coarse_dropout.py
+++ b/albumentations/augmentations/dropout/guided_coarse_dropout.py
@@ -228,15 +228,13 @@ class GuidedCoarseDropout(BaseDropout):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         height, width = image_shape
         region = self._get_dropout_region(data, image_shape)
         protected_mask = self._build_protected_mask(self._get_protected_bboxes(data, image_shape), image_shape)
         eligible_mask = region & ~protected_mask
         if not eligible_mask.any():
-            return SampledParams.shared_only(
-                {"holes": np.empty((0, 4), dtype=np.int32), "dropout_mask": None, "seed": 0}
-            )
+            return SampledParams(params={"holes": np.empty((0, 4), dtype=np.int32), "dropout_mask": None, "seed": 0})
 
         num_holes = sampling.py_random.randint(*self.num_holes_range)
         centers = self._sample_centers_uniform(eligible_mask, num_holes, sampling.random_generator)
@@ -250,8 +248,8 @@ class GuidedCoarseDropout(BaseDropout):
         )
         holes = self._centers_to_holes(centers, hole_heights, hole_widths, image_shape)
         dropout_mask = self._rasterize_holes(holes, image_shape) & eligible_mask
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "holes": holes,
                 "dropout_mask": dropout_mask if dropout_mask.any() else None,
                 "seed": int(sampling.random_generator.integers(0, 2**32 - 1)),

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -170,7 +170,7 @@ class MaskDropout(DualTransform):
 
         sampling.applied_overrides["max_objects_range"] = objects_to_drop
 
-        return SampledParams.shared_only({"dropout_mask": dropout_mask})
+        return SampledParams(params={"dropout_mask": dropout_mask})
 
     def apply(self, img: ImageType, dropout_mask: np.ndarray | None, **params: Any) -> ImageType:
         if dropout_mask is None:

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -17,6 +17,7 @@ from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, no
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
 from albumentations.core.type_definitions import ALL_TARGETS, ImageType
 
@@ -143,10 +144,10 @@ class MaskDropout(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         mask = np.squeeze(data["mask"], axis=2)
 
         label_image, num_labels = fdropout.label(mask, return_num=True)
@@ -168,7 +169,7 @@ class MaskDropout(DualTransform):
 
         sampling.applied_overrides["max_objects_range"] = objects_to_drop
 
-        return {"dropout_mask": dropout_mask}
+        return TransformParameterPlan.shared_only({"dropout_mask": dropout_mask})
 
     def apply(self, img: ImageType, dropout_mask: np.ndarray | None, **params: Any) -> ImageType:
         if dropout_mask is None:

--- a/albumentations/augmentations/dropout/mask_dropout.py
+++ b/albumentations/augmentations/dropout/mask_dropout.py
@@ -17,7 +17,7 @@ from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, no
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
 from albumentations.core.type_definitions import ALL_TARGETS, ImageType
 
@@ -144,10 +144,11 @@ class MaskDropout(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         mask = np.squeeze(data["mask"], axis=2)
 
         label_image, num_labels = fdropout.label(mask, return_num=True)
@@ -169,7 +170,7 @@ class MaskDropout(DualTransform):
 
         sampling.applied_overrides["max_objects_range"] = objects_to_drop
 
-        return TransformParameterPlan.shared_only({"dropout_mask": dropout_mask})
+        return SampledParams.shared_only({"dropout_mask": dropout_mask})
 
     def apply(self, img: ImageType, dropout_mask: np.ndarray | None, **params: Any) -> ImageType:
         if dropout_mask is None:

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -422,9 +422,10 @@ class PixelDropout(DualTransform):
     ) -> SampledParams:
         sampling.applied_overrides["dropout_prob"] = self.dropout_prob
         annotations = tuple(view for view in targets.ordered if view.canonical_type in {"bboxes", "keypoints"})
+        annotations_attached = False
         groups: list[TargetParams] = []
 
-        for index, views in enumerate(targets.group_image_like_by(_pixel_dropout_group_key)):
+        for views in targets.group_image_like_by(_pixel_dropout_group_key):
             reference = _pixel_dropout_reference(views[0])
             groups.append(
                 _pixel_dropout_group(
@@ -446,9 +447,10 @@ class PixelDropout(DualTransform):
                             sampling.random_generator,
                         ),
                     },
-                    annotations=annotations if index == 0 else (),
+                    annotations=annotations if not annotations_attached else (),
                 )
             )
+            annotations_attached = annotations_attached or bool(annotations)
 
         for views in targets.group_by(_pixel_dropout_group_key):
             if not views or views[0].canonical_type not in {"mask", "masks", "mask3d"}:
@@ -486,7 +488,9 @@ class PixelDropout(DualTransform):
                             )
                         ),
                     },
+                    annotations=annotations if not annotations_attached else (),
                 )
             )
+            annotations_attached = annotations_attached or bool(annotations)
 
         return SampledParams(params={}, target_params=tuple(groups))

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -6,6 +6,7 @@ PixelDropout. These transforms randomly remove or modify pixels, channels, or re
 in images, which can help models become more robust to occlusions and missing information.
 """
 
+from collections.abc import Callable
 from typing import Any, ClassVar, cast
 
 import numpy as np
@@ -23,6 +24,14 @@ from albumentations.augmentations.pixel import functional as fpixel
 from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, normalize_bboxes
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.keypoints_utils import KeypointsProcessor
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TargetRequirement,
+    TargetView,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
 from albumentations.core.type_definitions import ALL_TARGETS, ImageType, Targets, VolumeType
 
@@ -55,6 +64,46 @@ def _get_pixel_dropout_reference(data: dict[str, Any]) -> np.ndarray:
         return np.empty(target.shape[leading_dimensions:], dtype=target.dtype)
 
     raise RuntimeError("PixelDropout requires at least one image, volume, or mask target")
+
+
+def _pixel_dropout_reference(view: Any) -> np.ndarray:
+    value = view.value
+    if view.canonical_type in {"images", "volume", "masks", "mask3d"}:
+        if value.shape[0] == 0:
+            return np.empty(value.shape[1:], dtype=value.dtype)
+        return value[0]
+    return value
+
+
+def _pixel_dropout_is_empty(view: Any) -> bool:
+    return view.canonical_type in {"images", "volume", "masks", "mask3d"} and view.value.shape[0] == 0
+
+
+def _pixel_dropout_group_key(view: Any) -> tuple[Any, ...]:
+    descriptor = view.descriptor
+    return (
+        "mask" if view.canonical_type in {"mask", "masks", "mask3d"} else "image",
+        descriptor.shape,
+        descriptor.dtype_scale,
+        descriptor.sampling_topology,
+    )
+
+
+def _pixel_dropout_group(
+    views: tuple[Any, ...],
+    params: dict[str, Any],
+    *,
+    annotations: tuple[Any, ...] = (),
+) -> TargetParameterGroup:
+    target_views = list(views)
+    requirements = requirements_for_views(views, shape=True, dtype=True, sampling_topology=True)
+    target_views.extend(annotations)
+    requirements.update({view.name: TargetRequirement() for view in annotations})
+    return TargetParameterGroup(
+        targets=tuple(view.name for view in target_views),
+        params=params,
+        requirements=requirements,
+    )
 
 
 class BaseDropoutInitSchema(BaseTransformInitSchema):
@@ -93,8 +142,8 @@ class BaseDropout(DualTransform):
         ...         self.num_holes_range = num_holes_range
         ...         self.hole_size_range = hole_size_range
         ...
-        ...     def sample_parameters(self, params, data, sampling):
-        ...         img = data["image"]
+        ...     def sample_parameters(self, inputs, sampling):
+        ...         img = inputs.data["image"]
         ...         height, width = img.shape[:2]
         ...
         ...         # Generate random holes
@@ -110,11 +159,12 @@ class BaseDropout(DualTransform):
         ...             y2 = min(height, y1 + hole_sizes[i])
         ...             holes.append([x1, y1, x2, y2])
         ...
-        ...         # Return holes and random seed
-        ...         return {
+        ...         from albumentations.core.transform_params import TransformParameterPlan
+        ...
+        ...         return TransformParameterPlan.shared_only({
         ...             "holes": np.array(holes) if holes else np.empty((0, 4), dtype=np.int32),
-        ...             "seed": int(sampling.random_generator.integers(0, 100000))
-        ...         }
+        ...             "seed": int(sampling.random_generator.integers(0, 100000)),
+        ...         })
         >>>
         >>> # Prepare sample data
         >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -163,6 +213,49 @@ class BaseDropout(DualTransform):
 
         if self.fill in {"inpaint_telea", "inpaint_ns"} and num_channels not in {1, 3}:
             raise ValueError("Inpainting works only for 1 or 3 channel images")
+
+    def _build_spatial_parameter_plan(
+        self,
+        inputs: TransformSamplingInput,
+        materialize: Callable[[tuple[int, int], tuple[TargetView, ...]], dict[str, Any]],
+    ) -> TransformParameterPlan:
+        spatial_views = tuple(
+            view
+            for view in inputs.targets.ordered
+            if view.descriptor.spatial_shape is not None
+            and view.canonical_type in {"image", "images", "volume", "mask", "masks", "mask3d"}
+        )
+        annotations = tuple(view for view in inputs.targets.ordered if view.canonical_type in {"bboxes", "keypoints"})
+        spatial_names = {view.name for view in spatial_views}
+        annotations_attached = False
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_by(
+            lambda view: None if view.descriptor.spatial_shape is None else tuple(view.descriptor.spatial_shape[-2:]),
+        ):
+            if not views or views[0].name not in spatial_names:
+                continue
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                continue
+            group_views = tuple(view for view in views if view.name in spatial_names)
+            if not group_views:
+                continue
+            group_annotations = annotations if not annotations_attached else ()
+            target_views = group_views + group_annotations
+            requirements = requirements_for_views(group_views, spatial_shape_suffix=True)
+            group_names = {view.name for view in group_views}
+            requirements.update(
+                {view.name: TargetRequirement() for view in group_annotations if view.name not in group_names},
+            )
+            annotations_attached = annotations_attached or bool(group_annotations)
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(view.name for view in target_views),
+                    params=materialize((spatial_shape[-2], spatial_shape[-1]), group_views),
+                    requirements=requirements,
+                )
+            )
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
     def apply(self, img: ImageType, holes: np.ndarray, seed: int, **params: Any) -> ImageType:
         if holes.size == 0:
@@ -235,10 +328,9 @@ class BaseDropout(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         raise NotImplementedError("Subclasses must implement this method.")
 
 
@@ -327,17 +419,19 @@ class PixelDropout(DualTransform):
     def apply(
         self,
         img: ImageType,
-        drop_mask: np.ndarray,
-        drop_values: np.ndarray,
+        drop_mask: np.ndarray | None,
+        drop_values: np.ndarray | None,
         **params: Any,
     ) -> ImageType:
+        if drop_mask is None or drop_values is None:
+            return img
         return fpixel.pixel_dropout(img, drop_mask, drop_values)
 
     def apply_to_images(
         self,
         images: ImageType,
-        drop_mask: np.ndarray,
-        drop_values: np.ndarray,
+        drop_mask: np.ndarray | None,
+        drop_values: np.ndarray | None,
         **params: Any,
     ) -> ImageType:
         return self.apply(images, drop_mask, drop_values, **params)
@@ -345,14 +439,14 @@ class PixelDropout(DualTransform):
     def apply_to_mask(
         self,
         mask: ImageType,
-        mask_drop_mask: np.ndarray | None,
-        mask_drop_values: np.ndarray | None,
+        drop_mask: np.ndarray | None,
+        drop_values: np.ndarray | None,
         **params: Any,
     ) -> ImageType:
-        if self.mask_drop_value is None or mask_drop_mask is None or mask_drop_values is None:
+        if self.mask_drop_value is None or drop_mask is None or drop_values is None:
             return mask
 
-        return fpixel.pixel_dropout(mask, mask_drop_mask, mask_drop_values)
+        return fpixel.pixel_dropout(mask, drop_mask, drop_values)
 
     def apply_to_bboxes(
         self,
@@ -389,47 +483,76 @@ class PixelDropout(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        reference_array = _get_pixel_dropout_reference(data)
-
-        # Generate drop mask and values for all targets
-        drop_mask = fpixel.get_drop_mask(
-            reference_array.shape,
-            self.per_channel,
-            self.dropout_prob,
-            sampling.random_generator,
-        )
-        drop_values = fpixel.prepare_drop_values(
-            reference_array,
-            self.drop_value,
-            sampling.random_generator,
-        )
-
-        # Handle mask drop values if specified
-        mask_drop_mask = None
-        mask_drop_values = None
-        mask = fpixel.get_mask_array(data)
-        if self.mask_drop_value is not None and mask is not None:
-            mask_drop_mask = fpixel.get_drop_mask(
-                mask.shape,
-                self.per_channel,
-                self.dropout_prob,
-                sampling.random_generator,
-            )
-            mask_drop_values = fpixel.prepare_drop_values(
-                mask,
-                self.mask_drop_value,
-                sampling.random_generator,
-            )
-
+    ) -> TransformParameterPlan:
         sampling.applied_overrides["dropout_prob"] = self.dropout_prob
+        annotations = tuple(view for view in inputs.targets.ordered if view.canonical_type in {"bboxes", "keypoints"})
+        groups: list[TargetParameterGroup] = []
 
-        return {
-            "drop_mask": drop_mask,
-            "drop_values": drop_values,
-            "mask_drop_mask": mask_drop_mask if mask_drop_mask is not None else None,
-            "mask_drop_values": mask_drop_values if mask_drop_values is not None else None,
-        }
+        for index, views in enumerate(inputs.targets.group_image_like_by(_pixel_dropout_group_key)):
+            reference = _pixel_dropout_reference(views[0])
+            groups.append(
+                _pixel_dropout_group(
+                    views,
+                    {
+                        "drop_mask": None
+                        if _pixel_dropout_is_empty(views[0])
+                        else fpixel.get_drop_mask(
+                            reference.shape,
+                            self.per_channel,
+                            self.dropout_prob,
+                            sampling.random_generator,
+                        ),
+                        "drop_values": None
+                        if _pixel_dropout_is_empty(views[0])
+                        else fpixel.prepare_drop_values(
+                            reference,
+                            self.drop_value,
+                            sampling.random_generator,
+                        ),
+                    },
+                    annotations=annotations if index == 0 else (),
+                )
+            )
+
+        for views in inputs.targets.group_by(_pixel_dropout_group_key):
+            if not views or views[0].canonical_type not in {"mask", "masks", "mask3d"}:
+                continue
+            reference = _pixel_dropout_reference(views[0])
+            groups.append(
+                _pixel_dropout_group(
+                    views,
+                    {
+                        "drop_mask": (
+                            None
+                            if _pixel_dropout_is_empty(views[0])
+                            else (
+                                fpixel.get_drop_mask(
+                                    reference.shape,
+                                    self.per_channel,
+                                    self.dropout_prob,
+                                    sampling.random_generator,
+                                )
+                                if self.mask_drop_value is not None
+                                else None
+                            )
+                        ),
+                        "drop_values": (
+                            None
+                            if _pixel_dropout_is_empty(views[0])
+                            else (
+                                fpixel.prepare_drop_values(
+                                    reference,
+                                    self.mask_drop_value,
+                                    sampling.random_generator,
+                                )
+                                if self.mask_drop_value is not None
+                                else None
+                            )
+                        ),
+                    },
+                )
+            )
+
+        return TransformParameterPlan(shared={}, groups=tuple(groups))

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -6,7 +6,6 @@ PixelDropout. These transforms randomly remove or modify pixels, channels, or re
 in images, which can help models become more robust to occlusions and missing information.
 """
 
-from collections.abc import Callable
 from typing import Any, ClassVar, cast
 
 import numpy as np
@@ -39,34 +38,8 @@ __all__ = ["PixelDropout"]
 
 DropoutFillValue = tuple[float, ...] | float | FillValueLiteral
 
-_PIXEL_DROPOUT_REFERENCE_TARGETS = (
-    ("image", 0),
-    ("images", 1),
-    ("volume", 1),
-    ("mask", 0),
-    ("masks", 1),
-    ("mask3d", 1),
-)
 
-
-def _get_pixel_dropout_reference(data: dict[str, Any]) -> np.ndarray:
-    """Return one spatial target for PixelDropout parameter sampling while preserving shape and dtype metadata for
-    empty batches and zero-depth volume data.
-    """
-    for key, leading_dimensions in _PIXEL_DROPOUT_REFERENCE_TARGETS:
-        if key not in data:
-            continue
-        target = data[key]
-        if leading_dimensions == 0:
-            return target
-        if all(size > 0 for size in target.shape[:leading_dimensions]):
-            return target[(0,) * leading_dimensions]
-        return np.empty(target.shape[leading_dimensions:], dtype=target.dtype)
-
-    raise RuntimeError("PixelDropout requires at least one image, volume, or mask target")
-
-
-def _pixel_dropout_reference(view: Any) -> np.ndarray:
+def _pixel_dropout_reference(view: TargetView) -> np.ndarray:
     value = view.value
     if view.canonical_type in {"images", "volume", "masks", "mask3d"}:
         if value.shape[0] == 0:
@@ -75,25 +48,25 @@ def _pixel_dropout_reference(view: Any) -> np.ndarray:
     return value
 
 
-def _pixel_dropout_is_empty(view: Any) -> bool:
+def _pixel_dropout_is_empty(view: TargetView) -> bool:
     return view.canonical_type in {"images", "volume", "masks", "mask3d"} and view.value.shape[0] == 0
 
 
-def _pixel_dropout_group_key(view: Any) -> tuple[Any, ...]:
+def _pixel_dropout_group_key(view: TargetView) -> tuple[Any, ...]:
     descriptor = view.descriptor
     return (
         "mask" if view.canonical_type in {"mask", "masks", "mask3d"} else "image",
         descriptor.shape,
-        descriptor.dtype_scale,
+        descriptor.value_scale,
         descriptor.sampling_topology,
     )
 
 
 def _pixel_dropout_group(
-    views: tuple[Any, ...],
+    views: tuple[TargetView, ...],
     params: dict[str, Any],
     *,
-    annotations: tuple[Any, ...] = (),
+    annotations: tuple[TargetView, ...] = (),
 ) -> TargetParams:
     target_views = list(views)
     requirements = requirements_for_views(views, shape=True, dtype=True, sampling_topology=True)
@@ -213,49 +186,6 @@ class BaseDropout(DualTransform):
 
         if self.fill in {"inpaint_telea", "inpaint_ns"} and num_channels not in {1, 3}:
             raise ValueError("Inpainting works only for 1 or 3 channel images")
-
-    def _build_spatial_parameter_plan(
-        self,
-        targets: TargetSet,
-        materialize: Callable[[tuple[int, int], tuple[TargetView, ...]], dict[str, Any]],
-    ) -> SampledParams:
-        spatial_views = tuple(
-            view
-            for view in targets.ordered
-            if view.descriptor.spatial_shape is not None
-            and view.canonical_type in {"image", "images", "volume", "mask", "masks", "mask3d"}
-        )
-        annotations = tuple(view for view in targets.ordered if view.canonical_type in {"bboxes", "keypoints"})
-        spatial_names = {view.name for view in spatial_views}
-        annotations_attached = False
-        groups: list[TargetParams] = []
-        for views in targets.group_by(
-            lambda view: None if view.descriptor.spatial_shape is None else tuple(view.descriptor.spatial_shape[-2:]),
-        ):
-            if not views or views[0].name not in spatial_names:
-                continue
-            spatial_shape = views[0].descriptor.spatial_shape
-            if spatial_shape is None:
-                continue
-            group_views = tuple(view for view in views if view.name in spatial_names)
-            if not group_views:
-                continue
-            group_annotations = annotations if not annotations_attached else ()
-            target_views = group_views + group_annotations
-            requirements = requirements_for_views(group_views, spatial_shape_suffix=True)
-            group_names = {view.name for view in group_views}
-            requirements.update(
-                {view.name: TargetRequirement() for view in group_annotations if view.name not in group_names},
-            )
-            annotations_attached = annotations_attached or bool(group_annotations)
-            groups.append(
-                TargetParams(
-                    targets=tuple(view.name for view in target_views),
-                    params=materialize((spatial_shape[-2], spatial_shape[-1]), group_views),
-                    requirements=requirements,
-                )
-            )
-        return SampledParams(params={}, target_params=tuple(groups))
 
     def apply(self, img: ImageType, holes: np.ndarray, seed: int, **params: Any) -> ImageType:
         if holes.size == 0:

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -161,7 +161,7 @@ class BaseDropout(DualTransform):
         ...
         ...         from albumentations.core.transform_params import SampledParams
         ...
-        ...         return SampledParams.shared_only({
+        ...         return SampledParams(params={
         ...             "holes": np.array(holes) if holes else np.empty((0, 4), dtype=np.int32),
         ...             "seed": int(sampling.random_generator.integers(0, 100000)),
         ...         })
@@ -255,7 +255,7 @@ class BaseDropout(DualTransform):
                     requirements=requirements,
                 )
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
     def apply(self, img: ImageType, holes: np.ndarray, seed: int, **params: Any) -> ImageType:
         if holes.size == 0:
@@ -559,4 +559,4 @@ class PixelDropout(DualTransform):
                 )
             )
 
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))

--- a/albumentations/augmentations/dropout/transforms.py
+++ b/albumentations/augmentations/dropout/transforms.py
@@ -25,11 +25,11 @@ from albumentations.core.bbox_utils import BboxProcessor, denormalize_bboxes, no
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
+    SampledParams,
+    TargetParams,
     TargetRequirement,
+    TargetSet,
     TargetView,
-    TransformParameterPlan,
-    TransformSamplingInput,
     requirements_for_views,
 )
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
@@ -94,12 +94,12 @@ def _pixel_dropout_group(
     params: dict[str, Any],
     *,
     annotations: tuple[Any, ...] = (),
-) -> TargetParameterGroup:
+) -> TargetParams:
     target_views = list(views)
     requirements = requirements_for_views(views, shape=True, dtype=True, sampling_topology=True)
     target_views.extend(annotations)
     requirements.update({view.name: TargetRequirement() for view in annotations})
-    return TargetParameterGroup(
+    return TargetParams(
         targets=tuple(view.name for view in target_views),
         params=params,
         requirements=requirements,
@@ -142,8 +142,8 @@ class BaseDropout(DualTransform):
         ...         self.num_holes_range = num_holes_range
         ...         self.hole_size_range = hole_size_range
         ...
-        ...     def sample_parameters(self, inputs, sampling):
-        ...         img = inputs.data["image"]
+        ...     def sample_parameters(self, params, data, targets, sampling):
+        ...         img = data["image"]
         ...         height, width = img.shape[:2]
         ...
         ...         # Generate random holes
@@ -159,9 +159,9 @@ class BaseDropout(DualTransform):
         ...             y2 = min(height, y1 + hole_sizes[i])
         ...             holes.append([x1, y1, x2, y2])
         ...
-        ...         from albumentations.core.transform_params import TransformParameterPlan
+        ...         from albumentations.core.transform_params import SampledParams
         ...
-        ...         return TransformParameterPlan.shared_only({
+        ...         return SampledParams.shared_only({
         ...             "holes": np.array(holes) if holes else np.empty((0, 4), dtype=np.int32),
         ...             "seed": int(sampling.random_generator.integers(0, 100000)),
         ...         })
@@ -216,20 +216,20 @@ class BaseDropout(DualTransform):
 
     def _build_spatial_parameter_plan(
         self,
-        inputs: TransformSamplingInput,
+        targets: TargetSet,
         materialize: Callable[[tuple[int, int], tuple[TargetView, ...]], dict[str, Any]],
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         spatial_views = tuple(
             view
-            for view in inputs.targets.ordered
+            for view in targets.ordered
             if view.descriptor.spatial_shape is not None
             and view.canonical_type in {"image", "images", "volume", "mask", "masks", "mask3d"}
         )
-        annotations = tuple(view for view in inputs.targets.ordered if view.canonical_type in {"bboxes", "keypoints"})
+        annotations = tuple(view for view in targets.ordered if view.canonical_type in {"bboxes", "keypoints"})
         spatial_names = {view.name for view in spatial_views}
         annotations_attached = False
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_by(
+        groups: list[TargetParams] = []
+        for views in targets.group_by(
             lambda view: None if view.descriptor.spatial_shape is None else tuple(view.descriptor.spatial_shape[-2:]),
         ):
             if not views or views[0].name not in spatial_names:
@@ -249,13 +249,13 @@ class BaseDropout(DualTransform):
             )
             annotations_attached = annotations_attached or bool(group_annotations)
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(view.name for view in target_views),
                     params=materialize((spatial_shape[-2], spatial_shape[-1]), group_views),
                     requirements=requirements,
                 )
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
     def apply(self, img: ImageType, holes: np.ndarray, seed: int, **params: Any) -> ImageType:
         if holes.size == 0:
@@ -328,9 +328,11 @@ class BaseDropout(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         raise NotImplementedError("Subclasses must implement this method.")
 
 
@@ -483,14 +485,16 @@ class PixelDropout(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides["dropout_prob"] = self.dropout_prob
-        annotations = tuple(view for view in inputs.targets.ordered if view.canonical_type in {"bboxes", "keypoints"})
-        groups: list[TargetParameterGroup] = []
+        annotations = tuple(view for view in targets.ordered if view.canonical_type in {"bboxes", "keypoints"})
+        groups: list[TargetParams] = []
 
-        for index, views in enumerate(inputs.targets.group_image_like_by(_pixel_dropout_group_key)):
+        for index, views in enumerate(targets.group_image_like_by(_pixel_dropout_group_key)):
             reference = _pixel_dropout_reference(views[0])
             groups.append(
                 _pixel_dropout_group(
@@ -516,7 +520,7 @@ class PixelDropout(DualTransform):
                 )
             )
 
-        for views in inputs.targets.group_by(_pixel_dropout_group_key):
+        for views in targets.group_by(_pixel_dropout_group_key):
             if not views or views[0].canonical_type not in {"mask", "masks", "mask3d"}:
                 continue
             reference = _pixel_dropout_reference(views[0])
@@ -555,4 +559,4 @@ class PixelDropout(DualTransform):
                 )
             )
 
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -178,40 +178,38 @@ class XYMasking(BaseDropout):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
-            self._validate_integer_axis_ranges(image_shape)
+        image_shape = targets.require_aligned_spatial_shape(2)
+        self._validate_integer_axis_ranges(image_shape)
 
-            masks_x = self._generate_axis_masks(
-                self.num_masks_x_range,
-                image_shape,
-                self.mask_x_length_range,
-                axis="x",
-                sampling=sampling,
-            )
-            masks_y = self._generate_axis_masks(
-                self.num_masks_y_range,
-                image_shape,
-                self.mask_y_length_range,
-                axis="y",
-                sampling=sampling,
-            )
+        masks_x = self._generate_axis_masks(
+            self.num_masks_x_range,
+            image_shape,
+            self.mask_x_length_range,
+            axis="x",
+            sampling=sampling,
+        )
+        masks_y = self._generate_axis_masks(
+            self.num_masks_y_range,
+            image_shape,
+            self.mask_y_length_range,
+            axis="y",
+            sampling=sampling,
+        )
 
-            rectangles = masks_x + masks_y
-            holes = np.array(rectangles) if rectangles else np.empty((0, 4), dtype=np.int32)
+        rectangles = masks_x + masks_y
+        holes = np.array(rectangles) if rectangles else np.empty((0, 4), dtype=np.int32)
 
-            sampling.applied_overrides.update(
-                {
-                    "num_masks_x_range": len(masks_x),
-                    "num_masks_y_range": len(masks_y),
-                    "mask_x_length_range": self.mask_x_length_range,
-                    "mask_y_length_range": self.mask_y_length_range,
-                    "fill": self.fill,
-                    "fill_mask": self.fill_mask,
-                },
-            )
-            return {"holes": holes, "seed": int(sampling.random_generator.integers(0, 2**32 - 1))}
-
-        return self._build_spatial_parameter_plan(targets, materialize)
+        sampling.applied_overrides.update(
+            {
+                "num_masks_x_range": len(masks_x),
+                "num_masks_y_range": len(masks_y),
+                "mask_x_length_range": self.mask_x_length_range,
+                "mask_y_length_range": self.mask_y_length_range,
+                "fill": self.fill,
+                "fill_mask": self.fill_mask,
+            },
+        )
+        return SampledParams(params={"holes": holes, "seed": int(sampling.random_generator.integers(0, 2**32 - 1))})
 
     def _validate_integer_axis_ranges(self, image_shape: tuple[int, int]) -> None:
         if self._mask_x_length_is_integer and self.mask_x_length_range[1] > image_shape[1]:

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -18,6 +18,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import BaseTransformInitSchema
 
 __all__ = ["XYMasking"]
@@ -172,44 +173,43 @@ class XYMasking(BaseDropout):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, int | np.ndarray]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
+            self._validate_integer_axis_ranges(image_shape)
 
-        self._validate_integer_axis_ranges(image_shape)
+            masks_x = self._generate_axis_masks(
+                self.num_masks_x_range,
+                image_shape,
+                self.mask_x_length_range,
+                axis="x",
+                sampling=sampling,
+            )
+            masks_y = self._generate_axis_masks(
+                self.num_masks_y_range,
+                image_shape,
+                self.mask_y_length_range,
+                axis="y",
+                sampling=sampling,
+            )
 
-        masks_x = self._generate_axis_masks(
-            self.num_masks_x_range,
-            image_shape,
-            self.mask_x_length_range,
-            axis="x",
-            sampling=sampling,
-        )
-        masks_y = self._generate_axis_masks(
-            self.num_masks_y_range,
-            image_shape,
-            self.mask_y_length_range,
-            axis="y",
-            sampling=sampling,
-        )
+            rectangles = masks_x + masks_y
+            holes = np.array(rectangles) if rectangles else np.empty((0, 4), dtype=np.int32)
 
-        rectangles = masks_x + masks_y
-        holes = np.array(rectangles) if rectangles else np.empty((0, 4), dtype=np.int32)
+            sampling.applied_overrides.update(
+                {
+                    "num_masks_x_range": len(masks_x),
+                    "num_masks_y_range": len(masks_y),
+                    "mask_x_length_range": self.mask_x_length_range,
+                    "mask_y_length_range": self.mask_y_length_range,
+                    "fill": self.fill,
+                    "fill_mask": self.fill_mask,
+                },
+            )
+            return {"holes": holes, "seed": int(sampling.random_generator.integers(0, 2**32 - 1))}
 
-        sampling.applied_overrides.update(
-            {
-                "num_masks_x_range": len(masks_x),
-                "num_masks_y_range": len(masks_y),
-                "mask_x_length_range": self.mask_x_length_range,
-                "mask_y_length_range": self.mask_y_length_range,
-                "fill": self.fill,
-                "fill_mask": self.fill_mask,
-            },
-        )
-
-        return {"holes": holes, "seed": int(sampling.random_generator.integers(0, 2**32 - 1))}
+        return self._build_spatial_parameter_plan(inputs, materialize)
 
     def _validate_integer_axis_ranges(self, image_shape: tuple[int, int]) -> None:
         if self._mask_x_length_is_integer and self.mask_x_length_range[1] > image_shape[1]:

--- a/albumentations/augmentations/dropout/xy_masking.py
+++ b/albumentations/augmentations/dropout/xy_masking.py
@@ -18,7 +18,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import BaseTransformInitSchema
 
 __all__ = ["XYMasking"]
@@ -173,9 +173,11 @@ class XYMasking(BaseDropout):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         def materialize(image_shape: tuple[int, int], _: tuple[Any, ...]) -> dict[str, Any]:
             self._validate_integer_axis_ranges(image_shape)
 
@@ -209,7 +211,7 @@ class XYMasking(BaseDropout):
             )
             return {"holes": holes, "seed": int(sampling.random_generator.integers(0, 2**32 - 1))}
 
-        return self._build_spatial_parameter_plan(inputs, materialize)
+        return self._build_spatial_parameter_plan(targets, materialize)
 
     def _validate_integer_axis_ranges(self, image_shape: tuple[int, int]) -> None:
         if self._mask_x_length_is_integer and self.mask_x_length_range[1] > image_shape[1]:

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -51,7 +51,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -379,19 +379,20 @@ class ElasticTransform(BaseRemapTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         del data
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+        image_shape = targets.require_spatial_shape(2)
         low, high = self.displacement_range
         magnitude = low if low == high else sampling.py_random.uniform(low, high)
         sampling.applied_overrides["displacement_range"] = (magnitude, magnitude)
 
         height, width = image_shape
         if magnitude == 0 or min(height - 1, width - 1) <= 0:
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {
                     "displacement_magnitude": magnitude,
                     "control_coefficients": [],
@@ -405,7 +406,7 @@ class ElasticTransform(BaseRemapTransform):
         control_coefficients = np.empty((*self.control_grid_shape, 2), dtype=np.float32)
         control_coefficients[..., 0] = vector_radius * np.cos(angle)
         control_coefficients[..., 1] = vector_radius * np.sin(angle)
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "displacement_magnitude": magnitude,
                 "control_coefficients": control_coefficients.tolist(),
@@ -427,19 +428,18 @@ class ElasticTransform(BaseRemapTransform):
             result = self._apply_label_mapping_to_semantic_masks(result, **params)
         return result
 
-    def apply_with_params(self, plan: TransformParameterPlan, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Build one dense map for the invocation and reject replay on another spatial shape before dispatching all
         synchronized targets with exact map sharing.
         """
-        params = dict(plan.params_for("image"))
+        params = dict(sampled_params.params_for("image"))
         recorded_shape = tuple(params["shape"][:2])
         if self.replay_mode:
             current_targets = self._build_target_set(kwargs)
-            current_frame = self._build_spatial_frame(current_targets)
-            if current_frame is not None and current_frame.shape != recorded_shape:
+            current_shape = current_targets.spatial_shape(2)
+            if current_shape is not None and current_shape != recorded_shape:
                 raise ValueError(
-                    f"ElasticTransform replay requires the same spatial shape {recorded_shape}, "
-                    f"got {current_frame.shape}",
+                    f"ElasticTransform replay requires the same spatial shape {recorded_shape}, got {current_shape}",
                 )
         if not params["control_coefficients"]:
             return self._apply_label_mappings_without_geometry(params, kwargs)
@@ -451,12 +451,12 @@ class ElasticTransform(BaseRemapTransform):
             control_coefficients,
             recorded_shape,
         )
-        runtime_plan = TransformParameterPlan(
+        runtime_sampled_params = SampledParams(
             shared=runtime_params,
-            groups=plan.groups,
-            target_schema=plan.target_schema,
+            groups=sampled_params.groups,
+            target_schema=sampled_params.target_schema,
         )
-        return super().apply_with_params(runtime_plan, *args, **kwargs)
+        return super().apply_with_params(runtime_sampled_params, *args, **kwargs)
 
     def apply_to_keypoints(
         self,
@@ -583,10 +583,12 @@ class PiecewiseAffine(BaseDistortion):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
 
         nb_rows = np.clip(sampling.py_random.randint(*self.nb_rows_range), 2, None)
@@ -613,7 +615,7 @@ class PiecewiseAffine(BaseDistortion):
         else:
             map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
+        return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
 
 
 class OpticalDistortion(BaseDistortion):
@@ -718,10 +720,12 @@ class OpticalDistortion(BaseDistortion):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
 
         k = sampling.py_random.uniform(*self.distort_range)
@@ -735,7 +739,7 @@ class OpticalDistortion(BaseDistortion):
                 np.arange(width, dtype=np.float32),
                 indexing="ij",
             )
-            return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
+            return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
 
         if self.mode == "camera":
             map_x, map_y = fgeometric.get_camera_matrix_distortion_maps(
@@ -749,7 +753,7 @@ class OpticalDistortion(BaseDistortion):
             )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
+        return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
 
 
 class GridDistortion(BaseDistortion):
@@ -859,10 +863,12 @@ class GridDistortion(BaseDistortion):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         num_steps = min(self.num_steps, *scaled_shape)
 
@@ -881,7 +887,7 @@ class GridDistortion(BaseDistortion):
                 np.arange(width, dtype=np.float32),
                 indexing="ij",
             )
-            return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
+            return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
 
         if self.normalized:
             normalized_params = fgeometric.normalize_grid_distortion_steps(
@@ -903,7 +909,7 @@ class GridDistortion(BaseDistortion):
         )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
+        return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
 
 
 class ThinPlateSpline(BaseDistortion):
@@ -1062,10 +1068,12 @@ class ThinPlateSpline(BaseDistortion):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        height, width = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        height, width = targets.require_spatial_shape(2)
         image_shape = (height, width)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
@@ -1100,7 +1108,7 @@ class ThinPlateSpline(BaseDistortion):
         map_y = transformed[:, 1].reshape(scaled_height, scaled_width).astype(np.float32)
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "map_x": map_x,
                 "map_y": map_y,
@@ -1204,10 +1212,12 @@ class WaterRefraction(BaseDistortion):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
 
@@ -1232,7 +1242,7 @@ class WaterRefraction(BaseDistortion):
         )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "map_x": map_x,
                 "map_y": map_y,
@@ -1346,10 +1356,12 @@ class PixelSpread(BaseDistortion):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         map_resolution, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
 
@@ -1369,4 +1381,4 @@ class PixelSpread(BaseDistortion):
         map_x = (col_coords + offsets[..., 1]).astype(np.float32)
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
+        return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -385,15 +385,15 @@ class ElasticTransform(BaseRemapTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         del data
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         low, high = self.displacement_range
         magnitude = low if low == high else sampling.py_random.uniform(low, high)
         sampling.applied_overrides["displacement_range"] = (magnitude, magnitude)
 
         height, width = image_shape
         if magnitude == 0 or min(height - 1, width - 1) <= 0:
-            return SampledParams.shared_only(
-                {
+            return SampledParams(
+                params={
                     "displacement_magnitude": magnitude,
                     "control_coefficients": [],
                 }
@@ -406,8 +406,8 @@ class ElasticTransform(BaseRemapTransform):
         control_coefficients = np.empty((*self.control_grid_shape, 2), dtype=np.float32)
         control_coefficients[..., 0] = vector_radius * np.cos(angle)
         control_coefficients[..., 1] = vector_radius * np.sin(angle)
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "displacement_magnitude": magnitude,
                 "control_coefficients": control_coefficients.tolist(),
             }
@@ -436,7 +436,7 @@ class ElasticTransform(BaseRemapTransform):
         recorded_shape = tuple(params["shape"][:2])
         if self.replay_mode:
             current_targets = self._build_target_set(kwargs)
-            current_shape = current_targets.spatial_shape(2)
+            current_shape = current_targets.aligned_spatial_shape(2)
             if current_shape is not None and current_shape != recorded_shape:
                 raise ValueError(
                     f"ElasticTransform replay requires the same spatial shape {recorded_shape}, got {current_shape}",
@@ -452,8 +452,8 @@ class ElasticTransform(BaseRemapTransform):
             recorded_shape,
         )
         runtime_sampled_params = SampledParams(
-            shared=runtime_params,
-            groups=sampled_params.groups,
+            params=runtime_params,
+            target_params=sampled_params.target_params,
             target_schema=sampled_params.target_schema,
         )
         return super().apply_with_params(runtime_sampled_params, *args, **kwargs)
@@ -588,7 +588,7 @@ class PiecewiseAffine(BaseDistortion):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
 
         nb_rows = np.clip(sampling.py_random.randint(*self.nb_rows_range), 2, None)
@@ -615,7 +615,7 @@ class PiecewiseAffine(BaseDistortion):
         else:
             map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
+        return SampledParams(params={"map_x": map_x, "map_y": map_y})
 
 
 class OpticalDistortion(BaseDistortion):
@@ -725,7 +725,7 @@ class OpticalDistortion(BaseDistortion):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
 
         k = sampling.py_random.uniform(*self.distort_range)
@@ -739,7 +739,7 @@ class OpticalDistortion(BaseDistortion):
                 np.arange(width, dtype=np.float32),
                 indexing="ij",
             )
-            return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
+            return SampledParams(params={"map_x": map_x, "map_y": map_y})
 
         if self.mode == "camera":
             map_x, map_y = fgeometric.get_camera_matrix_distortion_maps(
@@ -753,7 +753,7 @@ class OpticalDistortion(BaseDistortion):
             )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
+        return SampledParams(params={"map_x": map_x, "map_y": map_y})
 
 
 class GridDistortion(BaseDistortion):
@@ -868,7 +868,7 @@ class GridDistortion(BaseDistortion):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         num_steps = min(self.num_steps, *scaled_shape)
 
@@ -887,7 +887,7 @@ class GridDistortion(BaseDistortion):
                 np.arange(width, dtype=np.float32),
                 indexing="ij",
             )
-            return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
+            return SampledParams(params={"map_x": map_x, "map_y": map_y})
 
         if self.normalized:
             normalized_params = fgeometric.normalize_grid_distortion_steps(
@@ -909,7 +909,7 @@ class GridDistortion(BaseDistortion):
         )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
+        return SampledParams(params={"map_x": map_x, "map_y": map_y})
 
 
 class ThinPlateSpline(BaseDistortion):
@@ -1073,7 +1073,7 @@ class ThinPlateSpline(BaseDistortion):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        height, width = targets.require_spatial_shape(2)
+        height, width = targets.require_aligned_spatial_shape(2)
         image_shape = (height, width)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
@@ -1108,8 +1108,8 @@ class ThinPlateSpline(BaseDistortion):
         map_y = transformed[:, 1].reshape(scaled_height, scaled_width).astype(np.float32)
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "map_x": map_x,
                 "map_y": map_y,
             }
@@ -1217,7 +1217,7 @@ class WaterRefraction(BaseDistortion):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
 
@@ -1242,8 +1242,8 @@ class WaterRefraction(BaseDistortion):
         )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "map_x": map_x,
                 "map_y": map_y,
             }
@@ -1361,7 +1361,7 @@ class PixelSpread(BaseDistortion):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         map_resolution, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
 
@@ -1381,4 +1381,4 @@ class PixelSpread(BaseDistortion):
         map_x = (col_coords + offsets[..., 1]).astype(np.float32)
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
+        return SampledParams(params={"map_x": map_x, "map_y": map_y})

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -51,6 +51,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -325,6 +326,8 @@ class ElasticTransform(BaseRemapTransform):
 
     """
 
+    _runtime_generated_params = frozenset({"map_x", "map_y"})
+
     class InitSchema(BaseRemapTransform.InitSchema):
         displacement_range: Annotated[
             tuple[float, float],
@@ -376,22 +379,24 @@ class ElasticTransform(BaseRemapTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         del data
-        image_shape = params["shape"][:2]
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         low, high = self.displacement_range
         magnitude = low if low == high else sampling.py_random.uniform(low, high)
         sampling.applied_overrides["displacement_range"] = (magnitude, magnitude)
 
         height, width = image_shape
         if magnitude == 0 or min(height - 1, width - 1) <= 0:
-            return {
-                "displacement_magnitude": magnitude,
-                "control_coefficients": [],
-            }
+            return TransformParameterPlan.shared_only(
+                {
+                    "displacement_magnitude": magnitude,
+                    "control_coefficients": [],
+                }
+            )
 
         random_values = sampling.random_generator.random((*self.control_grid_shape, 2), dtype=np.float32)
         radius = np.float32(magnitude * min(height - 1, width - 1))
@@ -400,10 +405,12 @@ class ElasticTransform(BaseRemapTransform):
         control_coefficients = np.empty((*self.control_grid_shape, 2), dtype=np.float32)
         control_coefficients[..., 0] = vector_radius * np.cos(angle)
         control_coefficients[..., 1] = vector_radius * np.sin(angle)
-        return {
-            "displacement_magnitude": magnitude,
-            "control_coefficients": control_coefficients.tolist(),
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "displacement_magnitude": magnitude,
+                "control_coefficients": control_coefficients.tolist(),
+            }
+        )
 
     def _apply_label_mappings_without_geometry(
         self,
@@ -420,17 +427,19 @@ class ElasticTransform(BaseRemapTransform):
             result = self._apply_label_mapping_to_semantic_masks(result, **params)
         return result
 
-    def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def apply_with_params(self, plan: TransformParameterPlan, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Build one dense map for the invocation and reject replay on another spatial shape before dispatching all
         synchronized targets with exact map sharing.
         """
+        params = dict(plan.params_for("image"))
         recorded_shape = tuple(params["shape"][:2])
         if self.replay_mode:
-            current_shape = self._extract_shape_from_data(kwargs)
-            if current_shape is not None and tuple(current_shape[:2]) != recorded_shape:
+            current_targets = self._build_target_set(kwargs)
+            current_frame = self._build_spatial_frame(current_targets)
+            if current_frame is not None and current_frame.shape != recorded_shape:
                 raise ValueError(
                     f"ElasticTransform replay requires the same spatial shape {recorded_shape}, "
-                    f"got {tuple(current_shape[:2])}",
+                    f"got {current_frame.shape}",
                 )
         if not params["control_coefficients"]:
             return self._apply_label_mappings_without_geometry(params, kwargs)
@@ -442,7 +451,12 @@ class ElasticTransform(BaseRemapTransform):
             control_coefficients,
             recorded_shape,
         )
-        return super().apply_with_params(runtime_params, *args, **kwargs)
+        runtime_plan = TransformParameterPlan(
+            shared=runtime_params,
+            groups=plan.groups,
+            target_schema=plan.target_schema,
+        )
+        return super().apply_with_params(runtime_plan, *args, **kwargs)
 
     def apply_to_keypoints(
         self,
@@ -569,11 +583,10 @@ class PiecewiseAffine(BaseDistortion):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
 
         nb_rows = np.clip(sampling.py_random.randint(*self.nb_rows_range), 2, None)
@@ -600,7 +613,7 @@ class PiecewiseAffine(BaseDistortion):
         else:
             map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return {"map_x": map_x, "map_y": map_y}
+        return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
 
 
 class OpticalDistortion(BaseDistortion):
@@ -705,11 +718,10 @@ class OpticalDistortion(BaseDistortion):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
 
         k = sampling.py_random.uniform(*self.distort_range)
@@ -723,7 +735,7 @@ class OpticalDistortion(BaseDistortion):
                 np.arange(width, dtype=np.float32),
                 indexing="ij",
             )
-            return {"map_x": map_x, "map_y": map_y}
+            return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
 
         if self.mode == "camera":
             map_x, map_y = fgeometric.get_camera_matrix_distortion_maps(
@@ -737,7 +749,7 @@ class OpticalDistortion(BaseDistortion):
             )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return {"map_x": map_x, "map_y": map_y}
+        return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
 
 
 class GridDistortion(BaseDistortion):
@@ -847,11 +859,10 @@ class GridDistortion(BaseDistortion):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         num_steps = min(self.num_steps, *scaled_shape)
 
@@ -870,7 +881,7 @@ class GridDistortion(BaseDistortion):
                 np.arange(width, dtype=np.float32),
                 indexing="ij",
             )
-            return {"map_x": map_x, "map_y": map_y}
+            return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
 
         if self.normalized:
             normalized_params = fgeometric.normalize_grid_distortion_steps(
@@ -892,7 +903,7 @@ class GridDistortion(BaseDistortion):
         )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return {"map_x": map_x, "map_y": map_y}
+        return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
 
 
 class ThinPlateSpline(BaseDistortion):
@@ -1051,11 +1062,10 @@ class ThinPlateSpline(BaseDistortion):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        height, width = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        height, width = inputs.require_spatial_frame().spatial_shape_2d
         image_shape = (height, width)
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
@@ -1090,10 +1100,12 @@ class ThinPlateSpline(BaseDistortion):
         map_y = transformed[:, 1].reshape(scaled_height, scaled_width).astype(np.float32)
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return {
-            "map_x": map_x,
-            "map_y": map_y,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "map_x": map_x,
+                "map_y": map_y,
+            }
+        )
 
 
 class WaterRefraction(BaseDistortion):
@@ -1192,11 +1204,10 @@ class WaterRefraction(BaseDistortion):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         _, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
 
@@ -1221,10 +1232,12 @@ class WaterRefraction(BaseDistortion):
         )
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return {
-            "map_x": map_x,
-            "map_y": map_y,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "map_x": map_x,
+                "map_y": map_y,
+            }
+        )
 
 
 class PixelSpread(BaseDistortion):
@@ -1333,11 +1346,10 @@ class PixelSpread(BaseDistortion):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         map_resolution, scaled_shape = self._get_map_resolution_and_shape(image_shape, sampling)
         scaled_height, scaled_width = scaled_shape
 
@@ -1357,4 +1369,4 @@ class PixelSpread(BaseDistortion):
         map_x = (col_coords + offsets[..., 1]).astype(np.float32)
         map_x, map_y = self._maybe_upscale_maps(map_x, map_y, image_shape)
 
-        return {"map_x": map_x, "map_y": map_y}
+        return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -30,7 +30,7 @@ import torch
 from albucore import hflip, vflip
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -572,15 +572,17 @@ class D4(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         if self.group_element is not None:
             group_element = self.group_element
         else:
             group_element = sampling.random_generator.choice(d4_group_elements)
         sampling.applied_overrides["group_element"] = group_element
-        return TransformParameterPlan.shared_only({"group_element": group_element})
+        return SampledParams.shared_only({"group_element": group_element})
 
     def inverse(self) -> D4:
         """Return a new D4 with the inverse group element to undo this transform. Use after inference

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -582,7 +582,7 @@ class D4(DualTransform):
         else:
             group_element = sampling.random_generator.choice(d4_group_elements)
         sampling.applied_overrides["group_element"] = group_element
-        return SampledParams.shared_only({"group_element": group_element})
+        return SampledParams(params={"group_element": group_element})
 
     def inverse(self) -> D4:
         """Return a new D4 with the inverse group element to undo this transform. Use after inference

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -30,6 +30,7 @@ import torch
 from albucore import hflip, vflip
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -571,16 +572,15 @@ class D4(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"]]:
+    ) -> TransformParameterPlan:
         if self.group_element is not None:
             group_element = self.group_element
         else:
             group_element = sampling.random_generator.choice(d4_group_elements)
         sampling.applied_overrides["group_element"] = group_element
-        return {"group_element": group_element}
+        return TransformParameterPlan.shared_only({"group_element": group_element})
 
     def inverse(self) -> D4:
         """Return a new D4 with the inverse group element to undo this transform. Use after inference

--- a/albumentations/augmentations/geometric/pad.py
+++ b/albumentations/augmentations/geometric/pad.py
@@ -28,7 +28,7 @@ from albumentations.core.bbox_utils import (
     normalize_bboxes,
 )
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -307,9 +307,11 @@ class Pad(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         if isinstance(self.padding, Real):
             pad_top = pad_bottom = pad_left = pad_right = self.padding
         elif isinstance(self.padding, (tuple, list)):
@@ -327,7 +329,7 @@ class Pad(DualTransform):
                 "Padding must be a single number, a pair of numbers, or a quadruple of numbers",
             )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "pad_top": pad_top,
                 "pad_bottom": pad_bottom,
@@ -561,11 +563,13 @@ class PadIfNeeded(Pad):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         h_pad_top, h_pad_bottom, w_pad_left, w_pad_right = fgeometric.get_padding_params(
-            image_shape=inputs.require_spatial_frame().spatial_shape_2d,
+            image_shape=targets.require_spatial_shape(2),
             min_height=self.min_height,
             min_width=self.min_width,
             pad_height_divisor=self.pad_height_divisor,
@@ -581,7 +585,7 @@ class PadIfNeeded(Pad):
             py_random=sampling.py_random,
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "pad_top": h_pad_top,
                 "pad_bottom": h_pad_bottom,

--- a/albumentations/augmentations/geometric/pad.py
+++ b/albumentations/augmentations/geometric/pad.py
@@ -28,6 +28,7 @@ from albumentations.core.bbox_utils import (
     normalize_bboxes,
 )
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -306,10 +307,9 @@ class Pad(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         if isinstance(self.padding, Real):
             pad_top = pad_bottom = pad_left = pad_right = self.padding
         elif isinstance(self.padding, (tuple, list)):
@@ -327,12 +327,14 @@ class Pad(DualTransform):
                 "Padding must be a single number, a pair of numbers, or a quadruple of numbers",
             )
 
-        return {
-            "pad_top": pad_top,
-            "pad_bottom": pad_bottom,
-            "pad_left": pad_left,
-            "pad_right": pad_right,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "pad_top": pad_top,
+                "pad_bottom": pad_bottom,
+                "pad_left": pad_left,
+                "pad_right": pad_right,
+            }
+        )
 
 
 class PadIfNeeded(Pad):
@@ -559,12 +561,11 @@ class PadIfNeeded(Pad):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         h_pad_top, h_pad_bottom, w_pad_left, w_pad_right = fgeometric.get_padding_params(
-            image_shape=params["shape"][:2],
+            image_shape=inputs.require_spatial_frame().spatial_shape_2d,
             min_height=self.min_height,
             min_width=self.min_width,
             pad_height_divisor=self.pad_height_divisor,
@@ -580,9 +581,11 @@ class PadIfNeeded(Pad):
             py_random=sampling.py_random,
         )
 
-        return {
-            "pad_top": h_pad_top,
-            "pad_bottom": h_pad_bottom,
-            "pad_left": w_pad_left,
-            "pad_right": w_pad_right,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "pad_top": h_pad_top,
+                "pad_bottom": h_pad_bottom,
+                "pad_left": w_pad_left,
+                "pad_right": w_pad_right,
+            }
+        )

--- a/albumentations/augmentations/geometric/pad.py
+++ b/albumentations/augmentations/geometric/pad.py
@@ -329,8 +329,8 @@ class Pad(DualTransform):
                 "Padding must be a single number, a pair of numbers, or a quadruple of numbers",
             )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "pad_top": pad_top,
                 "pad_bottom": pad_bottom,
                 "pad_left": pad_left,
@@ -569,7 +569,7 @@ class PadIfNeeded(Pad):
         sampling: SamplingContext,
     ) -> SampledParams:
         h_pad_top, h_pad_bottom, w_pad_left, w_pad_right = fgeometric.get_padding_params(
-            image_shape=targets.require_spatial_shape(2),
+            image_shape=targets.require_aligned_spatial_shape(2),
             min_height=self.min_height,
             min_width=self.min_width,
             pad_height_divisor=self.pad_height_divisor,
@@ -585,8 +585,8 @@ class PadIfNeeded(Pad):
             py_random=sampling.py_random,
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "pad_top": h_pad_top,
                 "pad_bottom": h_pad_bottom,
                 "pad_left": w_pad_left,

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -14,6 +14,7 @@ from typing_extensions import Self
 
 from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
 from albumentations.core.type_definitions import (
     ALL_TARGETS,
@@ -205,10 +206,9 @@ class RandomScale(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float]:
+    ) -> TransformParameterPlan:
         if isinstance(self.scale_range, dict):
             scale_x = sampling.py_random.uniform(*self.scale_range["x"]) + 1.0
             scale_y = sampling.py_random.uniform(*self.scale_range["y"]) + 1.0
@@ -217,7 +217,7 @@ class RandomScale(DualTransform):
             scale = sampling.py_random.uniform(*self.scale_range) + 1.0
             scale_x = scale_y = scale
             sampling.applied_overrides["scale_range"] = scale - 1.0
-        return {"scale_x": scale_x, "scale_y": scale_y}
+        return TransformParameterPlan.shared_only({"scale_x": scale_x, "scale_y": scale_y})
 
     def apply(
         self,
@@ -321,13 +321,13 @@ class BaseMaxSizeTransform(DualTransform):
         >>>
         >>> # Example of creating a custom transform that extends BaseMaxSizeTransform
         >>> class CustomMaxSize(BaseMaxSizeTransform):
-        ...     def sample_parameters(self, params, data, sampling):
-        ...         img_h, img_w = params["shape"][:2]
+        ...     def sample_parameters(self, inputs, sampling):
+        ...         img_h, img_w = inputs.require_spatial_frame().spatial_shape_2d
         ...         # Calculate scale factor - here we scale to make the image area constant
         ...         target_area = 300 * 300  # Target area of 300x300
         ...         current_area = img_h * img_w
         ...         scale = np.sqrt(target_area / current_area)
-        ...         return {"scale": scale}
+        ...         return TransformParameterPlan.shared_only({"scale": scale})
         >>>
         >>> # Prepare sample data
         >>> image = np.zeros((100, 200, 3), dtype=np.uint8)
@@ -551,17 +551,13 @@ class LongestMaxSize(BaseMaxSizeTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        img_h, img_w = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        img_h, img_w = inputs.require_spatial_frame().spatial_shape_2d
 
         if self.max_size is not None:
-            if isinstance(self.max_size, (list, tuple)):
-                max_size = sampling.py_random.choice(self.max_size)
-            else:
-                max_size = self.max_size
+            max_size = self.max_size if isinstance(self.max_size, int) else sampling.py_random.choice(self.max_size)
             sampling.applied_overrides["max_size"] = max_size
             scale = max_size / max(img_h, img_w)
         elif self.max_size_hw is not None:
@@ -579,7 +575,7 @@ class LongestMaxSize(BaseMaxSizeTransform):
         else:
             raise RuntimeError("Either max_size or max_size_hw must be set")
 
-        return {"scale": scale}
+        return TransformParameterPlan.shared_only({"scale": scale})
 
 
 class SmallestMaxSize(BaseMaxSizeTransform):
@@ -674,17 +670,13 @@ class SmallestMaxSize(BaseMaxSizeTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        img_h, img_w = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        img_h, img_w = inputs.require_spatial_frame().spatial_shape_2d
 
         if self.max_size is not None:
-            if isinstance(self.max_size, (list, tuple)):
-                max_size = sampling.py_random.choice(self.max_size)
-            else:
-                max_size = self.max_size
+            max_size = self.max_size if isinstance(self.max_size, int) else sampling.py_random.choice(self.max_size)
             sampling.applied_overrides["max_size"] = max_size
             scale = max_size / min(img_h, img_w)
         elif self.max_size_hw is not None:
@@ -702,7 +694,7 @@ class SmallestMaxSize(BaseMaxSizeTransform):
         else:
             raise RuntimeError("Either max_size or max_size_hw must be set")
 
-        return {"scale": scale}
+        return TransformParameterPlan.shared_only({"scale": scale})
 
 
 class Resize(DualTransform):
@@ -1052,11 +1044,10 @@ class LetterBox(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        img_h, img_w = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        img_h, img_w = inputs.require_spatial_frame().spatial_shape_2d
         target_h, target_w = self.size
 
         scale = min(target_h / img_h, target_w / img_w)
@@ -1079,12 +1070,14 @@ class LetterBox(DualTransform):
             py_random=sampling.py_random,
         )
 
-        return {
-            "scale": scale,
-            "new_height": new_h,
-            "new_width": new_w,
-            "pad_top": pad_top,
-            "pad_bottom": pad_bottom,
-            "pad_left": pad_left,
-            "pad_right": pad_right,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "scale": scale,
+                "new_height": new_h,
+                "new_width": new_w,
+                "pad_top": pad_top,
+                "pad_bottom": pad_bottom,
+                "pad_left": pad_left,
+                "pad_right": pad_right,
+            }
+        )

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -14,7 +14,7 @@ from typing_extensions import Self
 
 from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
 from albumentations.core.type_definitions import (
     ALL_TARGETS,
@@ -206,9 +206,11 @@ class RandomScale(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         if isinstance(self.scale_range, dict):
             scale_x = sampling.py_random.uniform(*self.scale_range["x"]) + 1.0
             scale_y = sampling.py_random.uniform(*self.scale_range["y"]) + 1.0
@@ -217,7 +219,7 @@ class RandomScale(DualTransform):
             scale = sampling.py_random.uniform(*self.scale_range) + 1.0
             scale_x = scale_y = scale
             sampling.applied_overrides["scale_range"] = scale - 1.0
-        return TransformParameterPlan.shared_only({"scale_x": scale_x, "scale_y": scale_y})
+        return SampledParams.shared_only({"scale_x": scale_x, "scale_y": scale_y})
 
     def apply(
         self,
@@ -321,13 +323,13 @@ class BaseMaxSizeTransform(DualTransform):
         >>>
         >>> # Example of creating a custom transform that extends BaseMaxSizeTransform
         >>> class CustomMaxSize(BaseMaxSizeTransform):
-        ...     def sample_parameters(self, inputs, sampling):
-        ...         img_h, img_w = inputs.require_spatial_frame().spatial_shape_2d
+        ...     def sample_parameters(self, params, data, targets, sampling):
+        ...         img_h, img_w = targets.require_spatial_shape(2)
         ...         # Calculate scale factor - here we scale to make the image area constant
         ...         target_area = 300 * 300  # Target area of 300x300
         ...         current_area = img_h * img_w
         ...         scale = np.sqrt(target_area / current_area)
-        ...         return TransformParameterPlan.shared_only({"scale": scale})
+        ...         return SampledParams.shared_only({"scale": scale})
         >>>
         >>> # Prepare sample data
         >>> image = np.zeros((100, 200, 3), dtype=np.uint8)
@@ -551,10 +553,12 @@ class LongestMaxSize(BaseMaxSizeTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        img_h, img_w = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        img_h, img_w = targets.require_spatial_shape(2)
 
         if self.max_size is not None:
             max_size = self.max_size if isinstance(self.max_size, int) else sampling.py_random.choice(self.max_size)
@@ -575,7 +579,7 @@ class LongestMaxSize(BaseMaxSizeTransform):
         else:
             raise RuntimeError("Either max_size or max_size_hw must be set")
 
-        return TransformParameterPlan.shared_only({"scale": scale})
+        return SampledParams.shared_only({"scale": scale})
 
 
 class SmallestMaxSize(BaseMaxSizeTransform):
@@ -670,10 +674,12 @@ class SmallestMaxSize(BaseMaxSizeTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        img_h, img_w = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        img_h, img_w = targets.require_spatial_shape(2)
 
         if self.max_size is not None:
             max_size = self.max_size if isinstance(self.max_size, int) else sampling.py_random.choice(self.max_size)
@@ -694,7 +700,7 @@ class SmallestMaxSize(BaseMaxSizeTransform):
         else:
             raise RuntimeError("Either max_size or max_size_hw must be set")
 
-        return TransformParameterPlan.shared_only({"scale": scale})
+        return SampledParams.shared_only({"scale": scale})
 
 
 class Resize(DualTransform):
@@ -1044,10 +1050,12 @@ class LetterBox(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        img_h, img_w = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        img_h, img_w = targets.require_spatial_shape(2)
         target_h, target_w = self.size
 
         scale = min(target_h / img_h, target_w / img_w)
@@ -1070,7 +1078,7 @@ class LetterBox(DualTransform):
             py_random=sampling.py_random,
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "scale": scale,
                 "new_height": new_h,

--- a/albumentations/augmentations/geometric/resize.py
+++ b/albumentations/augmentations/geometric/resize.py
@@ -219,7 +219,7 @@ class RandomScale(DualTransform):
             scale = sampling.py_random.uniform(*self.scale_range) + 1.0
             scale_x = scale_y = scale
             sampling.applied_overrides["scale_range"] = scale - 1.0
-        return SampledParams.shared_only({"scale_x": scale_x, "scale_y": scale_y})
+        return SampledParams(params={"scale_x": scale_x, "scale_y": scale_y})
 
     def apply(
         self,
@@ -324,12 +324,12 @@ class BaseMaxSizeTransform(DualTransform):
         >>> # Example of creating a custom transform that extends BaseMaxSizeTransform
         >>> class CustomMaxSize(BaseMaxSizeTransform):
         ...     def sample_parameters(self, params, data, targets, sampling):
-        ...         img_h, img_w = targets.require_spatial_shape(2)
+        ...         img_h, img_w = targets.require_aligned_spatial_shape(2)
         ...         # Calculate scale factor - here we scale to make the image area constant
         ...         target_area = 300 * 300  # Target area of 300x300
         ...         current_area = img_h * img_w
         ...         scale = np.sqrt(target_area / current_area)
-        ...         return SampledParams.shared_only({"scale": scale})
+        ...         return SampledParams(params={"scale": scale})
         >>>
         >>> # Prepare sample data
         >>> image = np.zeros((100, 200, 3), dtype=np.uint8)
@@ -558,7 +558,7 @@ class LongestMaxSize(BaseMaxSizeTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        img_h, img_w = targets.require_spatial_shape(2)
+        img_h, img_w = targets.require_aligned_spatial_shape(2)
 
         if self.max_size is not None:
             max_size = self.max_size if isinstance(self.max_size, int) else sampling.py_random.choice(self.max_size)
@@ -579,7 +579,7 @@ class LongestMaxSize(BaseMaxSizeTransform):
         else:
             raise RuntimeError("Either max_size or max_size_hw must be set")
 
-        return SampledParams.shared_only({"scale": scale})
+        return SampledParams(params={"scale": scale})
 
 
 class SmallestMaxSize(BaseMaxSizeTransform):
@@ -679,7 +679,7 @@ class SmallestMaxSize(BaseMaxSizeTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        img_h, img_w = targets.require_spatial_shape(2)
+        img_h, img_w = targets.require_aligned_spatial_shape(2)
 
         if self.max_size is not None:
             max_size = self.max_size if isinstance(self.max_size, int) else sampling.py_random.choice(self.max_size)
@@ -700,7 +700,7 @@ class SmallestMaxSize(BaseMaxSizeTransform):
         else:
             raise RuntimeError("Either max_size or max_size_hw must be set")
 
-        return SampledParams.shared_only({"scale": scale})
+        return SampledParams(params={"scale": scale})
 
 
 class Resize(DualTransform):
@@ -1055,7 +1055,7 @@ class LetterBox(DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        img_h, img_w = targets.require_spatial_shape(2)
+        img_h, img_w = targets.require_aligned_spatial_shape(2)
         target_h, target_w = self.size
 
         scale = min(target_h / img_h, target_w / img_w)
@@ -1078,8 +1078,8 @@ class LetterBox(DualTransform):
             py_random=sampling.py_random,
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "scale": scale,
                 "new_height": new_h,
                 "new_width": new_w,

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -17,7 +17,7 @@ from typing_extensions import Self
 from albumentations.augmentations.crops import functional as fcrops
 from albumentations.augmentations.geometric.transforms import Affine
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -194,9 +194,11 @@ class RandomRotate90(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         if self.group_element is not None:
             group_element = self.group_element
         elif self.group_elements is not None:
@@ -208,7 +210,7 @@ class RandomRotate90(DualTransform):
         # merge the unused constructor tuple (e.g. ("r90", "r270")) into the record,
         # which would cause InitSchema to reject the replay as mutually exclusive.
         sampling.applied_overrides.update({"group_element": group_element, "group_elements": None})
-        return TransformParameterPlan.shared_only({"group_element": group_element})
+        return SampledParams.shared_only({"group_element": group_element})
 
     def apply_to_bboxes(
         self,
@@ -530,16 +532,18 @@ class Rotate(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         angle = sampling.py_random.uniform(*self.angle_range)
 
         sampling.applied_overrides["angle_range"] = angle
 
         if self.crop_border:
-            height, width = inputs.require_spatial_frame().spatial_shape_2d
+            height, width = targets.require_spatial_shape(2)
             out_params: dict[str, Any] = self._rotated_rect_with_max_area(height, width, angle)
         else:
             out_params = {"x_min": -1, "x_max": -1, "y_min": -1, "y_max": -1}
@@ -569,7 +573,7 @@ class Rotate(DualTransform):
         out_params["matrix"] = matrix
         out_params["bbox_matrix"] = bbox_matrix
 
-        return TransformParameterPlan.shared_only(out_params)
+        return SampledParams.shared_only(out_params)
 
 
 class SafeRotate(Affine):
@@ -727,10 +731,12 @@ class SafeRotate(Affine):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         angle = sampling.py_random.uniform(*self.angle_range)
 
         sampling.applied_overrides["angle_range"] = angle
@@ -749,7 +755,7 @@ class SafeRotate(Affine):
             image_shape,
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "rotate": angle,
                 "scale": scale,

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -210,7 +210,7 @@ class RandomRotate90(DualTransform):
         # merge the unused constructor tuple (e.g. ("r90", "r270")) into the record,
         # which would cause InitSchema to reject the replay as mutually exclusive.
         sampling.applied_overrides.update({"group_element": group_element, "group_elements": None})
-        return SampledParams.shared_only({"group_element": group_element})
+        return SampledParams(params={"group_element": group_element})
 
     def apply_to_bboxes(
         self,
@@ -537,13 +537,13 @@ class Rotate(DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         angle = sampling.py_random.uniform(*self.angle_range)
 
         sampling.applied_overrides["angle_range"] = angle
 
         if self.crop_border:
-            height, width = targets.require_spatial_shape(2)
+            height, width = targets.require_aligned_spatial_shape(2)
             out_params: dict[str, Any] = self._rotated_rect_with_max_area(height, width, angle)
         else:
             out_params = {"x_min": -1, "x_max": -1, "y_min": -1, "y_max": -1}
@@ -573,7 +573,7 @@ class Rotate(DualTransform):
         out_params["matrix"] = matrix
         out_params["bbox_matrix"] = bbox_matrix
 
-        return SampledParams.shared_only(out_params)
+        return SampledParams(params=out_params)
 
 
 class SafeRotate(Affine):
@@ -736,7 +736,7 @@ class SafeRotate(Affine):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         angle = sampling.py_random.uniform(*self.angle_range)
 
         sampling.applied_overrides["angle_range"] = angle
@@ -755,8 +755,8 @@ class SafeRotate(Affine):
             image_shape,
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "rotate": angle,
                 "scale": scale,
                 "matrix": matrix,

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -17,6 +17,7 @@ from typing_extensions import Self
 from albumentations.augmentations.crops import functional as fcrops
 from albumentations.augmentations.geometric.transforms import Affine
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -193,10 +194,9 @@ class RandomRotate90(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Literal["e", "r90", "r180", "r270"]]:
+    ) -> TransformParameterPlan:
         if self.group_element is not None:
             group_element = self.group_element
         elif self.group_elements is not None:
@@ -208,7 +208,7 @@ class RandomRotate90(DualTransform):
         # merge the unused constructor tuple (e.g. ("r90", "r270")) into the record,
         # which would cause InitSchema to reject the replay as mutually exclusive.
         sampling.applied_overrides.update({"group_element": group_element, "group_elements": None})
-        return {"group_element": group_element}
+        return TransformParameterPlan.shared_only({"group_element": group_element})
 
     def apply_to_bboxes(
         self,
@@ -530,22 +530,22 @@ class Rotate(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         angle = sampling.py_random.uniform(*self.angle_range)
 
         sampling.applied_overrides["angle_range"] = angle
 
         if self.crop_border:
-            height, width = params["shape"][:2]
+            height, width = inputs.require_spatial_frame().spatial_shape_2d
             out_params: dict[str, Any] = self._rotated_rect_with_max_area(height, width, angle)
         else:
             out_params = {"x_min": -1, "x_max": -1, "y_min": -1, "y_max": -1}
 
-        center = fgeometric.center(params["shape"][:2])
-        bbox_center = fgeometric.center_bbox(params["shape"][:2])
+        center = fgeometric.center(image_shape)
+        bbox_center = fgeometric.center_bbox(image_shape)
 
         translate: dict[str, int] = {"x": 0, "y": 0}
         shear: dict[str, float] = {"x": 0, "y": 0}
@@ -569,7 +569,7 @@ class Rotate(DualTransform):
         out_params["matrix"] = matrix
         out_params["bbox_matrix"] = bbox_matrix
 
-        return out_params
+        return TransformParameterPlan.shared_only(out_params)
 
 
 class SafeRotate(Affine):
@@ -727,11 +727,10 @@ class SafeRotate(Affine):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         angle = sampling.py_random.uniform(*self.angle_range)
 
         sampling.applied_overrides["angle_range"] = angle
@@ -750,10 +749,12 @@ class SafeRotate(Affine):
             image_shape,
         )
 
-        return {
-            "rotate": angle,
-            "scale": scale,
-            "matrix": matrix,
-            "bbox_matrix": bbox_matrix,
-            "output_shape": image_shape,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "rotate": angle,
+                "scale": scale,
+                "matrix": matrix,
+                "bbox_matrix": bbox_matrix,
+                "output_shape": image_shape,
+            }
+        )

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -299,7 +299,7 @@ class Perspective(DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
         scale = sampling.py_random.uniform(*self.scale)
 
         points = fgeometric.generate_perspective_points(
@@ -322,8 +322,8 @@ class Perspective(DualTransform):
 
         sampling.applied_overrides["scale"] = scale
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "matrix": matrix,
                 "max_height": max_height,
                 "max_width": max_width,
@@ -759,7 +759,7 @@ class Affine(DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
 
         translate = self._get_translate_params(image_shape, sampling)
         shear = self._get_shear_params(sampling)
@@ -807,8 +807,8 @@ class Affine(DualTransform):
         else:
             output_shape = image_shape
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "rotate": rotate,
                 "scale": scale,
                 "matrix": matrix,
@@ -1145,7 +1145,7 @@ class GridElasticDeform(DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
 
         # Replace calculate_grid_dimensions with split_uniform_grid
         tiles = fgeometric.split_uniform_grid(
@@ -1177,7 +1177,7 @@ class GridElasticDeform(DualTransform):
 
         generated_mesh = self._generate_mesh(polygons, dimensions)
 
-        return SampledParams.shared_only({"generated_mesh": generated_mesh})
+        return SampledParams(params={"generated_mesh": generated_mesh})
 
     def apply(
         self,
@@ -1391,7 +1391,7 @@ class RandomGridShuffle(DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_shape = targets.require_spatial_shape(2)
+        image_shape = targets.require_aligned_spatial_shape(2)
 
         original_tiles = fgeometric.split_uniform_grid(
             image_shape,
@@ -1404,7 +1404,7 @@ class RandomGridShuffle(DualTransform):
             sampling.random_generator,
         )
 
-        return SampledParams.shared_only({"tiles": original_tiles, "mapping": mapping})
+        return SampledParams(params={"tiles": original_tiles, "mapping": mapping})
 
 
 class Morphological(DualTransform):
@@ -1545,8 +1545,8 @@ class Morphological(DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "kernel": cv2.getStructuringElement(cv2.MORPH_ELLIPSE, self.scale),
             }
         )

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -32,6 +32,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -293,11 +294,10 @@ class Perspective(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
         scale = sampling.py_random.uniform(*self.scale)
 
         points = fgeometric.generate_perspective_points(
@@ -320,12 +320,14 @@ class Perspective(DualTransform):
 
         sampling.applied_overrides["scale"] = scale
 
-        return {
-            "matrix": matrix,
-            "max_height": max_height,
-            "max_width": max_width,
-            "matrix_bbox": matrix,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "matrix": matrix,
+                "max_height": max_height,
+                "max_width": max_width,
+                "matrix_bbox": matrix,
+            }
+        )
 
 
 class _AffineInitSchema(BaseTransformInitSchema):
@@ -750,11 +752,10 @@ class Affine(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
 
         translate = self._get_translate_params(image_shape, sampling)
         shear = self._get_shear_params(sampling)
@@ -802,13 +803,15 @@ class Affine(DualTransform):
         else:
             output_shape = image_shape
 
-        return {
-            "rotate": rotate,
-            "scale": scale,
-            "matrix": matrix,
-            "bbox_matrix": bbox_matrix,
-            "output_shape": output_shape,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "rotate": rotate,
+                "scale": scale,
+                "matrix": matrix,
+                "bbox_matrix": bbox_matrix,
+                "output_shape": output_shape,
+            }
+        )
 
     def _get_translate_params(self, image_shape: tuple[int, int], sampling: SamplingContext) -> dict[str, int]:
         height, width = image_shape[:2]
@@ -1133,11 +1136,10 @@ class GridElasticDeform(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
 
         # Replace calculate_grid_dimensions with split_uniform_grid
         tiles = fgeometric.split_uniform_grid(
@@ -1169,7 +1171,7 @@ class GridElasticDeform(DualTransform):
 
         generated_mesh = self._generate_mesh(polygons, dimensions)
 
-        return {"generated_mesh": generated_mesh}
+        return TransformParameterPlan.shared_only({"generated_mesh": generated_mesh})
 
     def apply(
         self,
@@ -1378,11 +1380,10 @@ class RandomGridShuffle(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray | list[int]]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
+        image_shape = inputs.require_spatial_frame().spatial_shape_2d
 
         original_tiles = fgeometric.split_uniform_grid(
             image_shape,
@@ -1395,7 +1396,7 @@ class RandomGridShuffle(DualTransform):
             sampling.random_generator,
         )
 
-        return {"tiles": original_tiles, "mapping": mapping}
+        return TransformParameterPlan.shared_only({"tiles": original_tiles, "mapping": mapping})
 
 
 class Morphological(DualTransform):
@@ -1531,10 +1532,11 @@ class Morphological(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray]:
-        return {
-            "kernel": cv2.getStructuringElement(cv2.MORPH_ELLIPSE, self.scale),
-        }
+    ) -> TransformParameterPlan:
+        return TransformParameterPlan.shared_only(
+            {
+                "kernel": cv2.getStructuringElement(cv2.MORPH_ELLIPSE, self.scale),
+            }
+        )

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -32,7 +32,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     DualTransform,
@@ -294,10 +294,12 @@ class Perspective(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
         scale = sampling.py_random.uniform(*self.scale)
 
         points = fgeometric.generate_perspective_points(
@@ -320,7 +322,7 @@ class Perspective(DualTransform):
 
         sampling.applied_overrides["scale"] = scale
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "matrix": matrix,
                 "max_height": max_height,
@@ -752,10 +754,12 @@ class Affine(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
 
         translate = self._get_translate_params(image_shape, sampling)
         shear = self._get_shear_params(sampling)
@@ -803,7 +807,7 @@ class Affine(DualTransform):
         else:
             output_shape = image_shape
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "rotate": rotate,
                 "scale": scale,
@@ -1136,10 +1140,12 @@ class GridElasticDeform(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
 
         # Replace calculate_grid_dimensions with split_uniform_grid
         tiles = fgeometric.split_uniform_grid(
@@ -1171,7 +1177,7 @@ class GridElasticDeform(DualTransform):
 
         generated_mesh = self._generate_mesh(polygons, dimensions)
 
-        return TransformParameterPlan.shared_only({"generated_mesh": generated_mesh})
+        return SampledParams.shared_only({"generated_mesh": generated_mesh})
 
     def apply(
         self,
@@ -1380,10 +1386,12 @@ class RandomGridShuffle(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_shape = inputs.require_spatial_frame().spatial_shape_2d
+    ) -> SampledParams:
+        image_shape = targets.require_spatial_shape(2)
 
         original_tiles = fgeometric.split_uniform_grid(
             image_shape,
@@ -1396,7 +1404,7 @@ class RandomGridShuffle(DualTransform):
             sampling.random_generator,
         )
 
-        return TransformParameterPlan.shared_only({"tiles": original_tiles, "mapping": mapping})
+        return SampledParams.shared_only({"tiles": original_tiles, "mapping": mapping})
 
 
 class Morphological(DualTransform):
@@ -1532,10 +1540,12 @@ class Morphological(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        return TransformParameterPlan.shared_only(
+    ) -> SampledParams:
+        return SampledParams.shared_only(
             {
                 "kernel": cv2.getStructuringElement(cv2.MORPH_ELLIPSE, self.scale),
             }

--- a/albumentations/augmentations/mixing/copy_paste.py
+++ b/albumentations/augmentations/mixing/copy_paste.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from typing import Annotated, Any, Literal, cast
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 from ._transforms_shared import (
     _BBOX_INSTANCE_ID,
@@ -1080,22 +1080,23 @@ class CopyAndPaste(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         # Sample blend_sigma + scale_jitter upfront so the applied record captures them even when the
         # no-op path is taken (e.g. no valid paste items provided). scale_jitter is shared across
         # all donors in a single call so the recorded value matches what was actually applied.
-        data = inputs.data
         blend_sigma = sampling.py_random.uniform(*self.blend_sigma_range)
         sampling.applied_overrides["blend_sigma_range"] = blend_sigma
         scale_jitter = sampling.py_random.uniform(*self.scale_range)
         sampling.applied_overrides["scale_range"] = scale_jitter
 
-        target_shape = inputs.require_spatial_frame().spatial_shape_2d
+        target_shape = targets.require_spatial_shape(2)
         gathered = self._gather_valid_copy_paste_items(data, target_shape, scale_jitter, sampling)
         if gathered is None:
-            return TransformParameterPlan.shared_only(self._no_op_params())
+            return SampledParams.shared_only(self._no_op_params())
 
         valid_items, pasted_masks_list, composite_image, donor_mask = gathered
         pasted_masks = np.stack(pasted_masks_list, axis=0)
@@ -1134,7 +1135,7 @@ class CopyAndPaste(DualTransform):
                 stacklevel=2,
             )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "paste_donor_image": composite_image,
                 "paste_alpha": alpha,

--- a/albumentations/augmentations/mixing/copy_paste.py
+++ b/albumentations/augmentations/mixing/copy_paste.py
@@ -1093,10 +1093,10 @@ class CopyAndPaste(DualTransform):
         scale_jitter = sampling.py_random.uniform(*self.scale_range)
         sampling.applied_overrides["scale_range"] = scale_jitter
 
-        target_shape = targets.require_spatial_shape(2)
+        target_shape = targets.require_aligned_spatial_shape(2)
         gathered = self._gather_valid_copy_paste_items(data, target_shape, scale_jitter, sampling)
         if gathered is None:
-            return SampledParams.shared_only(self._no_op_params())
+            return SampledParams(params=self._no_op_params())
 
         valid_items, pasted_masks_list, composite_image, donor_mask = gathered
         pasted_masks = np.stack(pasted_masks_list, axis=0)
@@ -1135,8 +1135,8 @@ class CopyAndPaste(DualTransform):
                 stacklevel=2,
             )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "paste_donor_image": composite_image,
                 "paste_alpha": alpha,
                 "paste_instance_masks": pasted_masks,

--- a/albumentations/augmentations/mixing/copy_paste.py
+++ b/albumentations/augmentations/mixing/copy_paste.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import Annotated, Any, Literal, cast
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 from ._transforms_shared import (
     _BBOX_INSTANCE_ID,
@@ -1079,22 +1080,22 @@ class CopyAndPaste(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         # Sample blend_sigma + scale_jitter upfront so the applied record captures them even when the
         # no-op path is taken (e.g. no valid paste items provided). scale_jitter is shared across
         # all donors in a single call so the recorded value matches what was actually applied.
+        data = inputs.data
         blend_sigma = sampling.py_random.uniform(*self.blend_sigma_range)
         sampling.applied_overrides["blend_sigma_range"] = blend_sigma
         scale_jitter = sampling.py_random.uniform(*self.scale_range)
         sampling.applied_overrides["scale_range"] = scale_jitter
 
-        target_shape = params["shape"][:2]
+        target_shape = inputs.require_spatial_frame().spatial_shape_2d
         gathered = self._gather_valid_copy_paste_items(data, target_shape, scale_jitter, sampling)
         if gathered is None:
-            return self._no_op_params()
+            return TransformParameterPlan.shared_only(self._no_op_params())
 
         valid_items, pasted_masks_list, composite_image, donor_mask = gathered
         pasted_masks = np.stack(pasted_masks_list, axis=0)
@@ -1133,18 +1134,20 @@ class CopyAndPaste(DualTransform):
                 stacklevel=2,
             )
 
-        return {
-            "paste_donor_image": composite_image,
-            "paste_alpha": alpha,
-            "paste_instance_masks": pasted_masks,
-            "paste_surviving_indices": surviving_indices,
-            "paste_surviving_ids_ordered": paste_surviving_ids_ordered,
-            "paste_primary_instance_count": paste_primary_instance_count,
-            "paste_bboxes": pasted_bboxes,
-            "paste_keypoints": pasted_keypoints,
-            "paste_donor_mask": donor_mask,
-            "paste_instance_ids": paste_instance_ids,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "paste_donor_image": composite_image,
+                "paste_alpha": alpha,
+                "paste_instance_masks": pasted_masks,
+                "paste_surviving_indices": surviving_indices,
+                "paste_surviving_ids_ordered": paste_surviving_ids_ordered,
+                "paste_primary_instance_count": paste_primary_instance_count,
+                "paste_bboxes": pasted_bboxes,
+                "paste_keypoints": pasted_keypoints,
+                "paste_donor_mask": donor_mask,
+                "paste_instance_ids": paste_instance_ids,
+            }
+        )
 
     @staticmethod
     def _no_op_params() -> dict[str, Any]:

--- a/albumentations/augmentations/mixing/domain_adaptation.py
+++ b/albumentations/augmentations/mixing/domain_adaptation.py
@@ -110,8 +110,8 @@ class BaseDomainAdaptation(ImageOnlyTransform):
         ...         target_image = data.get(self.reference_key)
         ...         if target_image is None:
         ...             # Fallback if target image is not provided
-        ...             return SampledParams.shared_only({"target_image": None})
-        ...         return SampledParams.shared_only({"target_image": target_image})
+        ...             return SampledParams(params={"target_image": None})
+        ...         return SampledParams(params={"target_image": target_image})
         ...
         ...     def apply(
         ...         self,
@@ -318,8 +318,8 @@ class HistogramMatching(BaseDomainAdaptation):
 
         sampling.applied_overrides["blend_ratio"] = blend_ratio
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "reference_image": reference_image,
                 "blend_ratio": blend_ratio,
             }
@@ -505,7 +505,7 @@ class FDA(BaseDomainAdaptation):
         sampling: SamplingContext,
     ) -> SampledParams:
         target_image = self._get_reference_image(data, sampling)
-        height, width = targets.require_spatial_shape(2)
+        height, width = targets.require_aligned_spatial_shape(2)
 
         # Resize the target image to match the input image dimensions
         target_image_resized = fgeometric.resize(target_image, (height, width), cv2.INTER_LINEAR)
@@ -514,7 +514,7 @@ class FDA(BaseDomainAdaptation):
 
         sampling.applied_overrides["beta_range"] = beta
 
-        return SampledParams.shared_only({"target_image": target_image_resized, "beta": beta})
+        return SampledParams(params={"target_image": target_image_resized, "beta": beta})
 
     def apply(
         self,
@@ -694,8 +694,8 @@ class PixelDistributionAdaptation(BaseDomainAdaptation):
 
         sampling.applied_overrides["blend_ratio"] = blend_ratio
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "reference_image": self._get_reference_image(data, sampling),
                 "blend_ratio": blend_ratio,
             }

--- a/albumentations/augmentations/mixing/domain_adaptation.py
+++ b/albumentations/augmentations/mixing/domain_adaptation.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any, ClassVar, Literal
 
 import cv2
 import numpy as np
+from albucore import from_float, to_float
 from pydantic import field_validator
 from pydantic.functional_validators import AfterValidator
 
@@ -193,6 +194,50 @@ class BaseDomainAdaptation(ImageOnlyTransform):
 
         return sampling.py_random.choice(metadata_images)
 
+    @staticmethod
+    def _reference_for_target(reference_image: np.ndarray, target_dtype: Any) -> np.ndarray:
+        target_numpy_dtype = np.dtype(str(target_dtype).removeprefix("torch."))
+        if reference_image.dtype == target_numpy_dtype:
+            return reference_image
+
+        reference_float = to_float(reference_image)
+        return reference_float if target_numpy_dtype == np.float32 else from_float(reference_float, target_numpy_dtype)
+
+    def _target_reference_params(
+        self,
+        reference_image: np.ndarray,
+        targets: TargetSet,
+        parameter_name: str,
+    ) -> tuple[TargetParams, ...]:
+        reference_channels = reference_image.shape[-1] if reference_image.ndim > 2 else 1
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
+            lambda view: (
+                tuple((view.descriptor.spatial_shape or ())[-2:]),
+                view.descriptor.channels,
+                str(view.descriptor.dtype),
+            ),
+        ):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError(f"{self.__class__.__name__} requires image-like targets with known spatial shapes")
+            channels = views[0].descriptor.channels or 1
+            if channels != reference_channels:
+                raise ValueError(
+                    f"{self.__class__.__name__} reference image has {reference_channels} channels; "
+                    f"target {views[0].name!r} has {channels}",
+                )
+            height, width = spatial_shape[-2:]
+            resized_reference = fgeometric.resize(reference_image, (height, width), cv2.INTER_LINEAR)
+            groups.append(
+                TargetParams(
+                    targets=tuple(view.name for view in views),
+                    params={parameter_name: self._reference_for_target(resized_reference, views[0].descriptor.dtype)},
+                    requirements=requirements_for_views(views, spatial_shape_suffix=True, channels=True, dtype=True),
+                ),
+            )
+        return tuple(groups)
+
 
 class HistogramMatching(BaseDomainAdaptation):
     """Match input histogram to a reference image (metadata_key). Aligns intensity and
@@ -319,10 +364,8 @@ class HistogramMatching(BaseDomainAdaptation):
         sampling.applied_overrides["blend_ratio"] = blend_ratio
 
         return SampledParams(
-            params={
-                "reference_image": reference_image,
-                "blend_ratio": blend_ratio,
-            }
+            params={"blend_ratio": blend_ratio},
+            target_params=self._target_reference_params(reference_image, targets, "reference_image"),
         )
 
     def apply(
@@ -507,36 +550,10 @@ class FDA(BaseDomainAdaptation):
         target_image = self._get_reference_image(data, sampling)
         beta = sampling.py_random.uniform(*self.beta_range)
         sampling.applied_overrides["beta_range"] = beta
-        reference_channels = target_image.shape[-1] if target_image.ndim > 2 else 1
-        groups: list[TargetParams] = []
-        for views in targets.group_image_like_by(
-            lambda view: (
-                tuple((view.descriptor.spatial_shape or ())[-2:]),
-                view.descriptor.channels,
-            ),
-        ):
-            spatial_shape = views[0].descriptor.spatial_shape
-            if spatial_shape is None:
-                raise ValueError("FDA requires image-like targets with known spatial shapes")
-            channels = views[0].descriptor.channels or 1
-            if channels != reference_channels:
-                raise ValueError(
-                    f"FDA reference image has {reference_channels} channels; target {views[0].name!r} has {channels}",
-                )
-            height, width = spatial_shape[-2:]
-            target_image_resized = fgeometric.resize(
-                target_image,
-                (height, width),
-                cv2.INTER_LINEAR,
-            )
-            groups.append(
-                TargetParams(
-                    targets=tuple(view.name for view in views),
-                    params={"target_image": target_image_resized},
-                    requirements=requirements_for_views(views, spatial_shape_suffix=True, channels=True),
-                ),
-            )
-        return SampledParams(params={"beta": beta}, target_params=tuple(groups))
+        return SampledParams(
+            params={"beta": beta},
+            target_params=self._target_reference_params(target_image, targets, "target_image"),
+        )
 
     def apply(
         self,
@@ -717,10 +734,12 @@ class PixelDistributionAdaptation(BaseDomainAdaptation):
         sampling.applied_overrides["blend_ratio"] = blend_ratio
 
         return SampledParams(
-            params={
-                "reference_image": self._get_reference_image(data, sampling),
-                "blend_ratio": blend_ratio,
-            }
+            params={"blend_ratio": blend_ratio},
+            target_params=self._target_reference_params(
+                self._get_reference_image(data, sampling),
+                targets,
+                "reference_image",
+            ),
         )
 
     def apply(self, img: ImageType, reference_image: ImageType, blend_ratio: float, **params: Any) -> ImageType:

--- a/albumentations/augmentations/mixing/domain_adaptation.py
+++ b/albumentations/augmentations/mixing/domain_adaptation.py
@@ -25,7 +25,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
-from albumentations.core.transform_params import SampledParams, TargetSet
+from albumentations.core.transform_params import SampledParams, TargetParams, TargetSet, requirements_for_views
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -505,16 +505,38 @@ class FDA(BaseDomainAdaptation):
         sampling: SamplingContext,
     ) -> SampledParams:
         target_image = self._get_reference_image(data, sampling)
-        height, width = targets.require_aligned_spatial_shape(2)
-
-        # Resize the target image to match the input image dimensions
-        target_image_resized = fgeometric.resize(target_image, (height, width), cv2.INTER_LINEAR)
-
         beta = sampling.py_random.uniform(*self.beta_range)
-
         sampling.applied_overrides["beta_range"] = beta
-
-        return SampledParams(params={"target_image": target_image_resized, "beta": beta})
+        reference_channels = target_image.shape[-1] if target_image.ndim > 2 else 1
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
+            lambda view: (
+                tuple((view.descriptor.spatial_shape or ())[-2:]),
+                view.descriptor.channels,
+            ),
+        ):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("FDA requires image-like targets with known spatial shapes")
+            channels = views[0].descriptor.channels or 1
+            if channels != reference_channels:
+                raise ValueError(
+                    f"FDA reference image has {reference_channels} channels; target {views[0].name!r} has {channels}",
+                )
+            height, width = spatial_shape[-2:]
+            target_image_resized = fgeometric.resize(
+                target_image,
+                (height, width),
+                cv2.INTER_LINEAR,
+            )
+            groups.append(
+                TargetParams(
+                    targets=tuple(view.name for view in views),
+                    params={"target_image": target_image_resized},
+                    requirements=requirements_for_views(views, spatial_shape_suffix=True, channels=True),
+                ),
+            )
+        return SampledParams(params={"beta": beta}, target_params=tuple(groups))
 
     def apply(
         self,

--- a/albumentations/augmentations/mixing/domain_adaptation.py
+++ b/albumentations/augmentations/mixing/domain_adaptation.py
@@ -25,6 +25,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -101,14 +102,14 @@ class BaseDomainAdaptation(ImageOnlyTransform):
         ...
         ...     def sample_parameters(
         ...         self,
-        ...         params: dict[str, Any],
-        ...         data: dict[str, Any]
-        ...     ) -> dict[str, Any]:
-        ...         target_image = data.get(self.reference_key)
+        ...         inputs: TransformSamplingInput,
+        ...         sampling: SamplingContext,
+        ...     ) -> TransformParameterPlan:
+        ...         target_image = inputs.data.get(self.reference_key)
         ...         if target_image is None:
         ...             # Fallback if target image is not provided
-        ...             return {"target_image": None}
-        ...         return {"target_image": target_image}
+        ...             return TransformParameterPlan.shared_only({"target_image": None})
+        ...         return TransformParameterPlan.shared_only({"target_image": target_image})
         ...
         ...     def apply(
         ...         self,
@@ -305,19 +306,21 @@ class HistogramMatching(BaseDomainAdaptation):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         reference_image = self._get_reference_image(data, sampling)
         blend_ratio = sampling.py_random.uniform(*self.blend_ratio)
 
         sampling.applied_overrides["blend_ratio"] = blend_ratio
 
-        return {
-            "reference_image": reference_image,
-            "blend_ratio": blend_ratio,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "reference_image": reference_image,
+                "blend_ratio": blend_ratio,
+            }
+        )
 
     def apply(
         self,
@@ -493,12 +496,12 @@ class FDA(BaseDomainAdaptation):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         target_image = self._get_reference_image(data, sampling)
-        height, width = params["shape"][:2]
+        height, width = inputs.require_spatial_frame().spatial_shape_2d
 
         # Resize the target image to match the input image dimensions
         target_image_resized = fgeometric.resize(target_image, (height, width), cv2.INTER_LINEAR)
@@ -507,7 +510,7 @@ class FDA(BaseDomainAdaptation):
 
         sampling.applied_overrides["beta_range"] = beta
 
-        return {"target_image": target_image_resized, "beta": beta}
+        return TransformParameterPlan.shared_only({"target_image": target_image_resized, "beta": beta})
 
     def apply(
         self,
@@ -678,18 +681,20 @@ class PixelDistributionAdaptation(BaseDomainAdaptation):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         blend_ratio = sampling.py_random.uniform(*self.blend_ratio)
 
         sampling.applied_overrides["blend_ratio"] = blend_ratio
 
-        return {
-            "reference_image": self._get_reference_image(data, sampling),
-            "blend_ratio": blend_ratio,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "reference_image": self._get_reference_image(data, sampling),
+                "blend_ratio": blend_ratio,
+            }
+        )
 
     def apply(self, img: ImageType, reference_image: ImageType, blend_ratio: float, **params: Any) -> ImageType:
         return adapt_pixel_distribution(

--- a/albumentations/augmentations/mixing/domain_adaptation.py
+++ b/albumentations/augmentations/mixing/domain_adaptation.py
@@ -25,7 +25,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -102,14 +102,16 @@ class BaseDomainAdaptation(ImageOnlyTransform):
         ...
         ...     def sample_parameters(
         ...         self,
-        ...         inputs: TransformSamplingInput,
+        ...         params: dict[str, Any],
+        ...         data: dict[str, Any],
+        ...         targets: TargetSet,
         ...         sampling: SamplingContext,
-        ...     ) -> TransformParameterPlan:
-        ...         target_image = inputs.data.get(self.reference_key)
+        ...     ) -> SampledParams:
+        ...         target_image = data.get(self.reference_key)
         ...         if target_image is None:
         ...             # Fallback if target image is not provided
-        ...             return TransformParameterPlan.shared_only({"target_image": None})
-        ...         return TransformParameterPlan.shared_only({"target_image": target_image})
+        ...             return SampledParams.shared_only({"target_image": None})
+        ...         return SampledParams.shared_only({"target_image": target_image})
         ...
         ...     def apply(
         ...         self,
@@ -306,16 +308,17 @@ class HistogramMatching(BaseDomainAdaptation):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         reference_image = self._get_reference_image(data, sampling)
         blend_ratio = sampling.py_random.uniform(*self.blend_ratio)
 
         sampling.applied_overrides["blend_ratio"] = blend_ratio
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "reference_image": reference_image,
                 "blend_ratio": blend_ratio,
@@ -496,12 +499,13 @@ class FDA(BaseDomainAdaptation):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         target_image = self._get_reference_image(data, sampling)
-        height, width = inputs.require_spatial_frame().spatial_shape_2d
+        height, width = targets.require_spatial_shape(2)
 
         # Resize the target image to match the input image dimensions
         target_image_resized = fgeometric.resize(target_image, (height, width), cv2.INTER_LINEAR)
@@ -510,7 +514,7 @@ class FDA(BaseDomainAdaptation):
 
         sampling.applied_overrides["beta_range"] = beta
 
-        return TransformParameterPlan.shared_only({"target_image": target_image_resized, "beta": beta})
+        return SampledParams.shared_only({"target_image": target_image_resized, "beta": beta})
 
     def apply(
         self,
@@ -681,15 +685,16 @@ class PixelDistributionAdaptation(BaseDomainAdaptation):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         blend_ratio = sampling.py_random.uniform(*self.blend_ratio)
 
         sampling.applied_overrides["blend_ratio"] = blend_ratio
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "reference_image": self._get_reference_image(data, sampling),
                 "blend_ratio": blend_ratio,

--- a/albumentations/augmentations/mixing/mosaic.py
+++ b/albumentations/augmentations/mixing/mosaic.py
@@ -441,7 +441,7 @@ class Mosaic(DualTransform):
         # way to mirror the survival, breaking positional alignment on the way to the next
         # transform (the root cause of the Mosaic+Perspective+CopyAndPaste IndexError).
         result.update(self._compute_mosaic_survival(processed_cells, data))
-        return SampledParams.shared_only(result)
+        return SampledParams(params=result)
 
     @staticmethod
     def _filter_cell_masks_to_surviving_bboxes(

--- a/albumentations/augmentations/mixing/mosaic.py
+++ b/albumentations/augmentations/mixing/mosaic.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Literal, cast
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 from ._transforms_shared import (
     _BBOX_INSTANCE_ID,
@@ -368,10 +369,10 @@ class Mosaic(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         cell_placements = self._calculate_geometry(data, sampling)
 
         num_cells = len(cell_placements)
@@ -439,7 +440,7 @@ class Mosaic(DualTransform):
         # way to mirror the survival, breaking positional alignment on the way to the next
         # transform (the root cause of the Mosaic+Perspective+CopyAndPaste IndexError).
         result.update(self._compute_mosaic_survival(processed_cells, data))
-        return result
+        return TransformParameterPlan.shared_only(result)
 
     @staticmethod
     def _filter_cell_masks_to_surviving_bboxes(

--- a/albumentations/augmentations/mixing/mosaic.py
+++ b/albumentations/augmentations/mixing/mosaic.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, Literal, cast
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 from ._transforms_shared import (
     _BBOX_INSTANCE_ID,
@@ -369,10 +369,11 @@ class Mosaic(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         cell_placements = self._calculate_geometry(data, sampling)
 
         num_cells = len(cell_placements)
@@ -440,7 +441,7 @@ class Mosaic(DualTransform):
         # way to mirror the survival, breaking positional alignment on the way to the next
         # transform (the root cause of the Mosaic+Perspective+CopyAndPaste IndexError).
         result.update(self._compute_mosaic_survival(processed_cells, data))
-        return TransformParameterPlan.shared_only(result)
+        return SampledParams.shared_only(result)
 
     @staticmethod
     def _filter_cell_masks_to_surviving_bboxes(

--- a/albumentations/augmentations/mixing/overlay.py
+++ b/albumentations/augmentations/mixing/overlay.py
@@ -235,8 +235,8 @@ class OverlayElements(DualTransform):
         else:
             overlay_data = [self.preprocess_metadata(metadata, img_shape, sampling.py_random)]
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "overlay_data": overlay_data,
             }
         )

--- a/albumentations/augmentations/mixing/overlay.py
+++ b/albumentations/augmentations/mixing/overlay.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 from ._transforms_shared import (
     LENGTH_RAW_BBOX,
@@ -210,21 +211,34 @@ class OverlayElements(DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         metadata = data[self.metadata_key]
-        img_shape = params["shape"]
+        image_views = inputs.targets.image_like()
+        reference = (
+            image_views[0]
+            if image_views
+            else next(
+                (view for view in inputs.targets.ordered if view.descriptor.spatial_shape is not None),
+                None,
+            )
+        )
+        if reference is None or reference.descriptor.spatial_shape is None:
+            raise ValueError("OverlayElements requires a spatial target with a known shape")
+        img_shape = (reference.descriptor.spatial_shape[-2], reference.descriptor.spatial_shape[-1])
 
         if isinstance(metadata, list):
             overlay_data = [self.preprocess_metadata(md, img_shape, sampling.py_random) for md in metadata]
         else:
             overlay_data = [self.preprocess_metadata(metadata, img_shape, sampling.py_random)]
 
-        return {
-            "overlay_data": overlay_data,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "overlay_data": overlay_data,
+            }
+        )
 
     def apply(
         self,

--- a/albumentations/augmentations/mixing/overlay.py
+++ b/albumentations/augmentations/mixing/overlay.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 from ._transforms_shared import (
     LENGTH_RAW_BBOX,
@@ -211,17 +211,18 @@ class OverlayElements(DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         metadata = data[self.metadata_key]
-        image_views = inputs.targets.image_like()
+        image_views = targets.image_like()
         reference = (
             image_views[0]
             if image_views
             else next(
-                (view for view in inputs.targets.ordered if view.descriptor.spatial_shape is not None),
+                (view for view in targets.ordered if view.descriptor.spatial_shape is not None),
                 None,
             )
         )
@@ -234,7 +235,7 @@ class OverlayElements(DualTransform):
         else:
             overlay_data = [self.preprocess_metadata(metadata, img_shape, sampling.py_random)]
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "overlay_data": overlay_data,
             }

--- a/albumentations/augmentations/other/annotation_artifacts.py
+++ b/albumentations/augmentations/other/annotation_artifacts.py
@@ -12,7 +12,7 @@ from typing_extensions import Self
 from albumentations.augmentations.other import annotation_artifacts_functional as fannotation
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import SampledParams, TargetSet
+from albumentations.core.transform_params import SampledParams, TargetParams, TargetSet, requirements_for_views
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -298,25 +298,45 @@ class AnnotationArtifacts(ImageOnlyTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image_view = targets.primary_image_like()
-        shape = image_view.descriptor.shape
-        if shape is None:
-            raise ValueError("AnnotationArtifacts requires an image target with a known shape")
-        image_height, image_width = shape[:2]
-        num_channels = image_view.descriptor.channels or 1
-        artifacts = self._generate_artifacts(image_height, image_width, num_channels, sampling)
         record_line_length_ratio = self.line_geometry != "random_endpoints" and not (
             self.line_geometry == "random_angle" and self.line_length_range is not None
         )
-        sampling.applied_overrides.update(
-            self._get_applied_config(
-                artifacts,
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
+            lambda view: (
+                tuple((view.descriptor.spatial_shape or ())[-2:]),
+                view.descriptor.channels,
+            ),
+        ):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("AnnotationArtifacts requires image-like targets with known spatial shapes")
+            image_height, image_width = spatial_shape[-2:]
+            artifacts = self._generate_artifacts(
                 image_height,
                 image_width,
-                record_line_length_ratio=record_line_length_ratio,
+                views[0].descriptor.channels or 1,
+                sampling,
             )
-        )
-        return SampledParams(params={"artifacts": artifacts})
+            if not groups:
+                sampling.applied_overrides.update(
+                    self._get_applied_config(
+                        artifacts,
+                        image_height,
+                        image_width,
+                        record_line_length_ratio=record_line_length_ratio,
+                    )
+                )
+            groups.append(
+                TargetParams(
+                    targets=tuple(view.name for view in views),
+                    params={"artifacts": artifacts},
+                    requirements=requirements_for_views(views, spatial_shape_suffix=True, channels=True),
+                ),
+            )
+        if len(groups) == 1:
+            return SampledParams(params=groups[0].params)
+        return SampledParams(params={}, target_params=tuple(groups))
 
     @staticmethod
     def _get_applied_config(

--- a/albumentations/augmentations/other/annotation_artifacts.py
+++ b/albumentations/augmentations/other/annotation_artifacts.py
@@ -12,7 +12,7 @@ from typing_extensions import Self
 from albumentations.augmentations.other import annotation_artifacts_functional as fannotation
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -293,10 +293,12 @@ class AnnotationArtifacts(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        image_view = inputs.targets.primary_image_like()
+    ) -> SampledParams:
+        image_view = targets.primary_image_like()
         shape = image_view.descriptor.shape
         if shape is None:
             raise ValueError("AnnotationArtifacts requires an image target with a known shape")
@@ -314,7 +316,7 @@ class AnnotationArtifacts(ImageOnlyTransform):
                 record_line_length_ratio=record_line_length_ratio,
             )
         )
-        return TransformParameterPlan.shared_only({"artifacts": artifacts})
+        return SampledParams.shared_only({"artifacts": artifacts})
 
     @staticmethod
     def _get_applied_config(

--- a/albumentations/augmentations/other/annotation_artifacts.py
+++ b/albumentations/augmentations/other/annotation_artifacts.py
@@ -316,7 +316,7 @@ class AnnotationArtifacts(ImageOnlyTransform):
                 record_line_length_ratio=record_line_length_ratio,
             )
         )
-        return SampledParams.shared_only({"artifacts": artifacts})
+        return SampledParams(params={"artifacts": artifacts})
 
     @staticmethod
     def _get_applied_config(

--- a/albumentations/augmentations/other/annotation_artifacts.py
+++ b/albumentations/augmentations/other/annotation_artifacts.py
@@ -12,6 +12,7 @@ from typing_extensions import Self
 from albumentations.augmentations.other import annotation_artifacts_functional as fannotation
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -292,13 +293,15 @@ class AnnotationArtifacts(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        shape = params["shape"]
+    ) -> TransformParameterPlan:
+        image_view = inputs.targets.primary_image_like()
+        shape = image_view.descriptor.shape
+        if shape is None:
+            raise ValueError("AnnotationArtifacts requires an image target with a known shape")
         image_height, image_width = shape[:2]
-        num_channels = shape[2] if len(shape) > 2 else 1
+        num_channels = image_view.descriptor.channels or 1
         artifacts = self._generate_artifacts(image_height, image_width, num_channels, sampling)
         record_line_length_ratio = self.line_geometry != "random_endpoints" and not (
             self.line_geometry == "random_angle" and self.line_length_range is not None
@@ -311,7 +314,7 @@ class AnnotationArtifacts(ImageOnlyTransform):
                 record_line_length_ratio=record_line_length_ratio,
             )
         )
-        return {"artifacts": artifacts}
+        return TransformParameterPlan.shared_only({"artifacts": artifacts})
 
     @staticmethod
     def _get_applied_config(

--- a/albumentations/augmentations/pixel/channel.py
+++ b/albumentations/augmentations/pixel/channel.py
@@ -10,6 +10,12 @@ from pydantic import field_validator
 
 from albumentations.augmentations.pixel import functional as fpixel
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
@@ -123,31 +129,38 @@ class ChannelShuffle(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        shape = params["shape"]
-        num_channels = 1 if len(shape) == 2 else shape[-1]
-
-        if self.channel_order is not None:
-            if num_channels != len(self.channel_order):
-                warnings.warn(
-                    f"channel_order has {len(self.channel_order)} elements "
-                    f"but data has {num_channels} channel(s); "
-                    f"returning data unchanged.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                return {"channels_shuffled": None}
-            return {"channels_shuffled": list(self.channel_order)}
-
-        if num_channels <= 1:
-            return {"channels_shuffled": None}
-
-        ch_arr = list(range(num_channels))
-        sampling.py_random.shuffle(ch_arr)
-        return {"channels_shuffled": ch_arr}
+    ) -> TransformParameterPlan:
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(lambda view: view.descriptor.channels):
+            view = views[0]
+            num_channels = view.descriptor.channels or 1
+            if self.channel_order is not None:
+                if num_channels != len(self.channel_order):
+                    warnings.warn(
+                        f"channel_order has {len(self.channel_order)} elements "
+                        f"but data has {num_channels} channel(s); "
+                        f"returning data unchanged.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    channels_shuffled = None
+                else:
+                    channels_shuffled = list(self.channel_order)
+            elif num_channels <= 1:
+                channels_shuffled = None
+            else:
+                channels_shuffled = list(range(num_channels))
+                sampling.py_random.shuffle(channels_shuffled)
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(item.name for item in views),
+                    params={"channels_shuffled": channels_shuffled},
+                    requirements=requirements_for_views(views, channels=True),
+                ),
+            )
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
 
 class ChannelSwap(ChannelShuffle):

--- a/albumentations/augmentations/pixel/channel.py
+++ b/albumentations/augmentations/pixel/channel.py
@@ -11,9 +11,9 @@ from pydantic import field_validator
 from albumentations.augmentations.pixel import functional as fpixel
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    SampledParams,
+    TargetParams,
+    TargetSet,
     requirements_for_views,
 )
 from albumentations.core.transforms_interface import (
@@ -129,11 +129,13 @@ class ChannelShuffle(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(lambda view: view.descriptor.channels):
+    ) -> SampledParams:
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(lambda view: view.descriptor.channels):
             view = views[0]
             num_channels = view.descriptor.channels or 1
             if self.channel_order is not None:
@@ -154,13 +156,13 @@ class ChannelShuffle(ImageOnlyTransform):
                 channels_shuffled = list(range(num_channels))
                 sampling.py_random.shuffle(channels_shuffled)
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(item.name for item in views),
                     params={"channels_shuffled": channels_shuffled},
                     requirements=requirements_for_views(views, channels=True),
                 ),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
 
 class ChannelSwap(ChannelShuffle):

--- a/albumentations/augmentations/pixel/channel.py
+++ b/albumentations/augmentations/pixel/channel.py
@@ -162,7 +162,7 @@ class ChannelShuffle(ImageOnlyTransform):
                     requirements=requirements_for_views(views, channels=True),
                 ),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
 
 class ChannelSwap(ChannelShuffle):

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -1029,7 +1029,7 @@ class HEStain(ImageOnlyTransform):
             args["stain_matrix"] = args["stain_matrix"].tolist()
         return args
 
-    def _get_stain_matrix(self, img: ImageType, sampling: SamplingContext) -> np.ndarray:
+    def _get_stain_matrix(self, img: ImageType | None, sampling: SamplingContext) -> np.ndarray:
         if self.method == "preset" and self.preset is not None:
             return fpixel.STAIN_MATRICES[self.preset]
         if self.method == "random_preset":
@@ -1038,6 +1038,8 @@ class HEStain(ImageOnlyTransform):
         if self.method == "custom":
             return cast("np.ndarray", self.stain_matrix)
         # vahadane or macenko
+        if img is None:
+            raise RuntimeError("Stain extraction requires an image-like target")
         self.stain_extractor.fit(img)
         stain_matrix = self.stain_extractor.stain_matrix_target
         if stain_matrix is None:
@@ -1073,19 +1075,9 @@ class HEStain(ImageOnlyTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        # Get stain matrix
-        if "image" in data:
-            image = data["image"]
-        elif "images" in data:
-            image = data["images"][0]
-        elif "volume" in data:
-            image = data["volume"][0]
-        else:
-            raise RuntimeError("Expected image, images, or volume data for stain augmentation")
-
-        stain_matrix = self._get_stain_matrix(image, sampling)
-
-        # Generate random scaling and shift parameters for both H&E channels
+        shared_stain_matrix = (
+            self._get_stain_matrix(None, sampling) if self.method not in {"vahadane", "macenko"} else None
+        )
         scale_h = sampling.py_random.uniform(*self.intensity_scale_range)
         scale_e = sampling.py_random.uniform(*self.intensity_scale_range)
         shift_h = sampling.py_random.uniform(*self.intensity_shift_range)
@@ -1118,13 +1110,26 @@ class HEStain(ImageOnlyTransform):
             },
         )
 
-        return SampledParams(
-            params={
-                "stain_matrix": stain_matrix,
-                "scale_factors": scale_factors,
-                "shift_values": shift_values,
-            }
-        )
+        shared_params = {
+            "scale_factors": scale_factors,
+            "shift_values": shift_values,
+        }
+        if self.method not in {"vahadane", "macenko"}:
+            return SampledParams(params={**shared_params, "stain_matrix": shared_stain_matrix})
+
+        groups = []
+        for view in targets.image_like():
+            image = view.value if view.canonical_type == "image" else view.value[0]
+            groups.append(
+                TargetParams(
+                    targets=(view.name,),
+                    params={"stain_matrix": self._get_stain_matrix(image, sampling)},
+                    requirements=requirements_for_views((view,), channels=True),
+                ),
+            )
+        if not groups:
+            raise RuntimeError("Expected an image-like target for stain augmentation")
+        return SampledParams(params=shared_params, target_params=tuple(groups))
 
 
 class PhotoMetricDistort(ImageOnlyTransform):

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -34,19 +34,6 @@ from ._color_shared import (
     np,
 )
 
-
-def _rgb_shift_shape(view: Any) -> tuple[int, int, int]:
-    shape = view.descriptor.shape
-    if shape is None:
-        raise ValueError(f"RGBShift target {view.name!r} has no shape")
-    if view.canonical_type == "volume":
-        return (shape[1], shape[2], view.descriptor.channels or 1)
-    spatial_shape = view.descriptor.spatial_shape
-    if spatial_shape is None:
-        raise ValueError(f"RGBShift target {view.name!r} has no spatial shape")
-    return (*spatial_shape[-2:], view.descriptor.channels or 1)
-
-
 ColorRange = tuple[tuple[int, int, int], tuple[int, int, int]]
 
 
@@ -745,19 +732,19 @@ class RGBShift(AdditiveNoise):
         groups: list[TargetParams] = []
         for views in targets.group_image_like_by(
             lambda view: (
-                _rgb_shift_shape(view),
-                view.descriptor.dtype_scale,
-                "image_2d",
+                view.descriptor.channels,
+                view.descriptor.value_scale,
             ),
         ):
             view = views[0]
-            shape = _rgb_shift_shape(view)
-            sampled = self._sample_noise_map(shape, MAX_VALUES_BY_DTYPE[view.value.dtype], sampling)
+            sampled = self._sample_noise_map(
+                (view.descriptor.channels or 1,),
+                MAX_VALUES_BY_DTYPE[view.value.dtype],
+                sampling,
+            )
 
-            # spatial_mode="constant" produces a (C,) noise_map of per-channel shifts already
-            # scaled to image dtype (uint8: [-255, 255], float: [-1, 1]). Record them as sampled scalars.
             noise_map = sampled.get("noise_map")
-            if noise_map is not None and noise_map.size >= 3:
+            if not groups and noise_map is not None and noise_map.size >= 3:
                 shifts = noise_map.reshape(-1)[:3].tolist()
                 sampling.applied_overrides["r_shift_range"] = float(shifts[0])
                 sampling.applied_overrides["g_shift_range"] = float(shifts[1])

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -6,9 +6,9 @@ from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    SampledParams,
+    TargetParams,
+    TargetSet,
     requirements_for_views,
 )
 
@@ -159,9 +159,11 @@ class ColorJitter(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         brightness = sampling.py_random.uniform(*self.brightness_range)
         contrast = sampling.py_random.uniform(*self.contrast_range)
         saturation = sampling.py_random.uniform(*self.saturation_range)
@@ -186,7 +188,7 @@ class ColorJitter(ImageOnlyTransform):
             order = [o for o in order if o not in ("brightness", "contrast")]
             order.insert(min(idx_b, idx_c), merged)
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "brightness": brightness,
                 "contrast": contrast,
@@ -323,9 +325,11 @@ class ChromaticAberration(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         primary_distortion_red = sampling.py_random.uniform(*self.primary_distortion_range)
         secondary_distortion_red = sampling.py_random.uniform(
             *self.secondary_distortion_range,
@@ -371,7 +375,7 @@ class ChromaticAberration(ImageOnlyTransform):
                 "secondary_distortion_range": (secondary_distortion_red, secondary_distortion_blue),
             },
         )
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "primary_distortion_red": primary_distortion_red,
                 "secondary_distortion_red": secondary_distortion_red,
@@ -561,9 +565,11 @@ class PlanckianJitter(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling_prob_boundary = PLANKIAN_JITTER_CONST["SAMPLING_TEMP_PROB"]
         sampling_temp_boundary = PLANKIAN_JITTER_CONST["WHITE_TEMP"]
 
@@ -618,7 +624,7 @@ class PlanckianJitter(ImageOnlyTransform):
                 ),
             },
         )
-        return TransformParameterPlan.shared_only({"temperature": int(temperature)})
+        return SampledParams.shared_only({"temperature": int(temperature)})
 
 
 class RGBShift(AdditiveNoise):
@@ -731,11 +737,13 @@ class RGBShift(AdditiveNoise):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(
+    ) -> SampledParams:
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
             lambda view: (
                 _rgb_shift_shape(view),
                 view.descriptor.dtype_scale,
@@ -756,7 +764,7 @@ class RGBShift(AdditiveNoise):
                 sampling.applied_overrides["b_shift_range"] = float(shifts[2])
 
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(item.name for item in views),
                     params=sampled,
                     requirements=requirements_for_views(
@@ -766,7 +774,7 @@ class RGBShift(AdditiveNoise):
                 ),
             )
 
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
 
 class HEStain(ImageOnlyTransform):
@@ -1070,11 +1078,12 @@ class HEStain(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         # Get stain matrix
-        data = inputs.data
         if "image" in data:
             image = data["image"]
         elif "images" in data:
@@ -1119,7 +1128,7 @@ class HEStain(ImageOnlyTransform):
             },
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "stain_matrix": stain_matrix,
                 "scale_factors": scale_factors,
@@ -1251,9 +1260,11 @@ class PhotoMetricDistort(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         brightness_factor = (
             sampling.py_random.uniform(*self.brightness_range) if sampling.py_random.random() < self.distort_p else None
         )
@@ -1280,8 +1291,8 @@ class PhotoMetricDistort(ImageOnlyTransform):
             applied["hue_range"] = hue_factor
         sampling.applied_overrides.update(applied)
 
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(lambda view: view.descriptor.channels):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(lambda view: view.descriptor.channels):
             num_channels = views[0].descriptor.channels or 1
             if sampling.py_random.random() < self.distort_p and num_channels > 1:
                 channel_permutation = list(range(num_channels))
@@ -1289,13 +1300,13 @@ class PhotoMetricDistort(ImageOnlyTransform):
             else:
                 channel_permutation = None
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(view.name for view in views),
                     params={"channel_permutation": channel_permutation},
                     requirements=requirements_for_views(views, channels=True),
                 ),
             )
-        return TransformParameterPlan(
+        return SampledParams(
             shared={
                 "brightness_factor": brightness_factor,
                 "contrast_factor": contrast_factor,

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -5,6 +5,12 @@ from typing import Annotated, Any, Literal, TypedDict, cast
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 
 from ._color_shared import (
     CV2_INTER_LINEAR,
@@ -27,6 +33,19 @@ from ._color_shared import (
     nondecreasing,
     np,
 )
+
+
+def _rgb_shift_shape(view: Any) -> tuple[int, int, int]:
+    shape = view.descriptor.shape
+    if shape is None:
+        raise ValueError(f"RGBShift target {view.name!r} has no shape")
+    if view.canonical_type == "volume":
+        return (shape[1], shape[2], view.descriptor.channels or 1)
+    spatial_shape = view.descriptor.spatial_shape
+    if spatial_shape is None:
+        raise ValueError(f"RGBShift target {view.name!r} has no spatial shape")
+    return (*spatial_shape[-2:], view.descriptor.channels or 1)
+
 
 ColorRange = tuple[tuple[int, int, int], tuple[int, int, int]]
 
@@ -140,10 +159,9 @@ class ColorJitter(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         brightness = sampling.py_random.uniform(*self.brightness_range)
         contrast = sampling.py_random.uniform(*self.contrast_range)
         saturation = sampling.py_random.uniform(*self.saturation_range)
@@ -168,13 +186,15 @@ class ColorJitter(ImageOnlyTransform):
             order = [o for o in order if o not in ("brightness", "contrast")]
             order.insert(min(idx_b, idx_c), merged)
 
-        return {
-            "brightness": brightness,
-            "contrast": contrast,
-            "saturation": saturation,
-            "hue": hue,
-            "order": order,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "brightness": brightness,
+                "contrast": contrast,
+                "saturation": saturation,
+                "hue": hue,
+                "order": order,
+            }
+        )
 
     def apply(
         self,
@@ -303,10 +323,9 @@ class ChromaticAberration(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float]:
+    ) -> TransformParameterPlan:
         primary_distortion_red = sampling.py_random.uniform(*self.primary_distortion_range)
         secondary_distortion_red = sampling.py_random.uniform(
             *self.secondary_distortion_range,
@@ -352,12 +371,14 @@ class ChromaticAberration(ImageOnlyTransform):
                 "secondary_distortion_range": (secondary_distortion_red, secondary_distortion_blue),
             },
         )
-        return {
-            "primary_distortion_red": primary_distortion_red,
-            "secondary_distortion_red": secondary_distortion_red,
-            "primary_distortion_blue": primary_distortion_blue,
-            "secondary_distortion_blue": secondary_distortion_blue,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "primary_distortion_red": primary_distortion_red,
+                "secondary_distortion_red": secondary_distortion_red,
+                "primary_distortion_blue": primary_distortion_blue,
+                "secondary_distortion_blue": secondary_distortion_blue,
+            }
+        )
 
     @staticmethod
     def _match_sign(a: float, b: float) -> float:
@@ -540,10 +561,9 @@ class PlanckianJitter(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         sampling_prob_boundary = PLANKIAN_JITTER_CONST["SAMPLING_TEMP_PROB"]
         sampling_temp_boundary = PLANKIAN_JITTER_CONST["WHITE_TEMP"]
 
@@ -598,7 +618,7 @@ class PlanckianJitter(ImageOnlyTransform):
                 ),
             },
         )
-        return {"temperature": int(temperature)}
+        return TransformParameterPlan.shared_only({"temperature": int(temperature)})
 
 
 class RGBShift(AdditiveNoise):
@@ -711,29 +731,42 @@ class RGBShift(AdditiveNoise):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        metadata = self.get_image_data(data)
-        result = self._sample_noise_map(
-            (metadata["height"], metadata["width"], metadata["num_channels"]),
-            MAX_VALUES_BY_DTYPE[metadata["dtype"]],
-            sampling,
-        )
-        if "volume" in data:
-            result["volume_noise_map"] = result["noise_map"]
+    ) -> TransformParameterPlan:
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: (
+                _rgb_shift_shape(view),
+                view.descriptor.dtype_scale,
+                "image_2d",
+            ),
+        ):
+            view = views[0]
+            shape = _rgb_shift_shape(view)
+            sampled = self._sample_noise_map(shape, MAX_VALUES_BY_DTYPE[view.value.dtype], sampling)
 
-        # spatial_mode="constant" produces a (C,) noise_map of per-channel shifts already
-        # scaled to image dtype (uint8: [-255, 255], float: [-1, 1]). Record them as sampled scalars.
-        noise_map = result.get("noise_map")
-        if noise_map is not None and noise_map.size >= 3:
-            shifts = noise_map.reshape(-1)[:3].tolist()
-            sampling.applied_overrides["r_shift_range"] = float(shifts[0])
-            sampling.applied_overrides["g_shift_range"] = float(shifts[1])
-            sampling.applied_overrides["b_shift_range"] = float(shifts[2])
+            # spatial_mode="constant" produces a (C,) noise_map of per-channel shifts already
+            # scaled to image dtype (uint8: [-255, 255], float: [-1, 1]). Record them as sampled scalars.
+            noise_map = sampled.get("noise_map")
+            if noise_map is not None and noise_map.size >= 3:
+                shifts = noise_map.reshape(-1)[:3].tolist()
+                sampling.applied_overrides["r_shift_range"] = float(shifts[0])
+                sampling.applied_overrides["g_shift_range"] = float(shifts[1])
+                sampling.applied_overrides["b_shift_range"] = float(shifts[2])
 
-        return result
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(item.name for item in views),
+                    params=sampled,
+                    requirements=requirements_for_views(
+                        views,
+                        dtype=True,
+                    ),
+                ),
+            )
+
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
 
 class HEStain(ImageOnlyTransform):
@@ -1037,11 +1070,11 @@ class HEStain(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         # Get stain matrix
+        data = inputs.data
         if "image" in data:
             image = data["image"]
         elif "images" in data:
@@ -1086,11 +1119,13 @@ class HEStain(ImageOnlyTransform):
             },
         )
 
-        return {
-            "stain_matrix": stain_matrix,
-            "scale_factors": scale_factors,
-            "shift_values": shift_values,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "stain_matrix": stain_matrix,
+                "scale_factors": scale_factors,
+                "shift_values": shift_values,
+            }
+        )
 
 
 class PhotoMetricDistort(ImageOnlyTransform):
@@ -1216,13 +1251,9 @@ class PhotoMetricDistort(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        shape = params["shape"]
-        num_channels = 1 if len(shape) == 2 else shape[-1]
-
+    ) -> TransformParameterPlan:
         brightness_factor = (
             sampling.py_random.uniform(*self.brightness_range) if sampling.py_random.random() < self.distort_p else None
         )
@@ -1238,13 +1269,6 @@ class PhotoMetricDistort(ImageOnlyTransform):
         # contrast_before controls where contrast sits relative to sat/hue; brightness always precedes contrast
         contrast_before = sampling.py_random.random() < 0.5
 
-        if sampling.py_random.random() < self.distort_p and num_channels > 1:
-            ch_arr = list(range(num_channels))
-            sampling.py_random.shuffle(ch_arr)
-            channel_permutation: list[int] | None = ch_arr
-        else:
-            channel_permutation = None
-
         applied: dict[str, Any] = {}
         if brightness_factor is not None:
             applied["brightness_range"] = brightness_factor
@@ -1256,14 +1280,31 @@ class PhotoMetricDistort(ImageOnlyTransform):
             applied["hue_range"] = hue_factor
         sampling.applied_overrides.update(applied)
 
-        return {
-            "brightness_factor": brightness_factor,
-            "contrast_factor": contrast_factor,
-            "saturation_factor": saturation_factor,
-            "hue_factor": hue_factor,
-            "contrast_before": contrast_before,
-            "channel_permutation": channel_permutation,
-        }
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(lambda view: view.descriptor.channels):
+            num_channels = views[0].descriptor.channels or 1
+            if sampling.py_random.random() < self.distort_p and num_channels > 1:
+                channel_permutation = list(range(num_channels))
+                sampling.py_random.shuffle(channel_permutation)
+            else:
+                channel_permutation = None
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(view.name for view in views),
+                    params={"channel_permutation": channel_permutation},
+                    requirements=requirements_for_views(views, channels=True),
+                ),
+            )
+        return TransformParameterPlan(
+            shared={
+                "brightness_factor": brightness_factor,
+                "contrast_factor": contrast_factor,
+                "saturation_factor": saturation_factor,
+                "hue_factor": hue_factor,
+                "contrast_before": contrast_before,
+            },
+            groups=tuple(groups),
+        )
 
     def apply(
         self,

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -14,7 +14,6 @@ from albumentations.core.transform_params import (
 
 from ._color_shared import (
     CV2_INTER_LINEAR,
-    MAX_VALUES_BY_DTYPE,
     AdditiveNoise,
     AfterValidator,
     BaseTransformInitSchema,
@@ -737,9 +736,12 @@ class RGBShift(AdditiveNoise):
             ),
         ):
             view = views[0]
+            value_scale = view.descriptor.value_scale
+            if value_scale is None:
+                raise ValueError(f"RGBShift target {view.name!r} has an unsupported dtype")
             sampled = self._sample_noise_map(
                 (view.descriptor.channels or 1,),
-                MAX_VALUES_BY_DTYPE[view.value.dtype],
+                value_scale,
                 sampling,
             )
 
@@ -756,6 +758,7 @@ class RGBShift(AdditiveNoise):
                     params=sampled,
                     requirements=requirements_for_views(
                         views,
+                        channels=True,
                         dtype=True,
                     ),
                 ),

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -188,8 +188,8 @@ class ColorJitter(ImageOnlyTransform):
             order = [o for o in order if o not in ("brightness", "contrast")]
             order.insert(min(idx_b, idx_c), merged)
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "brightness": brightness,
                 "contrast": contrast,
                 "saturation": saturation,
@@ -375,8 +375,8 @@ class ChromaticAberration(ImageOnlyTransform):
                 "secondary_distortion_range": (secondary_distortion_red, secondary_distortion_blue),
             },
         )
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "primary_distortion_red": primary_distortion_red,
                 "secondary_distortion_red": secondary_distortion_red,
                 "primary_distortion_blue": primary_distortion_blue,
@@ -624,7 +624,7 @@ class PlanckianJitter(ImageOnlyTransform):
                 ),
             },
         )
-        return SampledParams.shared_only({"temperature": int(temperature)})
+        return SampledParams(params={"temperature": int(temperature)})
 
 
 class RGBShift(AdditiveNoise):
@@ -774,7 +774,7 @@ class RGBShift(AdditiveNoise):
                 ),
             )
 
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
 
 class HEStain(ImageOnlyTransform):
@@ -1128,8 +1128,8 @@ class HEStain(ImageOnlyTransform):
             },
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "stain_matrix": stain_matrix,
                 "scale_factors": scale_factors,
                 "shift_values": shift_values,
@@ -1307,14 +1307,14 @@ class PhotoMetricDistort(ImageOnlyTransform):
                 ),
             )
         return SampledParams(
-            shared={
+            params={
                 "brightness_factor": brightness_factor,
                 "contrast_factor": contrast_factor,
                 "saturation_factor": saturation_factor,
                 "hue_factor": hue_factor,
                 "contrast_before": contrast_before,
             },
-            groups=tuple(groups),
+            target_params=tuple(groups),
         )
 
     def apply(

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -9,6 +9,7 @@ from albumentations.core.transform_params import (
     TargetParams,
     TargetRequirement,
     TargetSet,
+    TargetView,
     requirements_for_views,
 )
 
@@ -33,6 +34,15 @@ from ._color_shared import (
     nondecreasing,
     np,
 )
+
+
+def _equalize_mask_input(view: TargetView) -> ImageType:
+    """Return the image unit Equalize will receive when it applies a target."""
+    if view.canonical_type not in {"images", "volume"}:
+        return view.value
+    if view.value.shape[0] == 0:
+        return np.empty(view.value.shape[1:], dtype=view.value.dtype)
+    return view.value[0]
 
 
 class RandomToneCurve(ImageOnlyTransform):
@@ -664,16 +674,26 @@ class Equalize(ImageOnlyTransform):
             sampling.applied_overrides.update({"mask": None, "mask_params": ()})
             return SampledParams(params={"mask": self.mask})
 
-        mask_params = {"image": data["image"]}
-        for key in self.mask_params:
-            if key not in data:
-                raise KeyError(
-                    f"Required parameter '{key}' for mask function is missing in data.",
-                )
-            mask_params[key] = data[key]
-
         sampling.applied_overrides.update({"mask": None, "mask_params": ()})
-        return SampledParams(params={"mask": self.mask(**mask_params)})
+        groups: list[TargetParams] = []
+        for view in targets.image_like():
+            mask_params = {"image": _equalize_mask_input(view)}
+            for key in self.mask_params:
+                if key not in data:
+                    raise KeyError(
+                        f"Required parameter '{key}' for mask function is missing in data.",
+                    )
+                mask_params[key] = data[key]
+            groups.append(
+                TargetParams(
+                    targets=(view.name,),
+                    params={"mask": self.mask(**mask_params)},
+                    requirements=requirements_for_views((view,), spatial_shape_suffix=True, channels=True),
+                ),
+            )
+        if len(groups) == 1:
+            return SampledParams(params=groups[0].params)
+        return SampledParams(params={}, target_params=tuple(groups))
 
     @property
     def targets_as_params(self) -> list[str]:

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -170,7 +170,7 @@ class RandomToneCurve(ImageOnlyTransform):
                     requirements=requirements_for_views(views, channels=True),
                 ),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
 
 class HueSaturationValue(ImageOnlyTransform):
@@ -287,8 +287,8 @@ class HueSaturationValue(ImageOnlyTransform):
             },
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "hue_shift": hue_shift,
                 "sat_shift": sat_shift,
                 "val_shift": val_shift,
@@ -399,7 +399,7 @@ class Solarize(ImageOnlyTransform):
 
         sampling.applied_overrides["threshold_range"] = threshold
 
-        return SampledParams.shared_only({"threshold": threshold})
+        return SampledParams(params={"threshold": threshold})
 
 
 class Posterize(ImageOnlyTransform):
@@ -517,10 +517,10 @@ class Posterize(ImageOnlyTransform):
         if isinstance(self.num_bits, list):
             num_bits_list = [sampling.py_random.randint(*i) for i in self.num_bits]
             sampling.applied_overrides["num_bits"] = num_bits_list
-            return SampledParams.shared_only({"num_bits": num_bits_list})
+            return SampledParams(params={"num_bits": num_bits_list})
         num_bits = sampling.py_random.randint(*self.num_bits)
         sampling.applied_overrides["num_bits"] = num_bits
-        return SampledParams.shared_only({"num_bits": num_bits})
+        return SampledParams(params={"num_bits": num_bits})
 
 
 class Equalize(ImageOnlyTransform):
@@ -662,7 +662,7 @@ class Equalize(ImageOnlyTransform):
     ) -> SampledParams:
         if not callable(self.mask):
             sampling.applied_overrides.update({"mask": None, "mask_params": ()})
-            return SampledParams.shared_only({"mask": self.mask})
+            return SampledParams(params={"mask": self.mask})
 
         mask_params = {"image": data["image"]}
         for key in self.mask_params:
@@ -673,7 +673,7 @@ class Equalize(ImageOnlyTransform):
             mask_params[key] = data[key]
 
         sampling.applied_overrides.update({"mask": None, "mask_params": ()})
-        return SampledParams.shared_only({"mask": self.mask(**mask_params)})
+        return SampledParams(params={"mask": self.mask(**mask_params)})
 
     @property
     def targets_as_params(self) -> list[str]:
@@ -848,8 +848,8 @@ class RandomBrightnessContrast(ImageOnlyTransform):
             },
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "alpha": alpha,
                 "beta": beta,
             }
@@ -993,7 +993,7 @@ class ExposureMatching(ImageOnlyTransform):
         if not groups:
             raise RuntimeError("Expected image, images, or volume data for exposure matching")
 
-        return SampledParams(shared={"target_mean": target_mean}, groups=tuple(groups))
+        return SampledParams(params={"target_mean": target_mean}, target_params=tuple(groups))
 
 
 class CLAHE(ImageOnlyTransform):
@@ -1084,7 +1084,7 @@ class CLAHE(ImageOnlyTransform):
 
         sampling.applied_overrides["clip_range"] = clip_limit
 
-        return SampledParams.shared_only({"clip_limit": clip_limit})
+        return SampledParams(params={"clip_limit": clip_limit})
 
 
 class RandomGamma(ImageOnlyTransform):
@@ -1189,8 +1189,8 @@ class RandomGamma(ImageOnlyTransform):
 
         sampling.applied_overrides["gamma_range"] = gamma
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "gamma": gamma / 100.0,
             }
         )

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -7,7 +7,6 @@ from albumentations.core.invocation import SamplingContext
 from albumentations.core.transform_params import (
     SampledParams,
     TargetParams,
-    TargetRequirement,
     TargetSet,
     TargetView,
     requirements_for_views,
@@ -1007,7 +1006,10 @@ class ExposureMatching(ImageOnlyTransform):
                 TargetParams(
                     targets=(view.name,),
                     params={"gain": gain},
-                    requirements={view.name: TargetRequirement()},
+                    requirements=requirements_for_views(
+                        (view,),
+                        shape=view.canonical_type in {"images", "volume"},
+                    ),
                 ),
             )
         if not groups:

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -4,6 +4,13 @@ from collections.abc import Callable, Sequence
 from typing import Annotated, Any, Literal
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TargetRequirement,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 
 from ._color_shared import (
     PAIR,
@@ -132,42 +139,36 @@ class RandomToneCurve(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        num_channels = self.get_image_data(data)["num_channels"]
-        result = {
-            "num_channels": num_channels,
-        }
-
+    ) -> TransformParameterPlan:
         sampling.applied_overrides["scale"] = self.scale
-
-        if self.per_channel and result["num_channels"] != 1:
-            result["low_y"] = np.clip(
-                sampling.random_generator.normal(
-                    loc=0.25,
-                    scale=self.scale,
-                    size=(num_channels,),
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(lambda view: view.descriptor.channels):
+            view = views[0]
+            num_channels = view.descriptor.channels or 1
+            if self.per_channel and num_channels != 1:
+                low_y: float | np.ndarray = np.clip(
+                    sampling.random_generator.normal(loc=0.25, scale=self.scale, size=(num_channels,)),
+                    0,
+                    1,
+                )
+                high_y: float | np.ndarray = np.clip(
+                    sampling.random_generator.normal(loc=0.75, scale=self.scale, size=(num_channels,)),
+                    0,
+                    1,
+                )
+            else:
+                low_y = np.clip(sampling.random_generator.normal(loc=0.25, scale=self.scale), 0, 1)
+                high_y = np.clip(sampling.random_generator.normal(loc=0.75, scale=self.scale), 0, 1)
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(target.name for target in views),
+                    params={"low_y": low_y, "high_y": high_y, "num_channels": num_channels},
+                    requirements=requirements_for_views(views, channels=True),
                 ),
-                0,
-                1,
             )
-            result["high_y"] = np.clip(
-                sampling.random_generator.normal(
-                    loc=0.75,
-                    scale=self.scale,
-                    size=(num_channels,),
-                ),
-                0,
-                1,
-            )
-            return result
-
-        low_y = np.clip(sampling.random_generator.normal(loc=0.25, scale=self.scale), 0, 1)
-        high_y = np.clip(sampling.random_generator.normal(loc=0.75, scale=self.scale), 0, 1)
-
-        return {"low_y": low_y, "high_y": high_y, "num_channels": num_channels}
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
 
 class HueSaturationValue(ImageOnlyTransform):
@@ -267,10 +268,9 @@ class HueSaturationValue(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float]:
+    ) -> TransformParameterPlan:
         hue_shift = sampling.py_random.uniform(*self.hue_shift_range)
         sat_shift = sampling.py_random.uniform(*self.sat_shift_range)
         val_shift = sampling.py_random.uniform(*self.val_shift_range)
@@ -283,11 +283,13 @@ class HueSaturationValue(ImageOnlyTransform):
             },
         )
 
-        return {
-            "hue_shift": hue_shift,
-            "sat_shift": sat_shift,
-            "val_shift": val_shift,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "hue_shift": hue_shift,
+                "sat_shift": sat_shift,
+                "val_shift": val_shift,
+            }
+        )
 
 
 class Solarize(ImageOnlyTransform):
@@ -384,15 +386,14 @@ class Solarize(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float]:
+    ) -> TransformParameterPlan:
         threshold = sampling.py_random.uniform(*self.threshold_range)
 
         sampling.applied_overrides["threshold_range"] = threshold
 
-        return {"threshold": threshold}
+        return TransformParameterPlan.shared_only({"threshold": threshold})
 
 
 class Posterize(ImageOnlyTransform):
@@ -502,17 +503,16 @@ class Posterize(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         if isinstance(self.num_bits, list):
             num_bits_list = [sampling.py_random.randint(*i) for i in self.num_bits]
             sampling.applied_overrides["num_bits"] = num_bits_list
-            return {"num_bits": num_bits_list}
+            return TransformParameterPlan.shared_only({"num_bits": num_bits_list})
         num_bits = sampling.py_random.randint(*self.num_bits)
         sampling.applied_overrides["num_bits"] = num_bits
-        return {"num_bits": num_bits}
+        return TransformParameterPlan.shared_only({"num_bits": num_bits})
 
 
 class Equalize(ImageOnlyTransform):
@@ -647,13 +647,13 @@ class Equalize(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         if not callable(self.mask):
             sampling.applied_overrides.update({"mask": None, "mask_params": ()})
-            return {"mask": self.mask}
+            return TransformParameterPlan.shared_only({"mask": self.mask})
 
         mask_params = {"image": data["image"]}
         for key in self.mask_params:
@@ -664,7 +664,7 @@ class Equalize(ImageOnlyTransform):
             mask_params[key] = data[key]
 
         sampling.applied_overrides.update({"mask": None, "mask_params": ()})
-        return {"mask": self.mask(**mask_params)}
+        return TransformParameterPlan.shared_only({"mask": self.mask(**mask_params)})
 
     @property
     def targets_as_params(self) -> list[str]:
@@ -823,10 +823,9 @@ class RandomBrightnessContrast(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float]:
+    ) -> TransformParameterPlan:
         # Sample initial values
         alpha = 1.0 + sampling.py_random.uniform(*self.contrast_range)
         beta = sampling.py_random.uniform(*self.brightness_range)
@@ -838,10 +837,12 @@ class RandomBrightnessContrast(ImageOnlyTransform):
             },
         )
 
-        return {
-            "alpha": alpha,
-            "beta": beta,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "alpha": alpha,
+                "beta": beta,
+            }
+        )
 
 
 class ExposureMatching(ImageOnlyTransform):
@@ -952,40 +953,34 @@ class ExposureMatching(ImageOnlyTransform):
         result = albucore.multiply(img, gain, inplace=False)
         return fpixel.clip(result, img.dtype, inplace=True) if img.dtype == np.float32 else result
 
-    def apply_to_images(self, images: ImageType, image_gains: list[float], **params: Any) -> ImageType:
-        return fpixel.exposure_match_batch(images, np.asarray(image_gains, dtype=np.float32))
+    def apply_to_images(self, images: ImageType, gain: float | list[float], **params: Any) -> ImageType:
+        return fpixel.exposure_match_batch(images, np.asarray(gain, dtype=np.float32))
 
-    def apply_to_volume(self, volume: VolumeType, volume_gains: list[float], **params: Any) -> VolumeType:
-        return fpixel.exposure_match_batch(volume, np.asarray(volume_gains, dtype=np.float32))
+    def apply_to_volume(self, volume: VolumeType, gain: float | list[float], **params: Any) -> VolumeType:
+        return fpixel.exposure_match_batch(volume, np.asarray(gain, dtype=np.float32))
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float | list[float]]:
+    ) -> TransformParameterPlan:
         target_mean = sampling.py_random.uniform(*self.target_mean_range)
         sampling.applied_overrides["target_mean_range"] = target_mean
-        gains: dict[str, float | list[float]] = {}
-
-        if "image" in data:
-            gains["gain"] = float(
-                fpixel.get_exposure_gains(
-                    data["image"],
-                    target_mean,
-                    self.gain_range,
+        groups: list[TargetParameterGroup] = []
+        for view in inputs.targets.image_like():
+            gain = fpixel.get_exposure_gains(view.value, target_mean, self.gain_range)
+            gain = float(gain) if view.canonical_type == "image" else np.asarray(gain).tolist()
+            groups.append(
+                TargetParameterGroup(
+                    targets=(view.name,),
+                    params={"gain": gain},
+                    requirements={view.name: TargetRequirement()},
                 ),
             )
-        if "images" in data:
-            image_gains = fpixel.get_exposure_gains(data["images"], target_mean, self.gain_range)
-            gains["image_gains"] = np.asarray(image_gains).tolist()
-        if "volume" in data:
-            volume_gains = fpixel.get_exposure_gains(data["volume"], target_mean, self.gain_range)
-            gains["volume_gains"] = np.asarray(volume_gains).tolist()
-        if not gains:
+        if not groups:
             raise RuntimeError("Expected image, images, or volume data for exposure matching")
 
-        return {"target_mean": target_mean, **gains}
+        return TransformParameterPlan(shared={"target_mean": target_mean}, groups=tuple(groups))
 
 
 class CLAHE(ImageOnlyTransform):
@@ -1067,15 +1062,14 @@ class CLAHE(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float]:
+    ) -> TransformParameterPlan:
         clip_limit = sampling.py_random.uniform(*self.clip_range)
 
         sampling.applied_overrides["clip_range"] = clip_limit
 
-        return {"clip_limit": clip_limit}
+        return TransformParameterPlan.shared_only({"clip_limit": clip_limit})
 
 
 class RandomGamma(ImageOnlyTransform):
@@ -1171,17 +1165,18 @@ class RandomGamma(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         gamma = sampling.py_random.uniform(*self.gamma_range)
 
         sampling.applied_overrides["gamma_range"] = gamma
 
-        return {
-            "gamma": gamma / 100.0,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "gamma": gamma / 100.0,
+            }
+        )
 
 
 class AutoContrast(ImageOnlyTransform):

--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -5,10 +5,10 @@ from typing import Annotated, Any, Literal
 
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
+    SampledParams,
+    TargetParams,
     TargetRequirement,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    TargetSet,
     requirements_for_views,
 )
 
@@ -139,12 +139,14 @@ class RandomToneCurve(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides["scale"] = self.scale
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(lambda view: view.descriptor.channels):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(lambda view: view.descriptor.channels):
             view = views[0]
             num_channels = view.descriptor.channels or 1
             if self.per_channel and num_channels != 1:
@@ -162,13 +164,13 @@ class RandomToneCurve(ImageOnlyTransform):
                 low_y = np.clip(sampling.random_generator.normal(loc=0.25, scale=self.scale), 0, 1)
                 high_y = np.clip(sampling.random_generator.normal(loc=0.75, scale=self.scale), 0, 1)
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(target.name for target in views),
                     params={"low_y": low_y, "high_y": high_y, "num_channels": num_channels},
                     requirements=requirements_for_views(views, channels=True),
                 ),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
 
 class HueSaturationValue(ImageOnlyTransform):
@@ -268,9 +270,11 @@ class HueSaturationValue(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         hue_shift = sampling.py_random.uniform(*self.hue_shift_range)
         sat_shift = sampling.py_random.uniform(*self.sat_shift_range)
         val_shift = sampling.py_random.uniform(*self.val_shift_range)
@@ -283,7 +287,7 @@ class HueSaturationValue(ImageOnlyTransform):
             },
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "hue_shift": hue_shift,
                 "sat_shift": sat_shift,
@@ -386,14 +390,16 @@ class Solarize(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         threshold = sampling.py_random.uniform(*self.threshold_range)
 
         sampling.applied_overrides["threshold_range"] = threshold
 
-        return TransformParameterPlan.shared_only({"threshold": threshold})
+        return SampledParams.shared_only({"threshold": threshold})
 
 
 class Posterize(ImageOnlyTransform):
@@ -503,16 +509,18 @@ class Posterize(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         if isinstance(self.num_bits, list):
             num_bits_list = [sampling.py_random.randint(*i) for i in self.num_bits]
             sampling.applied_overrides["num_bits"] = num_bits_list
-            return TransformParameterPlan.shared_only({"num_bits": num_bits_list})
+            return SampledParams.shared_only({"num_bits": num_bits_list})
         num_bits = sampling.py_random.randint(*self.num_bits)
         sampling.applied_overrides["num_bits"] = num_bits
-        return TransformParameterPlan.shared_only({"num_bits": num_bits})
+        return SampledParams.shared_only({"num_bits": num_bits})
 
 
 class Equalize(ImageOnlyTransform):
@@ -647,13 +655,14 @@ class Equalize(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         if not callable(self.mask):
             sampling.applied_overrides.update({"mask": None, "mask_params": ()})
-            return TransformParameterPlan.shared_only({"mask": self.mask})
+            return SampledParams.shared_only({"mask": self.mask})
 
         mask_params = {"image": data["image"]}
         for key in self.mask_params:
@@ -664,7 +673,7 @@ class Equalize(ImageOnlyTransform):
             mask_params[key] = data[key]
 
         sampling.applied_overrides.update({"mask": None, "mask_params": ()})
-        return TransformParameterPlan.shared_only({"mask": self.mask(**mask_params)})
+        return SampledParams.shared_only({"mask": self.mask(**mask_params)})
 
     @property
     def targets_as_params(self) -> list[str]:
@@ -823,9 +832,11 @@ class RandomBrightnessContrast(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         # Sample initial values
         alpha = 1.0 + sampling.py_random.uniform(*self.contrast_range)
         beta = sampling.py_random.uniform(*self.brightness_range)
@@ -837,7 +848,7 @@ class RandomBrightnessContrast(ImageOnlyTransform):
             },
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "alpha": alpha,
                 "beta": beta,
@@ -961,17 +972,19 @@ class ExposureMatching(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         target_mean = sampling.py_random.uniform(*self.target_mean_range)
         sampling.applied_overrides["target_mean_range"] = target_mean
-        groups: list[TargetParameterGroup] = []
-        for view in inputs.targets.image_like():
+        groups: list[TargetParams] = []
+        for view in targets.image_like():
             gain = fpixel.get_exposure_gains(view.value, target_mean, self.gain_range)
             gain = float(gain) if view.canonical_type == "image" else np.asarray(gain).tolist()
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=(view.name,),
                     params={"gain": gain},
                     requirements={view.name: TargetRequirement()},
@@ -980,7 +993,7 @@ class ExposureMatching(ImageOnlyTransform):
         if not groups:
             raise RuntimeError("Expected image, images, or volume data for exposure matching")
 
-        return TransformParameterPlan(shared={"target_mean": target_mean}, groups=tuple(groups))
+        return SampledParams(shared={"target_mean": target_mean}, groups=tuple(groups))
 
 
 class CLAHE(ImageOnlyTransform):
@@ -1062,14 +1075,16 @@ class CLAHE(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         clip_limit = sampling.py_random.uniform(*self.clip_range)
 
         sampling.applied_overrides["clip_range"] = clip_limit
 
-        return TransformParameterPlan.shared_only({"clip_limit": clip_limit})
+        return SampledParams.shared_only({"clip_limit": clip_limit})
 
 
 class RandomGamma(ImageOnlyTransform):
@@ -1165,14 +1180,16 @@ class RandomGamma(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         gamma = sampling.py_random.uniform(*self.gamma_range)
 
         sampling.applied_overrides["gamma_range"] = gamma
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "gamma": gamma / 100.0,
             }

--- a/albumentations/augmentations/pixel/color_gray.py
+++ b/albumentations/augmentations/pixel/color_gray.py
@@ -4,9 +4,9 @@ from typing import Annotated, Any, Literal, cast
 
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    SampledParams,
+    TargetParams,
+    TargetSet,
     requirements_for_views,
 )
 
@@ -409,9 +409,11 @@ class Colorize(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         black_color = self._sample_color(self.black_range, sampling)
         white_color = self._sample_color(self.white_range, sampling)
         mid_color = self._sample_color(self.mid_range, sampling) if self.mid_range is not None else None
@@ -429,7 +431,7 @@ class Colorize(ImageOnlyTransform):
         sampling.applied_overrides["mid_range"] = mid_color
         sampling.applied_overrides["mid_value_range"] = applied_mid_value
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "black_color": black_color,
                 "white_color": white_color,
@@ -616,11 +618,13 @@ class FancyPCA(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         groups = tuple(
-            TargetParameterGroup(
+            TargetParams(
                 targets=tuple(view.name for view in views),
                 params={
                     "alpha_vector": sampling.random_generator.normal(
@@ -631,9 +635,9 @@ class FancyPCA(ImageOnlyTransform):
                 },
                 requirements=requirements_for_views(views, channels=True),
             )
-            for views in inputs.targets.group_image_like_by(lambda view: view.descriptor.channels)
+            for views in targets.group_image_like_by(lambda view: view.descriptor.channels)
         )
-        return TransformParameterPlan(shared={}, groups=groups)
+        return SampledParams(shared={}, groups=groups)
 
 
 __all__ = [

--- a/albumentations/augmentations/pixel/color_gray.py
+++ b/albumentations/augmentations/pixel/color_gray.py
@@ -431,8 +431,8 @@ class Colorize(ImageOnlyTransform):
         sampling.applied_overrides["mid_range"] = mid_color
         sampling.applied_overrides["mid_value_range"] = applied_mid_value
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "black_color": black_color,
                 "white_color": white_color,
                 "mid_color": mid_color,
@@ -637,7 +637,7 @@ class FancyPCA(ImageOnlyTransform):
             )
             for views in targets.group_image_like_by(lambda view: view.descriptor.channels)
         )
-        return SampledParams(shared={}, groups=groups)
+        return SampledParams(params={}, target_params=groups)
 
 
 __all__ = [

--- a/albumentations/augmentations/pixel/color_gray.py
+++ b/albumentations/augmentations/pixel/color_gray.py
@@ -3,6 +3,12 @@
 from typing import Annotated, Any, Literal, cast
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 
 from ._color_shared import (
     NUM_RGB_CHANNELS,
@@ -403,10 +409,9 @@ class Colorize(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         black_color = self._sample_color(self.black_range, sampling)
         white_color = self._sample_color(self.white_range, sampling)
         mid_color = self._sample_color(self.mid_range, sampling) if self.mid_range is not None else None
@@ -424,12 +429,14 @@ class Colorize(ImageOnlyTransform):
         sampling.applied_overrides["mid_range"] = mid_color
         sampling.applied_overrides["mid_value_range"] = applied_mid_value
 
-        return {
-            "black_color": black_color,
-            "white_color": white_color,
-            "mid_color": mid_color,
-            "mid_value": mid_value,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "black_color": black_color,
+                "white_color": white_color,
+                "mid_color": mid_color,
+                "mid_value": mid_value,
+            }
+        )
 
     def apply(
         self,
@@ -609,17 +616,24 @@ class FancyPCA(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        shape = params["shape"]
-        # All images now have channel dimension
-        num_channels = shape[-1]
-        alpha_vector = sampling.random_generator.normal(0, self.alpha, num_channels).astype(
-            np.float32,
+    ) -> TransformParameterPlan:
+        groups = tuple(
+            TargetParameterGroup(
+                targets=tuple(view.name for view in views),
+                params={
+                    "alpha_vector": sampling.random_generator.normal(
+                        0,
+                        self.alpha,
+                        views[0].descriptor.channels or 1,
+                    ).astype(np.float32),
+                },
+                requirements=requirements_for_views(views, channels=True),
+            )
+            for views in inputs.targets.group_image_like_by(lambda view: view.descriptor.channels)
         )
-        return {"alpha_vector": alpha_vector}
+        return TransformParameterPlan(shared={}, groups=groups)
 
 
 __all__ = [

--- a/albumentations/augmentations/pixel/color_lighting.py
+++ b/albumentations/augmentations/pixel/color_lighting.py
@@ -4,9 +4,9 @@ from typing import Annotated, Any, Literal
 
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    SampledParams,
+    TargetParams,
+    TargetSet,
     requirements_for_views,
 )
 
@@ -182,9 +182,11 @@ class PlasmaBrightnessContrast(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         # Sample adjustment strengths
         brightness = sampling.py_random.uniform(*self.brightness_range)
         contrast = sampling.py_random.uniform(*self.contrast_range)
@@ -192,7 +194,7 @@ class PlasmaBrightnessContrast(ImageOnlyTransform):
         sampling.applied_overrides.update({"brightness_range": brightness, "contrast_range": contrast})
 
         groups = []
-        for views in inputs.targets.group_image_like_by(
+        for views in targets.group_image_like_by(
             lambda view: tuple((view.descriptor.spatial_shape or ())[-2:]),
         ):
             spatial_shape = views[0].descriptor.spatial_shape
@@ -206,13 +208,13 @@ class PlasmaBrightnessContrast(ImageOnlyTransform):
                 random_generator=sampling.random_generator,
             )
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(view.name for view in views),
                     params={"plasma_pattern": plasma},
                     requirements=requirements_for_views(views),
                 ),
             )
-        return TransformParameterPlan(
+        return SampledParams(
             shared={"brightness_factor": brightness, "contrast_factor": contrast},
             groups=tuple(groups),
         )
@@ -354,16 +356,18 @@ class PlasmaShadow(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         # Sample shadow intensity
         intensity = sampling.py_random.uniform(*self.shadow_intensity_range)
 
         sampling.applied_overrides["shadow_intensity_range"] = intensity
 
         groups = []
-        for views in inputs.targets.group_image_like_by(
+        for views in targets.group_image_like_by(
             lambda view: tuple((view.descriptor.spatial_shape or ())[-2:]),
         ):
             spatial_shape = views[0].descriptor.spatial_shape
@@ -377,13 +381,13 @@ class PlasmaShadow(ImageOnlyTransform):
                 random_generator=sampling.random_generator,
             )
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(view.name for view in views),
                     params={"plasma_pattern": plasma},
                     requirements=requirements_for_views(views),
                 ),
             )
-        return TransformParameterPlan(shared={"intensity": intensity}, groups=tuple(groups))
+        return SampledParams(shared={"intensity": intensity}, groups=tuple(groups))
 
     def apply(
         self,
@@ -572,9 +576,11 @@ class Illumination(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         intensity = sampling.py_random.uniform(*self.intensity_range)
 
         # Determine if brightening or darkening
@@ -600,7 +606,7 @@ class Illumination(ImageOnlyTransform):
         if self.mode == "linear":
             angle = sampling.py_random.uniform(*self.angle_range)
             sampling.applied_overrides["angle_range"] = angle
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {
                     "intensity": intensity,
                     "angle": angle,
@@ -608,7 +614,7 @@ class Illumination(ImageOnlyTransform):
             )
         if self.mode == "corner":
             corner = sampling.py_random.randint(0, 3)  # Choose random corner
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {
                     "intensity": intensity,
                     "corner": corner,
@@ -620,7 +626,7 @@ class Illumination(ImageOnlyTransform):
         sigma = sampling.py_random.uniform(*self.sigma_range)
         sampling.applied_overrides["center_range"] = (x, y)
         sampling.applied_overrides["sigma_range"] = sigma
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "intensity": intensity,
                 "center": (x, y),
@@ -731,9 +737,11 @@ class Vignetting(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         intensity = sampling.py_random.uniform(*self.intensity_range)
         center_x = sampling.py_random.uniform(*self.center_range)
         center_y = sampling.py_random.uniform(*self.center_range)
@@ -743,7 +751,7 @@ class Vignetting(ImageOnlyTransform):
                 "center_range": (min(center_x, center_y), max(center_x, center_y)),
             },
         )
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "intensity": intensity,
                 "center_x": center_x,

--- a/albumentations/augmentations/pixel/color_lighting.py
+++ b/albumentations/augmentations/pixel/color_lighting.py
@@ -3,6 +3,12 @@
 from typing import Annotated, Any, Literal
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 
 from ._color_shared import (
     AfterValidator,
@@ -176,30 +182,40 @@ class PlasmaBrightnessContrast(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        shape = params["shape"]
-
+    ) -> TransformParameterPlan:
         # Sample adjustment strengths
         brightness = sampling.py_random.uniform(*self.brightness_range)
         contrast = sampling.py_random.uniform(*self.contrast_range)
 
         sampling.applied_overrides.update({"brightness_range": brightness, "contrast_range": contrast})
 
-        plasma = _generate_resized_plasma(
-            target_shape=shape[:2],
-            plasma_size=self.plasma_size,
-            roughness=self.roughness,
-            random_generator=sampling.random_generator,
+        groups = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: tuple((view.descriptor.spatial_shape or ())[-2:]),
+        ):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("PlasmaBrightnessContrast requires image-like targets with known shapes")
+            target_shape = (spatial_shape[-2], spatial_shape[-1])
+            plasma = _generate_resized_plasma(
+                target_shape=target_shape,
+                plasma_size=self.plasma_size,
+                roughness=self.roughness,
+                random_generator=sampling.random_generator,
+            )
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(view.name for view in views),
+                    params={"plasma_pattern": plasma},
+                    requirements=requirements_for_views(views),
+                ),
+            )
+        return TransformParameterPlan(
+            shared={"brightness_factor": brightness, "contrast_factor": contrast},
+            groups=tuple(groups),
         )
-
-        return {
-            "brightness_factor": brightness,
-            "contrast_factor": contrast,
-            "plasma_pattern": plasma,
-        }
 
     def apply(
         self,
@@ -338,28 +354,36 @@ class PlasmaShadow(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        shape = params["shape"]
-
+    ) -> TransformParameterPlan:
         # Sample shadow intensity
         intensity = sampling.py_random.uniform(*self.shadow_intensity_range)
 
         sampling.applied_overrides["shadow_intensity_range"] = intensity
 
-        plasma = _generate_resized_plasma(
-            target_shape=shape[:2],
-            plasma_size=self.plasma_size,
-            roughness=self.roughness,
-            random_generator=sampling.random_generator,
-        )
-
-        return {
-            "intensity": intensity,
-            "plasma_pattern": plasma,
-        }
+        groups = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: tuple((view.descriptor.spatial_shape or ())[-2:]),
+        ):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("PlasmaShadow requires image-like targets with known shapes")
+            target_shape = (spatial_shape[-2], spatial_shape[-1])
+            plasma = _generate_resized_plasma(
+                target_shape=target_shape,
+                plasma_size=self.plasma_size,
+                roughness=self.roughness,
+                random_generator=sampling.random_generator,
+            )
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(view.name for view in views),
+                    params={"plasma_pattern": plasma},
+                    requirements=requirements_for_views(views),
+                ),
+            )
+        return TransformParameterPlan(shared={"intensity": intensity}, groups=tuple(groups))
 
     def apply(
         self,
@@ -548,10 +572,9 @@ class Illumination(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         intensity = sampling.py_random.uniform(*self.intensity_range)
 
         # Determine if brightening or darkening
@@ -577,27 +600,33 @@ class Illumination(ImageOnlyTransform):
         if self.mode == "linear":
             angle = sampling.py_random.uniform(*self.angle_range)
             sampling.applied_overrides["angle_range"] = angle
-            return {
-                "intensity": intensity,
-                "angle": angle,
-            }
+            return TransformParameterPlan.shared_only(
+                {
+                    "intensity": intensity,
+                    "angle": angle,
+                }
+            )
         if self.mode == "corner":
             corner = sampling.py_random.randint(0, 3)  # Choose random corner
-            return {
-                "intensity": intensity,
-                "corner": corner,
-            }
+            return TransformParameterPlan.shared_only(
+                {
+                    "intensity": intensity,
+                    "corner": corner,
+                }
+            )
 
         x = sampling.py_random.uniform(*self.center_range)
         y = sampling.py_random.uniform(*self.center_range)
         sigma = sampling.py_random.uniform(*self.sigma_range)
         sampling.applied_overrides["center_range"] = (x, y)
         sampling.applied_overrides["sigma_range"] = sigma
-        return {
-            "intensity": intensity,
-            "center": (x, y),
-            "sigma": sigma,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "intensity": intensity,
+                "center": (x, y),
+                "sigma": sigma,
+            }
+        )
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if self.mode == "linear":
@@ -702,10 +731,9 @@ class Vignetting(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float]:
+    ) -> TransformParameterPlan:
         intensity = sampling.py_random.uniform(*self.intensity_range)
         center_x = sampling.py_random.uniform(*self.center_range)
         center_y = sampling.py_random.uniform(*self.center_range)
@@ -715,11 +743,13 @@ class Vignetting(ImageOnlyTransform):
                 "center_range": (min(center_x, center_y), max(center_x, center_y)),
             },
         )
-        return {
-            "intensity": intensity,
-            "center_x": center_x,
-            "center_y": center_y,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "intensity": intensity,
+                "center_x": center_x,
+                "center_y": center_y,
+            }
+        )
 
 
 __all__ = [

--- a/albumentations/augmentations/pixel/color_lighting.py
+++ b/albumentations/augmentations/pixel/color_lighting.py
@@ -215,8 +215,8 @@ class PlasmaBrightnessContrast(ImageOnlyTransform):
                 ),
             )
         return SampledParams(
-            shared={"brightness_factor": brightness, "contrast_factor": contrast},
-            groups=tuple(groups),
+            params={"brightness_factor": brightness, "contrast_factor": contrast},
+            target_params=tuple(groups),
         )
 
     def apply(
@@ -387,7 +387,7 @@ class PlasmaShadow(ImageOnlyTransform):
                     requirements=requirements_for_views(views),
                 ),
             )
-        return SampledParams(shared={"intensity": intensity}, groups=tuple(groups))
+        return SampledParams(params={"intensity": intensity}, target_params=tuple(groups))
 
     def apply(
         self,
@@ -606,16 +606,16 @@ class Illumination(ImageOnlyTransform):
         if self.mode == "linear":
             angle = sampling.py_random.uniform(*self.angle_range)
             sampling.applied_overrides["angle_range"] = angle
-            return SampledParams.shared_only(
-                {
+            return SampledParams(
+                params={
                     "intensity": intensity,
                     "angle": angle,
                 }
             )
         if self.mode == "corner":
             corner = sampling.py_random.randint(0, 3)  # Choose random corner
-            return SampledParams.shared_only(
-                {
+            return SampledParams(
+                params={
                     "intensity": intensity,
                     "corner": corner,
                 }
@@ -626,8 +626,8 @@ class Illumination(ImageOnlyTransform):
         sigma = sampling.py_random.uniform(*self.sigma_range)
         sampling.applied_overrides["center_range"] = (x, y)
         sampling.applied_overrides["sigma_range"] = sigma
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "intensity": intensity,
                 "center": (x, y),
                 "sigma": sigma,
@@ -751,8 +751,8 @@ class Vignetting(ImageOnlyTransform):
                 "center_range": (min(center_x, center_y), max(center_x, center_y)),
             },
         )
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "intensity": intensity,
                 "center_x": center_x,
                 "center_y": center_y,

--- a/albumentations/augmentations/pixel/color_lighting.py
+++ b/albumentations/augmentations/pixel/color_lighting.py
@@ -211,7 +211,7 @@ class PlasmaBrightnessContrast(ImageOnlyTransform):
                 TargetParams(
                     targets=tuple(view.name for view in views),
                     params={"plasma_pattern": plasma},
-                    requirements=requirements_for_views(views),
+                    requirements=requirements_for_views(views, spatial_shape_suffix=True),
                 ),
             )
         return SampledParams(
@@ -384,7 +384,7 @@ class PlasmaShadow(ImageOnlyTransform):
                 TargetParams(
                     targets=tuple(view.name for view in views),
                     params={"plasma_pattern": plasma},
-                    requirements=requirements_for_views(views),
+                    requirements=requirements_for_views(views, spatial_shape_suffix=True),
                 ),
             )
         return SampledParams(params={"intensity": intensity}, target_params=tuple(groups))

--- a/albumentations/augmentations/pixel/compression.py
+++ b/albumentations/augmentations/pixel/compression.py
@@ -14,6 +14,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
@@ -112,20 +113,21 @@ class ImageCompression(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, int | str]:
+    ) -> TransformParameterPlan:
         image_type = ".jpg" if self.compression_type == "jpeg" else ".webp"
 
         quality = sampling.py_random.randint(*self.quality_range)
 
         sampling.applied_overrides["quality_range"] = quality
 
-        return {
-            "quality": quality,
-            "image_type": image_type,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "quality": quality,
+                "image_type": image_type,
+            }
+        )
 
 
 class InterpolationPydantic(BaseModel):
@@ -223,12 +225,11 @@ class Downscale(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         scale = sampling.py_random.uniform(*self.scale_range)
 
         sampling.applied_overrides["scale_range"] = scale
 
-        return {"scale": scale}
+        return TransformParameterPlan.shared_only({"scale": scale})

--- a/albumentations/augmentations/pixel/compression.py
+++ b/albumentations/augmentations/pixel/compression.py
@@ -14,7 +14,7 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
@@ -113,16 +113,18 @@ class ImageCompression(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         image_type = ".jpg" if self.compression_type == "jpeg" else ".webp"
 
         quality = sampling.py_random.randint(*self.quality_range)
 
         sampling.applied_overrides["quality_range"] = quality
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "quality": quality,
                 "image_type": image_type,
@@ -225,11 +227,13 @@ class Downscale(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         scale = sampling.py_random.uniform(*self.scale_range)
 
         sampling.applied_overrides["scale_range"] = scale
 
-        return TransformParameterPlan.shared_only({"scale": scale})
+        return SampledParams.shared_only({"scale": scale})

--- a/albumentations/augmentations/pixel/compression.py
+++ b/albumentations/augmentations/pixel/compression.py
@@ -124,8 +124,8 @@ class ImageCompression(ImageOnlyTransform):
 
         sampling.applied_overrides["quality_range"] = quality
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "quality": quality,
                 "image_type": image_type,
             }
@@ -236,4 +236,4 @@ class Downscale(ImageOnlyTransform):
 
         sampling.applied_overrides["scale_range"] = scale
 
-        return SampledParams.shared_only({"scale": scale})
+        return SampledParams(params={"scale": scale})

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -213,7 +213,7 @@ class GaussNoise(_FullVolumeNoiseTransform):
         for views in targets.group_image_like_by(
             lambda view: (
                 _target_noise_map_shape(view),
-                view.descriptor.dtype_scale,
+                view.descriptor.value_scale,
                 _sampling_family(view),
             ),
         ):
@@ -946,7 +946,7 @@ class AdditiveNoise(ImageOnlyTransform):
         for views in targets.group_image_like_by(
             lambda view: (
                 _target_additive_shape(self, view),
-                view.descriptor.dtype_scale,
+                view.descriptor.value_scale,
                 _sampling_family(view, volume_is_3d=not self._volume_sampling_is_slice_wise),
             ),
         ):

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -236,7 +236,7 @@ class GaussNoise(_FullVolumeNoiseTransform):
                     topology=True,
                 ),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
 
 class ISONoise(_FullVolumeNoiseTransform):
@@ -370,8 +370,8 @@ class ISONoise(_FullVolumeNoiseTransform):
 
         sampling.applied_overrides.update({"color_shift_range": color_shift, "intensity_range": intensity})
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "color_shift": color_shift,
                 "intensity": intensity,
                 "random_seed": random_seed,
@@ -502,7 +502,7 @@ class MultiplicativeNoise(ImageOnlyTransform):
                         channels=True,
                     ),
                 )
-            return SampledParams(shared={}, groups=tuple(groups))
+            return SampledParams(params={}, target_params=tuple(groups))
 
         for compatible_views in targets.group_image_like_by(
             lambda view: (_target_noise_map_shape(view), _sampling_family(view)),
@@ -518,7 +518,7 @@ class MultiplicativeNoise(ImageOnlyTransform):
                     topology=True,
                 ),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
     def _sample_multiplier(
         self,
@@ -640,8 +640,8 @@ class ShotNoise(_FullVolumeNoiseTransform):
     ) -> SampledParams:
         scale = sampling.py_random.uniform(*self.scale_range)
         sampling.applied_overrides["scale_range"] = scale
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "scale": scale,
                 "random_seed": sampling.random_generator.integers(0, 2**32 - 1),
             }
@@ -978,7 +978,7 @@ class AdditiveNoise(ImageOnlyTransform):
                     ),
                 ),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
     def _sample_noise_map(
         self,
@@ -1180,7 +1180,7 @@ class SaltAndPepper(_FullVolumeNoiseTransform):
                     requirements=requirements_for_views(views, shape=True, sampling_topology=True),
                 ),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
     @staticmethod
     def _sample_masks(
@@ -1345,7 +1345,7 @@ class FilmGrain(_FullVolumeNoiseTransform):
                     requirements=requirements_for_views(views, shape=True, sampling_topology=True),
                 ),
             )
-        return SampledParams(shared={"intensity": intensity}, groups=tuple(groups))
+        return SampledParams(params={"intensity": intensity}, target_params=tuple(groups))
 
     @staticmethod
     def _sample_grain(
@@ -1470,7 +1470,7 @@ class RicianNoise(_FullVolumeNoiseTransform):
         sampling.applied_overrides["std_range"] = std
         if std == 0:
             return SampledParams(
-                shared={"std": std, "real_noise": None, "imaginary_noise": None},
+                params={"std": std, "real_noise": None, "imaginary_noise": None},
             )
 
         groups: list[TargetParams] = []
@@ -1493,7 +1493,7 @@ class RicianNoise(_FullVolumeNoiseTransform):
                     requirements=requirements_for_views(views, shape=True, sampling_topology=True),
                 ),
             )
-        return SampledParams(shared={"std": std}, groups=tuple(groups))
+        return SampledParams(params={"std": std}, target_params=tuple(groups))
 
     @staticmethod
     def _sample_noise(

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -28,9 +28,9 @@ from albumentations.core.pydantic import (
     nondecreasing,
 )
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    SampledParams,
+    TargetParams,
+    TargetSet,
     requirements_for_views,
 )
 from albumentations.core.transforms_interface import (
@@ -87,8 +87,8 @@ def _target_parameter_group(
     channels: bool = False,
     dtype: bool = False,
     topology: bool = False,
-) -> TargetParameterGroup:
-    return TargetParameterGroup(
+) -> TargetParams:
+    return TargetParams(
         targets=tuple(view.name for view in views),
         params={parameter_name: value},
         requirements=requirements_for_views(
@@ -199,16 +199,18 @@ class GaussNoise(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sigma = sampling.py_random.uniform(*self.std_range)
         mean = sampling.py_random.uniform(*self.mean_range)
         sampling.applied_overrides.update({"std_range": sigma, "mean_range": mean})
         spatial_mode: Literal["per_pixel", "shared"] = "per_pixel" if self.per_channel else "shared"
         noise_params = {"mean_range": (mean, mean), "std_range": (sigma, sigma)}
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
             lambda view: (
                 _target_noise_map_shape(view),
                 view.descriptor.dtype_scale,
@@ -234,7 +236,7 @@ class GaussNoise(_FullVolumeNoiseTransform):
                     topology=True,
                 ),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
 
 class ISONoise(_FullVolumeNoiseTransform):
@@ -357,16 +359,18 @@ class ISONoise(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         random_seed = sampling.random_generator.integers(0, 2**32 - 1)
         color_shift = sampling.py_random.uniform(*self.color_shift_range)
         intensity = sampling.py_random.uniform(*self.intensity_range)
 
         sampling.applied_overrides.update({"color_shift_range": color_shift, "intensity_range": intensity})
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "color_shift": color_shift,
                 "intensity": intensity,
@@ -476,12 +480,14 @@ class MultiplicativeNoise(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        groups: list[TargetParameterGroup] = []
+    ) -> SampledParams:
+        groups: list[TargetParams] = []
         if not self.elementwise and not self.per_channel:
-            compatible_groups = inputs.targets.group_image_like_by(lambda view: view.descriptor.channels)
+            compatible_groups = targets.group_image_like_by(lambda view: view.descriptor.channels)
             for compatible_views in compatible_groups:
                 channels = compatible_views[0].descriptor.channels or 1
                 groups.append(
@@ -496,9 +502,9 @@ class MultiplicativeNoise(ImageOnlyTransform):
                         channels=True,
                     ),
                 )
-            return TransformParameterPlan(shared={}, groups=tuple(groups))
+            return SampledParams(shared={}, groups=tuple(groups))
 
-        for compatible_views in inputs.targets.group_image_like_by(
+        for compatible_views in targets.group_image_like_by(
             lambda view: (_target_noise_map_shape(view), _sampling_family(view)),
         ):
             view = compatible_views[0]
@@ -512,7 +518,7 @@ class MultiplicativeNoise(ImageOnlyTransform):
                     topology=True,
                 ),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
     def _sample_multiplier(
         self,
@@ -627,12 +633,14 @@ class ShotNoise(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         scale = sampling.py_random.uniform(*self.scale_range)
         sampling.applied_overrides["scale_range"] = scale
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "scale": scale,
                 "random_seed": sampling.random_generator.integers(0, 2**32 - 1),
@@ -939,11 +947,13 @@ class AdditiveNoise(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(
+    ) -> SampledParams:
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
             lambda view: (
                 _target_additive_shape(self, view),
                 view.descriptor.dtype_scale,
@@ -957,7 +967,7 @@ class AdditiveNoise(ImageOnlyTransform):
                 sampling,
             )
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(item.name for item in views),
                     params=sampled,
                     requirements=requirements_for_views(
@@ -968,7 +978,7 @@ class AdditiveNoise(ImageOnlyTransform):
                     ),
                 ),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
     def _sample_noise_map(
         self,
@@ -1139,14 +1149,16 @@ class SaltAndPepper(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         total_amount = sampling.py_random.uniform(*self.amount_range)
         salt_ratio = sampling.py_random.uniform(*self.salt_vs_pepper_range)
         sampling.applied_overrides.update({"amount_range": total_amount, "salt_vs_pepper_range": salt_ratio})
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
             lambda view: (
                 tuple((view.descriptor.shape or ())[:3])
                 if view.canonical_type == "volume"
@@ -1162,13 +1174,13 @@ class SaltAndPepper(_FullVolumeNoiseTransform):
             )
             salt_mask, pepper_mask = self._sample_masks(spatial_shape, total_amount, salt_ratio, sampling)
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(item.name for item in views),
                     params={"salt_mask": salt_mask, "pepper_mask": pepper_mask},
                     requirements=requirements_for_views(views, shape=True, sampling_topology=True),
                 ),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
     @staticmethod
     def _sample_masks(
@@ -1299,9 +1311,11 @@ class FilmGrain(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         intensity = sampling.py_random.uniform(*self.intensity_range)
         grain_size = (
             sampling.py_random.randint(*self.grain_size_range)
@@ -1309,8 +1323,8 @@ class FilmGrain(_FullVolumeNoiseTransform):
             else self.grain_size_range[0]
         )
         sampling.applied_overrides.update({"intensity_range": intensity, "grain_size_range": grain_size})
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
             lambda view: (
                 tuple((view.descriptor.shape or ())[:3])
                 if view.canonical_type == "volume"
@@ -1325,13 +1339,13 @@ class FilmGrain(_FullVolumeNoiseTransform):
                 else tuple(view.descriptor.spatial_shape or ())
             )
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(item.name for item in views),
                     params={"grain": self._sample_grain(spatial_shape, grain_size, sampling)},
                     requirements=requirements_for_views(views, shape=True, sampling_topology=True),
                 ),
             )
-        return TransformParameterPlan(shared={"intensity": intensity}, groups=tuple(groups))
+        return SampledParams(shared={"intensity": intensity}, groups=tuple(groups))
 
     @staticmethod
     def _sample_grain(
@@ -1447,18 +1461,20 @@ class RicianNoise(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         std = sampling.py_random.uniform(*self.std_range)
         sampling.applied_overrides["std_range"] = std
         if std == 0:
-            return TransformParameterPlan(
+            return SampledParams(
                 shared={"std": std, "real_noise": None, "imaginary_noise": None},
             )
 
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
             lambda view: (
                 _target_noise_map_shape(view),
                 self.per_channel,
@@ -1471,13 +1487,13 @@ class RicianNoise(_FullVolumeNoiseTransform):
                 noise_shape = (*noise_shape[:-1], 1)
             real_noise, imaginary_noise = self._sample_noise(noise_shape, std, sampling)
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(item.name for item in views),
                     params={"real_noise": real_noise, "imaginary_noise": imaginary_noise},
                     requirements=requirements_for_views(views, shape=True, sampling_topology=True),
                 ),
             )
-        return TransformParameterPlan(shared={"std": std}, groups=tuple(groups))
+        return SampledParams(shared={"std": std}, groups=tuple(groups))
 
     @staticmethod
     def _sample_noise(

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -9,12 +9,7 @@ from typing import Annotated, Any, ClassVar, Literal, TypeAlias, cast
 
 import cv2
 import numpy as np
-from albucore import (
-    MAX_VALUES_BY_DTYPE,
-    clip,
-    multiply,
-    resize3d,
-)
+from albucore import clip, multiply, resize3d
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.functional_validators import AfterValidator
 from typing_extensions import Self
@@ -31,6 +26,7 @@ from albumentations.core.transform_params import (
     SampledParams,
     TargetParams,
     TargetSet,
+    TargetView,
     requirements_for_views,
 )
 from albumentations.core.transforms_interface import (
@@ -75,6 +71,13 @@ def _sampling_family(view: Any, *, volume_is_3d: bool = True) -> str:
     if view.canonical_type == "volume" and volume_is_3d:
         return "volume_3d"
     return "image_2d"
+
+
+def _target_value_scale(view: TargetView) -> float:
+    value_scale = view.descriptor.value_scale
+    if value_scale is None:
+        raise ValueError(f"Noise target {view.name!r} has an unsupported dtype")
+    return value_scale
 
 
 def _target_parameter_group(
@@ -223,7 +226,7 @@ class GaussNoise(_FullVolumeNoiseTransform):
                 spatial_mode=spatial_mode,
                 shape=_target_noise_map_shape(view),
                 params=noise_params,
-                max_value=MAX_VALUES_BY_DTYPE[view.value.dtype],
+                max_value=_target_value_scale(view),
                 random_generator=sampling.random_generator,
             )
             groups.append(
@@ -953,7 +956,7 @@ class AdditiveNoise(ImageOnlyTransform):
             view = views[0]
             sampled = self._sample_noise_map(
                 _target_additive_shape(self, view),
-                MAX_VALUES_BY_DTYPE[view.value.dtype],
+                _target_value_scale(view),
                 sampling,
             )
             groups.append(

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -12,7 +12,6 @@ import numpy as np
 from albucore import (
     MAX_VALUES_BY_DTYPE,
     clip,
-    get_num_channels,
     multiply,
     resize3d,
 )
@@ -27,6 +26,12 @@ from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
+)
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
 )
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
@@ -46,16 +51,55 @@ __all__ = [
 ]
 
 
-def _get_noise_map_shape(
-    data: dict[str, Any],
-    metadata: dict[str, Any],
+def _target_noise_map_shape(view: Any) -> tuple[int, ...]:
+    descriptor = view.descriptor
+    if descriptor.canonical_type == "image":
+        return (*descriptor.spatial_shape, descriptor.channels or 1)
+    if descriptor.canonical_type == "images":
+        return (*descriptor.spatial_shape, descriptor.channels or 1)
+    if descriptor.canonical_type == "volume":
+        if descriptor.shape is None:
+            raise ValueError(f"Volume target {view.name!r} has no shape")
+        return descriptor.shape
+    raise ValueError(f"Noise transforms do not support target {view.name!r}")
+
+
+def _target_additive_shape(transform: Any, view: Any) -> tuple[int, ...]:
+    shape = _target_noise_map_shape(view)
+    if view.canonical_type == "volume" and transform._volume_sampling_is_slice_wise:  # noqa: SLF001
+        return (shape[1], shape[2], shape[3])
+    return shape
+
+
+def _sampling_family(view: Any, *, volume_is_3d: bool = True) -> str:
+    if view.canonical_type == "volume" and volume_is_3d:
+        return "volume_3d"
+    return "image_2d"
+
+
+def _target_parameter_group(
+    views: tuple[Any, ...],
+    parameter_name: str,
+    value: Any,
     *,
-    use_volume: bool,
-) -> tuple[int, ...]:
-    if use_volume:
-        volume = data["volume"]
-        return (*volume.shape[:-1], get_num_channels(volume))
-    return (metadata["height"], metadata["width"], metadata["num_channels"])
+    shape: bool = False,
+    spatial_shape: bool = False,
+    channels: bool = False,
+    dtype: bool = False,
+    topology: bool = False,
+) -> TargetParameterGroup:
+    return TargetParameterGroup(
+        targets=tuple(view.name for view in views),
+        params={parameter_name: value},
+        requirements=requirements_for_views(
+            views,
+            shape=shape,
+            spatial_shape=spatial_shape,
+            channels=channels,
+            dtype=dtype,
+            sampling_topology=topology,
+        ),
+    )
 
 
 class _FullVolumeNoiseTransform(ImageOnlyTransform):
@@ -149,48 +193,48 @@ class GaussNoise(_FullVolumeNoiseTransform):
         self,
         volume: ImageType,
         noise_map: np.ndarray,
-        volume_noise_map: np.ndarray,
         **params: Any,
     ) -> ImageType:
-        return fpixel.add_noise(volume, volume_noise_map)
+        return fpixel.add_noise(volume, noise_map)
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray]:
-        metadata = self.get_image_data(data)
+    ) -> TransformParameterPlan:
         sigma = sampling.py_random.uniform(*self.std_range)
         mean = sampling.py_random.uniform(*self.mean_range)
         sampling.applied_overrides.update({"std_range": sigma, "mean_range": mean})
         spatial_mode: Literal["per_pixel", "shared"] = "per_pixel" if self.per_channel else "shared"
         noise_params = {"mean_range": (mean, mean), "std_range": (sigma, sigma)}
-        has_image_target = "image" in data or "images" in data
-        use_volume = "volume" in data and not has_image_target
-        noise_map = fpixel.generate_spatial_noise(
-            noise_type="gaussian",
-            spatial_mode=spatial_mode,
-            shape=_get_noise_map_shape(data, metadata, use_volume=use_volume),
-            params=noise_params,
-            max_value=MAX_VALUES_BY_DTYPE[data["volume"].dtype]
-            if use_volume
-            else MAX_VALUES_BY_DTYPE[metadata["dtype"]],
-            random_generator=sampling.random_generator,
-        )
-        result = {"noise_map": noise_map}
-        if "volume" in data and has_image_target:
-            result["volume_noise_map"] = fpixel.generate_spatial_noise(
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: (
+                _target_noise_map_shape(view),
+                view.descriptor.dtype_scale,
+                _sampling_family(view),
+            ),
+        ):
+            view = views[0]
+            noise_map = fpixel.generate_spatial_noise(
                 noise_type="gaussian",
                 spatial_mode=spatial_mode,
-                shape=_get_noise_map_shape(data, metadata, use_volume=True),
+                shape=_target_noise_map_shape(view),
                 params=noise_params,
-                max_value=MAX_VALUES_BY_DTYPE[data["volume"].dtype],
+                max_value=MAX_VALUES_BY_DTYPE[view.value.dtype],
                 random_generator=sampling.random_generator,
             )
-        elif "volume" in data:
-            result["volume_noise_map"] = noise_map
-        return result
+            groups.append(
+                _target_parameter_group(
+                    views,
+                    "noise_map",
+                    noise_map,
+                    shape=True,
+                    dtype=True,
+                    topology=True,
+                ),
+            )
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
 
 class ISONoise(_FullVolumeNoiseTransform):
@@ -313,21 +357,22 @@ class ISONoise(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         random_seed = sampling.random_generator.integers(0, 2**32 - 1)
         color_shift = sampling.py_random.uniform(*self.color_shift_range)
         intensity = sampling.py_random.uniform(*self.intensity_range)
 
         sampling.applied_overrides.update({"color_shift_range": color_shift, "intensity_range": intensity})
 
-        return {
-            "color_shift": color_shift,
-            "intensity": intensity,
-            "random_seed": random_seed,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "color_shift": color_shift,
+                "intensity": intensity,
+                "random_seed": random_seed,
+            }
+        )
 
 
 class MultiplicativeNoise(ImageOnlyTransform):
@@ -425,54 +470,61 @@ class MultiplicativeNoise(ImageOnlyTransform):
         self,
         volume: ImageType,
         multiplier: float | np.ndarray,
-        volume_multiplier: np.ndarray,
         **kwargs: Any,
     ) -> ImageType:
-        return self.apply(volume, volume_multiplier, **kwargs)
+        return self.apply(volume, multiplier, **kwargs)
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        del params, sampling.applied_overrides
-        metadata = self.get_image_data(data)
-        has_image_target = "image" in data or "images" in data
-        use_volume = "volume" in data and not has_image_target
-        result = {
-            "multiplier": self._sample_multiplier(
-                _get_noise_map_shape(data, metadata, use_volume=use_volume),
-                sampling,
-                is_volume=use_volume,
-            ),
-        }
-        if "volume" in data and has_image_target and self.elementwise:
-            result["volume_multiplier"] = self._sample_multiplier(
-                _get_noise_map_shape(data, metadata, use_volume=True),
-                sampling,
-                is_volume=True,
+    ) -> TransformParameterPlan:
+        groups: list[TargetParameterGroup] = []
+        if not self.elementwise and not self.per_channel:
+            compatible_groups = inputs.targets.group_image_like_by(lambda view: view.descriptor.channels)
+            for compatible_views in compatible_groups:
+                channels = compatible_views[0].descriptor.channels or 1
+                groups.append(
+                    _target_parameter_group(
+                        compatible_views,
+                        "multiplier",
+                        sampling.random_generator.uniform(
+                            self.multiplier[0],
+                            self.multiplier[1],
+                            size=(channels,),
+                        ).astype(np.float32),
+                        channels=True,
+                    ),
+                )
+            return TransformParameterPlan(shared={}, groups=tuple(groups))
+
+        for compatible_views in inputs.targets.group_image_like_by(
+            lambda view: (_target_noise_map_shape(view), _sampling_family(view)),
+        ):
+            view = compatible_views[0]
+            groups.append(
+                _target_parameter_group(
+                    compatible_views,
+                    "multiplier",
+                    self._sample_multiplier(_target_noise_map_shape(view), sampling),
+                    shape=True,
+                    channels=self.per_channel,
+                    topology=True,
+                ),
             )
-        elif "volume" in data:
-            result["volume_multiplier"] = result["multiplier"]
-        return result
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
     def _sample_multiplier(
         self,
         image_shape: tuple[int, ...],
         sampling: SamplingContext,
-        *,
-        is_volume: bool,
     ) -> np.ndarray:
         """Generates the multiplier for the current layout without replay-policy overrides, keeping pixel execution
         independent from constructor serialization concerns.
         """
         num_channels = image_shape[-1]
 
-        if self.elementwise:
-            multiplier_shape: tuple[int, ...] = image_shape if self.per_channel else (*image_shape[:-1], 1)
-        else:
-            multiplier_shape = (num_channels,) if self.per_channel else (1,)
+        multiplier_shape = image_shape if self.elementwise else (num_channels,) if self.per_channel else (1,)
 
         multiplier = sampling.random_generator.uniform(
             self.multiplier[0],
@@ -480,15 +532,14 @@ class MultiplicativeNoise(ImageOnlyTransform):
             multiplier_shape,
         ).astype(np.float32)
 
-        if not self.per_channel and num_channels > 1 and not is_volume:
-            # Replicate the multiplier for all channels if not per_channel
-            multiplier = np.repeat(multiplier, num_channels, axis=-1)
-
         if not self.elementwise and self.per_channel:
             # Reshape to broadcast correctly when not elementwise but per_channel
             multiplier = multiplier.reshape((1,) * (len(image_shape) - 1) + (-1,))
 
-        if not is_volume and multiplier.shape != image_shape:
+        if not self.elementwise and not self.per_channel:
+            return multiplier
+
+        if not self.elementwise and multiplier.shape != image_shape:
             multiplier = multiplier.squeeze()
 
         return multiplier
@@ -576,16 +627,17 @@ class ShotNoise(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         scale = sampling.py_random.uniform(*self.scale_range)
         sampling.applied_overrides["scale_range"] = scale
-        return {
-            "scale": scale,
-            "random_seed": sampling.random_generator.integers(0, 2**32 - 1),
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "scale": scale,
+                "random_seed": sampling.random_generator.integers(0, 2**32 - 1),
+            }
+        )
 
 
 class NoiseParamsBase(BaseModel):
@@ -881,33 +933,42 @@ class AdditiveNoise(ImageOnlyTransform):
         self,
         volume: ImageType,
         noise_map: np.ndarray,
-        volume_noise_map: np.ndarray,
         **params: Any,
     ) -> ImageType:
-        return self.apply(volume, volume_noise_map, **params)
+        return self.apply(volume, noise_map, **params)
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        del params, sampling.applied_overrides
-        metadata = self.get_image_data(data)
-        has_image_target = "image" in data or "images" in data
-        use_volume = "volume" in data and not has_image_target and self.spatial_mode != "patch"
-        shape = _get_noise_map_shape(data, metadata, use_volume=use_volume)
-        max_value = MAX_VALUES_BY_DTYPE[data["volume"].dtype] if use_volume else MAX_VALUES_BY_DTYPE[metadata["dtype"]]
-        result = self._sample_noise_map(shape, max_value, sampling)
-        if "volume" in data and has_image_target and self.spatial_mode in {"per_pixel", "shared"}:
-            result["volume_noise_map"] = self._sample_noise_map(
-                _get_noise_map_shape(data, metadata, use_volume=True),
-                MAX_VALUES_BY_DTYPE[data["volume"].dtype],
+    ) -> TransformParameterPlan:
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: (
+                _target_additive_shape(self, view),
+                view.descriptor.dtype_scale,
+                _sampling_family(view, volume_is_3d=not self._volume_sampling_is_slice_wise),
+            ),
+        ):
+            view = views[0]
+            sampled = self._sample_noise_map(
+                _target_additive_shape(self, view),
+                MAX_VALUES_BY_DTYPE[view.value.dtype],
                 sampling,
-            )["noise_map"]
-        elif "volume" in data:
-            result["volume_noise_map"] = result["noise_map"]
-        return result
+            )
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(item.name for item in views),
+                    params=sampled,
+                    requirements=requirements_for_views(
+                        views,
+                        shape=True,
+                        dtype=True,
+                        sampling_topology=True,
+                    ),
+                ),
+            )
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
     def _sample_noise_map(
         self,
@@ -1078,40 +1139,36 @@ class SaltAndPepper(_FullVolumeNoiseTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        metadata = self.get_image_data(data)
+    ) -> TransformParameterPlan:
         total_amount = sampling.py_random.uniform(*self.amount_range)
         salt_ratio = sampling.py_random.uniform(*self.salt_vs_pepper_range)
         sampling.applied_overrides.update({"amount_range": total_amount, "salt_vs_pepper_range": salt_ratio})
-        has_image_target = "image" in data or "images" in data
-        use_volume = "volume" in data and not has_image_target
-        spatial_shape = tuple(data["volume"].shape[:-1]) if use_volume else (metadata["height"], metadata["width"])
-        salt_mask, pepper_mask = self._sample_masks(spatial_shape, total_amount, salt_ratio, sampling)
-        result = {"salt_mask": salt_mask, "pepper_mask": pepper_mask}
-        if "volume" in data and has_image_target:
-            volume_salt_mask, volume_pepper_mask = self._sample_masks(
-                tuple(data["volume"].shape[:-1]),
-                total_amount,
-                salt_ratio,
-                sampling,
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: (
+                tuple((view.descriptor.shape or ())[:3])
+                if view.canonical_type == "volume"
+                else tuple(view.descriptor.spatial_shape or ()),
+                _sampling_family(view),
+            ),
+        ):
+            view = views[0]
+            spatial_shape = (
+                tuple(view.descriptor.shape[:-1])
+                if view.canonical_type == "volume" and view.descriptor.shape is not None
+                else tuple(view.descriptor.spatial_shape or ())
             )
-            result.update(
-                {
-                    "volume_salt_mask": volume_salt_mask,
-                    "volume_pepper_mask": volume_pepper_mask,
-                },
+            salt_mask, pepper_mask = self._sample_masks(spatial_shape, total_amount, salt_ratio, sampling)
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(item.name for item in views),
+                    params={"salt_mask": salt_mask, "pepper_mask": pepper_mask},
+                    requirements=requirements_for_views(views, shape=True, sampling_topology=True),
+                ),
             )
-        elif "volume" in data:
-            result.update(
-                {
-                    "volume_salt_mask": salt_mask,
-                    "volume_pepper_mask": pepper_mask,
-                },
-            )
-        return result
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
     @staticmethod
     def _sample_masks(
@@ -1147,16 +1204,9 @@ class SaltAndPepper(_FullVolumeNoiseTransform):
         volume: ImageType,
         salt_mask: np.ndarray,
         pepper_mask: np.ndarray,
-        volume_salt_mask: np.ndarray,
-        volume_pepper_mask: np.ndarray,
         **params: Any,
     ) -> ImageType:
-        return self.apply(
-            volume,
-            volume_salt_mask,
-            volume_pepper_mask,
-            **params,
-        )
+        return self.apply(volume, salt_mask, pepper_mask, **params)
 
 
 class FilmGrain(_FullVolumeNoiseTransform):
@@ -1243,17 +1293,15 @@ class FilmGrain(_FullVolumeNoiseTransform):
         volume: ImageType,
         grain: np.ndarray,
         intensity: float,
-        volume_grain: np.ndarray,
         **params: Any,
     ) -> ImageType:
-        return self.apply(volume, volume_grain, intensity, **params)
+        return self.apply(volume, grain, intensity, **params)
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         intensity = sampling.py_random.uniform(*self.intensity_range)
         grain_size = (
             sampling.py_random.randint(*self.grain_size_range)
@@ -1261,22 +1309,29 @@ class FilmGrain(_FullVolumeNoiseTransform):
             else self.grain_size_range[0]
         )
         sampling.applied_overrides.update({"intensity_range": intensity, "grain_size_range": grain_size})
-        metadata = self.get_image_data(data)
-        has_image_target = "image" in data or "images" in data
-        spatial_shape = (
-            tuple(data["volume"].shape[:3])
-            if "volume" in data and not has_image_target
-            else (
-                metadata["height"],
-                metadata["width"],
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: (
+                tuple((view.descriptor.shape or ())[:3])
+                if view.canonical_type == "volume"
+                else tuple(view.descriptor.spatial_shape or ()),
+                _sampling_family(view),
+            ),
+        ):
+            view = views[0]
+            spatial_shape = (
+                tuple(view.descriptor.shape[:3])
+                if view.canonical_type == "volume" and view.descriptor.shape is not None
+                else tuple(view.descriptor.spatial_shape or ())
             )
-        )
-        result = {"grain": self._sample_grain(spatial_shape, grain_size, sampling), "intensity": intensity}
-        if "volume" in data and has_image_target:
-            result["volume_grain"] = self._sample_grain(tuple(data["volume"].shape[:3]), grain_size, sampling)
-        elif "volume" in data:
-            result["volume_grain"] = result["grain"]
-        return result
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(item.name for item in views),
+                    params={"grain": self._sample_grain(spatial_shape, grain_size, sampling)},
+                    requirements=requirements_for_views(views, shape=True, sampling_topology=True),
+                ),
+            )
+        return TransformParameterPlan(shared={"intensity": intensity}, groups=tuple(groups))
 
     @staticmethod
     def _sample_grain(
@@ -1384,70 +1439,45 @@ class RicianNoise(_FullVolumeNoiseTransform):
         self,
         volume: ImageType,
         std: float,
-        volume_real_noise: np.ndarray | None,
-        volume_imaginary_noise: np.ndarray | None,
+        real_noise: np.ndarray | None,
+        imaginary_noise: np.ndarray | None,
         **params: Any,
     ) -> ImageType:
-        return self.apply(volume, std, volume_real_noise, volume_imaginary_noise)
+        return self.apply(volume, std, real_noise, imaginary_noise)
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        del params
-        metadata = self.get_image_data(data)
+    ) -> TransformParameterPlan:
         std = sampling.py_random.uniform(*self.std_range)
         sampling.applied_overrides["std_range"] = std
         if std == 0:
-            zero_params: dict[str, Any] = {"std": std, "real_noise": None, "imaginary_noise": None}
-            if "volume" in data:
-                zero_params.update({"volume_real_noise": None, "volume_imaginary_noise": None})
-            return zero_params
+            return TransformParameterPlan(
+                shared={"std": std, "real_noise": None, "imaginary_noise": None},
+            )
 
-        has_image_target = "image" in data or "images" in data
-        use_volume = "volume" in data and not has_image_target
-        real_noise, imaginary_noise = self._sample_noise(
-            self._noise_shape(data, metadata, use_volume=use_volume),
-            std,
-            sampling,
-        )
-        result: dict[str, Any] = {
-            "std": std,
-            "real_noise": real_noise,
-            "imaginary_noise": imaginary_noise,
-        }
-        if "volume" in data and has_image_target:
-            volume_real_noise, volume_imaginary_noise = self._sample_noise(
-                self._noise_shape(data, metadata, use_volume=True),
-                std,
-                sampling,
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: (
+                _target_noise_map_shape(view),
+                self.per_channel,
+                _sampling_family(view),
+            ),
+        ):
+            view = views[0]
+            noise_shape = _target_noise_map_shape(view)
+            if not self.per_channel:
+                noise_shape = (*noise_shape[:-1], 1)
+            real_noise, imaginary_noise = self._sample_noise(noise_shape, std, sampling)
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(item.name for item in views),
+                    params={"real_noise": real_noise, "imaginary_noise": imaginary_noise},
+                    requirements=requirements_for_views(views, shape=True, sampling_topology=True),
+                ),
             )
-            result.update(
-                {
-                    "volume_real_noise": volume_real_noise,
-                    "volume_imaginary_noise": volume_imaginary_noise,
-                },
-            )
-        elif "volume" in data:
-            result.update(
-                {
-                    "volume_real_noise": real_noise,
-                    "volume_imaginary_noise": imaginary_noise,
-                },
-            )
-        return result
-
-    def _noise_shape(
-        self,
-        data: dict[str, Any],
-        metadata: dict[str, Any],
-        *,
-        use_volume: bool,
-    ) -> tuple[int, ...]:
-        shape = _get_noise_map_shape(data, metadata, use_volume=use_volume)
-        return shape if self.per_channel else (*shape[:-1], 1)
+        return TransformParameterPlan(shared={"std": std}, groups=tuple(groups))
 
     @staticmethod
     def _sample_noise(

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -485,10 +485,13 @@ class MultiplicativeNoise(ImageOnlyTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        groups: list[TargetParams] = []
         if not self.elementwise and not self.per_channel:
-            compatible_groups = targets.group_image_like_by(lambda view: view.descriptor.channels)
-            for compatible_views in compatible_groups:
+            multiplier = sampling.random_generator.uniform(self.multiplier[0], self.multiplier[1])
+            return SampledParams(params={"multiplier": multiplier})
+
+        groups: list[TargetParams] = []
+        if not self.elementwise:
+            for compatible_views in targets.group_image_like_by(lambda view: view.descriptor.channels):
                 channels = compatible_views[0].descriptor.channels or 1
                 groups.append(
                     _target_parameter_group(
@@ -505,7 +508,7 @@ class MultiplicativeNoise(ImageOnlyTransform):
             return SampledParams(params={}, target_params=tuple(groups))
 
         for compatible_views in targets.group_image_like_by(
-            lambda view: (_target_noise_map_shape(view), _sampling_family(view)),
+            lambda view: (self._multiplier_shape(_target_noise_map_shape(view)), _sampling_family(view)),
         ):
             view = compatible_views[0]
             groups.append(
@@ -513,7 +516,7 @@ class MultiplicativeNoise(ImageOnlyTransform):
                     compatible_views,
                     "multiplier",
                     self._sample_multiplier(_target_noise_map_shape(view), sampling),
-                    shape=True,
+                    spatial_shape=True,
                     channels=self.per_channel,
                     topology=True,
                 ),
@@ -522,33 +525,20 @@ class MultiplicativeNoise(ImageOnlyTransform):
 
     def _sample_multiplier(
         self,
-        image_shape: tuple[int, ...],
+        target_shape: tuple[int, ...],
         sampling: SamplingContext,
     ) -> np.ndarray:
         """Generates the multiplier for the current layout without replay-policy overrides, keeping pixel execution
         independent from constructor serialization concerns.
         """
-        num_channels = image_shape[-1]
-
-        multiplier_shape = image_shape if self.elementwise else (num_channels,) if self.per_channel else (1,)
-
-        multiplier = sampling.random_generator.uniform(
+        return sampling.random_generator.uniform(
             self.multiplier[0],
             self.multiplier[1],
-            multiplier_shape,
+            self._multiplier_shape(target_shape),
         ).astype(np.float32)
 
-        if not self.elementwise and self.per_channel:
-            # Reshape to broadcast correctly when not elementwise but per_channel
-            multiplier = multiplier.reshape((1,) * (len(image_shape) - 1) + (-1,))
-
-        if not self.elementwise and not self.per_channel:
-            return multiplier
-
-        if not self.elementwise and multiplier.shape != image_shape:
-            multiplier = multiplier.squeeze()
-
-        return multiplier
+    def _multiplier_shape(self, target_shape: tuple[int, ...]) -> tuple[int, ...]:
+        return target_shape if self.per_channel else (*target_shape[:-1], 1)
 
 
 class ShotNoise(_FullVolumeNoiseTransform):

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -29,6 +29,12 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
@@ -432,25 +438,26 @@ class Sharpen(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         alpha = sampling.py_random.uniform(*self.alpha_range)
 
         if self.method == "kernel":
             lightness = sampling.py_random.uniform(*self.lightness_range)
             sampling.applied_overrides.update({"alpha_range": alpha, "lightness_range": lightness})
-            return {
-                "alpha": alpha,
-                "sharpening_matrix": self.__generate_sharpening_matrix(
-                    alpha,
-                    lightness,
-                ),
-            }
+            return TransformParameterPlan.shared_only(
+                {
+                    "alpha": alpha,
+                    "sharpening_matrix": self.__generate_sharpening_matrix(
+                        alpha,
+                        lightness,
+                    ),
+                }
+            )
 
         sampling.applied_overrides["alpha_range"] = alpha
-        return {"alpha": alpha, "sharpening_matrix": None}
+        return TransformParameterPlan.shared_only({"alpha": alpha, "sharpening_matrix": None})
 
     def apply(
         self,
@@ -555,10 +562,9 @@ class Emboss(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray]:
+    ) -> TransformParameterPlan:
         alpha = sampling.py_random.uniform(*self.alpha_range)
         strength = sampling.py_random.uniform(*self.strength_range)
         emboss_matrix = self.__generate_emboss_matrix(
@@ -566,7 +572,7 @@ class Emboss(ImageOnlyTransform):
             strength_sample=strength,
         )
         sampling.applied_overrides.update({"alpha_range": alpha, "strength_range": strength})
-        return {"emboss_matrix": emboss_matrix}
+        return TransformParameterPlan.shared_only({"emboss_matrix": emboss_matrix})
 
     def apply(
         self,
@@ -672,15 +678,14 @@ class Enhance(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         alpha = sampling.py_random.uniform(*self.alpha_range)
         # Record the resolved scalar (not the range) for replay/debug, per the
         # applied record contract documented on get_applied_config.
         sampling.applied_overrides["alpha_range"] = alpha
-        return {"enhance_matrix": fpixel.generate_enhance_matrix(self.mode, alpha)}
+        return TransformParameterPlan.shared_only({"enhance_matrix": fpixel.generate_enhance_matrix(self.mode, alpha)})
 
     def apply(
         self,
@@ -814,17 +819,18 @@ class Superpixels(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         n_segments = sampling.py_random.randint(*self.n_segments_range)
         p = sampling.py_random.uniform(*self.p_replace_range)
         sampling.applied_overrides.update({"n_segments_range": n_segments, "p_replace_range": p})
-        return {
-            "replace_samples": sampling.random_generator.random(n_segments) < p,
-            "n_segments": n_segments,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "replace_samples": sampling.random_generator.random(n_segments) < p,
+                "n_segments": n_segments,
+            }
+        )
 
     def apply(
         self,
@@ -943,10 +949,9 @@ class RingingOvershoot(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray]:
+    ) -> TransformParameterPlan:
         ksize = sampling.py_random.randrange(self.blur_range[0], self.blur_range[1] + 1, 2)
         if ksize % 2 == 0:
             ksize += 1
@@ -971,7 +976,7 @@ class RingingOvershoot(ImageOnlyTransform):
         kernel = kernel.astype(np.float32) / reduce_sum(kernel)
 
         sampling.applied_overrides.update({"blur_range": ksize, "cutoff_range": cutoff})
-        return {"kernel": kernel}
+        return TransformParameterPlan.shared_only({"kernel": kernel})
 
     def apply(self, img: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
         return fpixel.convolve(img, kernel)
@@ -1080,15 +1085,14 @@ class UnsharpMask(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         ksize = sampling.py_random.randrange(self.blur_range[0], self.blur_range[1] + 1, 2)
         sigma = sampling.py_random.uniform(*self.sigma_range)
         alpha = sampling.py_random.uniform(*self.alpha_range)
         sampling.applied_overrides.update({"blur_range": ksize, "sigma_range": sigma, "alpha_range": alpha})
-        return {"ksize": ksize, "sigma": sigma, "alpha": alpha}
+        return TransformParameterPlan.shared_only({"ksize": ksize, "sigma": sigma, "alpha": alpha})
 
     def apply(
         self,
@@ -1323,29 +1327,46 @@ class Dithering(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         sampling.applied_overrides["noise_range"] = self.noise_range
         if self.method != "random":
-            return {"random_noise": None}
-
-        height, width = params["shape"][:2]
-        channels = params["shape"][2] if len(params["shape"]) > 2 else 1
-        per_item_noise_shape = (height, width, 1) if self.color_mode == "grayscale" else (height, width, channels)
-        item_count = len(data["images"]) if "images" in data else len(data["volume"]) if "volume" in data else 1
-        noise_shape = per_item_noise_shape if item_count == 1 else (item_count, *per_item_noise_shape)
-        dtype = self.get_image_data(data)["dtype"]
-        if dtype == np.uint8:
-            random_noise = sampling.random_generator.uniform(
-                self.noise_range[0] * 255,
-                self.noise_range[1] * 255,
-                size=noise_shape,
-            ).astype(np.int16)
-        else:
-            random_noise = sampling.random_generator.uniform(*self.noise_range, size=noise_shape)
-        return {"random_noise": random_noise}
+            return TransformParameterPlan.shared_only({"random_noise": None})
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: (
+                view.descriptor.shape,
+                view.descriptor.dtype_scale,
+                view.descriptor.sampling_topology,
+            ),
+        ):
+            view = views[0]
+            shape = view.descriptor.shape
+            spatial_shape = view.descriptor.spatial_shape
+            if shape is None or spatial_shape is None:
+                raise ValueError("Dithering requires image-like targets with known shapes")
+            height, width = spatial_shape[-2:]
+            channels = view.descriptor.channels or 1
+            per_item_noise_shape = (height, width, 1) if self.color_mode == "grayscale" else (height, width, channels)
+            item_count = shape[0] if view.canonical_type in {"images", "volume"} else 1
+            noise_shape = per_item_noise_shape if item_count == 1 else (item_count, *per_item_noise_shape)
+            if view.descriptor.dtype == np.uint8:
+                random_noise = sampling.random_generator.uniform(
+                    self.noise_range[0] * 255,
+                    self.noise_range[1] * 255,
+                    size=noise_shape,
+                ).astype(np.int16)
+            else:
+                random_noise = sampling.random_generator.uniform(*self.noise_range, size=noise_shape)
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(target.name for target in views),
+                    params={"random_noise": random_noise},
+                    requirements=requirements_for_views(views, shape=True, dtype=True, sampling_topology=True),
+                ),
+            )
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
     def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
         random_noise = params.pop("random_noise", None)
@@ -1439,17 +1460,18 @@ class Halftone(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         dot_size = sampling.py_random.randint(*self.dot_size_range)
         blend = sampling.py_random.uniform(*self.blend_range)
         sampling.applied_overrides.update({"dot_size_range": dot_size, "blend_range": blend})
-        return {
-            "dot_size": dot_size,
-            "blend": blend,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "dot_size": dot_size,
+                "blend": blend,
+            }
+        )
 
 
 class LensFlare(ImageOnlyTransform):
@@ -1584,56 +1606,62 @@ class LensFlare(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        height, width = params["shape"][:2]
+    ) -> TransformParameterPlan:
         x_min, y_min, x_max, y_max = self.flare_roi
-
-        fx_lo = min(int(x_min * width), width - 1)
-        fx_hi = min(int(x_max * width), width - 1)
-        fx = sampling.py_random.randint(fx_lo, max(fx_lo, fx_hi))
-        fy_lo = min(int(y_min * height), height - 1)
-        fy_hi = min(int(y_max * height), height - 1)
-        fy = sampling.py_random.randint(fy_lo, max(fy_lo, fy_hi))
-
         intensity = sampling.py_random.uniform(*self.intensity_range)
-        num_rays = sampling.py_random.randint(*self.num_rays_range)
-        num_ghosts = sampling.py_random.randint(*self.num_ghosts_range)
-
-        base_angle = sampling.py_random.uniform(0, math.pi / num_rays) if num_rays > 0 else 0
-        starburst_angles = np.array(
-            [base_angle + i * math.pi / num_rays for i in range(num_rays * 2)],
-            dtype=np.float32,
-        )
-
-        cx, cy = width // 2, height // 2
-        ghosts = []
-        for i in range(num_ghosts):
-            t = (i + 1) / (num_ghosts + 1)
-            gx = int(fx + (cx - fx) * 2 * t)
-            gy = int(fy + (cy - fy) * 2 * t)
-            gradius = max(2, int(min(height, width) * 0.02 * (1.0 - t * 0.5)))
-            galpha = intensity * (1.0 - t * 0.6)
-            ghosts.append((gx, gy, gradius, galpha))
-
-        diag = math.sqrt(height**2 + width**2)
-        bloom_frac = sampling.py_random.uniform(*self.bloom_range)
-        bloom_radius = max(1, int(diag * bloom_frac)) | 1
-
         sampling.applied_overrides.update(
             {
                 "intensity_range": intensity,
-                "num_rays_range": num_rays,
-                "num_ghosts_range": num_ghosts,
-                "bloom_range": bloom_frac,
+                "num_rays_range": self.num_rays_range,
+                "num_ghosts_range": self.num_ghosts_range,
+                "bloom_range": self.bloom_range,
             },
         )
-        return {
-            "flare_center": (fx, fy),
-            "ghosts": ghosts,
-            "starburst_angles": starburst_angles,
-            "starburst_intensity": intensity,
-            "bloom_radius": bloom_radius,
-        }
+        groups = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: tuple((view.descriptor.spatial_shape or ())[-2:]),
+        ):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("LensFlare requires image-like targets with known shapes")
+            height, width = spatial_shape[-2:]
+            fx_lo = min(int(x_min * width), width - 1)
+            fx_hi = min(int(x_max * width), width - 1)
+            fx = sampling.py_random.randint(fx_lo, max(fx_lo, fx_hi))
+            fy_lo = min(int(y_min * height), height - 1)
+            fy_hi = min(int(y_max * height), height - 1)
+            fy = sampling.py_random.randint(fy_lo, max(fy_lo, fy_hi))
+            num_rays = sampling.py_random.randint(*self.num_rays_range)
+            num_ghosts = sampling.py_random.randint(*self.num_ghosts_range)
+            base_angle = sampling.py_random.uniform(0, math.pi / num_rays) if num_rays > 0 else 0
+            starburst_angles = np.array(
+                [base_angle + i * math.pi / num_rays for i in range(num_rays * 2)],
+                dtype=np.float32,
+            )
+            cx, cy = width // 2, height // 2
+            ghosts = []
+            for i in range(num_ghosts):
+                t = (i + 1) / (num_ghosts + 1)
+                gx = int(fx + (cx - fx) * 2 * t)
+                gy = int(fy + (cy - fy) * 2 * t)
+                gradius = max(2, int(min(height, width) * 0.02 * (1.0 - t * 0.5)))
+                galpha = intensity * (1.0 - t * 0.6)
+                ghosts.append((gx, gy, gradius, galpha))
+            diag = math.sqrt(height**2 + width**2)
+            bloom_frac = sampling.py_random.uniform(*self.bloom_range)
+            bloom_radius = max(1, int(diag * bloom_frac)) | 1
+            groups.append(
+                TargetParameterGroup(
+                    targets=tuple(view.name for view in views),
+                    params={
+                        "flare_center": (fx, fy),
+                        "ghosts": ghosts,
+                        "starburst_angles": starburst_angles,
+                        "bloom_radius": bloom_radius,
+                    },
+                    requirements=requirements_for_views(views),
+                ),
+            )
+        return TransformParameterPlan(shared={"starburst_intensity": intensity}, groups=tuple(groups))

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -448,8 +448,8 @@ class Sharpen(ImageOnlyTransform):
         if self.method == "kernel":
             lightness = sampling.py_random.uniform(*self.lightness_range)
             sampling.applied_overrides.update({"alpha_range": alpha, "lightness_range": lightness})
-            return SampledParams.shared_only(
-                {
+            return SampledParams(
+                params={
                     "alpha": alpha,
                     "sharpening_matrix": self.__generate_sharpening_matrix(
                         alpha,
@@ -459,7 +459,7 @@ class Sharpen(ImageOnlyTransform):
             )
 
         sampling.applied_overrides["alpha_range"] = alpha
-        return SampledParams.shared_only({"alpha": alpha, "sharpening_matrix": None})
+        return SampledParams(params={"alpha": alpha, "sharpening_matrix": None})
 
     def apply(
         self,
@@ -576,7 +576,7 @@ class Emboss(ImageOnlyTransform):
             strength_sample=strength,
         )
         sampling.applied_overrides.update({"alpha_range": alpha, "strength_range": strength})
-        return SampledParams.shared_only({"emboss_matrix": emboss_matrix})
+        return SampledParams(params={"emboss_matrix": emboss_matrix})
 
     def apply(
         self,
@@ -691,7 +691,7 @@ class Enhance(ImageOnlyTransform):
         # Record the resolved scalar (not the range) for replay/debug, per the
         # applied record contract documented on get_applied_config.
         sampling.applied_overrides["alpha_range"] = alpha
-        return SampledParams.shared_only({"enhance_matrix": fpixel.generate_enhance_matrix(self.mode, alpha)})
+        return SampledParams(params={"enhance_matrix": fpixel.generate_enhance_matrix(self.mode, alpha)})
 
     def apply(
         self,
@@ -833,8 +833,8 @@ class Superpixels(ImageOnlyTransform):
         n_segments = sampling.py_random.randint(*self.n_segments_range)
         p = sampling.py_random.uniform(*self.p_replace_range)
         sampling.applied_overrides.update({"n_segments_range": n_segments, "p_replace_range": p})
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "replace_samples": sampling.random_generator.random(n_segments) < p,
                 "n_segments": n_segments,
             }
@@ -986,7 +986,7 @@ class RingingOvershoot(ImageOnlyTransform):
         kernel = kernel.astype(np.float32) / reduce_sum(kernel)
 
         sampling.applied_overrides.update({"blur_range": ksize, "cutoff_range": cutoff})
-        return SampledParams.shared_only({"kernel": kernel})
+        return SampledParams(params={"kernel": kernel})
 
     def apply(self, img: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
         return fpixel.convolve(img, kernel)
@@ -1104,7 +1104,7 @@ class UnsharpMask(ImageOnlyTransform):
         sigma = sampling.py_random.uniform(*self.sigma_range)
         alpha = sampling.py_random.uniform(*self.alpha_range)
         sampling.applied_overrides.update({"blur_range": ksize, "sigma_range": sigma, "alpha_range": alpha})
-        return SampledParams.shared_only({"ksize": ksize, "sigma": sigma, "alpha": alpha})
+        return SampledParams(params={"ksize": ksize, "sigma": sigma, "alpha": alpha})
 
     def apply(
         self,
@@ -1346,7 +1346,7 @@ class Dithering(ImageOnlyTransform):
     ) -> SampledParams:
         sampling.applied_overrides["noise_range"] = self.noise_range
         if self.method != "random":
-            return SampledParams.shared_only({"random_noise": None})
+            return SampledParams(params={"random_noise": None})
         groups: list[TargetParams] = []
         for views in targets.group_image_like_by(
             lambda view: (
@@ -1380,7 +1380,7 @@ class Dithering(ImageOnlyTransform):
                     requirements=requirements_for_views(views, shape=True, dtype=True, sampling_topology=True),
                 ),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
     def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
         random_noise = params.pop("random_noise", None)
@@ -1482,8 +1482,8 @@ class Halftone(ImageOnlyTransform):
         dot_size = sampling.py_random.randint(*self.dot_size_range)
         blend = sampling.py_random.uniform(*self.blend_range)
         sampling.applied_overrides.update({"dot_size_range": dot_size, "blend_range": blend})
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "dot_size": dot_size,
                 "blend": blend,
             }
@@ -1682,4 +1682,4 @@ class LensFlare(ImageOnlyTransform):
                     requirements=requirements_for_views(views),
                 ),
             )
-        return SampledParams(shared={"starburst_intensity": intensity}, groups=tuple(groups))
+        return SampledParams(params={"starburst_intensity": intensity}, target_params=tuple(groups))

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -30,9 +30,9 @@ from albumentations.core.pydantic import (
     nondecreasing,
 )
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    SampledParams,
+    TargetParams,
+    TargetSet,
     requirements_for_views,
 )
 from albumentations.core.transforms_interface import (
@@ -438,15 +438,17 @@ class Sharpen(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         alpha = sampling.py_random.uniform(*self.alpha_range)
 
         if self.method == "kernel":
             lightness = sampling.py_random.uniform(*self.lightness_range)
             sampling.applied_overrides.update({"alpha_range": alpha, "lightness_range": lightness})
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {
                     "alpha": alpha,
                     "sharpening_matrix": self.__generate_sharpening_matrix(
@@ -457,7 +459,7 @@ class Sharpen(ImageOnlyTransform):
             )
 
         sampling.applied_overrides["alpha_range"] = alpha
-        return TransformParameterPlan.shared_only({"alpha": alpha, "sharpening_matrix": None})
+        return SampledParams.shared_only({"alpha": alpha, "sharpening_matrix": None})
 
     def apply(
         self,
@@ -562,9 +564,11 @@ class Emboss(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         alpha = sampling.py_random.uniform(*self.alpha_range)
         strength = sampling.py_random.uniform(*self.strength_range)
         emboss_matrix = self.__generate_emboss_matrix(
@@ -572,7 +576,7 @@ class Emboss(ImageOnlyTransform):
             strength_sample=strength,
         )
         sampling.applied_overrides.update({"alpha_range": alpha, "strength_range": strength})
-        return TransformParameterPlan.shared_only({"emboss_matrix": emboss_matrix})
+        return SampledParams.shared_only({"emboss_matrix": emboss_matrix})
 
     def apply(
         self,
@@ -678,14 +682,16 @@ class Enhance(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         alpha = sampling.py_random.uniform(*self.alpha_range)
         # Record the resolved scalar (not the range) for replay/debug, per the
         # applied record contract documented on get_applied_config.
         sampling.applied_overrides["alpha_range"] = alpha
-        return TransformParameterPlan.shared_only({"enhance_matrix": fpixel.generate_enhance_matrix(self.mode, alpha)})
+        return SampledParams.shared_only({"enhance_matrix": fpixel.generate_enhance_matrix(self.mode, alpha)})
 
     def apply(
         self,
@@ -819,13 +825,15 @@ class Superpixels(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         n_segments = sampling.py_random.randint(*self.n_segments_range)
         p = sampling.py_random.uniform(*self.p_replace_range)
         sampling.applied_overrides.update({"n_segments_range": n_segments, "p_replace_range": p})
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "replace_samples": sampling.random_generator.random(n_segments) < p,
                 "n_segments": n_segments,
@@ -949,9 +957,11 @@ class RingingOvershoot(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         ksize = sampling.py_random.randrange(self.blur_range[0], self.blur_range[1] + 1, 2)
         if ksize % 2 == 0:
             ksize += 1
@@ -976,7 +986,7 @@ class RingingOvershoot(ImageOnlyTransform):
         kernel = kernel.astype(np.float32) / reduce_sum(kernel)
 
         sampling.applied_overrides.update({"blur_range": ksize, "cutoff_range": cutoff})
-        return TransformParameterPlan.shared_only({"kernel": kernel})
+        return SampledParams.shared_only({"kernel": kernel})
 
     def apply(self, img: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
         return fpixel.convolve(img, kernel)
@@ -1085,14 +1095,16 @@ class UnsharpMask(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         ksize = sampling.py_random.randrange(self.blur_range[0], self.blur_range[1] + 1, 2)
         sigma = sampling.py_random.uniform(*self.sigma_range)
         alpha = sampling.py_random.uniform(*self.alpha_range)
         sampling.applied_overrides.update({"blur_range": ksize, "sigma_range": sigma, "alpha_range": alpha})
-        return TransformParameterPlan.shared_only({"ksize": ksize, "sigma": sigma, "alpha": alpha})
+        return SampledParams.shared_only({"ksize": ksize, "sigma": sigma, "alpha": alpha})
 
     def apply(
         self,
@@ -1327,14 +1339,16 @@ class Dithering(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides["noise_range"] = self.noise_range
         if self.method != "random":
-            return TransformParameterPlan.shared_only({"random_noise": None})
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(
+            return SampledParams.shared_only({"random_noise": None})
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
             lambda view: (
                 view.descriptor.shape,
                 view.descriptor.dtype_scale,
@@ -1360,13 +1374,13 @@ class Dithering(ImageOnlyTransform):
             else:
                 random_noise = sampling.random_generator.uniform(*self.noise_range, size=noise_shape)
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(target.name for target in views),
                     params={"random_noise": random_noise},
                     requirements=requirements_for_views(views, shape=True, dtype=True, sampling_topology=True),
                 ),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
     def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
         random_noise = params.pop("random_noise", None)
@@ -1460,13 +1474,15 @@ class Halftone(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         dot_size = sampling.py_random.randint(*self.dot_size_range)
         blend = sampling.py_random.uniform(*self.blend_range)
         sampling.applied_overrides.update({"dot_size_range": dot_size, "blend_range": blend})
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "dot_size": dot_size,
                 "blend": blend,
@@ -1606,9 +1622,11 @@ class LensFlare(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         x_min, y_min, x_max, y_max = self.flare_roi
         intensity = sampling.py_random.uniform(*self.intensity_range)
         sampling.applied_overrides.update(
@@ -1620,7 +1638,7 @@ class LensFlare(ImageOnlyTransform):
             },
         )
         groups = []
-        for views in inputs.targets.group_image_like_by(
+        for views in targets.group_image_like_by(
             lambda view: tuple((view.descriptor.spatial_shape or ())[-2:]),
         ):
             spatial_shape = views[0].descriptor.spatial_shape
@@ -1653,7 +1671,7 @@ class LensFlare(ImageOnlyTransform):
             bloom_frac = sampling.py_random.uniform(*self.bloom_range)
             bloom_radius = max(1, int(diag * bloom_frac)) | 1
             groups.append(
-                TargetParameterGroup(
+                TargetParams(
                     targets=tuple(view.name for view in views),
                     params={
                         "flare_center": (fx, fy),
@@ -1664,4 +1682,4 @@ class LensFlare(ImageOnlyTransform):
                     requirements=requirements_for_views(views),
                 ),
             )
-        return TransformParameterPlan(shared={"starburst_intensity": intensity}, groups=tuple(groups))
+        return SampledParams(shared={"starburst_intensity": intensity}, groups=tuple(groups))

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -1351,7 +1351,7 @@ class Dithering(ImageOnlyTransform):
         for views in targets.group_image_like_by(
             lambda view: (
                 view.descriptor.shape,
-                view.descriptor.dtype_scale,
+                view.descriptor.value_scale,
                 view.descriptor.sampling_topology,
             ),
         ):
@@ -1679,7 +1679,7 @@ class LensFlare(ImageOnlyTransform):
                         "starburst_angles": starburst_angles,
                         "bloom_radius": bloom_radius,
                     },
-                    requirements=requirements_for_views(views),
+                    requirements=requirements_for_views(views, spatial_shape_suffix=True),
                 ),
             )
         return SampledParams(params={"starburst_intensity": intensity}, target_params=tuple(groups))

--- a/albumentations/augmentations/pixel/transforms.py
+++ b/albumentations/augmentations/pixel/transforms.py
@@ -1363,9 +1363,14 @@ class Dithering(ImageOnlyTransform):
             height, width = spatial_shape[-2:]
             channels = view.descriptor.channels or 1
             per_item_noise_shape = (height, width, 1) if self.color_mode == "grayscale" else (height, width, channels)
-            item_count = shape[0] if view.canonical_type in {"images", "volume"} else 1
+            if view.canonical_type not in {"images", "volume"}:
+                item_count = 1
+            elif view.descriptor.layout in {"images_clhw", "volume_cdhw"}:
+                item_count = shape[1]
+            else:
+                item_count = shape[0]
             noise_shape = per_item_noise_shape if item_count == 1 else (item_count, *per_item_noise_shape)
-            if view.descriptor.dtype == np.uint8:
+            if view.descriptor.value_scale == 255:
                 random_noise = sampling.random_generator.uniform(
                     self.noise_range[0] * 255,
                     self.noise_range[1] * 255,

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -1490,7 +1490,8 @@ class AtmosphericFog(ImageOnlyTransform):
         for views in targets.group_image_like_by(lambda view: (_weather_shape_key(view), view.descriptor.value_scale)):
             view = views[0]
             spatial_shape = view.descriptor.spatial_shape
-            if spatial_shape is None or view.descriptor.dtype is None:
+            actual_max = view.descriptor.value_scale
+            if spatial_shape is None or actual_max is None:
                 raise ValueError("AtmosphericFog requires image-like targets with known shape and dtype")
             height, width = spatial_shape[-2:]
             if self.depth_mode == "linear":
@@ -1506,7 +1507,6 @@ class AtmosphericFog(ImageOnlyTransform):
                 x = np.arange(width, dtype=np.float32)[np.newaxis, :] - cx
                 depth_map = albucore.sqrt(x * x + y * y, inplace=True)
                 depth_map *= np.float32(1 / math.hypot(cy, cx))
-            actual_max = albucore.MAX_VALUES_BY_DTYPE[view.descriptor.dtype]
             fog_color_scaled = tuple(c / max_val * actual_max for c in self.fog_color)
             groups.append(
                 _weather_group(

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -24,9 +24,9 @@ from albumentations.core.pydantic import (
     nondecreasing,
 )
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
-    TransformParameterPlan,
-    TransformSamplingInput,
+    SampledParams,
+    TargetParams,
+    TargetSet,
     requirements_for_views,
 )
 from albumentations.core.transforms_interface import (
@@ -62,8 +62,8 @@ def _weather_group(
     params: dict[str, Any],
     *,
     dtype: bool = False,
-) -> TargetParameterGroup:
-    return TargetParameterGroup(
+) -> TargetParams:
+    return TargetParams(
         targets=tuple(view.name for view in views),
         params=params,
         requirements=requirements_for_views(views, dtype=dtype),
@@ -194,18 +194,20 @@ class RandomSnow(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         snow_point = sampling.py_random.uniform(*self.snow_point_range)
         sampling.applied_overrides["snow_point_range"] = snow_point
         if self.method != "texture":
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {"snow_point": snow_point, "snow_texture": None, "sparkle_mask": None},
             )
 
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(_weather_shape_key):
             spatial_shape = views[0].descriptor.spatial_shape
             if spatial_shape is None:
                 raise ValueError("RandomSnow requires image-like targets with known spatial shapes")
@@ -220,7 +222,7 @@ class RandomSnow(ImageOnlyTransform):
                     {"snow_texture": snow_texture, "sparkle_mask": sparkle_mask},
                 ),
             )
-        return TransformParameterPlan(shared={"snow_point": snow_point}, groups=tuple(groups))
+        return SampledParams(shared={"snow_point": snow_point}, groups=tuple(groups))
 
 
 class RandomGravel(ImageOnlyTransform):
@@ -328,12 +330,14 @@ class RandomGravel(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides.update({"number_of_patches": self.number_of_patches, "gravel_roi": self.gravel_roi})
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(_weather_shape_key):
             spatial_shape = views[0].descriptor.spatial_shape
             if spatial_shape is None:
                 raise ValueError("RandomGravel requires image-like targets with known spatial shapes")
@@ -361,7 +365,7 @@ class RandomGravel(ImageOnlyTransform):
             groups.append(
                 _weather_group(views, {"gravels_infos": np.array(gravels_info, dtype=np.int64)}),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
 
 class RandomRain(ImageOnlyTransform):
@@ -502,9 +506,11 @@ class RandomRain(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         slant = sampling.py_random.uniform(*self.slant_range)
         sampling.applied_overrides.update(
             {
@@ -517,8 +523,8 @@ class RandomRain(ImageOnlyTransform):
             },
         )
 
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(_weather_shape_key):
             spatial_shape = views[0].descriptor.spatial_shape
             if spatial_shape is None:
                 raise ValueError("RandomRain requires image-like targets with known spatial shapes")
@@ -542,7 +548,7 @@ class RandomRain(ImageOnlyTransform):
             else:
                 rain_drops = np.empty((0, 2), dtype=np.int32)
             groups.append(_weather_group(views, {"drop_length": drop_length, "rain_drops": rain_drops}))
-        return TransformParameterPlan(shared={"slant": slant}, groups=tuple(groups))
+        return SampledParams(shared={"slant": slant}, groups=tuple(groups))
 
 
 class RandomFog(ImageOnlyTransform):
@@ -656,13 +662,15 @@ class RandomFog(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         intensity = sampling.py_random.uniform(*self.fog_coef_range)
         sampling.applied_overrides.update({"fog_coef_range": intensity, "alpha_coef": self.alpha_coef})
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(_weather_shape_key):
             spatial_shape = views[0].descriptor.spatial_shape
             if spatial_shape is None:
                 raise ValueError("RandomFog requires image-like targets with known spatial shapes")
@@ -696,7 +704,7 @@ class RandomFog(ImageOnlyTransform):
                     {"particle_positions": particle_positions, "radiuses": radiuses},
                 ),
             )
-        return TransformParameterPlan(shared={"intensity": intensity}, groups=tuple(groups))
+        return SampledParams(shared={"intensity": intensity}, groups=tuple(groups))
 
 
 class RandomSunFlare(ImageOnlyTransform):
@@ -903,9 +911,11 @@ class RandomSunFlare(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         angle = 2 * math.pi * sampling.py_random.uniform(*self.angle_range)
         sampling.applied_overrides.update(
             {
@@ -916,8 +926,8 @@ class RandomSunFlare(ImageOnlyTransform):
             },
         )
 
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(_weather_shape_key):
             spatial_shape = views[0].descriptor.spatial_shape
             if spatial_shape is None:
                 raise ValueError("RandomSunFlare requires image-like targets with known spatial shapes")
@@ -942,7 +952,7 @@ class RandomSunFlare(ImageOnlyTransform):
             groups.append(
                 _weather_group(views, {"circles": circles, "flare_center": (flare_center_x, flare_center_y)}),
             )
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
 
 class RandomShadow(ImageOnlyTransform):
@@ -1080,9 +1090,11 @@ class RandomShadow(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides.update(
             {
                 "num_shadows_range": self.num_shadows_range,
@@ -1091,8 +1103,8 @@ class RandomShadow(ImageOnlyTransform):
                 "shadow_intensity_range": self.shadow_intensity_range,
             },
         )
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(_weather_shape_key):
             spatial_shape = views[0].descriptor.spatial_shape
             if spatial_shape is None:
                 raise ValueError("RandomShadow requires image-like targets with known spatial shapes")
@@ -1113,7 +1125,7 @@ class RandomShadow(ImageOnlyTransform):
             ]
             intensities = sampling.random_generator.uniform(*self.shadow_intensity_range, size=num_shadows)
             groups.append(_weather_group(views, {"vertices_list": vertices_list, "intensities": intensities}))
-        return TransformParameterPlan(shared={}, groups=tuple(groups))
+        return SampledParams(shared={}, groups=tuple(groups))
 
 
 class Spatter(ImageOnlyTransform):
@@ -1317,9 +1329,11 @@ class Spatter(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         mean = sampling.py_random.uniform(*self.mean_range)
         std = sampling.py_random.uniform(*self.std_range)
         cutout_threshold = sampling.py_random.uniform(*self.cutout_threshold_range)
@@ -1338,8 +1352,8 @@ class Spatter(ImageOnlyTransform):
             },
         )
 
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(_weather_shape_key):
             spatial_shape = views[0].descriptor.spatial_shape
             if spatial_shape is None:
                 raise ValueError("Spatter requires image-like targets with known spatial shapes")
@@ -1369,7 +1383,7 @@ class Spatter(ImageOnlyTransform):
                     random_generator=sampling.random_generator,
                 )
             groups.append(_weather_group(views, group_params))
-        return TransformParameterPlan(shared={"mode": mode}, groups=tuple(groups))
+        return SampledParams(shared={"mode": mode}, groups=tuple(groups))
 
 
 class AtmosphericFog(ImageOnlyTransform):
@@ -1464,16 +1478,16 @@ class AtmosphericFog(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         density = sampling.py_random.uniform(*self.density_range)
         max_val = albucore.MAX_VALUES_BY_DTYPE[np.uint8]
         sampling.applied_overrides["density_range"] = density
-        groups: list[TargetParameterGroup] = []
-        for views in inputs.targets.group_image_like_by(
-            lambda view: (_weather_shape_key(view), view.descriptor.dtype_scale)
-        ):
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(lambda view: (_weather_shape_key(view), view.descriptor.dtype_scale)):
             view = views[0]
             spatial_shape = view.descriptor.spatial_shape
             if spatial_shape is None or view.descriptor.dtype is None:
@@ -1501,4 +1515,4 @@ class AtmosphericFog(ImageOnlyTransform):
                     dtype=True,
                 ),
             )
-        return TransformParameterPlan(shared={"density": density}, groups=tuple(groups))
+        return SampledParams(shared={"density": density}, groups=tuple(groups))

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -202,8 +202,8 @@ class RandomSnow(ImageOnlyTransform):
         snow_point = sampling.py_random.uniform(*self.snow_point_range)
         sampling.applied_overrides["snow_point_range"] = snow_point
         if self.method != "texture":
-            return SampledParams.shared_only(
-                {"snow_point": snow_point, "snow_texture": None, "sparkle_mask": None},
+            return SampledParams(
+                params={"snow_point": snow_point, "snow_texture": None, "sparkle_mask": None},
             )
 
         groups: list[TargetParams] = []
@@ -222,7 +222,7 @@ class RandomSnow(ImageOnlyTransform):
                     {"snow_texture": snow_texture, "sparkle_mask": sparkle_mask},
                 ),
             )
-        return SampledParams(shared={"snow_point": snow_point}, groups=tuple(groups))
+        return SampledParams(params={"snow_point": snow_point}, target_params=tuple(groups))
 
 
 class RandomGravel(ImageOnlyTransform):
@@ -365,7 +365,7 @@ class RandomGravel(ImageOnlyTransform):
             groups.append(
                 _weather_group(views, {"gravels_infos": np.array(gravels_info, dtype=np.int64)}),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
 
 class RandomRain(ImageOnlyTransform):
@@ -548,7 +548,7 @@ class RandomRain(ImageOnlyTransform):
             else:
                 rain_drops = np.empty((0, 2), dtype=np.int32)
             groups.append(_weather_group(views, {"drop_length": drop_length, "rain_drops": rain_drops}))
-        return SampledParams(shared={"slant": slant}, groups=tuple(groups))
+        return SampledParams(params={"slant": slant}, target_params=tuple(groups))
 
 
 class RandomFog(ImageOnlyTransform):
@@ -704,7 +704,7 @@ class RandomFog(ImageOnlyTransform):
                     {"particle_positions": particle_positions, "radiuses": radiuses},
                 ),
             )
-        return SampledParams(shared={"intensity": intensity}, groups=tuple(groups))
+        return SampledParams(params={"intensity": intensity}, target_params=tuple(groups))
 
 
 class RandomSunFlare(ImageOnlyTransform):
@@ -952,7 +952,7 @@ class RandomSunFlare(ImageOnlyTransform):
             groups.append(
                 _weather_group(views, {"circles": circles, "flare_center": (flare_center_x, flare_center_y)}),
             )
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
 
 class RandomShadow(ImageOnlyTransform):
@@ -1125,7 +1125,7 @@ class RandomShadow(ImageOnlyTransform):
             ]
             intensities = sampling.random_generator.uniform(*self.shadow_intensity_range, size=num_shadows)
             groups.append(_weather_group(views, {"vertices_list": vertices_list, "intensities": intensities}))
-        return SampledParams(shared={}, groups=tuple(groups))
+        return SampledParams(params={}, target_params=tuple(groups))
 
 
 class Spatter(ImageOnlyTransform):
@@ -1383,7 +1383,7 @@ class Spatter(ImageOnlyTransform):
                     random_generator=sampling.random_generator,
                 )
             groups.append(_weather_group(views, group_params))
-        return SampledParams(shared={"mode": mode}, groups=tuple(groups))
+        return SampledParams(params={"mode": mode}, target_params=tuple(groups))
 
 
 class AtmosphericFog(ImageOnlyTransform):
@@ -1515,4 +1515,4 @@ class AtmosphericFog(ImageOnlyTransform):
                     dtype=True,
                 ),
             )
-        return SampledParams(shared={"density": density}, groups=tuple(groups))
+        return SampledParams(params={"density": density}, target_params=tuple(groups))

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -66,7 +66,7 @@ def _weather_group(
     return TargetParams(
         targets=tuple(view.name for view in views),
         params=params,
-        requirements=requirements_for_views(views, dtype=dtype),
+        requirements=requirements_for_views(views, spatial_shape_suffix=True, dtype=dtype),
     )
 
 
@@ -1487,7 +1487,7 @@ class AtmosphericFog(ImageOnlyTransform):
         max_val = albucore.MAX_VALUES_BY_DTYPE[np.uint8]
         sampling.applied_overrides["density_range"] = density
         groups: list[TargetParams] = []
-        for views in targets.group_image_like_by(lambda view: (_weather_shape_key(view), view.descriptor.dtype_scale)):
+        for views in targets.group_image_like_by(lambda view: (_weather_shape_key(view), view.descriptor.value_scale)):
             view = views[0]
             spatial_shape = view.descriptor.spatial_shape
             if spatial_shape is None or view.descriptor.dtype is None:

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -23,6 +23,12 @@ from albumentations.core.pydantic import (
     check_range_bounds,
     nondecreasing,
 )
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TransformParameterPlan,
+    TransformSamplingInput,
+    requirements_for_views,
+)
 from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
@@ -49,6 +55,24 @@ _SPATTER_BATCH_FALLBACK_WORKING_SET_BYTES = {
     ("mud", "uint8"): 6 * 1024 * 1024,
     ("mud", "float32"): 24 * 1024 * 1024,
 }
+
+
+def _weather_group(
+    views: tuple[Any, ...],
+    params: dict[str, Any],
+    *,
+    dtype: bool = False,
+) -> TargetParameterGroup:
+    return TargetParameterGroup(
+        targets=tuple(view.name for view in views),
+        params=params,
+        requirements=requirements_for_views(views, dtype=dtype),
+    )
+
+
+def _weather_shape_key(view: Any) -> tuple[Any, ...]:
+    spatial_shape = view.descriptor.spatial_shape
+    return () if spatial_shape is None else tuple(spatial_shape[-2:])
 
 
 class RandomSnow(ImageOnlyTransform):
@@ -170,30 +194,33 @@ class RandomSnow(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, float | np.ndarray | None]:
-        image_shape = params["shape"][:2]
+    ) -> TransformParameterPlan:
         snow_point = sampling.py_random.uniform(*self.snow_point_range)
+        sampling.applied_overrides["snow_point_range"] = snow_point
+        if self.method != "texture":
+            return TransformParameterPlan.shared_only(
+                {"snow_point": snow_point, "snow_texture": None, "sparkle_mask": None},
+            )
 
-        result: dict[str, float | np.ndarray | None] = {
-            "snow_point": snow_point,
-            "snow_texture": None,
-            "sparkle_mask": None,
-        }
-
-        if self.method == "texture":
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("RandomSnow requires image-like targets with known spatial shapes")
+            image_shape = (spatial_shape[-2], spatial_shape[-1])
             snow_texture, sparkle_mask = fpixel.generate_snow_textures(
                 img_shape=image_shape,
                 random_generator=sampling.random_generator,
             )
-            result["snow_texture"] = snow_texture
-            result["sparkle_mask"] = sparkle_mask
-
-        sampling.applied_overrides["snow_point_range"] = snow_point
-
-        return result
+            groups.append(
+                _weather_group(
+                    views,
+                    {"snow_texture": snow_texture, "sparkle_mask": sparkle_mask},
+                ),
+            )
+        return TransformParameterPlan(shared={"snow_point": snow_point}, groups=tuple(groups))
 
 
 class RandomGravel(ImageOnlyTransform):
@@ -301,53 +328,40 @@ class RandomGravel(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray]:
-        metadata = self.get_image_data(data)
-        height, width = (metadata["height"], metadata["width"])
-
-        # Calculate ROI in pixels
-        x_min, y_min, x_max, y_max = (
-            int(coord * dim) for coord, dim in zip(self.gravel_roi, [width, height, width, height], strict=True)
-        )
-
-        roi_width = x_max - x_min
-        roi_height = y_max - y_min
-
-        gravels_info = []
-
-        for _ in range(self.number_of_patches):
-            # Generate a random rectangular region within the ROI
-            patch_width = sampling.py_random.randint(roi_width // 10, roi_width // 5)
-            patch_height = sampling.py_random.randint(roi_height // 10, roi_height // 5)
-
-            patch_x = sampling.py_random.randint(x_min, x_max - patch_width)
-            patch_y = sampling.py_random.randint(y_min, y_max - patch_height)
-
-            # Generate gravel particles within this patch
-            num_particles = (patch_width * patch_height) // 100  # Adjust this divisor to control density
-
-            for _ in range(num_particles):
-                x = sampling.py_random.randint(patch_x, patch_x + patch_width)
-                y = sampling.py_random.randint(patch_y, patch_y + patch_height)
-                r = sampling.py_random.randint(1, 3)
-                sat = sampling.py_random.randint(0, 255)
-
-                gravels_info.append(
-                    [
-                        max(y - r, 0),  # min_y
-                        min(y + r, height - 1),  # max_y
-                        max(x - r, 0),  # min_x
-                        min(x + r, width - 1),  # max_x
-                        sat,  # saturation
-                    ],
-                )
-
+    ) -> TransformParameterPlan:
         sampling.applied_overrides.update({"number_of_patches": self.number_of_patches, "gravel_roi": self.gravel_roi})
-
-        return {"gravels_infos": np.array(gravels_info, dtype=np.int64)}
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("RandomGravel requires image-like targets with known spatial shapes")
+            height, width = spatial_shape[-2:]
+            x_min, y_min, x_max, y_max = (
+                int(coord * dim) for coord, dim in zip(self.gravel_roi, [width, height, width, height], strict=True)
+            )
+            roi_width = x_max - x_min
+            roi_height = y_max - y_min
+            gravels_info = []
+            for _ in range(self.number_of_patches):
+                patch_width = sampling.py_random.randint(roi_width // 10, roi_width // 5)
+                patch_height = sampling.py_random.randint(roi_height // 10, roi_height // 5)
+                patch_x = sampling.py_random.randint(x_min, x_max - patch_width)
+                patch_y = sampling.py_random.randint(y_min, y_max - patch_height)
+                num_particles = (patch_width * patch_height) // 100
+                for _ in range(num_particles):
+                    x = sampling.py_random.randint(patch_x, patch_x + patch_width)
+                    y = sampling.py_random.randint(patch_y, patch_y + patch_height)
+                    r = sampling.py_random.randint(1, 3)
+                    sat = sampling.py_random.randint(0, 255)
+                    gravels_info.append(
+                        [max(y - r, 0), min(y + r, height - 1), max(x - r, 0), min(x + r, width - 1), sat],
+                    )
+            groups.append(
+                _weather_group(views, {"gravels_infos": np.array(gravels_info, dtype=np.int64)}),
+            )
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
 
 class RandomRain(ImageOnlyTransform):
@@ -488,45 +502,14 @@ class RandomRain(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        metadata = self.get_image_data(data)
-        height, width = (metadata["height"], metadata["width"])
-
-        # Simpler calculations, directly following Kornia
-        if self.rain_type == "drizzle":
-            num_drops = height // 4
-        elif self.rain_type == "heavy":
-            num_drops = height
-        elif self.rain_type == "torrential":
-            num_drops = height * 2
-        else:
-            num_drops = height // 3
-
-        drop_length = max(1, height // 8) if self.drop_length is None else self.drop_length
-
-        # Simplified slant calculation
+    ) -> TransformParameterPlan:
         slant = sampling.py_random.uniform(*self.slant_range)
-
-        # Single random call for all coordinates
-        if num_drops > 0:
-            # Generate all coordinates in one call
-            coords = sampling.random_generator.integers(
-                low=[0, 0],
-                high=[width, height - drop_length],
-                size=(num_drops, 2),
-                dtype=np.int32,
-            )
-            rain_drops = coords
-        else:
-            rain_drops = np.empty((0, 2), dtype=np.int32)
-
         sampling.applied_overrides.update(
             {
                 "slant_range": slant,
-                "drop_length": drop_length,
+                "drop_length": self.drop_length,
                 "drop_width": self.drop_width,
                 "blur_value": self.blur_value,
                 "brightness_coefficient": self.brightness_coefficient,
@@ -534,7 +517,32 @@ class RandomRain(ImageOnlyTransform):
             },
         )
 
-        return {"drop_length": drop_length, "slant": slant, "rain_drops": rain_drops}
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("RandomRain requires image-like targets with known spatial shapes")
+            height, width = spatial_shape[-2:]
+            if self.rain_type == "drizzle":
+                num_drops = height // 4
+            elif self.rain_type == "heavy":
+                num_drops = height
+            elif self.rain_type == "torrential":
+                num_drops = height * 2
+            else:
+                num_drops = height // 3
+            drop_length = max(1, height // 8) if self.drop_length is None else self.drop_length
+            if num_drops > 0:
+                rain_drops = sampling.random_generator.integers(
+                    low=[0, 0],
+                    high=[width, height - drop_length],
+                    size=(num_drops, 2),
+                    dtype=np.int32,
+                )
+            else:
+                rain_drops = np.empty((0, 2), dtype=np.int32)
+            groups.append(_weather_group(views, {"drop_length": drop_length, "rain_drops": rain_drops}))
+        return TransformParameterPlan(shared={"slant": slant}, groups=tuple(groups))
 
 
 class RandomFog(ImageOnlyTransform):
@@ -648,74 +656,47 @@ class RandomFog(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        # Select a random fog intensity within the specified range
+    ) -> TransformParameterPlan:
         intensity = sampling.py_random.uniform(*self.fog_coef_range)
-
-        image_shape = params["shape"][:2]
-
-        image_height, image_width = image_shape
-
-        # Calculate the size of the fog effect region based on image width and fog intensity
-        fog_region_size = max(1, int(image_width // 3 * intensity))
-
-        particle_positions = []
-
-        # Initialize the central region where fog will be most dense
-        center_x, center_y = (int(x) for x in fgeometric.center(image_shape))
-
-        # Define the initial size of the foggy area
-        current_width = image_width
-        current_height = image_height
-
-        # Define shrink factor for reducing the foggy area each iteration
-        shrink_factor = 0.1
-
-        max_iterations = 10  # Prevent infinite loop
-        iteration = 0
-
-        while current_width > fog_region_size and current_height > fog_region_size and iteration < max_iterations:
-            # Calculate the number of particles for this region
-            area = current_width * current_height
-            particles_in_region = int(
-                area / (fog_region_size * fog_region_size) * intensity * 10,
-            )
-
-            for _ in range(particles_in_region):
-                # Generate random positions within the current region
-                x = sampling.py_random.randint(
-                    center_x - current_width // 2,
-                    center_x + current_width // 2,
-                )
-                y = sampling.py_random.randint(
-                    center_y - current_height // 2,
-                    center_y + current_height // 2,
-                )
-                particle_positions.append((x, y))
-
-            # Shrink the region for the next iteration
-            current_width = int(current_width * (1 - shrink_factor))
-            current_height = int(current_height * (1 - shrink_factor))
-
-            iteration += 1
-
-        radiuses = fpixel.get_fog_particle_radiuses(
-            image_shape,
-            len(particle_positions),
-            intensity,
-            sampling.random_generator,
-        )
-
         sampling.applied_overrides.update({"fog_coef_range": intensity, "alpha_coef": self.alpha_coef})
-
-        return {
-            "particle_positions": particle_positions,
-            "intensity": intensity,
-            "radiuses": radiuses,
-        }
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("RandomFog requires image-like targets with known spatial shapes")
+            image_shape = (spatial_shape[-2], spatial_shape[-1])
+            image_height, image_width = image_shape
+            fog_region_size = max(1, int(image_width // 3 * intensity))
+            particle_positions: list[tuple[int, int]] = []
+            center_x, center_y = (int(x) for x in fgeometric.center(image_shape))
+            current_width = image_width
+            current_height = image_height
+            iteration = 0
+            while current_width > fog_region_size and current_height > fog_region_size and iteration < 10:
+                area = current_width * current_height
+                particles_in_region = int(area / (fog_region_size * fog_region_size) * intensity * 10)
+                for _ in range(particles_in_region):
+                    x = sampling.py_random.randint(center_x - current_width // 2, center_x + current_width // 2)
+                    y = sampling.py_random.randint(center_y - current_height // 2, center_y + current_height // 2)
+                    particle_positions.append((x, y))
+                current_width = int(current_width * 0.9)
+                current_height = int(current_height * 0.9)
+                iteration += 1
+            radiuses = fpixel.get_fog_particle_radiuses(
+                image_shape,
+                len(particle_positions),
+                intensity,
+                sampling.random_generator,
+            )
+            groups.append(
+                _weather_group(
+                    views,
+                    {"particle_positions": particle_positions, "radiuses": radiuses},
+                ),
+            )
+        return TransformParameterPlan(shared={"intensity": intensity}, groups=tuple(groups))
 
 
 class RandomSunFlare(ImageOnlyTransform):
@@ -922,69 +903,46 @@ class RandomSunFlare(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        metadata = self.get_image_data(data)
-        height, width = (metadata["height"], metadata["width"])
-        diagonal = math.sqrt(height**2 + width**2)
-
+    ) -> TransformParameterPlan:
         angle = 2 * math.pi * sampling.py_random.uniform(*self.angle_range)
-
-        # Calculate flare center in pixel coordinates
-        x_min, y_min, x_max, y_max = self.flare_roi
-        flare_center_x = int(width * sampling.py_random.uniform(x_min, x_max))
-        flare_center_y = int(height * sampling.py_random.uniform(y_min, y_max))
-
-        num_circles = sampling.py_random.randint(*self.num_flare_circles_range)
-
-        # Calculate parameters relative to image size
-        step_size = max(1, int(diagonal * 0.01))  # 1% of diagonal, minimum 1 pixel
-        max_radius = max(2, int(height * 0.01))  # 1% of height, minimum 2 pixels
-        color_range = int(max(self.src_color) * 0.2)  # 20% of max color value
-
-        def line(t: float) -> tuple[float, float]:
-            return (
-                flare_center_x + t * math.cos(angle),
-                flare_center_y + t * math.sin(angle),
-            )
-
-        # Generate points along the flare line
-        t_range = range(-flare_center_x, width - flare_center_x, step_size)
-        points = [line(t) for t in t_range]
-
-        circles = []
-        for _ in range(num_circles):
-            alpha = sampling.py_random.uniform(0.05, 0.2)
-            point = sampling.py_random.choice(points)
-            rad = sampling.py_random.randint(1, max_radius)
-
-            # Generate colors relative to src_color
-            colors = [sampling.py_random.randint(max(c - color_range, 0), c) for c in self.src_color]
-
-            circles.append(
-                (
-                    alpha,
-                    (int(point[0]), int(point[1])),
-                    pow(rad, 3),
-                    tuple(colors),
-                ),
-            )
-
         sampling.applied_overrides.update(
             {
                 "angle_range": angle / (2 * math.pi),
-                "num_flare_circles_range": num_circles,
+                "num_flare_circles_range": self.num_flare_circles_range,
                 "src_radius": self.src_radius,
                 "src_color": self.src_color,
             },
         )
 
-        return {
-            "circles": circles,
-            "flare_center": (flare_center_x, flare_center_y),
-        }
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("RandomSunFlare requires image-like targets with known spatial shapes")
+            height, width = spatial_shape[-2:]
+            diagonal = math.sqrt(height**2 + width**2)
+            x_min, y_min, x_max, y_max = self.flare_roi
+            flare_center_x = int(width * sampling.py_random.uniform(x_min, x_max))
+            flare_center_y = int(height * sampling.py_random.uniform(y_min, y_max))
+            num_circles = sampling.py_random.randint(*self.num_flare_circles_range)
+            step_size = max(1, int(diagonal * 0.01))
+            max_radius = max(2, int(height * 0.01))
+            color_range = int(max(self.src_color) * 0.2)
+            t_range = range(-flare_center_x, width - flare_center_x, step_size)
+            points = [(flare_center_x + t * math.cos(angle), flare_center_y + t * math.sin(angle)) for t in t_range]
+            circles = []
+            for _ in range(num_circles):
+                alpha = sampling.py_random.uniform(0.05, 0.2)
+                point = sampling.py_random.choice(points)
+                rad = sampling.py_random.randint(1, max_radius)
+                colors = [sampling.py_random.randint(max(c - color_range, 0), c) for c in self.src_color]
+                circles.append((alpha, (int(point[0]), int(point[1])), pow(rad, 3), tuple(colors)))
+            groups.append(
+                _weather_group(views, {"circles": circles, "flare_center": (flare_center_x, flare_center_y)}),
+            )
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
 
 class RandomShadow(ImageOnlyTransform):
@@ -1122,57 +1080,40 @@ class RandomShadow(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, list[np.ndarray] | np.ndarray]:
-        metadata = self.get_image_data(data)
-        height, width = (metadata["height"], metadata["width"])
-
-        num_shadows = sampling.py_random.randint(*self.num_shadows_range)
-
-        x_min, y_min, x_max, y_max = self.shadow_roi
-
-        x_min = int(x_min * width)
-        x_max = int(x_max * width)
-        y_min = int(y_min * height)
-        y_max = int(y_max * height)
-
-        vertices_list = [
-            np.stack(
-                [
-                    sampling.random_generator.integers(
-                        x_min,
-                        x_max,
-                        size=self.shadow_dimension,
-                    ),
-                    sampling.random_generator.integers(
-                        y_min,
-                        y_max,
-                        size=self.shadow_dimension,
-                    ),
-                ],
-                axis=1,
-            )
-            for _ in range(num_shadows)
-        ]
-
-        # Sample shadow intensity for each shadow
-        intensities = sampling.random_generator.uniform(
-            *self.shadow_intensity_range,
-            size=num_shadows,
-        )
-
+    ) -> TransformParameterPlan:
         sampling.applied_overrides.update(
             {
-                "num_shadows_range": num_shadows,
+                "num_shadows_range": self.num_shadows_range,
                 "shadow_dimension": self.shadow_dimension,
                 "shadow_roi": self.shadow_roi,
-                "shadow_intensity_range": (float(intensities.min()), float(intensities.max())),
+                "shadow_intensity_range": self.shadow_intensity_range,
             },
         )
-
-        return {"vertices_list": vertices_list, "intensities": intensities}
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("RandomShadow requires image-like targets with known spatial shapes")
+            height, width = spatial_shape[-2:]
+            num_shadows = sampling.py_random.randint(*self.num_shadows_range)
+            x_min, y_min, x_max, y_max = self.shadow_roi
+            x_min, x_max = int(x_min * width), int(x_max * width)
+            y_min, y_max = int(y_min * height), int(y_max * height)
+            vertices_list = [
+                np.stack(
+                    [
+                        sampling.random_generator.integers(x_min, x_max, size=self.shadow_dimension),
+                        sampling.random_generator.integers(y_min, y_max, size=self.shadow_dimension),
+                    ],
+                    axis=1,
+                )
+                for _ in range(num_shadows)
+            ]
+            intensities = sampling.random_generator.uniform(*self.shadow_intensity_range, size=num_shadows)
+            groups.append(_weather_group(views, {"vertices_list": vertices_list, "intensities": intensities}))
+        return TransformParameterPlan(shared={}, groups=tuple(groups))
 
 
 class Spatter(ImageOnlyTransform):
@@ -1376,13 +1317,9 @@ class Spatter(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        metadata = self.get_image_data(data)
-        height, width = (metadata["height"], metadata["width"])
-
+    ) -> TransformParameterPlan:
         mean = sampling.py_random.uniform(*self.mean_range)
         std = sampling.py_random.uniform(*self.std_range)
         cutout_threshold = sampling.py_random.uniform(*self.cutout_threshold_range)
@@ -1390,27 +1327,6 @@ class Spatter(ImageOnlyTransform):
         mode = self.mode
         intensity = sampling.py_random.uniform(*self.intensity_range)
         color = np.asarray(self.color, dtype=np.float32) / np.float32(255)
-
-        liquid_layer = sampling.random_generator.normal(
-            size=(height, width),
-            loc=mean,
-            scale=std,
-        )
-        if mode == "rain":
-            liquid_layer = liquid_layer.astype(np.float32)
-        # Convert sigma to kernel size (must be odd)
-        ksize = 2 * round(3 * sigma) + 1  # 3 sigma rule, rounded to nearest odd
-        cv2.GaussianBlur(
-            src=liquid_layer,
-            dst=liquid_layer,  # in-place operation
-            ksize=(ksize, ksize),
-            sigmaX=sigma,
-            sigmaY=sigma,
-            borderType=cv2.BORDER_REPLICATE,
-        )
-
-        # Important line, without it the rain effect looses drops
-        liquid_layer[liquid_layer < cutout_threshold] = 0
 
         sampling.applied_overrides.update(
             {
@@ -1422,23 +1338,38 @@ class Spatter(ImageOnlyTransform):
             },
         )
 
-        if mode == "rain":
-            return {
-                "mode": "rain",
-                **fpixel.get_rain_params(liquid_layer=liquid_layer, color=color, intensity=intensity),
-            }
-
-        return {
-            "mode": "mud",
-            **fpixel.get_mud_params(
-                liquid_layer=liquid_layer,
-                color=color,
-                cutout_threshold=cutout_threshold,
-                sigma=sigma,
-                intensity=intensity,
-                random_generator=sampling.random_generator,
-            ),
-        }
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(_weather_shape_key):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("Spatter requires image-like targets with known spatial shapes")
+            height, width = spatial_shape[-2:]
+            liquid_layer = sampling.random_generator.normal(size=(height, width), loc=mean, scale=std)
+            if mode == "rain":
+                liquid_layer = liquid_layer.astype(np.float32)
+            ksize = 2 * round(3 * sigma) + 1
+            cv2.GaussianBlur(
+                src=liquid_layer,
+                dst=liquid_layer,
+                ksize=(ksize, ksize),
+                sigmaX=sigma,
+                sigmaY=sigma,
+                borderType=cv2.BORDER_REPLICATE,
+            )
+            liquid_layer[liquid_layer < cutout_threshold] = 0
+            if mode == "rain":
+                group_params = fpixel.get_rain_params(liquid_layer=liquid_layer, color=color, intensity=intensity)
+            else:
+                group_params = fpixel.get_mud_params(
+                    liquid_layer=liquid_layer,
+                    color=color,
+                    cutout_threshold=cutout_threshold,
+                    sigma=sigma,
+                    intensity=intensity,
+                    random_generator=sampling.random_generator,
+                )
+            groups.append(_weather_group(views, group_params))
+        return TransformParameterPlan(shared={"mode": mode}, groups=tuple(groups))
 
 
 class AtmosphericFog(ImageOnlyTransform):
@@ -1533,37 +1464,41 @@ class AtmosphericFog(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        height, width = params["shape"][:2]
+    ) -> TransformParameterPlan:
         density = sampling.py_random.uniform(*self.density_range)
-
-        if self.depth_mode == "linear":
-            depth_map = np.linspace(1.0, 0.0, height, dtype=np.float32)[:, np.newaxis]
-            depth_map = np.broadcast_to(depth_map, (height, width)).copy()
-        elif self.depth_mode == "diagonal":
-            y = np.linspace(1.0, 0.0, height, dtype=np.float32)
-            x = np.linspace(1.0, 0.0, width, dtype=np.float32)
-            depth_map = (y[:, np.newaxis] + x[np.newaxis, :]) / 2.0
-        else:
-            cy, cx = height / 2.0, width / 2.0
-            y = np.arange(height, dtype=np.float32)[:, np.newaxis] - cy
-            x = np.arange(width, dtype=np.float32)[np.newaxis, :] - cx
-            depth_map = x * x + y * y
-            depth_map = albucore.sqrt(depth_map, inplace=True)
-            depth_map *= np.float32(1 / math.hypot(cy, cx))
-
         max_val = albucore.MAX_VALUES_BY_DTYPE[np.uint8]
-        image_data = self.get_image_data(data)
-        img_dtype = image_data["dtype"]
-        actual_max = albucore.MAX_VALUES_BY_DTYPE[img_dtype]
-        fog_color_scaled = tuple(c / max_val * actual_max for c in self.fog_color)
-
         sampling.applied_overrides["density_range"] = density
-        return {
-            "density": density,
-            "depth_map": depth_map,
-            "fog_color_scaled": fog_color_scaled,
-        }
+        groups: list[TargetParameterGroup] = []
+        for views in inputs.targets.group_image_like_by(
+            lambda view: (_weather_shape_key(view), view.descriptor.dtype_scale)
+        ):
+            view = views[0]
+            spatial_shape = view.descriptor.spatial_shape
+            if spatial_shape is None or view.descriptor.dtype is None:
+                raise ValueError("AtmosphericFog requires image-like targets with known shape and dtype")
+            height, width = spatial_shape[-2:]
+            if self.depth_mode == "linear":
+                depth_map = np.linspace(1.0, 0.0, height, dtype=np.float32)[:, np.newaxis]
+                depth_map = np.broadcast_to(depth_map, (height, width)).copy()
+            elif self.depth_mode == "diagonal":
+                y = np.linspace(1.0, 0.0, height, dtype=np.float32)
+                x = np.linspace(1.0, 0.0, width, dtype=np.float32)
+                depth_map = (y[:, np.newaxis] + x[np.newaxis, :]) / 2.0
+            else:
+                cy, cx = height / 2.0, width / 2.0
+                y = np.arange(height, dtype=np.float32)[:, np.newaxis] - cy
+                x = np.arange(width, dtype=np.float32)[np.newaxis, :] - cx
+                depth_map = albucore.sqrt(x * x + y * y, inplace=True)
+                depth_map *= np.float32(1 / math.hypot(cy, cx))
+            actual_max = albucore.MAX_VALUES_BY_DTYPE[view.descriptor.dtype]
+            fog_color_scaled = tuple(c / max_val * actual_max for c in self.fog_color)
+            groups.append(
+                _weather_group(
+                    views,
+                    {"depth_map": depth_map, "fog_color_scaled": fog_color_scaled},
+                    dtype=True,
+                ),
+            )
+        return TransformParameterPlan(shared={"density": density}, groups=tuple(groups))

--- a/albumentations/augmentations/text/transforms.py
+++ b/albumentations/augmentations/text/transforms.py
@@ -15,7 +15,7 @@ import albumentations.augmentations.text.functional as ftext
 from albumentations.core.bbox_utils import check_bboxes, denormalize_bboxes
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -224,16 +224,17 @@ class TextImage(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        data = inputs.data
+    ) -> SampledParams:
         image = data["image"] if "image" in data else data["images"][0]
 
         metadata = data[self.metadata_key]
 
         if metadata == []:
-            return TransformParameterPlan.shared_only(
+            return SampledParams.shared_only(
                 {
                     "overlay_data": [],
                 }
@@ -261,7 +262,7 @@ class TextImage(ImageOnlyTransform):
 
         sampling.applied_overrides["fraction_range"] = fraction
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "overlay_data": overlay_data,
             }
@@ -275,12 +276,12 @@ class TextImage(ImageOnlyTransform):
     ) -> ImageType:
         return ftext.render_text(img, overlay_data, clear_bg=self.clear_bg)
 
-    def apply_with_params(self, plan: TransformParameterPlan, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply transform and include overlay data in result. Returns dict with transformed data and
         overlay info. Used by Compose when metadata_key present.
 
         Args:
-            plan (TransformParameterPlan): Realized shared and target-specific parameters.
+            sampled_params (SampledParams): Realized shared and target-specific parameters.
             *args (Any): Additional positional arguments
             **kwargs (Any): Additional keyword arguments
 
@@ -288,7 +289,7 @@ class TextImage(ImageOnlyTransform):
             dict[str, Any]: Dictionary containing the transformed data and simplified overlay information
 
         """
-        res = super().apply_with_params(plan, *args, **kwargs)
+        res = super().apply_with_params(sampled_params, *args, **kwargs)
         res["overlay_data"] = [
             {
                 "bbox_coords": overlay["bbox_coords"],
@@ -297,7 +298,7 @@ class TextImage(ImageOnlyTransform):
                 "bbox_index": overlay["bbox_index"],
                 "font_color": overlay["font_color"],
             }
-            for overlay in plan.params_for("image")["overlay_data"]
+            for overlay in sampled_params.params_for("image")["overlay_data"]
         ]
 
         return res

--- a/albumentations/augmentations/text/transforms.py
+++ b/albumentations/augmentations/text/transforms.py
@@ -15,7 +15,7 @@ import albumentations.augmentations.text.functional as ftext
 from albumentations.core.bbox_utils import check_bboxes, denormalize_bboxes
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import SampledParams, TargetSet
+from albumentations.core.transform_params import SampledParams, TargetParams, TargetSet, requirements_for_views
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -162,7 +162,7 @@ class TextImage(ImageOnlyTransform):
 
     def preprocess_metadata(
         self,
-        image: ImageType,
+        image_shape: tuple[int, int],
         bbox: tuple[float, float, float, float],
         text: str,
         bbox_index: int,
@@ -172,7 +172,7 @@ class TextImage(ImageOnlyTransform):
         Returns dict with bbox_coords, text, font, font_color.
 
         Args:
-            image (ImageType): Input image
+            image_shape (tuple[int, int]): Height and width of the target image
             bbox (tuple[float, float, float, float]): Normalized bounding box coordinates
             text (str): Text to render in the bounding box
             bbox_index (int): Index of the bounding box in the original metadata
@@ -192,7 +192,6 @@ class TextImage(ImageOnlyTransform):
                 "ImageFont from PIL is required to use TextImage transform. Install it with `pip install Pillow`.",
             ) from err
         check_bboxes(np.array([bbox]))
-        image_shape = (image.shape[0], image.shape[1])
         denormalized_bbox = denormalize_bboxes(np.array([bbox]), image_shape)[0]
 
         x_min, y_min, x_max, y_max = (int(x) for x in denormalized_bbox[:4])
@@ -229,8 +228,6 @@ class TextImage(ImageOnlyTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        image = data["image"] if "image" in data else data["images"][0]
-
         metadata = data[self.metadata_key]
 
         if metadata == []:
@@ -249,24 +246,35 @@ class TextImage(ImageOnlyTransform):
 
         bbox_indices_to_update = sampling.py_random.sample(range(len(metadata)), num_bboxes_to_modify)
 
-        overlay_data = [
-            self.preprocess_metadata(
-                image,
-                metadata[bbox_index]["bbox"],
-                metadata[bbox_index]["text"],
-                bbox_index,
-                sampling,
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(
+            lambda view: tuple((view.descriptor.spatial_shape or ())[-2:]),
+        ):
+            spatial_shape = views[0].descriptor.spatial_shape
+            if spatial_shape is None:
+                raise ValueError("TextImage requires image-like targets with known spatial shapes")
+            height, width = spatial_shape[-2:]
+            overlay_data = [
+                self.preprocess_metadata(
+                    (height, width),
+                    metadata[bbox_index]["bbox"],
+                    metadata[bbox_index]["text"],
+                    bbox_index,
+                    sampling,
+                )
+                for bbox_index in bbox_indices_to_update
+            ]
+            groups.append(
+                TargetParams(
+                    targets=tuple(view.name for view in views),
+                    params={"overlay_data": overlay_data},
+                    requirements=requirements_for_views(views, spatial_shape_suffix=True),
+                ),
             )
-            for bbox_index in bbox_indices_to_update
-        ]
 
         sampling.applied_overrides["fraction_range"] = fraction
 
-        return SampledParams(
-            params={
-                "overlay_data": overlay_data,
-            }
-        )
+        return SampledParams(params={}, target_params=tuple(groups))
 
     def apply(
         self,
@@ -290,6 +298,7 @@ class TextImage(ImageOnlyTransform):
 
         """
         res = super().apply_with_params(sampled_params, *args, **kwargs)
+        target_name = next(name for name in ("image", "images", "volume") if name in kwargs)
         res["overlay_data"] = [
             {
                 "bbox_coords": overlay["bbox_coords"],
@@ -298,7 +307,7 @@ class TextImage(ImageOnlyTransform):
                 "bbox_index": overlay["bbox_index"],
                 "font_color": overlay["font_color"],
             }
-            for overlay in sampled_params.params_for("image")["overlay_data"]
+            for overlay in sampled_params.params_for(target_name)["overlay_data"]
         ]
 
         return res

--- a/albumentations/augmentations/text/transforms.py
+++ b/albumentations/augmentations/text/transforms.py
@@ -234,8 +234,8 @@ class TextImage(ImageOnlyTransform):
         metadata = data[self.metadata_key]
 
         if metadata == []:
-            return SampledParams.shared_only(
-                {
+            return SampledParams(
+                params={
                     "overlay_data": [],
                 }
             )
@@ -262,8 +262,8 @@ class TextImage(ImageOnlyTransform):
 
         sampling.applied_overrides["fraction_range"] = fraction
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "overlay_data": overlay_data,
             }
         )

--- a/albumentations/augmentations/text/transforms.py
+++ b/albumentations/augmentations/text/transforms.py
@@ -15,6 +15,7 @@ import albumentations.augmentations.text.functional as ftext
 from albumentations.core.bbox_utils import check_bboxes, denormalize_bboxes
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 
@@ -223,18 +224,20 @@ class TextImage(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        data = inputs.data
         image = data["image"] if "image" in data else data["images"][0]
 
         metadata = data[self.metadata_key]
 
         if metadata == []:
-            return {
-                "overlay_data": [],
-            }
+            return TransformParameterPlan.shared_only(
+                {
+                    "overlay_data": [],
+                }
+            )
 
         if isinstance(metadata, dict):
             metadata = [metadata]
@@ -258,9 +261,11 @@ class TextImage(ImageOnlyTransform):
 
         sampling.applied_overrides["fraction_range"] = fraction
 
-        return {
-            "overlay_data": overlay_data,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "overlay_data": overlay_data,
+            }
+        )
 
     def apply(
         self,
@@ -270,12 +275,12 @@ class TextImage(ImageOnlyTransform):
     ) -> ImageType:
         return ftext.render_text(img, overlay_data, clear_bg=self.clear_bg)
 
-    def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def apply_with_params(self, plan: TransformParameterPlan, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply transform and include overlay data in result. Returns dict with transformed data and
         overlay info. Used by Compose when metadata_key present.
 
         Args:
-            params (dict[str, Any]): Parameters for the transform
+            plan (TransformParameterPlan): Realized shared and target-specific parameters.
             *args (Any): Additional positional arguments
             **kwargs (Any): Additional keyword arguments
 
@@ -283,7 +288,7 @@ class TextImage(ImageOnlyTransform):
             dict[str, Any]: Dictionary containing the transformed data and simplified overlay information
 
         """
-        res = super().apply_with_params(params, *args, **kwargs)
+        res = super().apply_with_params(plan, *args, **kwargs)
         res["overlay_data"] = [
             {
                 "bbox_coords": overlay["bbox_coords"],
@@ -292,7 +297,7 @@ class TextImage(ImageOnlyTransform):
                 "bbox_index": overlay["bbox_index"],
                 "font_color": overlay["font_color"],
             }
-            for overlay in params["overlay_data"]
+            for overlay in plan.params_for("image")["overlay_data"]
         ]
 
         return res

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -10,7 +10,6 @@ interface and implements specific 3D augmentation logic.
 from typing import Annotated, Any, ClassVar, Literal, cast
 
 import numpy as np
-import torch
 from albucore import resize3d
 from pydantic import AfterValidator, field_validator, model_validator
 from typing_extensions import Self
@@ -20,6 +19,7 @@ from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import BaseTransformInitSchema, Transform3D, VolumeOnlyTransform
 from albumentations.core.type_definitions import (
     C4_INVERSE,
@@ -65,34 +65,11 @@ DEFAULT_FLIP_AXES: tuple[AxisIndex3D, ...] = (0, 1, 2)
 AXIS_NAMES_3D: tuple[AxisName3D, ...] = ("x", "y", "z")
 
 
-def _get_volume_shape(data: dict[str, Any]) -> tuple[int, ...]:
-    """Return a volume shape from available image and mask targets without indexing into potentially empty input arrays.
-    Avoids indexing empty leading axes.
-    """
-    if "volume" in data:
-        volume = data["volume"]
-        if isinstance(volume, np.ndarray):
-            if volume.ndim not in (NUM_DIMENSIONS, NUM_DIMENSIONS + 1):
-                raise ValueError("volume must be a 3D or 4D array")
-            return volume.shape
-        if isinstance(volume, torch.Tensor):
-            if volume.ndim != NUM_DIMENSIONS + 1:
-                raise ValueError("volume must be a 4D torch.Tensor")
-            return tuple(volume.shape[1:])
-    if "mask3d" in data:
-        if isinstance(data["mask3d"], np.ndarray) and data["mask3d"].ndim != NUM_DIMENSIONS:
-            raise ValueError("mask3d must be a 3D array")
-        if isinstance(data["mask3d"], torch.Tensor) and data["mask3d"].ndim != NUM_DIMENSIONS:
-            raise ValueError("mask3d must be a 3D Tensor")
-        return data["mask3d"].shape
-    raise ValueError("No volume or mask3d found in data")
-
-
-def _get_volume_spatial_shape(data: dict[str, Any]) -> tuple[int, int, int]:
-    """Return depth, height, and width for one input volume target while retaining support for empty leading dimensions.
-    Avoids indexing empty leading axes.
-    """
-    return cast("tuple[int, int, int]", _get_volume_shape(data)[:3])
+def _sampling_volume_shape(inputs: TransformSamplingInput) -> tuple[int, int, int]:
+    frame = inputs.spatial_frame
+    if frame is None or frame.rank != NUM_DIMENSIONS:
+        raise ValueError("3D transform sampling requires a volume spatial frame")
+    return cast("tuple[int, int, int]", frame.shape)
 
 
 class Affine3D(Transform3D):
@@ -218,11 +195,10 @@ class Affine3D(Transform3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        source_shape = _get_volume_spatial_shape(data)
+    ) -> TransformParameterPlan:
+        source_shape = _sampling_volume_shape(inputs)
         rotate = {axis: sampling.py_random.uniform(*self.rotate_range[axis]) for axis in AXIS_NAMES_3D}
         scale = {axis: sampling.py_random.uniform(*self.scale_range[axis]) for axis in AXIS_NAMES_3D}
         translate_percent = {
@@ -245,7 +221,7 @@ class Affine3D(Transform3D):
                 },
             },
         )
-        return {"matrix": matrix, "output_shape": source_shape}
+        return TransformParameterPlan.shared_only({"matrix": matrix, "output_shape": source_shape})
 
     def apply_to_volume(
         self,
@@ -368,15 +344,14 @@ class Anisotropy3D(VolumeOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         selected_axis_count = sampling.py_random.randint(*self.num_axes_range)
         selected_axes = tuple(sorted(sampling.py_random.sample(self.axes, selected_axis_count)))
         downscale_factor = sampling.py_random.uniform(*self.downscale_factor_range)
         downsample_shape = f3d.get_anisotropy_downsample_shape(
-            _get_volume_spatial_shape(data),
+            _sampling_volume_shape(inputs),
             selected_axes,
             downscale_factor,
         )
@@ -388,7 +363,7 @@ class Anisotropy3D(VolumeOnlyTransform):
                 "downscale_factor_range": (downscale_factor, downscale_factor),
             },
         )
-        return {"downsample_shape": downsample_shape}
+        return TransformParameterPlan.shared_only({"downsample_shape": downsample_shape})
 
     def apply_to_volume(
         self,
@@ -477,11 +452,10 @@ class Resize3D(Transform3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, tuple[int, int, int]]:
-        return {"source_shape": _get_volume_spatial_shape(data)}
+    ) -> TransformParameterPlan:
+        return TransformParameterPlan.shared_only({"source_shape": _sampling_volume_shape(inputs)})
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
         return cast("VolumeType", resize3d(volume, self.size, self.interpolation))
@@ -541,11 +515,11 @@ class BasePad3D(Transform3D):
         ...         super().__init__(*args, **kwargs)
         ...         self.padding_size = padding_size
         ...
-        ...     def sample_parameters(self, params, data, sampling):
+        ...     def sample_parameters(self, inputs, sampling):
         ...         # Create symmetric padding: same amount on all sides of each dimension
         ...         pad_d, pad_h, pad_w = self.padding_size
         ...         padding = (pad_d, pad_d, pad_h, pad_h, pad_w, pad_w)
-        ...         return {"padding": padding}
+        ...         return TransformParameterPlan.shared_only({"padding": padding})
         >>>
         >>> # Prepare sample data
         >>> volume = np.random.randint(0, 256, (10, 100, 100), dtype=np.uint8)  # (D, H, W)
@@ -738,20 +712,18 @@ class Pad3D(BasePad3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        """Get padding parameters from input data (volume shape). Returns dict with padding tuple
+    ) -> TransformParameterPlan:
+        """Get padding parameters from input data (volume shape) as a structured plan with a padding tuple
         (d_front, d_back, h_top, h_bottom, w_left, w_right). For Pad3D.
 
         Args:
-            params (dict[str, Any]): Dictionary of existing parameters
-            data (dict[str, Any]): Dictionary containing input data with volume, mask, etc.
+            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            dict[str, Any]: Dictionary containing the padding parameter tuple in format:
+            TransformParameterPlan: Plan containing the padding parameter tuple in format:
                 (depth_front, depth_back, height_top, height_bottom, width_left, width_right)
 
         """
@@ -764,7 +736,7 @@ class Pad3D(BasePad3D):
         else:
             padding = self.padding  # type: ignore[assignment]
 
-        return {"padding": padding}
+        return TransformParameterPlan.shared_only({"padding": padding})
 
 
 class PadIfNeeded3D(BasePad3D):
@@ -870,23 +842,21 @@ class PadIfNeeded3D(BasePad3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         """Calculate padding parameters from volume shape to meet min_zyx or pad_divisor_zyx.
-        Returns dict with padding tuple. For PadIfNeeded3D.
+        Returns a structured plan with a padding tuple. For PadIfNeeded3D.
 
         Args:
-            params (dict[str, Any]): Dictionary of existing parameters
-            data (dict[str, Any]): Dictionary containing input data with volume, mask, etc.
+            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            dict[str, Any]: Dictionary containing calculated padding parameters
+            TransformParameterPlan: Plan containing calculated padding parameters
 
         """
-        depth, height, width = _get_volume_spatial_shape(data)
+        depth, height, width = _sampling_volume_shape(inputs)
         sizes = (depth, height, width)
 
         paddings = [
@@ -904,7 +874,7 @@ class PadIfNeeded3D(BasePad3D):
             py_random=sampling.py_random,
         )
 
-        return {"padding": padding}
+        return TransformParameterPlan.shared_only({"padding": padding})
 
 
 class BaseCropAndPad3D(Transform3D):
@@ -948,10 +918,9 @@ class BaseCropAndPad3D(Transform3D):
         ...         )
         ...         self.crop_size = crop_size
         ...
-        ...     def sample_parameters(self, params, data, sampling):
-        ...         # Get the volume shape
-        ...         volume = data["volume"]
-        ...         z, h, w = volume.shape[:3]
+        ...     def sample_parameters(self, inputs, sampling):
+        ...         # Get the validated spatial frame
+        ...         z, h, w = inputs.require_spatial_frame().shape
         ...         target_z, target_h, target_w = self.crop_size
         ...
         ...         # Check if padding is needed and calculate parameters
@@ -970,10 +939,12 @@ class BaseCropAndPad3D(Transform3D):
         ...         # Calculate fixed crop coordinates - always start at position (0,0,0)
         ...         crop_coords = (0, target_z, 0, target_h, 0, target_w)
         ...
-        ...         return {
+        ...         from albumentations.core.transform_params import TransformParameterPlan
+        ...
+        ...         return TransformParameterPlan.shared_only({
         ...             "crop_coords": crop_coords,
         ...             "pad_params": pad_params,
-        ...         }
+        ...         })
         >>>
         >>> # Prepare sample data
         >>> volume = np.random.randint(0, 256, (10, 100, 100), dtype=np.uint8)  # (D, H, W)
@@ -1297,23 +1268,21 @@ class CenterCrop3D(BaseCropAndPad3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        """Calculate center crop coordinates from volume shape and self.size. Returns dict with
+    ) -> TransformParameterPlan:
+        """Calculate center crop coordinates from volume shape and self.size as a structured plan with
         crop_coords (z_min, z_max, y_min, y_max, x_min, x_max). For CenterCrop3D.
 
         Args:
-            params (dict[str, Any]): Dictionary of existing parameters
-            data (dict[str, Any]): Dictionary containing input data with volume, mask, etc.
+            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            dict[str, Any]: Dictionary containing crop coordinates and optional padding parameters
+            TransformParameterPlan: Plan containing crop coordinates and optional padding parameters
 
         """
-        z, h, w = _get_volume_spatial_shape(data)
+        z, h, w = _sampling_volume_shape(inputs)
         target_z, target_h, target_w = self.size
 
         # Get padding params if needed
@@ -1351,10 +1320,12 @@ class CenterCrop3D(BaseCropAndPad3D):
             w_start + target_w,
         )
 
-        return {
-            "crop_coords": crop_coords,
-            "pad_params": pad_params,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "crop_coords": crop_coords,
+                "pad_params": pad_params,
+            }
+        )
 
 
 class RandomCrop3D(BaseCropAndPad3D):
@@ -1443,23 +1414,21 @@ class RandomCrop3D(BaseCropAndPad3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        """Calculate random crop coordinates from volume shape and self.size. Returns dict with
+    ) -> TransformParameterPlan:
+        """Calculate random crop coordinates from volume shape and self.size as a structured plan with
         crop_coords (z_min, z_max, y_min, y_max, x_min, x_max). For RandomCrop3D.
 
         Args:
-            params (dict[str, Any]): Dictionary of existing parameters
-            data (dict[str, Any]): Dictionary containing input data with volume, mask, etc.
+            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            dict[str, Any]: Dictionary containing randomly generated crop coordinates and optional padding parameters
+            TransformParameterPlan: Plan containing randomly generated crop coordinates and optional padding parameters
 
         """
-        z, h, w = _get_volume_spatial_shape(data)
+        z, h, w = _sampling_volume_shape(inputs)
         target_z, target_h, target_w = self.size
 
         # Get padding params if needed
@@ -1489,10 +1458,12 @@ class RandomCrop3D(BaseCropAndPad3D):
             w_start + target_w,
         )
 
-        return {
-            "crop_coords": crop_coords,
-            "pad_params": pad_params,
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "crop_coords": crop_coords,
+                "pad_params": pad_params,
+            }
+        )
 
 
 class CoarseDropout3D(Transform3D):
@@ -1660,23 +1631,21 @@ class CoarseDropout3D(Transform3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        """Generate hole parameters for CoarseDropout3D from volume shape. Returns dict with holes
+    ) -> TransformParameterPlan:
+        """Generate hole parameters for CoarseDropout3D from volume shape as a structured plan with holes
         (n, 6) and params. Uses depth/height/width ranges, num_holes.
 
         Args:
-            params (dict[str, Any]): Dictionary of existing parameters
-            data (dict[str, Any]): Dictionary containing input data with volume, mask, etc.
+            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            dict[str, Any]: Dictionary containing generated hole parameters for dropout
+            TransformParameterPlan: Plan containing generated hole parameters for dropout
 
         """
-        volume_shape = _get_volume_spatial_shape(data)
+        volume_shape = _sampling_volume_shape(inputs)
 
         num_holes = sampling.py_random.randint(*self.num_holes_range)
 
@@ -1709,7 +1678,7 @@ class CoarseDropout3D(Transform3D):
             },
         )
 
-        return {"holes": holes}
+        return TransformParameterPlan.shared_only({"holes": holes})
 
     def apply_to_volume(self, volume: VolumeType, holes: np.ndarray, **params: Any) -> VolumeType:
         if holes.size == 0:
@@ -1821,16 +1790,17 @@ class Flip3D(Transform3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         flip_axes = self.flip_axes
         if flip_axes is None:
             flip_axes = tuple(axis for axis in self.axes if sampling.py_random.random() < 0.5)
 
         sampling.applied_overrides["flip_axes"] = flip_axes
-        return {"flip_axes": flip_axes, "volume_shape": _get_volume_spatial_shape(data)}
+        return TransformParameterPlan.shared_only(
+            {"flip_axes": flip_axes, "volume_shape": _sampling_volume_shape(inputs)}
+        )
 
     def _get_label_transform_name(self, **params: Any) -> str | None:
         """Return the Flip3D semantic-mapping event for a realized orientation-reversing reflection, allowing mask3d
@@ -1958,25 +1928,25 @@ class CubicSymmetry(Transform3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        """Generate cubic symmetry params: random index 0-47. Returns dict with index for
+    ) -> TransformParameterPlan:
+        """Generate cubic symmetry parameters: random index 0-47. Returns a structured plan with index for
         transform_cube and transform_cube_keypoints. For CubicSymmetry.
 
         Args:
-            params (dict[str, Any]): Dictionary of existing parameters
-            data (dict[str, Any]): Dictionary containing input data with volume, mask, etc.
+            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            dict[str, Any]: Dictionary containing the randomly selected transformation index
+            TransformParameterPlan: Plan containing the randomly selected transformation index
 
         """
         # Randomly select one of 48 possible transformations
-        volume_shape = _get_volume_shape(data)
-        return {"index": sampling.py_random.randint(0, 47), "volume_shape": volume_shape}
+        volume_shape = _sampling_volume_shape(inputs)
+        return TransformParameterPlan.shared_only(
+            {"index": sampling.py_random.randint(0, 47), "volume_shape": volume_shape}
+        )
 
     def _get_label_transform_name(self, **params: Any) -> str | None:
         """Return the CubicSymmetry mapping event for a rotoreflection, while pure cube rotations preserve class
@@ -2072,10 +2042,9 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         axis_pair = self.axis_pair if self.axis_pair is not None else sampling.py_random.choice(self.axis_pairs)
         if self.group_element is not None:
             group_element = self.group_element
@@ -2085,11 +2054,13 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         rotation_count = cast("RotationCount3D", fgeometric.C4_GROUP_ELEMENT_TO_K[group_element])
 
         sampling.applied_overrides.update({"axis_pair": axis_pair, "group_element": group_element})
-        return {
-            "axis_pair": axis_pair,
-            "rotation_count": rotation_count,
-            "volume_shape": _get_volume_spatial_shape(data),
-        }
+        return TransformParameterPlan.shared_only(
+            {
+                "axis_pair": axis_pair,
+                "rotation_count": rotation_count,
+                "volume_shape": _sampling_volume_shape(inputs),
+            }
+        )
 
     def apply_to_volume(
         self,
@@ -2234,11 +2205,10 @@ class GridShuffle3D(Transform3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, np.ndarray | list[int]]:
-        volume_shape = _get_volume_spatial_shape(data)
+    ) -> TransformParameterPlan:
+        volume_shape = _sampling_volume_shape(inputs)
 
         original_tiles = f3d.split_uniform_grid_3d(
             volume_shape,
@@ -2251,4 +2221,4 @@ class GridShuffle3D(Transform3D):
             sampling.random_generator,
         )
 
-        return {"tiles": original_tiles, "mapping": mapping}
+        return TransformParameterPlan.shared_only({"tiles": original_tiles, "mapping": mapping})

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -7,7 +7,7 @@ such as spatial dimensions, apply dropout effects, and perform symmetry operatio
 interface and implements specific 3D augmentation logic.
 """
 
-from typing import Annotated, Any, ClassVar, Literal, cast
+from typing import Annotated, Any, ClassVar, Final, Literal, cast
 
 import numpy as np
 from albucore import resize3d
@@ -19,7 +19,7 @@ from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.pydantic import check_range_bounds, nondecreasing
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import BaseTransformInitSchema, Transform3D, VolumeOnlyTransform
 from albumentations.core.type_definitions import (
     C4_INVERSE,
@@ -47,7 +47,7 @@ __all__ = [
     "Resize3D",
 ]
 
-NUM_DIMENSIONS = 3
+NUM_DIMENSIONS: Final = 3
 AxisIndex3D = Literal[0, 1, 2]
 AxisPair3D = tuple[AxisIndex3D, AxisIndex3D]
 RotationCount3D = Literal[0, 1, 2, 3]
@@ -65,11 +65,8 @@ DEFAULT_FLIP_AXES: tuple[AxisIndex3D, ...] = (0, 1, 2)
 AXIS_NAMES_3D: tuple[AxisName3D, ...] = ("x", "y", "z")
 
 
-def _sampling_volume_shape(inputs: TransformSamplingInput) -> tuple[int, int, int]:
-    frame = inputs.spatial_frame
-    if frame is None or frame.rank != NUM_DIMENSIONS:
-        raise ValueError("3D transform sampling requires a volume spatial frame")
-    return cast("tuple[int, int, int]", frame.shape)
+def _sampling_volume_shape(targets: TargetSet) -> tuple[int, int, int]:
+    return targets.require_spatial_shape(NUM_DIMENSIONS)
 
 
 class Affine3D(Transform3D):
@@ -195,10 +192,12 @@ class Affine3D(Transform3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        source_shape = _sampling_volume_shape(inputs)
+    ) -> SampledParams:
+        source_shape = _sampling_volume_shape(targets)
         rotate = {axis: sampling.py_random.uniform(*self.rotate_range[axis]) for axis in AXIS_NAMES_3D}
         scale = {axis: sampling.py_random.uniform(*self.scale_range[axis]) for axis in AXIS_NAMES_3D}
         translate_percent = {
@@ -221,7 +220,7 @@ class Affine3D(Transform3D):
                 },
             },
         )
-        return TransformParameterPlan.shared_only({"matrix": matrix, "output_shape": source_shape})
+        return SampledParams.shared_only({"matrix": matrix, "output_shape": source_shape})
 
     def apply_to_volume(
         self,
@@ -344,14 +343,16 @@ class Anisotropy3D(VolumeOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         selected_axis_count = sampling.py_random.randint(*self.num_axes_range)
         selected_axes = tuple(sorted(sampling.py_random.sample(self.axes, selected_axis_count)))
         downscale_factor = sampling.py_random.uniform(*self.downscale_factor_range)
         downsample_shape = f3d.get_anisotropy_downsample_shape(
-            _sampling_volume_shape(inputs),
+            _sampling_volume_shape(targets),
             selected_axes,
             downscale_factor,
         )
@@ -363,7 +364,7 @@ class Anisotropy3D(VolumeOnlyTransform):
                 "downscale_factor_range": (downscale_factor, downscale_factor),
             },
         )
-        return TransformParameterPlan.shared_only({"downsample_shape": downsample_shape})
+        return SampledParams.shared_only({"downsample_shape": downsample_shape})
 
     def apply_to_volume(
         self,
@@ -452,10 +453,12 @@ class Resize3D(Transform3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        return TransformParameterPlan.shared_only({"source_shape": _sampling_volume_shape(inputs)})
+    ) -> SampledParams:
+        return SampledParams.shared_only({"source_shape": _sampling_volume_shape(targets)})
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
         return cast("VolumeType", resize3d(volume, self.size, self.interpolation))
@@ -515,11 +518,11 @@ class BasePad3D(Transform3D):
         ...         super().__init__(*args, **kwargs)
         ...         self.padding_size = padding_size
         ...
-        ...     def sample_parameters(self, inputs, sampling):
+        ...     def sample_parameters(self, params, data, targets, sampling):
         ...         # Create symmetric padding: same amount on all sides of each dimension
         ...         pad_d, pad_h, pad_w = self.padding_size
         ...         padding = (pad_d, pad_d, pad_h, pad_h, pad_w, pad_w)
-        ...         return TransformParameterPlan.shared_only({"padding": padding})
+        ...         return SampledParams.shared_only({"padding": padding})
         >>>
         >>> # Prepare sample data
         >>> volume = np.random.randint(0, 256, (10, 100, 100), dtype=np.uint8)  # (D, H, W)
@@ -712,18 +715,22 @@ class Pad3D(BasePad3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         """Get padding parameters from input data (volume shape) as a structured plan with a padding tuple
         (d_front, d_back, h_top, h_bottom, w_left, w_right). For Pad3D.
 
         Args:
-            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
+            params (dict[str, Any]): Common execution parameters.
+            data (dict[str, Any]): Preprocessed invocation data.
+            targets (TargetSet): Active target metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            TransformParameterPlan: Plan containing the padding parameter tuple in format:
+            SampledParams: Plan containing the padding parameter tuple in format:
                 (depth_front, depth_back, height_top, height_bottom, width_left, width_right)
 
         """
@@ -731,12 +738,12 @@ class Pad3D(BasePad3D):
             pad_d = pad_h = pad_w = self.padding
             padding = (pad_d, pad_d, pad_h, pad_h, pad_w, pad_w)
         elif len(self.padding) == NUM_DIMENSIONS:
-            pad_d, pad_h, pad_w = self.padding  # type: ignore[misc]
+            pad_d, pad_h, pad_w = self.padding
             padding = (pad_d, pad_d, pad_h, pad_h, pad_w, pad_w)
         else:
-            padding = self.padding  # type: ignore[assignment]
+            padding = self.padding
 
-        return TransformParameterPlan.shared_only({"padding": padding})
+        return SampledParams.shared_only({"padding": padding})
 
 
 class PadIfNeeded3D(BasePad3D):
@@ -842,21 +849,25 @@ class PadIfNeeded3D(BasePad3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         """Calculate padding parameters from volume shape to meet min_zyx or pad_divisor_zyx.
         Returns a structured plan with a padding tuple. For PadIfNeeded3D.
 
         Args:
-            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
+            params (dict[str, Any]): Common execution parameters.
+            data (dict[str, Any]): Preprocessed invocation data.
+            targets (TargetSet): Active target metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            TransformParameterPlan: Plan containing calculated padding parameters
+            SampledParams: Plan containing calculated padding parameters
 
         """
-        depth, height, width = _sampling_volume_shape(inputs)
+        depth, height, width = _sampling_volume_shape(targets)
         sizes = (depth, height, width)
 
         paddings = [
@@ -874,7 +885,7 @@ class PadIfNeeded3D(BasePad3D):
             py_random=sampling.py_random,
         )
 
-        return TransformParameterPlan.shared_only({"padding": padding})
+        return SampledParams.shared_only({"padding": padding})
 
 
 class BaseCropAndPad3D(Transform3D):
@@ -918,9 +929,9 @@ class BaseCropAndPad3D(Transform3D):
         ...         )
         ...         self.crop_size = crop_size
         ...
-        ...     def sample_parameters(self, inputs, sampling):
+        ...     def sample_parameters(self, params, data, targets, sampling):
         ...         # Get the validated spatial frame
-        ...         z, h, w = inputs.require_spatial_frame().shape
+        ...         z, h, w = targets.require_spatial_shape(3)
         ...         target_z, target_h, target_w = self.crop_size
         ...
         ...         # Check if padding is needed and calculate parameters
@@ -939,9 +950,9 @@ class BaseCropAndPad3D(Transform3D):
         ...         # Calculate fixed crop coordinates - always start at position (0,0,0)
         ...         crop_coords = (0, target_z, 0, target_h, 0, target_w)
         ...
-        ...         from albumentations.core.transform_params import TransformParameterPlan
+        ...         from albumentations.core.transform_params import SampledParams
         ...
-        ...         return TransformParameterPlan.shared_only({
+        ...         return SampledParams.shared_only({
         ...             "crop_coords": crop_coords,
         ...             "pad_params": pad_params,
         ...         })
@@ -1268,21 +1279,25 @@ class CenterCrop3D(BaseCropAndPad3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         """Calculate center crop coordinates from volume shape and self.size as a structured plan with
         crop_coords (z_min, z_max, y_min, y_max, x_min, x_max). For CenterCrop3D.
 
         Args:
-            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
+            params (dict[str, Any]): Common execution parameters.
+            data (dict[str, Any]): Preprocessed invocation data.
+            targets (TargetSet): Active target metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            TransformParameterPlan: Plan containing crop coordinates and optional padding parameters
+            SampledParams: Plan containing crop coordinates and optional padding parameters
 
         """
-        z, h, w = _sampling_volume_shape(inputs)
+        z, h, w = _sampling_volume_shape(targets)
         target_z, target_h, target_w = self.size
 
         # Get padding params if needed
@@ -1320,7 +1335,7 @@ class CenterCrop3D(BaseCropAndPad3D):
             w_start + target_w,
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "crop_coords": crop_coords,
                 "pad_params": pad_params,
@@ -1414,21 +1429,25 @@ class RandomCrop3D(BaseCropAndPad3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         """Calculate random crop coordinates from volume shape and self.size as a structured plan with
         crop_coords (z_min, z_max, y_min, y_max, x_min, x_max). For RandomCrop3D.
 
         Args:
-            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
+            params (dict[str, Any]): Common execution parameters.
+            data (dict[str, Any]): Preprocessed invocation data.
+            targets (TargetSet): Active target metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            TransformParameterPlan: Plan containing randomly generated crop coordinates and optional padding parameters
+            SampledParams: Plan containing randomly generated crop coordinates and optional padding parameters
 
         """
-        z, h, w = _sampling_volume_shape(inputs)
+        z, h, w = _sampling_volume_shape(targets)
         target_z, target_h, target_w = self.size
 
         # Get padding params if needed
@@ -1458,7 +1477,7 @@ class RandomCrop3D(BaseCropAndPad3D):
             w_start + target_w,
         )
 
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "crop_coords": crop_coords,
                 "pad_params": pad_params,
@@ -1631,21 +1650,25 @@ class CoarseDropout3D(Transform3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         """Generate hole parameters for CoarseDropout3D from volume shape as a structured plan with holes
         (n, 6) and params. Uses depth/height/width ranges, num_holes.
 
         Args:
-            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
+            params (dict[str, Any]): Common execution parameters.
+            data (dict[str, Any]): Preprocessed invocation data.
+            targets (TargetSet): Active target metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            TransformParameterPlan: Plan containing generated hole parameters for dropout
+            SampledParams: Plan containing generated hole parameters for dropout
 
         """
-        volume_shape = _sampling_volume_shape(inputs)
+        volume_shape = _sampling_volume_shape(targets)
 
         num_holes = sampling.py_random.randint(*self.num_holes_range)
 
@@ -1678,7 +1701,7 @@ class CoarseDropout3D(Transform3D):
             },
         )
 
-        return TransformParameterPlan.shared_only({"holes": holes})
+        return SampledParams.shared_only({"holes": holes})
 
     def apply_to_volume(self, volume: VolumeType, holes: np.ndarray, **params: Any) -> VolumeType:
         if holes.size == 0:
@@ -1790,17 +1813,17 @@ class Flip3D(Transform3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         flip_axes = self.flip_axes
         if flip_axes is None:
             flip_axes = tuple(axis for axis in self.axes if sampling.py_random.random() < 0.5)
 
         sampling.applied_overrides["flip_axes"] = flip_axes
-        return TransformParameterPlan.shared_only(
-            {"flip_axes": flip_axes, "volume_shape": _sampling_volume_shape(inputs)}
-        )
+        return SampledParams.shared_only({"flip_axes": flip_axes, "volume_shape": _sampling_volume_shape(targets)})
 
     def _get_label_transform_name(self, **params: Any) -> str | None:
         """Return the Flip3D semantic-mapping event for a realized orientation-reversing reflection, allowing mask3d
@@ -1928,25 +1951,27 @@ class CubicSymmetry(Transform3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         """Generate cubic symmetry parameters: random index 0-47. Returns a structured plan with index for
         transform_cube and transform_cube_keypoints. For CubicSymmetry.
 
         Args:
-            inputs (TransformSamplingInput): Preprocessed volume targets and shared sampling metadata.
+            params (dict[str, Any]): Common execution parameters.
+            data (dict[str, Any]): Preprocessed invocation data.
+            targets (TargetSet): Active target metadata.
             sampling (SamplingContext): Call-local random streams and applied-configuration capture.
 
         Returns:
-            TransformParameterPlan: Plan containing the randomly selected transformation index
+            SampledParams: Plan containing the randomly selected transformation index
 
         """
         # Randomly select one of 48 possible transformations
-        volume_shape = _sampling_volume_shape(inputs)
-        return TransformParameterPlan.shared_only(
-            {"index": sampling.py_random.randint(0, 47), "volume_shape": volume_shape}
-        )
+        volume_shape = _sampling_volume_shape(targets)
+        return SampledParams.shared_only({"index": sampling.py_random.randint(0, 47), "volume_shape": volume_shape})
 
     def _get_label_transform_name(self, **params: Any) -> str | None:
         """Return the CubicSymmetry mapping event for a rotoreflection, while pure cube rotations preserve class
@@ -2042,9 +2067,11 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         axis_pair = self.axis_pair if self.axis_pair is not None else sampling.py_random.choice(self.axis_pairs)
         if self.group_element is not None:
             group_element = self.group_element
@@ -2054,11 +2081,11 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         rotation_count = cast("RotationCount3D", fgeometric.C4_GROUP_ELEMENT_TO_K[group_element])
 
         sampling.applied_overrides.update({"axis_pair": axis_pair, "group_element": group_element})
-        return TransformParameterPlan.shared_only(
+        return SampledParams.shared_only(
             {
                 "axis_pair": axis_pair,
                 "rotation_count": rotation_count,
-                "volume_shape": _sampling_volume_shape(inputs),
+                "volume_shape": _sampling_volume_shape(targets),
             }
         )
 
@@ -2205,10 +2232,12 @@ class GridShuffle3D(Transform3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        volume_shape = _sampling_volume_shape(inputs)
+    ) -> SampledParams:
+        volume_shape = _sampling_volume_shape(targets)
 
         original_tiles = f3d.split_uniform_grid_3d(
             volume_shape,
@@ -2221,4 +2250,4 @@ class GridShuffle3D(Transform3D):
             sampling.random_generator,
         )
 
-        return TransformParameterPlan.shared_only({"tiles": original_tiles, "mapping": mapping})
+        return SampledParams.shared_only({"tiles": original_tiles, "mapping": mapping})

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -66,7 +66,7 @@ AXIS_NAMES_3D: tuple[AxisName3D, ...] = ("x", "y", "z")
 
 
 def _sampling_volume_shape(targets: TargetSet) -> tuple[int, int, int]:
-    return targets.require_spatial_shape(NUM_DIMENSIONS)
+    return targets.require_aligned_spatial_shape(NUM_DIMENSIONS)
 
 
 class Affine3D(Transform3D):
@@ -220,7 +220,7 @@ class Affine3D(Transform3D):
                 },
             },
         )
-        return SampledParams.shared_only({"matrix": matrix, "output_shape": source_shape})
+        return SampledParams(params={"matrix": matrix, "output_shape": source_shape})
 
     def apply_to_volume(
         self,
@@ -364,7 +364,7 @@ class Anisotropy3D(VolumeOnlyTransform):
                 "downscale_factor_range": (downscale_factor, downscale_factor),
             },
         )
-        return SampledParams.shared_only({"downsample_shape": downsample_shape})
+        return SampledParams(params={"downsample_shape": downsample_shape})
 
     def apply_to_volume(
         self,
@@ -458,7 +458,7 @@ class Resize3D(Transform3D):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        return SampledParams.shared_only({"source_shape": _sampling_volume_shape(targets)})
+        return SampledParams(params={"source_shape": _sampling_volume_shape(targets)})
 
     def apply_to_volume(self, volume: VolumeType, **params: Any) -> VolumeType:
         return cast("VolumeType", resize3d(volume, self.size, self.interpolation))
@@ -522,7 +522,7 @@ class BasePad3D(Transform3D):
         ...         # Create symmetric padding: same amount on all sides of each dimension
         ...         pad_d, pad_h, pad_w = self.padding_size
         ...         padding = (pad_d, pad_d, pad_h, pad_h, pad_w, pad_w)
-        ...         return SampledParams.shared_only({"padding": padding})
+        ...         return SampledParams(params={"padding": padding})
         >>>
         >>> # Prepare sample data
         >>> volume = np.random.randint(0, 256, (10, 100, 100), dtype=np.uint8)  # (D, H, W)
@@ -743,7 +743,7 @@ class Pad3D(BasePad3D):
         else:
             padding = self.padding
 
-        return SampledParams.shared_only({"padding": padding})
+        return SampledParams(params={"padding": padding})
 
 
 class PadIfNeeded3D(BasePad3D):
@@ -885,7 +885,7 @@ class PadIfNeeded3D(BasePad3D):
             py_random=sampling.py_random,
         )
 
-        return SampledParams.shared_only({"padding": padding})
+        return SampledParams(params={"padding": padding})
 
 
 class BaseCropAndPad3D(Transform3D):
@@ -931,7 +931,7 @@ class BaseCropAndPad3D(Transform3D):
         ...
         ...     def sample_parameters(self, params, data, targets, sampling):
         ...         # Get the validated spatial frame
-        ...         z, h, w = targets.require_spatial_shape(3)
+        ...         z, h, w = targets.require_aligned_spatial_shape(3)
         ...         target_z, target_h, target_w = self.crop_size
         ...
         ...         # Check if padding is needed and calculate parameters
@@ -952,7 +952,7 @@ class BaseCropAndPad3D(Transform3D):
         ...
         ...         from albumentations.core.transform_params import SampledParams
         ...
-        ...         return SampledParams.shared_only({
+        ...         return SampledParams(params={
         ...             "crop_coords": crop_coords,
         ...             "pad_params": pad_params,
         ...         })
@@ -1335,8 +1335,8 @@ class CenterCrop3D(BaseCropAndPad3D):
             w_start + target_w,
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "crop_coords": crop_coords,
                 "pad_params": pad_params,
             }
@@ -1477,8 +1477,8 @@ class RandomCrop3D(BaseCropAndPad3D):
             w_start + target_w,
         )
 
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "crop_coords": crop_coords,
                 "pad_params": pad_params,
             }
@@ -1701,7 +1701,7 @@ class CoarseDropout3D(Transform3D):
             },
         )
 
-        return SampledParams.shared_only({"holes": holes})
+        return SampledParams(params={"holes": holes})
 
     def apply_to_volume(self, volume: VolumeType, holes: np.ndarray, **params: Any) -> VolumeType:
         if holes.size == 0:
@@ -1823,7 +1823,7 @@ class Flip3D(Transform3D):
             flip_axes = tuple(axis for axis in self.axes if sampling.py_random.random() < 0.5)
 
         sampling.applied_overrides["flip_axes"] = flip_axes
-        return SampledParams.shared_only({"flip_axes": flip_axes, "volume_shape": _sampling_volume_shape(targets)})
+        return SampledParams(params={"flip_axes": flip_axes, "volume_shape": _sampling_volume_shape(targets)})
 
     def _get_label_transform_name(self, **params: Any) -> str | None:
         """Return the Flip3D semantic-mapping event for a realized orientation-reversing reflection, allowing mask3d
@@ -1971,7 +1971,7 @@ class CubicSymmetry(Transform3D):
         """
         # Randomly select one of 48 possible transformations
         volume_shape = _sampling_volume_shape(targets)
-        return SampledParams.shared_only({"index": sampling.py_random.randint(0, 47), "volume_shape": volume_shape})
+        return SampledParams(params={"index": sampling.py_random.randint(0, 47), "volume_shape": volume_shape})
 
     def _get_label_transform_name(self, **params: Any) -> str | None:
         """Return the CubicSymmetry mapping event for a rotoreflection, while pure cube rotations preserve class
@@ -2081,8 +2081,8 @@ class RandomRotate90_3D(Transform3D):  # noqa: N801 - Public API name specified 
         rotation_count = cast("RotationCount3D", fgeometric.C4_GROUP_ELEMENT_TO_K[group_element])
 
         sampling.applied_overrides.update({"axis_pair": axis_pair, "group_element": group_element})
-        return SampledParams.shared_only(
-            {
+        return SampledParams(
+            params={
                 "axis_pair": axis_pair,
                 "rotation_count": rotation_count,
                 "volume_shape": _sampling_volume_shape(targets),
@@ -2250,4 +2250,4 @@ class GridShuffle3D(Transform3D):
             sampling.random_generator,
         )
 
-        return SampledParams.shared_only({"tiles": original_tiles, "mapping": mapping})
+        return SampledParams(params={"tiles": original_tiles, "mapping": mapping})

--- a/albumentations/core/transform_params.py
+++ b/albumentations/core/transform_params.py
@@ -426,7 +426,7 @@ def _describe_target_cached(
         elif canonical_type == "images":
             spatial_shape = shape[2:4] if tensor else shape[1:3]
             channels = shape[0] if tensor else (shape[-1] if len(shape) > 3 else 1)
-            layout, topology = ("images_nchw", "batch_2d") if tensor else ("images_nhwc", "batch_2d")
+            layout, topology = ("images_clhw", "batch_2d") if tensor else ("images_nhwc", "batch_2d")
         elif canonical_type == "volume":
             spatial_shape = shape[1:] if tensor else shape[:3]
             channels = shape[0] if tensor else (shape[-1] if len(shape) > 3 else 1)

--- a/albumentations/core/transform_params.py
+++ b/albumentations/core/transform_params.py
@@ -8,7 +8,9 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Literal, overload
 
+import numpy as np
 import torch
+from albucore import MAX_VALUES_BY_DTYPE
 
 from .type_definitions import Targets
 
@@ -25,6 +27,19 @@ _TARGET_ORDER = {
 }
 _PARAMETER_SCHEMA = 2
 _PARAMETER_PAYLOAD_KEYS = frozenset({"parameter_schema", "target_schema", "params", "target_params"})
+_TARGET_PARAMETER_PAYLOAD_KEYS = frozenset({"targets", "params", "requirements"})
+_TARGET_REQUIREMENT_PAYLOAD_KEYS = frozenset(
+    {
+        "shape",
+        "spatial_shape",
+        "spatial_shape_suffix",
+        "channels",
+        "dtype",
+        "value_scale",
+        "layout",
+        "sampling_topology",
+    },
+)
 
 
 class SampledParamsError(ValueError):
@@ -41,7 +56,7 @@ class TargetDescriptor:
     spatial_shape: tuple[int, ...] | None
     channels: int | None
     dtype: Any
-    dtype_scale: str | None
+    value_scale: float | None
     layout: str
     sampling_topology: str
 
@@ -71,7 +86,7 @@ class TargetRequirement:
     spatial_shape_suffix: tuple[int, ...] | None = None
     channels: int | None = None
     dtype: Any = None
-    dtype_scale: str | None = None
+    value_scale: float | None = None
     layout: str | None = None
     sampling_topology: str | None = None
 
@@ -91,7 +106,7 @@ class TargetRequirement:
                 ),
                 ("channels", self.channels, descriptor.channels),
                 ("dtype", self.dtype, descriptor.dtype),
-                ("dtype_scale", self.dtype_scale, descriptor.dtype_scale),
+                ("value_scale", self.value_scale, descriptor.value_scale),
                 ("layout", self.layout, descriptor.layout),
                 ("sampling_topology", self.sampling_topology, descriptor.sampling_topology),
             )
@@ -104,13 +119,15 @@ class TargetRequirement:
             "spatial_shape_suffix": self.spatial_shape_suffix,
             "channels": self.channels,
             "dtype": None if self.dtype is None else str(self.dtype),
-            "dtype_scale": self.dtype_scale,
+            "value_scale": self.value_scale,
             "layout": self.layout,
             "sampling_topology": self.sampling_topology,
         }
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> TargetRequirement:
+        if set(payload) != _TARGET_REQUIREMENT_PAYLOAD_KEYS:
+            raise SampledParamsError("unsupported target parameter requirement schema")
         return cls(
             shape=None if payload.get("shape") is None else tuple(payload["shape"]),
             spatial_shape=None if payload.get("spatial_shape") is None else tuple(payload["spatial_shape"]),
@@ -119,7 +136,7 @@ class TargetRequirement:
             ),
             channels=payload.get("channels"),
             dtype=payload.get("dtype"),
-            dtype_scale=payload.get("dtype_scale"),
+            value_scale=payload.get("value_scale"),
             layout=payload.get("layout"),
             sampling_topology=payload.get("sampling_topology"),
         )
@@ -359,20 +376,34 @@ class SampledParams:
     def from_dict(cls, payload: Mapping[str, Any]) -> SampledParams:
         if payload.get("parameter_schema") != _PARAMETER_SCHEMA or set(payload) != _PARAMETER_PAYLOAD_KEYS:
             raise SampledParamsError("unsupported or legacy transform parameter schema")
-        target_params = tuple(
-            TargetParams(
-                targets=tuple(item["targets"]),
-                params=dict(item["params"]),
-                requirements={
-                    name: TargetRequirement.from_dict(requirement) for name, requirement in item["requirements"].items()
-                },
+        raw_target_params = payload.get("target_params", ())
+        if not isinstance(raw_target_params, list):
+            raise SampledParamsError("target parameters must be a list")
+        target_params: list[TargetParams] = []
+        for item in raw_target_params:
+            if not isinstance(item, Mapping) or set(item) != _TARGET_PARAMETER_PAYLOAD_KEYS:
+                raise SampledParamsError("unsupported target parameter schema")
+            raw_requirements = item["requirements"]
+            if not isinstance(raw_requirements, Mapping):
+                raise SampledParamsError("target parameter requirements must be a mapping")
+            requirements: dict[str, TargetRequirement] = {}
+            for name, requirement in raw_requirements.items():
+                if not isinstance(name, str) or not isinstance(requirement, Mapping):
+                    raise SampledParamsError(
+                        "target parameter requirements must map target names to requirement objects"
+                    )
+                requirements[name] = TargetRequirement.from_dict(requirement)
+            target_params.append(
+                TargetParams(
+                    targets=tuple(item["targets"]),
+                    params=dict(item["params"]),
+                    requirements=requirements,
+                ),
             )
-            for item in payload.get("target_params", ())
-        )
         target_schema = payload.get("target_schema")
         return cls(
             params=dict(payload.get("params", {})),
-            target_params=target_params,
+            target_params=tuple(target_params),
             target_schema=None if target_schema is None else dict(target_schema),
         )
 
@@ -403,6 +434,15 @@ def _describe_target(name: str, canonical_type: str, value: Any) -> TargetDescri
     shape = tuple(int(dim) for dim in value.shape) if hasattr(value, "shape") else None
     dtype = getattr(value, "dtype", None)
     return _describe_target_cached(name, canonical_type, shape, dtype, isinstance(value, torch.Tensor))
+
+
+def _value_scale(dtype: Any) -> float | None:
+    if dtype is None:
+        return None
+    try:
+        return MAX_VALUES_BY_DTYPE.get(np.dtype(str(dtype).removeprefix("torch.")))
+    except (TypeError, ValueError):
+        return None
 
 
 @lru_cache(maxsize=4096)
@@ -444,8 +484,17 @@ def _describe_target_cached(
             channels = shape[-1] if len(shape) > 3 else 1
             layout, topology = "mask3d_dhw", "mask_3d"
 
-    dtype_scale = None if dtype is None else str(dtype).replace("torch.", "")
-    return TargetDescriptor(name, canonical_type, shape, spatial_shape, channels, dtype, dtype_scale, layout, topology)
+    return TargetDescriptor(
+        name,
+        canonical_type,
+        shape,
+        spatial_shape,
+        channels,
+        dtype,
+        _value_scale(dtype),
+        layout,
+        topology,
+    )
 
 
 @lru_cache(maxsize=1024)
@@ -469,6 +518,7 @@ def requirements_for_views(
     spatial_shape_suffix: bool = False,
     channels: bool = False,
     dtype: bool = False,
+    value_scale: bool = False,
     layout: bool = False,
     sampling_topology: bool = False,
 ) -> dict[str, TargetRequirement]:
@@ -484,7 +534,7 @@ def requirements_for_views(
             ),
             channels=view.descriptor.channels if channels else None,
             dtype=view.descriptor.dtype if dtype else None,
-            dtype_scale=view.descriptor.dtype_scale if dtype else None,
+            value_scale=view.descriptor.value_scale if value_scale else None,
             layout=view.descriptor.layout if layout else None,
             sampling_topology=view.descriptor.sampling_topology if sampling_topology else None,
         )

--- a/albumentations/core/transform_params.py
+++ b/albumentations/core/transform_params.py
@@ -24,6 +24,7 @@ _TARGET_ORDER = {
     "user_data": 8,
 }
 _PARAMETER_SCHEMA = 2
+_PARAMETER_PAYLOAD_KEYS = frozenset({"parameter_schema", "target_schema", "params", "target_params"})
 
 
 class SampledParamsError(ValueError):
@@ -126,7 +127,7 @@ class TargetRequirement:
 
 @dataclass(frozen=True, slots=True)
 class TargetParams:
-    """Parameters shared by a named set of compatible actual target keys."""
+    """Parameters for a named set of actual targets with compatible representations."""
 
     targets: tuple[str, ...]
     params: Mapping[str, Any]
@@ -134,11 +135,11 @@ class TargetParams:
 
     def __post_init__(self) -> None:
         if not self.targets:
-            raise SampledParamsError("target parameter groups cannot be empty")
+            raise SampledParamsError("target parameter sets cannot be empty")
         if len(set(self.targets)) != len(self.targets):
-            raise SampledParamsError("target parameter groups cannot repeat target keys")
+            raise SampledParamsError("target parameter sets cannot repeat target keys")
         if set(self.targets) != set(self.requirements):
-            raise SampledParamsError("target parameter groups require one requirement per target")
+            raise SampledParamsError("target parameter sets require one requirement per target")
         object.__setattr__(self, "params", dict(self.params))
         object.__setattr__(self, "requirements", dict(self.requirements))
 
@@ -156,7 +157,7 @@ class TargetSet:
     def __init__(self, views: tuple[TargetView, ...]) -> None:
         self.ordered = views
         self._by_name = {view.name: view for view in views}
-        self._spatial_shapes: dict[int, tuple[int, ...] | None] = {}
+        self._aligned_spatial_shapes: dict[int, tuple[int, ...] | None] = {}
 
     @classmethod
     def from_data(cls, data: Mapping[str, Any], canonical_by_name: Mapping[str, str]) -> TargetSet:
@@ -202,20 +203,20 @@ class TargetSet:
         return tuple(tuple(views) for views in grouped.values())
 
     @overload
-    def spatial_shape(self, rank: Literal[2]) -> tuple[int, int] | None: ...
+    def aligned_spatial_shape(self, rank: Literal[2]) -> tuple[int, int] | None: ...
 
     @overload
-    def spatial_shape(self, rank: Literal[3]) -> tuple[int, int, int] | None: ...
+    def aligned_spatial_shape(self, rank: Literal[3]) -> tuple[int, int, int] | None: ...
 
     @overload
-    def spatial_shape(self, rank: int) -> tuple[int, ...] | None: ...
+    def aligned_spatial_shape(self, rank: int) -> tuple[int, ...] | None: ...
 
-    def spatial_shape(self, rank: int) -> tuple[int, ...] | None:
-        """Return the common spatial shape for a transform family, if these targets provide one."""
+    def aligned_spatial_shape(self, rank: int) -> tuple[int, ...] | None:
+        """Return the spatial shape after verifying that all relevant targets are aligned."""
         if rank not in {2, 3}:
             raise ValueError(f"spatial rank must be 2 or 3, got {rank}")
-        if rank in self._spatial_shapes:
-            return self._spatial_shapes[rank]
+        if rank in self._aligned_spatial_shapes:
+            return self._aligned_spatial_shapes[rank]
 
         shapes = {
             shape
@@ -228,27 +229,27 @@ class TargetSet:
                 (shape for view in self.ordered if (shape := _spatial_shape_for_rank(view, rank)) is not None),
                 None,
             )
-            self._spatial_shapes[rank] = fallback
+            self._aligned_spatial_shapes[rank] = fallback
             return fallback
         if len(shapes) != 1:
             raise SampledParamsError(f"transform sampling requires aligned spatial targets, got {sorted(shapes)}")
 
         shape = next(iter(shapes))
-        self._spatial_shapes[rank] = shape
+        self._aligned_spatial_shapes[rank] = shape
         return shape
 
     @overload
-    def require_spatial_shape(self, rank: Literal[2]) -> tuple[int, int]: ...
+    def require_aligned_spatial_shape(self, rank: Literal[2]) -> tuple[int, int]: ...
 
     @overload
-    def require_spatial_shape(self, rank: Literal[3]) -> tuple[int, int, int]: ...
+    def require_aligned_spatial_shape(self, rank: Literal[3]) -> tuple[int, int, int]: ...
 
     @overload
-    def require_spatial_shape(self, rank: int) -> tuple[int, ...]: ...
+    def require_aligned_spatial_shape(self, rank: int) -> tuple[int, ...]: ...
 
-    def require_spatial_shape(self, rank: int) -> tuple[int, ...]:
-        """Return the common spatial shape required by a spatial sampler."""
-        shape = self.spatial_shape(rank)
+    def require_aligned_spatial_shape(self, rank: int) -> tuple[int, ...]:
+        """Return the spatial shape required by a sampler with aligned targets."""
+        shape = self.aligned_spatial_shape(rank)
         if shape is None:
             raise SampledParamsError("transform sampling requires a spatial target")
         return shape
@@ -263,18 +264,11 @@ class TargetSet:
 
 @dataclass(frozen=True, slots=True)
 class SampledParams:
-    """Shared and target-specific values sampled for one transform event."""
+    """Parameters and target-specific values sampled for one transform event."""
 
-    shared: Mapping[str, Any]
-    groups: tuple[TargetParams, ...] = ()
+    params: Mapping[str, Any]
+    target_params: tuple[TargetParams, ...] = ()
     target_schema: Mapping[str, str] | None = None
-
-    @classmethod
-    def shared_only(cls, params: Mapping[str, Any]) -> SampledParams:
-        return cls(shared=dict(params))
-
-    def bind(self, targets: TargetSet) -> SampledParams:
-        return SampledParams(self.shared, self.groups, targets.schema())
 
     def validate(
         self,
@@ -284,7 +278,7 @@ class SampledParams:
     ) -> None:
         active_names = targets.names
         self._validate_target_schema(targets, active_names, transform_name)
-        seen = self._validate_groups(targets, active_names, transform_name)
+        seen = self._validate_target_params(targets, active_names, transform_name)
         self._validate_required(required_params, seen, transform_name)
 
     def _validate_target_schema(
@@ -305,29 +299,29 @@ class SampledParams:
                     f"{transform_name} sampled parameter canonical target mismatch for {name!r}",
                 )
 
-    def _validate_groups(
+    def _validate_target_params(
         self,
         targets: TargetSet,
         active_names: frozenset[str],
         transform_name: str,
     ) -> dict[str, set[str]]:
         seen: dict[str, set[str]] = {}
-        for group in self.groups:
-            if any(name not in active_names for name in group.targets):
+        for target_params in self.target_params:
+            if any(name not in active_names for name in target_params.targets):
                 raise SampledParamsError(f"{transform_name} sampled parameters name an inactive target")
-            for name in group.targets:
+            for name in target_params.targets:
                 descriptor = targets.by_name(name).descriptor
-                requirement = group.requirements[name]
+                requirement = target_params.requirements[name]
                 if not requirement.check(descriptor):
                     raise SampledParamsError(
                         f"{transform_name} sampled parameter requirements do not match target {name!r}",
                     )
-                duplicate = seen.setdefault(name, set()).intersection(group.params)
-                if duplicate or set(group.params).intersection(self.shared):
+                duplicate = seen.setdefault(name, set()).intersection(target_params.params)
+                if duplicate or set(target_params.params).intersection(self.params):
                     raise SampledParamsError(
                         f"{transform_name} sampled parameters have duplicate keys for target {name!r}",
                     )
-                seen[name].update(group.params)
+                seen[name].update(target_params.params)
         return seen
 
     def _validate_required(
@@ -337,7 +331,7 @@ class SampledParams:
         transform_name: str,
     ) -> None:
         for name, required in required_params.items():
-            available = set(self.shared).union(seen.get(name, set()))
+            available = set(self.params).union(seen.get(name, set()))
             missing = required - available
             if missing:
                 raise SampledParamsError(
@@ -345,41 +339,40 @@ class SampledParams:
                 )
 
     def params_for(self, target_name: str) -> Mapping[str, Any]:
-        if not self.groups:
-            return self.shared
-        resolved = dict(self.shared)
-        for group in self.groups:
-            if target_name in group.targets:
-                resolved.update(group.params)
+        if not self.target_params:
+            return self.params
+        resolved = dict(self.params)
+        for target_params in self.target_params:
+            if target_name in target_params.targets:
+                resolved.update(target_params.params)
         return resolved
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "parameter_schema": _PARAMETER_SCHEMA,
             "target_schema": None if self.target_schema is None else dict(self.target_schema),
-            "shared": dict(self.shared),
-            "groups": [group.to_dict() for group in self.groups],
+            "params": dict(self.params),
+            "target_params": [target_params.to_dict() for target_params in self.target_params],
         }
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> SampledParams:
-        if payload.get("parameter_schema") != _PARAMETER_SCHEMA:
+        if payload.get("parameter_schema") != _PARAMETER_SCHEMA or set(payload) != _PARAMETER_PAYLOAD_KEYS:
             raise SampledParamsError("unsupported or legacy transform parameter schema")
-        groups = tuple(
+        target_params = tuple(
             TargetParams(
-                targets=tuple(group["targets"]),
-                params=dict(group["params"]),
+                targets=tuple(item["targets"]),
+                params=dict(item["params"]),
                 requirements={
-                    name: TargetRequirement.from_dict(requirement)
-                    for name, requirement in group["requirements"].items()
+                    name: TargetRequirement.from_dict(requirement) for name, requirement in item["requirements"].items()
                 },
             )
-            for group in payload.get("groups", ())
+            for item in payload.get("target_params", ())
         )
         target_schema = payload.get("target_schema")
         return cls(
-            shared=dict(payload.get("shared", {})),
-            groups=groups,
+            params=dict(payload.get("params", {})),
+            target_params=target_params,
             target_schema=None if target_schema is None else dict(target_schema),
         )
 

--- a/albumentations/core/transform_params.py
+++ b/albumentations/core/transform_params.py
@@ -1,0 +1,476 @@
+"""Invocation-local target metadata and structured transform parameters."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Hashable, Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import torch
+
+from .type_definitions import Targets
+
+_TARGET_ORDER = {
+    "image": 0,
+    "images": 1,
+    "volume": 2,
+    "mask": 3,
+    "masks": 4,
+    "mask3d": 5,
+    "bboxes": 6,
+    "keypoints": 7,
+    "user_data": 8,
+}
+_PARAMETER_SCHEMA = 2
+
+
+class TransformParameterPlanError(ValueError):
+    """Raised when a sampled parameter plan cannot be applied to an invocation."""
+
+
+@dataclass(frozen=True, slots=True)
+class TargetDescriptor:
+    """Representation metadata for one active target."""
+
+    name: str
+    canonical_type: str
+    shape: tuple[int, ...] | None
+    spatial_shape: tuple[int, ...] | None
+    channels: int | None
+    dtype: Any
+    dtype_scale: str | None
+    layout: str
+    sampling_topology: str
+
+
+@dataclass(frozen=True, slots=True)
+class TargetView:
+    """A borrowed target value and its invocation-local descriptor."""
+
+    descriptor: TargetDescriptor
+    value: Any
+
+    @property
+    def name(self) -> str:
+        return self.descriptor.name
+
+    @property
+    def canonical_type(self) -> str:
+        return self.descriptor.canonical_type
+
+
+@dataclass(frozen=True, slots=True)
+class TargetRequirement:
+    """Representation constraints required by a materialized target parameter."""
+
+    shape: tuple[int, ...] | None = None
+    spatial_shape: tuple[int, ...] | None = None
+    spatial_shape_suffix: tuple[int, ...] | None = None
+    channels: int | None = None
+    dtype: Any = None
+    dtype_scale: str | None = None
+    layout: str | None = None
+    sampling_topology: str | None = None
+
+    def check(self, descriptor: TargetDescriptor) -> bool:
+        """Return whether a descriptor satisfies the declared materialization constraints."""
+        return all(
+            (expected is None or actual == expected or (field_name == "dtype" and str(actual) == str(expected)))
+            for field_name, expected, actual in (
+                ("shape", self.shape, descriptor.shape),
+                ("spatial_shape", self.spatial_shape, descriptor.spatial_shape),
+                (
+                    "spatial_shape_suffix",
+                    self.spatial_shape_suffix,
+                    None
+                    if descriptor.spatial_shape is None or self.spatial_shape_suffix is None
+                    else descriptor.spatial_shape[-len(self.spatial_shape_suffix) :],
+                ),
+                ("channels", self.channels, descriptor.channels),
+                ("dtype", self.dtype, descriptor.dtype),
+                ("dtype_scale", self.dtype_scale, descriptor.dtype_scale),
+                ("layout", self.layout, descriptor.layout),
+                ("sampling_topology", self.sampling_topology, descriptor.sampling_topology),
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "shape": self.shape,
+            "spatial_shape": self.spatial_shape,
+            "spatial_shape_suffix": self.spatial_shape_suffix,
+            "channels": self.channels,
+            "dtype": None if self.dtype is None else str(self.dtype),
+            "dtype_scale": self.dtype_scale,
+            "layout": self.layout,
+            "sampling_topology": self.sampling_topology,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> TargetRequirement:
+        return cls(
+            shape=None if payload.get("shape") is None else tuple(payload["shape"]),
+            spatial_shape=None if payload.get("spatial_shape") is None else tuple(payload["spatial_shape"]),
+            spatial_shape_suffix=(
+                None if payload.get("spatial_shape_suffix") is None else tuple(payload["spatial_shape_suffix"])
+            ),
+            channels=payload.get("channels"),
+            dtype=payload.get("dtype"),
+            dtype_scale=payload.get("dtype_scale"),
+            layout=payload.get("layout"),
+            sampling_topology=payload.get("sampling_topology"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TargetParameterGroup:
+    """Parameters shared by a named set of compatible actual target keys."""
+
+    targets: tuple[str, ...]
+    params: Mapping[str, Any]
+    requirements: Mapping[str, TargetRequirement]
+
+    def __post_init__(self) -> None:
+        if not self.targets:
+            raise TransformParameterPlanError("target parameter groups cannot be empty")
+        if len(set(self.targets)) != len(self.targets):
+            raise TransformParameterPlanError("target parameter groups cannot repeat target keys")
+        if set(self.targets) != set(self.requirements):
+            raise TransformParameterPlanError("target parameter groups require one requirement per target")
+        object.__setattr__(self, "params", dict(self.params))
+        object.__setattr__(self, "requirements", dict(self.requirements))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "targets": list(self.targets),
+            "params": dict(self.params),
+            "requirements": {name: requirement.to_dict() for name, requirement in self.requirements.items()},
+        }
+
+
+class TargetSet:
+    """Deterministically ordered active targets for one transform step."""
+
+    def __init__(self, views: tuple[TargetView, ...]) -> None:
+        self.ordered = views
+        self._by_name = {view.name: view for view in views}
+
+    @classmethod
+    def from_data(cls, data: Mapping[str, Any], canonical_by_name: Mapping[str, str]) -> TargetSet:
+        active = [(name, value) for name, value in data.items() if value is not None and name in canonical_by_name]
+        if len(active) == 1:
+            name, value = active[0]
+            return cls((TargetView(_describe_target(name, canonical_by_name[name], value), value),))
+        views = [TargetView(_describe_target(name, canonical_by_name[name], value), value) for name, value in active]
+        views.sort(key=lambda view: _target_sort_key(view.descriptor))
+        return cls(tuple(views))
+
+    def by_name(self, name: str) -> TargetView:
+        return self._by_name[name]
+
+    def by_canonical_type(self, target_type: Targets | str) -> tuple[TargetView, ...]:
+        canonical = target_type.value if isinstance(target_type, Targets) else target_type
+        return tuple(view for view in self.ordered if view.canonical_type == canonical)
+
+    def image_like(self) -> tuple[TargetView, ...]:
+        return tuple(view for view in self.ordered if view.canonical_type in {"image", "images", "volume"})
+
+    def primary_image_like(self) -> TargetView:
+        """Return the canonical primary raster target used by image-level policies."""
+        for view in self.ordered:
+            if view.canonical_type == "image":
+                return view
+        for view in self.ordered:
+            if view.canonical_type in {"images", "volume"}:
+                return view
+        raise TransformParameterPlanError("transform sampling requires an image-like target")
+
+    def group_by(self, key: Callable[[TargetView], Hashable]) -> tuple[tuple[TargetView, ...], ...]:
+        grouped: dict[Hashable, list[TargetView]] = {}
+        for view in self.ordered:
+            grouped.setdefault(key(view), []).append(view)
+        return tuple(tuple(views) for views in grouped.values())
+
+    def group_image_like_by(self, key: Callable[[TargetView], Hashable]) -> tuple[tuple[TargetView, ...], ...]:
+        """Group only image-like targets, excluding annotations and user data."""
+        grouped: dict[Hashable, list[TargetView]] = {}
+        for view in self.image_like():
+            grouped.setdefault(key(view), []).append(view)
+        return tuple(tuple(views) for views in grouped.values())
+
+    @property
+    def names(self) -> frozenset[str]:
+        return frozenset(self._by_name)
+
+    def schema(self) -> dict[str, str]:
+        return {view.name: view.canonical_type for view in self.ordered}
+
+
+@dataclass(frozen=True, slots=True)
+class SpatialFrame:
+    """Validated spatial coordinates shared by a geometric transform family."""
+
+    rank: int
+    shape: tuple[int, ...]
+
+    @property
+    def spatial_shape_2d(self) -> tuple[int, int]:
+        """Return the height/width suffix used by 2D transforms."""
+        if len(self.shape) < 2:
+            raise TransformParameterPlanError("a 2D spatial frame requires at least two dimensions")
+        return self.shape[-2], self.shape[-1]
+
+
+@dataclass(frozen=True, slots=True)
+class TransformSamplingInput:
+    """Inputs supplied to a transform sampler for one invocation step."""
+
+    base_params: Mapping[str, Any]
+    spatial_frame: SpatialFrame | None
+    targets: TargetSet
+    data: dict[str, Any]
+
+    def require_spatial_frame(self) -> SpatialFrame:
+        """Return the validated spatial frame required by spatial samplers."""
+        if self.spatial_frame is None:
+            raise TransformParameterPlanError("transform sampling requires a spatial frame")
+        return self.spatial_frame
+
+
+@dataclass(frozen=True, slots=True)
+class TransformParameterPlan:
+    """Shared and target-specific realized parameters for one transform event."""
+
+    shared: Mapping[str, Any]
+    groups: tuple[TargetParameterGroup, ...] = ()
+    target_schema: Mapping[str, str] | None = None
+
+    @classmethod
+    def shared_only(cls, params: Mapping[str, Any]) -> TransformParameterPlan:
+        return cls(shared=dict(params))
+
+    def bind(self, targets: TargetSet) -> TransformParameterPlan:
+        return TransformParameterPlan(self.shared, self.groups, targets.schema())
+
+    def validate(
+        self,
+        targets: TargetSet,
+        required_params: Mapping[str, frozenset[str]],
+        transform_name: str,
+    ) -> None:
+        active_names = targets.names
+        self._validate_target_schema(targets, active_names, transform_name)
+        seen = self._validate_groups(targets, active_names, transform_name)
+        self._validate_required(required_params, seen, transform_name)
+
+    def _validate_target_schema(
+        self,
+        targets: TargetSet,
+        active_names: frozenset[str],
+        transform_name: str,
+    ) -> None:
+        if self.target_schema is None:
+            return
+        if set(self.target_schema) != active_names:
+            raise TransformParameterPlanError(
+                f"{transform_name} parameter plan target keys do not match the active invocation",
+            )
+        for name, canonical in self.target_schema.items():
+            if targets.by_name(name).canonical_type != canonical:
+                raise TransformParameterPlanError(
+                    f"{transform_name} parameter plan canonical target mismatch for {name!r}",
+                )
+
+    def _validate_groups(
+        self,
+        targets: TargetSet,
+        active_names: frozenset[str],
+        transform_name: str,
+    ) -> dict[str, set[str]]:
+        seen: dict[str, set[str]] = {}
+        for group in self.groups:
+            if any(name not in active_names for name in group.targets):
+                raise TransformParameterPlanError(f"{transform_name} parameter plan names an inactive target")
+            for name in group.targets:
+                descriptor = targets.by_name(name).descriptor
+                requirement = group.requirements[name]
+                if not requirement.check(descriptor):
+                    raise TransformParameterPlanError(
+                        f"{transform_name} parameter plan requirement mismatch for target {name!r}",
+                    )
+                duplicate = seen.setdefault(name, set()).intersection(group.params)
+                if duplicate or set(group.params).intersection(self.shared):
+                    raise TransformParameterPlanError(
+                        f"{transform_name} parameter plan has duplicate keys for target {name!r}",
+                    )
+                seen[name].update(group.params)
+        return seen
+
+    def _validate_required(
+        self,
+        required_params: Mapping[str, frozenset[str]],
+        seen: Mapping[str, set[str]],
+        transform_name: str,
+    ) -> None:
+        for name, required in required_params.items():
+            available = set(self.shared).union(seen.get(name, set()))
+            missing = required - available
+            if missing:
+                raise TransformParameterPlanError(
+                    f"{transform_name} parameter plan is missing {sorted(missing)} for target {name!r}",
+                )
+
+    def params_for(self, target_name: str) -> Mapping[str, Any]:
+        if not self.groups:
+            return self.shared
+        resolved = dict(self.shared)
+        for group in self.groups:
+            if target_name in group.targets:
+                resolved.update(group.params)
+        return resolved
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "parameter_schema": _PARAMETER_SCHEMA,
+            "target_schema": None if self.target_schema is None else dict(self.target_schema),
+            "shared": dict(self.shared),
+            "groups": [group.to_dict() for group in self.groups],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> TransformParameterPlan:
+        if payload.get("parameter_schema") != _PARAMETER_SCHEMA:
+            raise TransformParameterPlanError("unsupported or legacy transform parameter schema")
+        groups = tuple(
+            TargetParameterGroup(
+                targets=tuple(group["targets"]),
+                params=dict(group["params"]),
+                requirements={
+                    name: TargetRequirement.from_dict(requirement)
+                    for name, requirement in group["requirements"].items()
+                },
+            )
+            for group in payload.get("groups", ())
+        )
+        target_schema = payload.get("target_schema")
+        return cls(
+            shared=dict(payload.get("shared", {})),
+            groups=groups,
+            target_schema=None if target_schema is None else dict(target_schema),
+        )
+
+
+def _target_sort_key(descriptor: TargetDescriptor) -> tuple[int, int, str]:
+    canonical = descriptor.canonical_type
+    priority = _TARGET_ORDER.get(canonical, len(_TARGET_ORDER))
+    return priority, 0 if descriptor.name == canonical else 1, descriptor.name
+
+
+def _describe_target(name: str, canonical_type: str, value: Any) -> TargetDescriptor:
+    shape = tuple(int(dim) for dim in value.shape) if hasattr(value, "shape") else None
+    dtype = getattr(value, "dtype", None)
+    return _describe_target_cached(name, canonical_type, shape, dtype, isinstance(value, torch.Tensor))
+
+
+@lru_cache(maxsize=4096)
+def _describe_target_cached(
+    name: str,
+    canonical_type: str,
+    shape: tuple[int, ...] | None,
+    dtype: Any,
+    tensor: bool,
+) -> TargetDescriptor:
+    layout = canonical_type
+    topology = canonical_type
+    channels: int | None = None
+    spatial_shape: tuple[int, ...] | None = None
+
+    if shape is not None:
+        if canonical_type == "image":
+            spatial_shape = shape[1:3] if tensor else shape[:2]
+            channels = shape[0] if tensor else (shape[-1] if len(shape) > 2 else 1)
+            layout, topology = ("image_chw", "image_2d") if tensor else ("image_hwc", "image_2d")
+        elif canonical_type == "images":
+            spatial_shape = shape[2:4] if tensor else shape[1:3]
+            channels = shape[0] if tensor else (shape[-1] if len(shape) > 3 else 1)
+            layout, topology = ("images_nchw", "batch_2d") if tensor else ("images_nhwc", "batch_2d")
+        elif canonical_type == "volume":
+            spatial_shape = shape[1:] if tensor else shape[:3]
+            channels = shape[0] if tensor else (shape[-1] if len(shape) > 3 else 1)
+            layout, topology = ("volume_cdhw", "volume_3d") if tensor else ("volume_dhwc", "volume_3d")
+        elif canonical_type == "mask":
+            spatial_shape = shape[:2]
+            channels = shape[-1] if len(shape) > 2 else 1
+            layout, topology = "mask_hw", "mask_2d"
+        elif canonical_type == "masks":
+            spatial_shape = shape[1:3]
+            channels = shape[-1] if len(shape) > 3 else 1
+            layout, topology = "masks_nhw", "batch_mask_2d"
+        elif canonical_type == "mask3d":
+            spatial_shape = shape[:3]
+            channels = shape[-1] if len(shape) > 3 else 1
+            layout, topology = "mask3d_dhw", "mask_3d"
+
+    dtype_scale = None if dtype is None else str(dtype).replace("torch.", "")
+    return TargetDescriptor(name, canonical_type, shape, spatial_shape, channels, dtype, dtype_scale, layout, topology)
+
+
+@lru_cache(maxsize=1024)
+def required_parameter_names(function: Callable[..., Any]) -> frozenset[str]:
+    """Return required keyword parameters after the target value argument."""
+    signature = inspect.signature(function)
+    parameters = list(signature.parameters.values())[1:]
+    return frozenset(
+        parameter.name
+        for parameter in parameters
+        if parameter.kind in {inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY}
+        and parameter.default is inspect.Parameter.empty
+    )
+
+
+def requirements_for_views(
+    views: tuple[TargetView, ...],
+    *,
+    shape: bool = False,
+    spatial_shape: bool = False,
+    spatial_shape_suffix: bool = False,
+    channels: bool = False,
+    dtype: bool = False,
+    layout: bool = False,
+    sampling_topology: bool = False,
+) -> dict[str, TargetRequirement]:
+    """Build replay constraints from a deterministic compatible target group."""
+    return {
+        view.name: TargetRequirement(
+            shape=view.descriptor.shape if shape else None,
+            spatial_shape=view.descriptor.spatial_shape if spatial_shape else None,
+            spatial_shape_suffix=(
+                None
+                if not spatial_shape_suffix or view.descriptor.spatial_shape is None
+                else tuple(view.descriptor.spatial_shape[-2:])
+            ),
+            channels=view.descriptor.channels if channels else None,
+            dtype=view.descriptor.dtype if dtype else None,
+            dtype_scale=view.descriptor.dtype_scale if dtype else None,
+            layout=view.descriptor.layout if layout else None,
+            sampling_topology=view.descriptor.sampling_topology if sampling_topology else None,
+        )
+        for view in views
+    }
+
+
+__all__ = [
+    "SpatialFrame",
+    "TargetDescriptor",
+    "TargetParameterGroup",
+    "TargetRequirement",
+    "TargetSet",
+    "TargetView",
+    "TransformParameterPlan",
+    "TransformParameterPlanError",
+    "TransformSamplingInput",
+    "required_parameter_names",
+    "requirements_for_views",
+]

--- a/albumentations/core/transform_params.py
+++ b/albumentations/core/transform_params.py
@@ -6,7 +6,7 @@ import inspect
 from collections.abc import Callable, Hashable, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any
+from typing import Any, Literal, overload
 
 import torch
 
@@ -26,8 +26,8 @@ _TARGET_ORDER = {
 _PARAMETER_SCHEMA = 2
 
 
-class TransformParameterPlanError(ValueError):
-    """Raised when a sampled parameter plan cannot be applied to an invocation."""
+class SampledParamsError(ValueError):
+    """Raised when sampled parameters cannot be applied to an invocation."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -125,7 +125,7 @@ class TargetRequirement:
 
 
 @dataclass(frozen=True, slots=True)
-class TargetParameterGroup:
+class TargetParams:
     """Parameters shared by a named set of compatible actual target keys."""
 
     targets: tuple[str, ...]
@@ -134,11 +134,11 @@ class TargetParameterGroup:
 
     def __post_init__(self) -> None:
         if not self.targets:
-            raise TransformParameterPlanError("target parameter groups cannot be empty")
+            raise SampledParamsError("target parameter groups cannot be empty")
         if len(set(self.targets)) != len(self.targets):
-            raise TransformParameterPlanError("target parameter groups cannot repeat target keys")
+            raise SampledParamsError("target parameter groups cannot repeat target keys")
         if set(self.targets) != set(self.requirements):
-            raise TransformParameterPlanError("target parameter groups require one requirement per target")
+            raise SampledParamsError("target parameter groups require one requirement per target")
         object.__setattr__(self, "params", dict(self.params))
         object.__setattr__(self, "requirements", dict(self.requirements))
 
@@ -156,6 +156,7 @@ class TargetSet:
     def __init__(self, views: tuple[TargetView, ...]) -> None:
         self.ordered = views
         self._by_name = {view.name: view for view in views}
+        self._spatial_shapes: dict[int, tuple[int, ...] | None] = {}
 
     @classmethod
     def from_data(cls, data: Mapping[str, Any], canonical_by_name: Mapping[str, str]) -> TargetSet:
@@ -185,7 +186,7 @@ class TargetSet:
         for view in self.ordered:
             if view.canonical_type in {"images", "volume"}:
                 return view
-        raise TransformParameterPlanError("transform sampling requires an image-like target")
+        raise SampledParamsError("transform sampling requires an image-like target")
 
     def group_by(self, key: Callable[[TargetView], Hashable]) -> tuple[tuple[TargetView, ...], ...]:
         grouped: dict[Hashable, list[TargetView]] = {}
@@ -200,6 +201,58 @@ class TargetSet:
             grouped.setdefault(key(view), []).append(view)
         return tuple(tuple(views) for views in grouped.values())
 
+    @overload
+    def spatial_shape(self, rank: Literal[2]) -> tuple[int, int] | None: ...
+
+    @overload
+    def spatial_shape(self, rank: Literal[3]) -> tuple[int, int, int] | None: ...
+
+    @overload
+    def spatial_shape(self, rank: int) -> tuple[int, ...] | None: ...
+
+    def spatial_shape(self, rank: int) -> tuple[int, ...] | None:
+        """Return the common spatial shape for a transform family, if these targets provide one."""
+        if rank not in {2, 3}:
+            raise ValueError(f"spatial rank must be 2 or 3, got {rank}")
+        if rank in self._spatial_shapes:
+            return self._spatial_shapes[rank]
+
+        shapes = {
+            shape
+            for view in self.ordered
+            if _target_has_elements(view.value)
+            if (shape := _spatial_shape_for_rank(view, rank)) is not None
+        }
+        if not shapes:
+            fallback = next(
+                (shape for view in self.ordered if (shape := _spatial_shape_for_rank(view, rank)) is not None),
+                None,
+            )
+            self._spatial_shapes[rank] = fallback
+            return fallback
+        if len(shapes) != 1:
+            raise SampledParamsError(f"transform sampling requires aligned spatial targets, got {sorted(shapes)}")
+
+        shape = next(iter(shapes))
+        self._spatial_shapes[rank] = shape
+        return shape
+
+    @overload
+    def require_spatial_shape(self, rank: Literal[2]) -> tuple[int, int]: ...
+
+    @overload
+    def require_spatial_shape(self, rank: Literal[3]) -> tuple[int, int, int]: ...
+
+    @overload
+    def require_spatial_shape(self, rank: int) -> tuple[int, ...]: ...
+
+    def require_spatial_shape(self, rank: int) -> tuple[int, ...]:
+        """Return the common spatial shape required by a spatial sampler."""
+        shape = self.spatial_shape(rank)
+        if shape is None:
+            raise SampledParamsError("transform sampling requires a spatial target")
+        return shape
+
     @property
     def names(self) -> frozenset[str]:
         return frozenset(self._by_name)
@@ -209,50 +262,19 @@ class TargetSet:
 
 
 @dataclass(frozen=True, slots=True)
-class SpatialFrame:
-    """Validated spatial coordinates shared by a geometric transform family."""
-
-    rank: int
-    shape: tuple[int, ...]
-
-    @property
-    def spatial_shape_2d(self) -> tuple[int, int]:
-        """Return the height/width suffix used by 2D transforms."""
-        if len(self.shape) < 2:
-            raise TransformParameterPlanError("a 2D spatial frame requires at least two dimensions")
-        return self.shape[-2], self.shape[-1]
-
-
-@dataclass(frozen=True, slots=True)
-class TransformSamplingInput:
-    """Inputs supplied to a transform sampler for one invocation step."""
-
-    base_params: Mapping[str, Any]
-    spatial_frame: SpatialFrame | None
-    targets: TargetSet
-    data: dict[str, Any]
-
-    def require_spatial_frame(self) -> SpatialFrame:
-        """Return the validated spatial frame required by spatial samplers."""
-        if self.spatial_frame is None:
-            raise TransformParameterPlanError("transform sampling requires a spatial frame")
-        return self.spatial_frame
-
-
-@dataclass(frozen=True, slots=True)
-class TransformParameterPlan:
-    """Shared and target-specific realized parameters for one transform event."""
+class SampledParams:
+    """Shared and target-specific values sampled for one transform event."""
 
     shared: Mapping[str, Any]
-    groups: tuple[TargetParameterGroup, ...] = ()
+    groups: tuple[TargetParams, ...] = ()
     target_schema: Mapping[str, str] | None = None
 
     @classmethod
-    def shared_only(cls, params: Mapping[str, Any]) -> TransformParameterPlan:
+    def shared_only(cls, params: Mapping[str, Any]) -> SampledParams:
         return cls(shared=dict(params))
 
-    def bind(self, targets: TargetSet) -> TransformParameterPlan:
-        return TransformParameterPlan(self.shared, self.groups, targets.schema())
+    def bind(self, targets: TargetSet) -> SampledParams:
+        return SampledParams(self.shared, self.groups, targets.schema())
 
     def validate(
         self,
@@ -274,13 +296,13 @@ class TransformParameterPlan:
         if self.target_schema is None:
             return
         if set(self.target_schema) != active_names:
-            raise TransformParameterPlanError(
-                f"{transform_name} parameter plan target keys do not match the active invocation",
+            raise SampledParamsError(
+                f"{transform_name} sampled parameter targets do not match the active invocation",
             )
         for name, canonical in self.target_schema.items():
             if targets.by_name(name).canonical_type != canonical:
-                raise TransformParameterPlanError(
-                    f"{transform_name} parameter plan canonical target mismatch for {name!r}",
+                raise SampledParamsError(
+                    f"{transform_name} sampled parameter canonical target mismatch for {name!r}",
                 )
 
     def _validate_groups(
@@ -292,18 +314,18 @@ class TransformParameterPlan:
         seen: dict[str, set[str]] = {}
         for group in self.groups:
             if any(name not in active_names for name in group.targets):
-                raise TransformParameterPlanError(f"{transform_name} parameter plan names an inactive target")
+                raise SampledParamsError(f"{transform_name} sampled parameters name an inactive target")
             for name in group.targets:
                 descriptor = targets.by_name(name).descriptor
                 requirement = group.requirements[name]
                 if not requirement.check(descriptor):
-                    raise TransformParameterPlanError(
-                        f"{transform_name} parameter plan requirement mismatch for target {name!r}",
+                    raise SampledParamsError(
+                        f"{transform_name} sampled parameter requirements do not match target {name!r}",
                     )
                 duplicate = seen.setdefault(name, set()).intersection(group.params)
                 if duplicate or set(group.params).intersection(self.shared):
-                    raise TransformParameterPlanError(
-                        f"{transform_name} parameter plan has duplicate keys for target {name!r}",
+                    raise SampledParamsError(
+                        f"{transform_name} sampled parameters have duplicate keys for target {name!r}",
                     )
                 seen[name].update(group.params)
         return seen
@@ -318,8 +340,8 @@ class TransformParameterPlan:
             available = set(self.shared).union(seen.get(name, set()))
             missing = required - available
             if missing:
-                raise TransformParameterPlanError(
-                    f"{transform_name} parameter plan is missing {sorted(missing)} for target {name!r}",
+                raise SampledParamsError(
+                    f"{transform_name} sampled parameters are missing {sorted(missing)} for target {name!r}",
                 )
 
     def params_for(self, target_name: str) -> Mapping[str, Any]:
@@ -340,11 +362,11 @@ class TransformParameterPlan:
         }
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, Any]) -> TransformParameterPlan:
+    def from_dict(cls, payload: Mapping[str, Any]) -> SampledParams:
         if payload.get("parameter_schema") != _PARAMETER_SCHEMA:
-            raise TransformParameterPlanError("unsupported or legacy transform parameter schema")
+            raise SampledParamsError("unsupported or legacy transform parameter schema")
         groups = tuple(
-            TargetParameterGroup(
+            TargetParams(
                 targets=tuple(group["targets"]),
                 params=dict(group["params"]),
                 requirements={
@@ -360,6 +382,22 @@ class TransformParameterPlan:
             groups=groups,
             target_schema=None if target_schema is None else dict(target_schema),
         )
+
+
+def _target_has_elements(value: Any) -> bool:
+    if isinstance(value, torch.Tensor):
+        return value.numel() > 0
+    size = getattr(value, "size", None)
+    return not isinstance(size, int) or size > 0
+
+
+def _spatial_shape_for_rank(view: TargetView, rank: int) -> tuple[int, ...] | None:
+    spatial_shape = view.descriptor.spatial_shape
+    if spatial_shape is None:
+        return None
+    if rank == 3:
+        return tuple(spatial_shape) if view.canonical_type in {"volume", "mask3d"} and len(spatial_shape) == 3 else None
+    return tuple(spatial_shape[-2:]) if len(spatial_shape) >= 2 else None
 
 
 def _target_sort_key(descriptor: TargetDescriptor) -> tuple[int, int, str]:
@@ -462,15 +500,13 @@ def requirements_for_views(
 
 
 __all__ = [
-    "SpatialFrame",
+    "SampledParams",
+    "SampledParamsError",
     "TargetDescriptor",
-    "TargetParameterGroup",
+    "TargetParams",
     "TargetRequirement",
     "TargetSet",
     "TargetView",
-    "TransformParameterPlan",
-    "TransformParameterPlanError",
-    "TransformSamplingInput",
     "required_parameter_names",
     "requirements_for_views",
 ]

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -32,12 +32,10 @@ from albumentations.core.invocation import (
 )
 from albumentations.core.keypoints_utils import KeypointsProcessor
 from albumentations.core.transform_params import (
-    SpatialFrame,
-    TargetParameterGroup,
+    SampledParams,
+    SampledParamsError,
+    TargetParams,
     TargetSet,
-    TransformParameterPlan,
-    TransformParameterPlanError,
-    TransformSamplingInput,
     required_parameter_names,
 )
 from albumentations.core.validation import ValidatedTransformMeta
@@ -59,14 +57,12 @@ __all__ = [
     "DualTransform",
     "ImageOnlyTransform",
     "NoOp",
+    "SampledParams",
+    "SampledParamsError",
     "SamplingContext",
-    "SpatialFrame",
-    "TargetParameterGroup",
+    "TargetParams",
     "TargetSet",
     "Transform3D",
-    "TransformParameterPlan",
-    "TransformParameterPlanError",
-    "TransformSamplingInput",
     "VolumeOnlyTransform",
 ]
 
@@ -186,7 +182,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             names = ", ".join(removed_hooks)
             raise TypeError(
                 f"{cls.__name__} defines removed sampling hook(s): {names}. "
-                "Implement sample_parameters(inputs, sampling) instead.",
+                "Implement sample_parameters(params, data, targets, sampling) instead.",
             )
 
     @property
@@ -508,7 +504,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         ):
             return self.apply_with_shared_params(params, **kwargs)
 
-        applied_overrides, plan = self._sample_parameters_for_inputs(
+        applied_overrides, sampled_params = self._sample_parameters(
             params=params,
             data=kwargs,
             targets=targets,
@@ -516,15 +512,15 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             collect_applied=collect_applied,
         )
 
-        effective_plan = TransformParameterPlan(
-            shared={**params, **plan.shared},
-            groups=plan.groups,
-            target_schema=targets.schema() if targets is not None and plan.groups else None,
+        effective_params = SampledParams(
+            shared={**params, **sampled_params.shared},
+            groups=sampled_params.groups,
+            target_schema=targets.schema() if targets is not None and sampled_params.groups else None,
         )
-        self._validate_parameter_plan(effective_plan, targets, kwargs)
+        self._validate_sampled_params(effective_params, targets, kwargs)
 
         if state is not None:
-            state.params = effective_plan.to_dict()
+            state.params = effective_params.to_dict()
             self._build_applied_config(state=state, overrides=applied_overrides)
 
         if self.deterministic:
@@ -532,14 +528,14 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             transform_id = id(self)
             existing = saved_params.get(transform_id)
             if existing is None:
-                saved_params[transform_id] = [deepcopy(effective_plan.to_dict())]
+                saved_params[transform_id] = [deepcopy(effective_params.to_dict())]
             elif isinstance(existing, list):
-                existing.append(deepcopy(effective_plan.to_dict()))
+                existing.append(deepcopy(effective_params.to_dict()))
             else:
-                saved_params[transform_id] = [existing, deepcopy(effective_plan.to_dict())]
-        return self.apply_with_params(effective_plan, **kwargs)
+                saved_params[transform_id] = [existing, deepcopy(effective_params.to_dict())]
+        return self.apply_with_params(effective_params, **kwargs)
 
-    def _sample_parameters_for_inputs(
+    def _sample_parameters(
         self,
         *,
         params: dict[str, Any],
@@ -547,38 +543,36 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         targets: TargetSet | None,
         invocation: InvocationContext | None,
         collect_applied: bool,
-    ) -> tuple[Any, TransformParameterPlan]:
+    ) -> tuple[Any, SampledParams]:
         if targets is None:
-            return _EMPTY_APPLIED_OVERRIDES, TransformParameterPlan.shared_only({})
+            return _EMPTY_APPLIED_OVERRIDES, SampledParams.shared_only({})
         if invocation is None:
             msg = "sampling transforms require an active sampling context"
             raise RuntimeError(msg)
 
         applied_overrides = {} if collect_applied else cast("dict[str, Any]", _DISCARDED_APPLIED_OVERRIDES)
-        plan = self.sample_parameters(
-            inputs=TransformSamplingInput(
-                base_params=params,
-                spatial_frame=self._build_spatial_frame(targets),
-                targets=targets,
-                data=data,
-            ),
+        self._validate_spatial_targets(targets)
+        sampled_params = self.sample_parameters(
+            params=params,
+            data=data,
+            targets=targets,
             sampling=invocation.sampling_context(applied_overrides),
         )
-        if not isinstance(plan, TransformParameterPlan):
-            raise TypeError(f"{self.__class__.__name__}.sample_parameters must return TransformParameterPlan")
-        return applied_overrides, plan
+        if not isinstance(sampled_params, SampledParams):
+            raise TypeError(f"{self.__class__.__name__}.sample_parameters must return SampledParams")
+        return applied_overrides, sampled_params
 
-    def _validate_parameter_plan(
+    def _validate_sampled_params(
         self,
-        plan: TransformParameterPlan,
+        sampled_params: SampledParams,
         targets: TargetSet | None,
         data: Mapping[str, Any],
     ) -> None:
         if targets is None:
-            self._validate_shared_plan(plan, data)
+            self._validate_shared_params(sampled_params, data)
             return
 
-        plan.validate(
+        sampled_params.validate(
             targets,
             {
                 name: required.difference(self._runtime_generated_params)
@@ -588,14 +582,14 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             self.__class__.__name__,
         )
 
-    def _validate_shared_plan(self, plan: TransformParameterPlan, data: Mapping[str, Any]) -> None:
+    def _validate_shared_params(self, sampled_params: SampledParams, data: Mapping[str, Any]) -> None:
         """Validate required parameters without describing targets for shared-only samplers."""
         required_by_target = self._get_required_parameters_by_target()
         if not required_by_target:
             return
 
         missing_by_target = {
-            name: required.difference(self._runtime_generated_params).difference(plan.shared)
+            name: required.difference(self._runtime_generated_params).difference(sampled_params.shared)
             for name, required in required_by_target.items()
             if name in data and data[name] is not None
         }
@@ -629,10 +623,10 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         """
         if not self.applied_in_replay:
             return kwargs
-        plan = TransformParameterPlan.from_dict(deepcopy(self._replay_params))
+        sampled_params = SampledParams.from_dict(deepcopy(self._replay_params))
         targets = self._build_target_set(kwargs)
-        self._build_spatial_frame(targets)
-        plan.validate(
+        self._validate_spatial_targets(targets)
+        sampled_params.validate(
             targets,
             {
                 name: required_parameter_names(function).difference(self._runtime_generated_params)
@@ -642,8 +636,8 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             self.__class__.__name__,
         )
         if state is not None:
-            state.params = plan.to_dict()
-        return self.apply_with_params(plan, **kwargs)
+            state.params = sampled_params.to_dict()
+        return self.apply_with_params(sampled_params, **kwargs)
 
     def get_applied_params(self) -> dict[str, Any]:
         """Returns the parameters that were used in the last transform application; returns empty
@@ -743,7 +737,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         )
 
     def apply_with_shared_params(self, params: Mapping[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Apply shared-only parameters without constructing a target plan."""
+        """Apply shared-only parameters without constructing target-specific sampled values."""
         res: dict[str, Any] = {}
         for key, arg in kwargs.items():
             if key in self._key2func and arg is not None:
@@ -754,7 +748,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
 
     def apply_with_params(
         self,
-        plan: TransformParameterPlan,
+        sampled_params: SampledParams,
         *args: Any,
         **kwargs: Any,
     ) -> dict[str, Any]:
@@ -765,7 +759,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         for key, arg in kwargs.items():
             if key in self._key2func and arg is not None:
                 target_function = self._key2func[key]
-                res[key] = target_function(arg, **plan.params_for(key))
+                res[key] = target_function(arg, **sampled_params.params_for(key))
             else:
                 res[key] = arg
         return res
@@ -953,42 +947,9 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         canonical_by_name = {name: self._additional_targets.get(name, name) for name in self._key2func}
         return TargetSet.from_data(data, canonical_by_name)
 
-    def _spatial_frame_shape(self, view: Any) -> tuple[int, ...] | None:
-        descriptor = view.descriptor
-        spatial_shape = descriptor.spatial_shape
-        if spatial_shape is None:
-            return None
-        if self._sampling_spatial_rank == 3:
-            if view.canonical_type in {"volume", "mask3d"} and len(spatial_shape) == 3:
-                return tuple(spatial_shape)
-            return None
-        if self._sampling_spatial_rank == 2:
-            return tuple(spatial_shape[-2:])
-        return None
-
-    def _build_spatial_frame(self, targets: TargetSet) -> SpatialFrame | None:
-        if self._sampling_spatial_rank is None:
-            return None
-        frame_shapes: set[tuple[int, ...]] = set()
-        for view in targets.ordered:
-            if (isinstance(view.value, np.ndarray) and view.value.size == 0) or (
-                isinstance(view.value, torch.Tensor) and view.value.numel() == 0
-            ):
-                continue
-            shape = self._spatial_frame_shape(view)
-            if shape is not None:
-                frame_shapes.add(shape)
-        if not frame_shapes:
-            first_shape = next((self._spatial_frame_shape(view) for view in targets.ordered), None)
-            if first_shape is not None:
-                frame_shapes.add(first_shape)
-        if not frame_shapes:
-            return None
-        if len(frame_shapes) != 1:
-            raise TransformParameterPlanError(
-                f"{self.__class__.__name__} requires aligned spatial targets, got {sorted(frame_shapes)}",
-            )
-        return SpatialFrame(self._sampling_spatial_rank, next(iter(frame_shapes)))
+    def _validate_spatial_targets(self, targets: TargetSet) -> None:
+        if self._sampling_spatial_rank is not None:
+            targets.spatial_shape(self._sampling_spatial_rank)
 
     @staticmethod
     def _shared_shape_from_data_key(key: str, value: Any) -> tuple[int, ...]:
@@ -1026,19 +987,22 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         """Generates parameters and stores realized replay policy in call-local data, never retaining per-sample values
         on transform instances.
 
-        Override this method in every transform that samples data-dependent parameters. Return a structured plan whose
-        shared values and target groups are consumed by `apply_*` methods. Write constructor-valid realized policy
-        values to `sampling.applied_overrides`. The default supports deterministic transforms with no sampled
-        parameters.
+        Override this method in every transform that samples data-dependent parameters. `params` contains the common
+        execution parameters, `data` contains all invocation data, and `targets` describes active transform targets.
+        Return shared values and target-specific groups consumed by `apply_*` methods. Write constructor-valid
+        realized policy values to `sampling.applied_overrides`. The default supports deterministic transforms with no
+        sampled parameters.
         """
-        del inputs, sampling
-        return TransformParameterPlan.shared_only({})
+        del params, data, targets, sampling
+        return SampledParams.shared_only({})
 
     @property
     def targets(self) -> dict[str, Callable[..., Any]]:
@@ -1602,21 +1566,21 @@ class DualTransform(BasicTransform):
 
         return keypoints
 
-    def apply_with_params(self, plan: TransformParameterPlan, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply a dual transform with its parameters, including configured keypoint and transform-aware
         semantic-mask label mappings.
         """
-        res = super().apply_with_params(plan, *args, **kwargs)
+        res = super().apply_with_params(sampled_params, *args, **kwargs)
 
         # Apply label mapping to keypoints if they were transformed
         if "keypoints" in res and res["keypoints"] is not None:
             res["keypoints"] = self._apply_label_mapping_to_keypoints(
                 res["keypoints"],
-                **plan.params_for("keypoints"),
+                **sampled_params.params_for("keypoints"),
             )
 
         if self._semantic_mask_label_mappings:
-            res = self._apply_label_mapping_to_semantic_masks(res, **plan.shared)
+            res = self._apply_label_mapping_to_semantic_masks(res, **sampled_params.shared)
 
         return res
 
@@ -1878,8 +1842,8 @@ class CustomTransformsApplyMixin:
         >>> mask = np.random.randint(0, 2, (64, 64), dtype=np.uint8)
         >>>
         >>> class Rotate90WithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
-        ...     def sample_parameters(self, inputs, sampling):
-        ...         return TransformParameterPlan.shared_only({"k": 1})
+        ...     def sample_parameters(self, params, data, targets, sampling):
+        ...         return SampledParams.shared_only({"k": 1})
         ...     def apply(self, img, k=0, **p):
         ...         return np.rot90(img, k)
         ...     def apply_to_mask(self, mask, k=0, **p):

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -31,6 +31,15 @@ from albumentations.core.invocation import (
     publish_completed_transform_state,
 )
 from albumentations.core.keypoints_utils import KeypointsProcessor
+from albumentations.core.transform_params import (
+    SpatialFrame,
+    TargetParameterGroup,
+    TargetSet,
+    TransformParameterPlan,
+    TransformParameterPlanError,
+    TransformSamplingInput,
+    required_parameter_names,
+)
 from albumentations.core.validation import ValidatedTransformMeta
 
 from .serialization import Serializable, SerializableMeta, get_shortest_class_fullname
@@ -43,7 +52,6 @@ from .type_definitions import (
     VolumeType,
 )
 from .utils import format_args
-from .utils import get_image_data as _get_image_data_impl
 
 __all__ = [
     "BasicTransform",
@@ -52,7 +60,13 @@ __all__ = [
     "ImageOnlyTransform",
     "NoOp",
     "SamplingContext",
+    "SpatialFrame",
+    "TargetParameterGroup",
+    "TargetSet",
     "Transform3D",
+    "TransformParameterPlan",
+    "TransformParameterPlanError",
+    "TransformSamplingInput",
     "VolumeOnlyTransform",
 ]
 
@@ -153,6 +167,8 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
     _supports_cpu_tensor: ClassVar[bool] = False
     _cpu_tensor_targets: ClassVar[frozenset[str] | None] = None
     _cpu_tensor_channels: ClassVar[frozenset[int] | None] = None
+    _sampling_spatial_rank: ClassVar[int | None] = 2
+    _runtime_generated_params: ClassVar[frozenset[str]] = frozenset()
     _preserves_input_image_range: ClassVar[bool] = True  # image targets retain the input dtype's normalized range
     _removed_sampling_hooks: ClassVar[frozenset[str]] = frozenset({"get_params", "get_params_dependent_on_data"})
 
@@ -170,7 +186,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             names = ", ".join(removed_hooks)
             raise TypeError(
                 f"{cls.__name__} defines removed sampling hook(s): {names}. "
-                "Implement sample_parameters(params, data, sampling) instead.",
+                "Implement sample_parameters(inputs, sampling) instead.",
             )
 
     @property
@@ -473,7 +489,10 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         """Samples parameters after probability succeeds and records policy only for replay, trace, or explicit
         observation that needs the durable artifact.
         """
-        params = self.update_transform_params(params={}, data=kwargs, invocation=invocation)
+        targets = (
+            None if type(self).sample_parameters is BasicTransform.sample_parameters else self._build_target_set(kwargs)
+        )
+        params = self.update_transform_params(params={}, data=kwargs, invocation=invocation, targets=targets)
 
         if self.targets_as_params:
             missing_keys = set(self.targets_as_params).difference(kwargs.keys())
@@ -481,23 +500,31 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
                 msg = f"{self.__class__.__name__} requires {self.targets_as_params} missing keys: {missing_keys}"
                 raise ValueError(msg)
 
-        if type(self).sample_parameters is BasicTransform.sample_parameters:
-            applied_overrides = _EMPTY_APPLIED_OVERRIDES
-        else:
-            if invocation is None:
-                msg = "sampling transforms require an active sampling context"
-                raise RuntimeError(msg)
-            applied_overrides = {} if collect_applied else cast("dict[str, Any]", _DISCARDED_APPLIED_OVERRIDES)
-            params.update(
-                self.sample_parameters(
-                    params=params,
-                    data=kwargs,
-                    sampling=invocation.sampling_context(applied_overrides),
-                ),
-            )
+        if (
+            targets is None
+            and state is None
+            and not self.deterministic
+            and type(self).apply_with_params in {BasicTransform.apply_with_params, DualTransform.apply_with_params}
+        ):
+            return self.apply_with_shared_params(params, **kwargs)
+
+        applied_overrides, plan = self._sample_parameters_for_inputs(
+            params=params,
+            data=kwargs,
+            targets=targets,
+            invocation=invocation,
+            collect_applied=collect_applied,
+        )
+
+        effective_plan = TransformParameterPlan(
+            shared={**params, **plan.shared},
+            groups=plan.groups,
+            target_schema=targets.schema() if targets is not None and plan.groups else None,
+        )
+        self._validate_parameter_plan(effective_plan, targets, kwargs)
 
         if state is not None:
-            state.params = params
+            state.params = effective_plan.to_dict()
             self._build_applied_config(state=state, overrides=applied_overrides)
 
         if self.deterministic:
@@ -505,12 +532,90 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             transform_id = id(self)
             existing = saved_params.get(transform_id)
             if existing is None:
-                saved_params[transform_id] = [deepcopy(params)]
+                saved_params[transform_id] = [deepcopy(effective_plan.to_dict())]
             elif isinstance(existing, list):
-                existing.append(deepcopy(params))
+                existing.append(deepcopy(effective_plan.to_dict()))
             else:
-                saved_params[transform_id] = [existing, deepcopy(params)]
-        return self.apply_with_params(params, **kwargs)
+                saved_params[transform_id] = [existing, deepcopy(effective_plan.to_dict())]
+        return self.apply_with_params(effective_plan, **kwargs)
+
+    def _sample_parameters_for_inputs(
+        self,
+        *,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet | None,
+        invocation: InvocationContext | None,
+        collect_applied: bool,
+    ) -> tuple[Any, TransformParameterPlan]:
+        if targets is None:
+            return _EMPTY_APPLIED_OVERRIDES, TransformParameterPlan.shared_only({})
+        if invocation is None:
+            msg = "sampling transforms require an active sampling context"
+            raise RuntimeError(msg)
+
+        applied_overrides = {} if collect_applied else cast("dict[str, Any]", _DISCARDED_APPLIED_OVERRIDES)
+        plan = self.sample_parameters(
+            inputs=TransformSamplingInput(
+                base_params=params,
+                spatial_frame=self._build_spatial_frame(targets),
+                targets=targets,
+                data=data,
+            ),
+            sampling=invocation.sampling_context(applied_overrides),
+        )
+        if not isinstance(plan, TransformParameterPlan):
+            raise TypeError(f"{self.__class__.__name__}.sample_parameters must return TransformParameterPlan")
+        return applied_overrides, plan
+
+    def _validate_parameter_plan(
+        self,
+        plan: TransformParameterPlan,
+        targets: TargetSet | None,
+        data: Mapping[str, Any],
+    ) -> None:
+        if targets is None:
+            self._validate_shared_plan(plan, data)
+            return
+
+        plan.validate(
+            targets,
+            {
+                name: required.difference(self._runtime_generated_params)
+                for name, required in self._get_required_parameters_by_target().items()
+                if name in targets.names
+            },
+            self.__class__.__name__,
+        )
+
+    def _validate_shared_plan(self, plan: TransformParameterPlan, data: Mapping[str, Any]) -> None:
+        """Validate required parameters without describing targets for shared-only samplers."""
+        required_by_target = self._get_required_parameters_by_target()
+        if not required_by_target:
+            return
+
+        missing_by_target = {
+            name: required.difference(self._runtime_generated_params).difference(plan.shared)
+            for name, required in required_by_target.items()
+            if name in data and data[name] is not None
+        }
+        missing_by_target = {name: missing for name, missing in missing_by_target.items() if missing}
+        if missing_by_target:
+            raise ValueError(f"{self.__class__.__name__} missing required parameters: {missing_by_target}")
+
+    def _get_required_parameters_by_target(self) -> dict[str, frozenset[str]]:
+        transform_cls = type(self)
+        target_names = tuple(self._key2func)
+        cached = transform_cls.__dict__.get("_required_parameters_by_target_cache")
+        if cached is None or cached[0] != target_names:
+            required_by_target: dict[str, frozenset[str]] = {}
+            for name, function in self._key2func.items():
+                required = required_parameter_names(function)
+                if required:
+                    required_by_target[name] = required
+            cached = (target_names, required_by_target)
+            type.__setattr__(transform_cls, "_required_parameters_by_target_cache", cached)
+        return cached[1]
 
     def _should_apply_in_invocation(self, invocation: InvocationContext, *, force_apply: bool) -> bool:
         """Evaluates this leaf's probability against the root Python stream, avoiding configured mutable generators
@@ -524,10 +629,21 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         """
         if not self.applied_in_replay:
             return kwargs
-        params = deepcopy(self._replay_params)
+        plan = TransformParameterPlan.from_dict(deepcopy(self._replay_params))
+        targets = self._build_target_set(kwargs)
+        self._build_spatial_frame(targets)
+        plan.validate(
+            targets,
+            {
+                name: required_parameter_names(function).difference(self._runtime_generated_params)
+                for name, function in self._key2func.items()
+                if any(view.name == name for view in targets.ordered)
+            },
+            self.__class__.__name__,
+        )
         if state is not None:
-            state.params = params
-        return self.apply_with_params(params, **kwargs)
+            state.params = plan.to_dict()
+        return self.apply_with_params(plan, **kwargs)
 
     def get_applied_params(self) -> dict[str, Any]:
         """Returns the parameters that were used in the last transform application; returns empty
@@ -626,7 +742,22 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             "Only transforms that override `inverse()` can be used for TTA inversion.",
         )
 
-    def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def apply_with_shared_params(self, params: Mapping[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Apply shared-only parameters without constructing a target plan."""
+        res: dict[str, Any] = {}
+        for key, arg in kwargs.items():
+            if key in self._key2func and arg is not None:
+                res[key] = self._key2func[key](arg, **params)
+            else:
+                res[key] = arg
+        return res
+
+    def apply_with_params(
+        self,
+        plan: TransformParameterPlan,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         """Apply transforms with parameters. Dispatches each target (image, mask, bboxes, etc.) to
         the corresponding apply_* method.
         """
@@ -634,7 +765,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         for key, arg in kwargs.items():
             if key in self._key2func and arg is not None:
                 target_function = self._key2func[key]
-                res[key] = target_function(arg, **params)
+                res[key] = target_function(arg, **plan.params_for(key))
             else:
                 res[key] = arg
         return res
@@ -774,6 +905,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         params: dict[str, Any],
         data: dict[str, Any],
         invocation: InvocationContext | None = None,
+        targets: TargetSet | None = None,
     ) -> dict[str, Any]:
         """Update parameters with input shape and transform-specific settings (interpolation, fill,
         fill_mask, bbox type) before data-aware parameter sampling.
@@ -782,15 +914,31 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             params (dict[str, Any]): Parameters to be updated
             data (dict[str, Any]): Input data dictionary containing images and volume data
             invocation (InvocationContext | None): Active call state, when this transform runs in a Compose graph.
+            targets (TargetSet | None): Prebuilt invocation-local target descriptors, when available.
 
         Returns:
             dict[str, Any]: Updated parameters dictionary with shape and transform-specific params
 
         """
-        # Extract shape from any available data source
-        shape = self._extract_shape_from_data(data)
-        if shape is not None:
-            params["shape"] = shape
+        if targets is None:
+            shape = self._extract_shared_shape_from_data(data)
+            if shape is not None:
+                params["shape"] = shape
+        else:
+            for view in targets.ordered:
+                if view.descriptor.shape is not None:
+                    shape = view.descriptor.shape
+                    shared_shape: tuple[int, ...]
+                    if view.descriptor.layout == "image_chw":
+                        shared_shape = (shape[1], shape[2], shape[0])
+                    elif view.descriptor.layout in {"images_nchw", "volume_cdhw"}:
+                        shared_shape = (shape[2], shape[3], shape[0])
+                    elif view.canonical_type in {"images", "volume", "masks", "mask3d"}:
+                        shared_shape = shape[1:]
+                    else:
+                        shared_shape = shape
+                    params["shape"] = shared_shape
+                    break
 
         bbox_processor = None if invocation is None else invocation.get_processor("bboxes")
         if isinstance(bbox_processor, BboxProcessor):
@@ -801,8 +949,49 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
 
         return params
 
+    def _build_target_set(self, data: Mapping[str, Any]) -> TargetSet:
+        canonical_by_name = {name: self._additional_targets.get(name, name) for name in self._key2func}
+        return TargetSet.from_data(data, canonical_by_name)
+
+    def _spatial_frame_shape(self, view: Any) -> tuple[int, ...] | None:
+        descriptor = view.descriptor
+        spatial_shape = descriptor.spatial_shape
+        if spatial_shape is None:
+            return None
+        if self._sampling_spatial_rank == 3:
+            if view.canonical_type in {"volume", "mask3d"} and len(spatial_shape) == 3:
+                return tuple(spatial_shape)
+            return None
+        if self._sampling_spatial_rank == 2:
+            return tuple(spatial_shape[-2:])
+        return None
+
+    def _build_spatial_frame(self, targets: TargetSet) -> SpatialFrame | None:
+        if self._sampling_spatial_rank is None:
+            return None
+        frame_shapes: set[tuple[int, ...]] = set()
+        for view in targets.ordered:
+            if (isinstance(view.value, np.ndarray) and view.value.size == 0) or (
+                isinstance(view.value, torch.Tensor) and view.value.numel() == 0
+            ):
+                continue
+            shape = self._spatial_frame_shape(view)
+            if shape is not None:
+                frame_shapes.add(shape)
+        if not frame_shapes:
+            first_shape = next((self._spatial_frame_shape(view) for view in targets.ordered), None)
+            if first_shape is not None:
+                frame_shapes.add(first_shape)
+        if not frame_shapes:
+            return None
+        if len(frame_shapes) != 1:
+            raise TransformParameterPlanError(
+                f"{self.__class__.__name__} requires aligned spatial targets, got {sorted(frame_shapes)}",
+            )
+        return SpatialFrame(self._sampling_spatial_rank, next(iter(frame_shapes)))
+
     @staticmethod
-    def _shape_from_data_key(key: str, value: Any) -> tuple[int, ...]:
+    def _shared_shape_from_data_key(key: str, value: Any) -> tuple[int, ...]:
         if key == "image":
             if isinstance(value, torch.Tensor):
                 return value.shape[1], value.shape[2], value.shape[0]
@@ -813,25 +1002,16 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             return value.shape[1:]
         return value.shape if key == "mask" else value.shape[1:]
 
-    def _extract_shape_from_data(self, data: dict[str, Any]) -> tuple[int, ...] | None:
-        """Return the raw canonical spatial shape using the layout convention expected by every data-aware
-        transform parameter sampler.
+    def _extract_shared_shape_from_data(self, data: dict[str, Any]) -> tuple[int, ...] | None:
+        """Return the shared shape needed by the no-sampler execution fast path.
+
+        Data-dependent samplers receive target descriptors and must not call this helper.
         """
         for key in ("image", "images", "volume", "mask", "masks", "mask3d"):
             value = data.get(key)
             if value is not None:
-                return self._shape_from_data_key(key, value)
+                return self._shared_shape_from_data_key(key, value)
         return None
-
-    def get_image_data(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Return dtype, spatial dimensions, and channel count from the first canonical image, image batch, or
-        volume for parameter sampling.
-
-        Raises:
-            ValueError: If no valid image/volume data is present in `data`.
-
-        """
-        return _get_image_data_impl(data)
 
     def _add_transform_specific_params(self, params: dict[str, Any]) -> None:
         """Add transform-specific parameters to params dict (interpolation, fill, fill_mask).
@@ -846,19 +1026,19 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         """Generates parameters and stores realized replay policy in call-local data, never retaining per-sample values
         on transform instances.
 
-        Override this method in every transform that samples data-dependent parameters. Return values consumed by
-        `apply_*` methods and write constructor-valid realized policy values to `sampling.applied_overrides`. The
-        default supports deterministic transforms with no sampled parameters.
+        Override this method in every transform that samples data-dependent parameters. Return a structured plan whose
+        shared values and target groups are consumed by `apply_*` methods. Write constructor-valid realized policy
+        values to `sampling.applied_overrides`. The default supports deterministic transforms with no sampled
+        parameters.
         """
-        del params, data, sampling
-        return {}
+        del inputs, sampling
+        return TransformParameterPlan.shared_only({})
 
     @property
     def targets(self) -> dict[str, Callable[..., Any]]:
@@ -1422,19 +1602,31 @@ class DualTransform(BasicTransform):
 
         return keypoints
 
-    def apply_with_params(self, params: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def apply_with_params(self, plan: TransformParameterPlan, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply a dual transform with its parameters, including configured keypoint and transform-aware
         semantic-mask label mappings.
         """
-        res = super().apply_with_params(params, *args, **kwargs)
+        res = super().apply_with_params(plan, *args, **kwargs)
 
         # Apply label mapping to keypoints if they were transformed
         if "keypoints" in res and res["keypoints"] is not None:
-            res["keypoints"] = self._apply_label_mapping_to_keypoints(res["keypoints"], **params)
+            res["keypoints"] = self._apply_label_mapping_to_keypoints(
+                res["keypoints"],
+                **plan.params_for("keypoints"),
+            )
 
         if self._semantic_mask_label_mappings:
-            res = self._apply_label_mapping_to_semantic_masks(res, **params)
+            res = self._apply_label_mapping_to_semantic_masks(res, **plan.shared)
 
+        return res
+
+    def apply_with_shared_params(self, params: Mapping[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Apply shared-only parameters while preserving dual-target label mappings."""
+        res = super().apply_with_shared_params(params, *args, **kwargs)
+        if "keypoints" in res and res["keypoints"] is not None:
+            res["keypoints"] = self._apply_label_mapping_to_keypoints(res["keypoints"], **params)
+        if self._semantic_mask_label_mappings:
+            res = self._apply_label_mapping_to_semantic_masks(res, **params)
         return res
 
 
@@ -1579,6 +1771,8 @@ class Transform3D(DualTransform):
         keypoints: 3D numpy array of shape (N, 3)
     """
 
+    _sampling_spatial_rank = 3
+
     def apply_to_volume(self, volume: VolumeType, *args: Any, **params: Any) -> VolumeType:
         """Apply transform to single 3D volume. Override in subclasses; input shape (D, H, W, C)
         or (D, H, W). Returns same shape and dtype.
@@ -1641,6 +1835,7 @@ class VolumeOnlyTransform(BasicTransform):
     """
 
     _targets = (Targets.VOLUME,)
+    _sampling_spatial_rank = 3
 
     def apply_to_volume(self, volume: VolumeType, *args: Any, **params: Any) -> VolumeType:
         raise NotImplementedError
@@ -1683,8 +1878,8 @@ class CustomTransformsApplyMixin:
         >>> mask = np.random.randint(0, 2, (64, 64), dtype=np.uint8)
         >>>
         >>> class Rotate90WithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
-        ...     def sample_parameters(self, params, data, sampling):
-        ...         return {"k": 1}
+        ...     def sample_parameters(self, inputs, sampling):
+        ...         return TransformParameterPlan.shared_only({"k": 1})
         ...     def apply(self, img, k=0, **p):
         ...         return np.rot90(img, k)
         ...     def apply_to_mask(self, mask, k=0, **p):

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -502,7 +502,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             and not self.deterministic
             and type(self).apply_with_params in {BasicTransform.apply_with_params, DualTransform.apply_with_params}
         ):
-            return self.apply_with_shared_params(params, **kwargs)
+            return self.apply_with_uniform_params(params, **kwargs)
 
         applied_overrides, sampled_params = self._sample_parameters(
             params=params,
@@ -513,9 +513,9 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         )
 
         effective_params = SampledParams(
-            shared={**params, **sampled_params.shared},
-            groups=sampled_params.groups,
-            target_schema=targets.schema() if targets is not None and sampled_params.groups else None,
+            params={**params, **sampled_params.params},
+            target_params=sampled_params.target_params,
+            target_schema=targets.schema() if targets is not None and sampled_params.target_params else None,
         )
         self._validate_sampled_params(effective_params, targets, kwargs)
 
@@ -545,7 +545,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         collect_applied: bool,
     ) -> tuple[Any, SampledParams]:
         if targets is None:
-            return _EMPTY_APPLIED_OVERRIDES, SampledParams.shared_only({})
+            return _EMPTY_APPLIED_OVERRIDES, SampledParams(params={})
         if invocation is None:
             msg = "sampling transforms require an active sampling context"
             raise RuntimeError(msg)
@@ -569,7 +569,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         data: Mapping[str, Any],
     ) -> None:
         if targets is None:
-            self._validate_shared_params(sampled_params, data)
+            self._validate_uniform_params(sampled_params, data)
             return
 
         sampled_params.validate(
@@ -582,14 +582,14 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             self.__class__.__name__,
         )
 
-    def _validate_shared_params(self, sampled_params: SampledParams, data: Mapping[str, Any]) -> None:
-        """Validate required parameters without describing targets for shared-only samplers."""
+    def _validate_uniform_params(self, sampled_params: SampledParams, data: Mapping[str, Any]) -> None:
+        """Validate required parameters when sampling returns no target-specific parameters."""
         required_by_target = self._get_required_parameters_by_target()
         if not required_by_target:
             return
 
         missing_by_target = {
-            name: required.difference(self._runtime_generated_params).difference(sampled_params.shared)
+            name: required.difference(self._runtime_generated_params).difference(sampled_params.params)
             for name, required in required_by_target.items()
             if name in data and data[name] is not None
         }
@@ -736,8 +736,8 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
             "Only transforms that override `inverse()` can be used for TTA inversion.",
         )
 
-    def apply_with_shared_params(self, params: Mapping[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Apply shared-only parameters without constructing target-specific sampled values."""
+    def apply_with_uniform_params(self, params: Mapping[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Apply one parameter mapping to every target without target-specific values."""
         res: dict[str, Any] = {}
         for key, arg in kwargs.items():
             if key in self._key2func and arg is not None:
@@ -949,7 +949,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
 
     def _validate_spatial_targets(self, targets: TargetSet) -> None:
         if self._sampling_spatial_rank is not None:
-            targets.spatial_shape(self._sampling_spatial_rank)
+            targets.aligned_spatial_shape(self._sampling_spatial_rank)
 
     @staticmethod
     def _shared_shape_from_data_key(key: str, value: Any) -> tuple[int, ...]:
@@ -995,14 +995,14 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         """Generates parameters and stores realized replay policy in call-local data, never retaining per-sample values
         on transform instances.
 
-        Override this method in every transform that samples data-dependent parameters. `params` contains the common
-        execution parameters, `data` contains all invocation data, and `targets` describes active transform targets.
-        Return shared values and target-specific groups consumed by `apply_*` methods. Write constructor-valid
+        Override this method in every transform that samples data-dependent parameters. `params` contains execution
+        parameters, `data` contains all invocation data, and `targets` describes active transform targets.
+        Return parameters and target-specific values consumed by `apply_*` methods. Write constructor-valid
         realized policy values to `sampling.applied_overrides`. The default supports deterministic transforms with no
         sampled parameters.
         """
         del params, data, targets, sampling
-        return SampledParams.shared_only({})
+        return SampledParams(params={})
 
     @property
     def targets(self) -> dict[str, Callable[..., Any]]:
@@ -1580,13 +1580,13 @@ class DualTransform(BasicTransform):
             )
 
         if self._semantic_mask_label_mappings:
-            res = self._apply_label_mapping_to_semantic_masks(res, **sampled_params.shared)
+            res = self._apply_label_mapping_to_semantic_masks(res, **sampled_params.params)
 
         return res
 
-    def apply_with_shared_params(self, params: Mapping[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Apply shared-only parameters while preserving dual-target label mappings."""
-        res = super().apply_with_shared_params(params, *args, **kwargs)
+    def apply_with_uniform_params(self, params: Mapping[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Apply one parameter mapping to every target while preserving dual-target label mappings."""
+        res = super().apply_with_uniform_params(params, *args, **kwargs)
         if "keypoints" in res and res["keypoints"] is not None:
             res["keypoints"] = self._apply_label_mapping_to_keypoints(res["keypoints"], **params)
         if self._semantic_mask_label_mappings:
@@ -1843,7 +1843,7 @@ class CustomTransformsApplyMixin:
         >>>
         >>> class Rotate90WithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
         ...     def sample_parameters(self, params, data, targets, sampling):
-        ...         return SampledParams.shared_only({"k": 1})
+        ...         return SampledParams(params={"k": 1})
         ...     def apply(self, img, k=0, **p):
         ...         return np.rot90(img, k)
         ...     def apply_to_mask(self, mask, k=0, **p):

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -163,7 +163,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
     _supports_cpu_tensor: ClassVar[bool] = False
     _cpu_tensor_targets: ClassVar[frozenset[str] | None] = None
     _cpu_tensor_channels: ClassVar[frozenset[int] | None] = None
-    _sampling_spatial_rank: ClassVar[int | None] = 2
+    _sampling_spatial_rank: ClassVar[int | None] = None
     _runtime_generated_params: ClassVar[frozenset[str]] = frozenset()
     _preserves_input_image_range: ClassVar[bool] = True  # image targets retain the input dtype's normalized range
     _removed_sampling_hooks: ClassVar[frozenset[str]] = frozenset({"get_params", "get_params_dependent_on_data"})
@@ -925,7 +925,7 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
                     shared_shape: tuple[int, ...]
                     if view.descriptor.layout == "image_chw":
                         shared_shape = (shape[1], shape[2], shape[0])
-                    elif view.descriptor.layout in {"images_nchw", "volume_cdhw"}:
+                    elif view.descriptor.layout in {"images_clhw", "volume_cdhw"}:
                         shared_shape = (shape[2], shape[3], shape[0])
                     elif view.canonical_type in {"images", "volume", "masks", "mask3d"}:
                         shared_shape = shape[1:]
@@ -1253,6 +1253,8 @@ class DualTransform(BasicTransform):
             multiple single-channel masks.
 
     """
+
+    _sampling_spatial_rank = 2
 
     _supported_bbox_types: frozenset[str] = frozenset({"hbb"})  # Default: only axis-aligned boxes
     _semantic_mask_label_mappings: dict[str, dict[int, int]]
@@ -1799,7 +1801,6 @@ class VolumeOnlyTransform(BasicTransform):
     """
 
     _targets = (Targets.VOLUME,)
-    _sampling_spatial_rank = 3
 
     def apply_to_volume(self, volume: VolumeType, *args: Any, **params: Any) -> VolumeType:
         raise NotImplementedError

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -51,8 +51,8 @@ We use pre-commit hooks to maintain consistent code quality. These hooks automat
 - Pyrefly runs through the official pre-commit hook in system mode, using the same `uv` environment as CI.
 
 The repository-specific deterministic rules run through one package-wide hook:
-`pre-commit run check-ax-coding-guidance --all-files`. It emits `AXG001`–`AXG020` diagnostics for transform API,
-sampling, schema, naming, performance-shape, documentation, and bbox propagation contracts. The public
+`pre-commit run check-ax-coding-guidance --all-files`. It emits `AXG001`–`AXG023` diagnostics for transform API,
+sampling, schema, naming, performance-shape, documentation, bbox propagation, and target-plan contracts. The public
 `BboxParams.__init__(bbox_type="hbb")` compatibility default is intentional; all internal transform, processor, and
 functional calls must pass `bbox_type` explicitly. Keep design judgment and benchmark interpretation in the relevant
 review skill rather than duplicating these mechanical checks. `AGENTS.md`, `.codex/rules/`, and `.codex/skills/` point to
@@ -263,7 +263,7 @@ Instead, follow this preferred pattern:
 
 1. **Pass the auxiliary data** within the main `data` dictionary provided to the transform's `__call__` method, using a descriptive key (e.g., `mosaic_metadata`, `copy_paste_metadata`).
 2. **Declare this key** in the transform's `targets_as_params` property. This signals to `Compose` that the key should be extracted and forwarded to `sample_parameters`.
-3. **Access the data** inside `sample_parameters` using `data.get("your_metadata_key")`.
+3. **Access the data** inside `sample_parameters` using `inputs.data.get("your_metadata_key")`.
 4. **Define empty metadata deliberately**. A transform may no-op or use a documented fallback; it must not reach into a
    dataset or another global donor source to fill the gap.
 
@@ -367,22 +367,26 @@ applied-configuration record. Do not read RNG state from the transform instance 
 
 ```python
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 
 def sample_parameters(
     self,
-    params: dict[str, Any],
-    data: dict[str, Any],
+    inputs: TransformSamplingInput,
     sampling: SamplingContext,
-) -> dict[str, Any]:
+) -> TransformParameterPlan:
     brightness = sampling.py_random.uniform(*self.brightness_range)
-    noise = sampling.random_generator.uniform(-1, 1, size=params["shape"])
+    height, width = inputs.require_spatial_frame().spatial_shape_2d
+    noise = sampling.random_generator.uniform(-1, 1, size=(height, width))
     sampling.applied_overrides["brightness_range"] = brightness
-    return {"brightness": brightness, "noise": noise}
+    return TransformParameterPlan.shared_only({"brightness": brightness, "noise": noise})
 ```
 
 Use `sampling.py_random` for a few scalar choices. Use `sampling.random_generator` for array-valued draws. Generate
-all stochastic parameters before `apply`, then pass the generated values to `apply` through the returned dictionary.
+all stochastic parameters before `apply`, then pass them through a `TransformParameterPlan`. Shared values go in
+`plan.shared`; representation-dependent values belong in `TargetParameterGroup` entries addressed by actual target key.
+Use `inputs.targets` and its descriptors for channel, dtype, layout, topology, or target-content decisions. Do not derive
+those decisions from the first-target `inputs.base_params["shape"]` field.
 
 ## Transform Development
 
@@ -417,36 +421,36 @@ does not apply to `Compose` orchestration such as `apply_in_invocation`; it is e
 
 #### Using sample_parameters
 
-This method provides access to image shape and target data for parameter generation:
+This method provides the invocation-local target descriptors, spatial frame, preprocessed data, and shared metadata for
+parameter generation:
 
 ```python
 def sample_parameters(
     self,
-    params: dict[str, Any],
-    data: dict[str, Any],
+    inputs: TransformSamplingInput,
     sampling: SamplingContext,
-) -> dict[str, Any]:
-    # Access image shape - always available
-    height, width = params["shape"][:2]
+) -> TransformParameterPlan:
+    # Shared geometry uses the declared frame; target-dependent code uses inputs.targets.
+    height, width = inputs.require_spatial_frame().spatial_shape_2d
 
-    # Access targets if they were passed to transform
-    image = data.get("image")  # Original image
-    mask = data.get("mask")  # Segmentation mask
-    bboxes = data.get("bboxes")  # Bounding boxes
-    keypoints = data.get("keypoints")  # Keypoint coordinates
+    # Auxiliary content is still available through inputs.data.
+    image = inputs.data.get("image")
+    mask = inputs.data.get("mask")
+    bboxes = inputs.data.get("bboxes")
+    keypoints = inputs.data.get("keypoints")
 
     # Example: Calculate parameters based on image size
     crop_size = min(height, width) // 2
     center_x = width // 2
     center_y = height // 2
 
-    return {"crop_size": crop_size, "center": (center_x, center_y)}
+    return TransformParameterPlan.shared_only({"crop_size": crop_size, "center": (center_x, center_y)})
 ```
 
 The method receives:
 
-- `params`: Dictionary containing image metadata, where `params["shape"]` is always available
-- `data`: Dictionary containing all targets passed to the transform
+- `inputs`: `TransformSamplingInput`, containing `base_params`, `spatial_frame`, the ordered `TargetSet`, and all preprocessed
+  data
 - `sampling`: Call-local Python and NumPy RNG streams plus the applied-configuration sink
 
 Use this method when you need to:
@@ -454,6 +458,10 @@ Use this method when you need to:
 - Calculate parameters based on image dimensions
 - Access target data for parameter generation
 - Ensure transform parameters are appropriate for the input data
+
+Never return a plain dictionary. For target-specific materialization, group by a transform-defined compatibility key and
+return `TargetParameterGroup(targets=..., params=..., requirements=...)`. The core stores the resulting schema in replay and
+rejects legacy flat payloads.
 
 ### Parameter Validation with `InitSchema`
 
@@ -524,6 +532,11 @@ If a transform only repeats inherited constructor inputs and explicitly forwards
 When it adds an input or changes an annotation, its non-empty schema must declare that input (`AXG020`).
 Compatibility aliases that deliberately preserve a parent validator's permissive boundary may retain an empty schema;
 they must not introduce new constructor fields.
+
+Sampling overrides must return `TransformParameterPlan` rather than a flat dictionary (`AXG021`), and must not derive
+target-sensitive values from first-target `base_params["shape"]` or legacy shape helpers (`AXG022`). Application methods
+use semantic parameter names; target routing belongs in plan groups rather than names such as `volume_noise_map`
+(`AXG023`).
 
 #### No `get_transform_init_args_names` Override
 
@@ -713,14 +726,14 @@ Examples:
     ...         super().__init__(*args, **kwargs)
     ...         # Add custom parameters here
     ...
-    ...     def sample_parameters(self, params, data, sampling):
-    ...         height, width = params["shape"][:2]
+    ...     def sample_parameters(self, inputs, sampling):
+    ...         height, width = inputs.require_spatial_frame().spatial_shape_2d
     ...         # Generate distortion maps
     ...         map_x = np.zeros((height, width), dtype=np.float32)
     ...         map_y = np.zeros((height, width), dtype=np.float32)
     ...         # Apply your custom distortion logic here
     ...         # ...
-    ...         return {"map_x": map_x, "map_y": map_y}
+    ...         return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
     >>>
     >>> # Prepare sample data
     >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -52,7 +52,7 @@ We use pre-commit hooks to maintain consistent code quality. These hooks automat
 
 The repository-specific deterministic rules run through one package-wide hook:
 `pre-commit run check-ax-coding-guidance --all-files`. It emits `AXG001`–`AXG023` diagnostics for transform API,
-sampling, schema, naming, performance-shape, documentation, bbox propagation, and target-plan contracts. The public
+sampling, schema, naming, performance-shape, documentation, bbox propagation, and target-specific sampling contracts. The public
 `BboxParams.__init__(bbox_type="hbb")` compatibility default is intentional; all internal transform, processor, and
 functional calls must pass `bbox_type` explicitly. Keep design judgment and benchmark interpretation in the relevant
 review skill rather than duplicating these mechanical checks. `AGENTS.md`, `.codex/rules/`, and `.codex/skills/` point to
@@ -263,7 +263,7 @@ Instead, follow this preferred pattern:
 
 1. **Pass the auxiliary data** within the main `data` dictionary provided to the transform's `__call__` method, using a descriptive key (e.g., `mosaic_metadata`, `copy_paste_metadata`).
 2. **Declare this key** in the transform's `targets_as_params` property. This signals to `Compose` that the key should be extracted and forwarded to `sample_parameters`.
-3. **Access the data** inside `sample_parameters` using `inputs.data.get("your_metadata_key")`.
+3. **Access the data** inside `sample_parameters` using `data.get("your_metadata_key")`.
 4. **Define empty metadata deliberately**. A transform may no-op or use a documented fallback; it must not reach into a
    dataset or another global donor source to fill the gap.
 
@@ -367,26 +367,28 @@ applied-configuration record. Do not read RNG state from the transform instance 
 
 ```python
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 
 def sample_parameters(
     self,
-    inputs: TransformSamplingInput,
+    params: dict[str, Any],
+    data: dict[str, Any],
+    targets: TargetSet,
     sampling: SamplingContext,
-) -> TransformParameterPlan:
+) -> SampledParams:
     brightness = sampling.py_random.uniform(*self.brightness_range)
-    height, width = inputs.require_spatial_frame().spatial_shape_2d
+    height, width = targets.require_spatial_shape(2)
     noise = sampling.random_generator.uniform(-1, 1, size=(height, width))
     sampling.applied_overrides["brightness_range"] = brightness
-    return TransformParameterPlan.shared_only({"brightness": brightness, "noise": noise})
+    return SampledParams.shared_only({"brightness": brightness, "noise": noise})
 ```
 
 Use `sampling.py_random` for a few scalar choices. Use `sampling.random_generator` for array-valued draws. Generate
-all stochastic parameters before `apply`, then pass them through a `TransformParameterPlan`. Shared values go in
-`plan.shared`; representation-dependent values belong in `TargetParameterGroup` entries addressed by actual target key.
-Use `inputs.targets` and its descriptors for channel, dtype, layout, topology, or target-content decisions. Do not derive
-those decisions from the first-target `inputs.base_params["shape"]` field.
+all stochastic parameters before `apply`, then return a `SampledParams`. Shared values go in
+`SampledParams.shared`; representation-dependent values belong in `TargetParams` entries addressed by actual target key.
+Use `targets` and its descriptors for channel, dtype, layout, topology, or target-content decisions. Do not derive
+those decisions from the first-target `params["shape"]` field.
 
 ## Transform Development
 
@@ -421,36 +423,37 @@ does not apply to `Compose` orchestration such as `apply_in_invocation`; it is e
 
 #### Using sample_parameters
 
-This method provides the invocation-local target descriptors, spatial frame, preprocessed data, and shared metadata for
-parameter generation:
+This method receives explicit execution parameters, preprocessed data, and invocation-local target descriptors for parameter
+generation:
 
 ```python
 def sample_parameters(
     self,
-    inputs: TransformSamplingInput,
+    params: dict[str, Any],
+    data: dict[str, Any],
+    targets: TargetSet,
     sampling: SamplingContext,
-) -> TransformParameterPlan:
-    # Shared geometry uses the declared frame; target-dependent code uses inputs.targets.
-    height, width = inputs.require_spatial_frame().spatial_shape_2d
+) -> SampledParams:
+    height, width = targets.require_spatial_shape(2)
 
-    # Auxiliary content is still available through inputs.data.
-    image = inputs.data.get("image")
-    mask = inputs.data.get("mask")
-    bboxes = inputs.data.get("bboxes")
-    keypoints = inputs.data.get("keypoints")
+    image = data.get("image")
+    mask = data.get("mask")
+    bboxes = data.get("bboxes")
+    keypoints = data.get("keypoints")
 
     # Example: Calculate parameters based on image size
     crop_size = min(height, width) // 2
     center_x = width // 2
     center_y = height // 2
 
-    return TransformParameterPlan.shared_only({"crop_size": crop_size, "center": (center_x, center_y)})
+    return SampledParams.shared_only({"crop_size": crop_size, "center": (center_x, center_y)})
 ```
 
 The method receives:
 
-- `inputs`: `TransformSamplingInput`, containing `base_params`, `spatial_frame`, the ordered `TargetSet`, and all preprocessed
-  data
+- `params`: Common execution parameters such as interpolation and fill values
+- `data`: The full preprocessed invocation, including auxiliary values outside the active targets
+- `targets`: The ordered `TargetSet`; use `require_spatial_shape(2)` or `require_spatial_shape(3)` for synchronized geometry
 - `sampling`: Call-local Python and NumPy RNG streams plus the applied-configuration sink
 
 Use this method when you need to:
@@ -460,7 +463,7 @@ Use this method when you need to:
 - Ensure transform parameters are appropriate for the input data
 
 Never return a plain dictionary. For target-specific materialization, group by a transform-defined compatibility key and
-return `TargetParameterGroup(targets=..., params=..., requirements=...)`. The core stores the resulting schema in replay and
+return `TargetParams(targets=..., params=..., requirements=...)`. The core stores the resulting schema in replay and
 rejects legacy flat payloads.
 
 ### Parameter Validation with `InitSchema`
@@ -533,9 +536,9 @@ When it adds an input or changes an annotation, its non-empty schema must declar
 Compatibility aliases that deliberately preserve a parent validator's permissive boundary may retain an empty schema;
 they must not introduce new constructor fields.
 
-Sampling overrides must return `TransformParameterPlan` rather than a flat dictionary (`AXG021`), and must not derive
-target-sensitive values from first-target `base_params["shape"]` or legacy shape helpers (`AXG022`). Application methods
-use semantic parameter names; target routing belongs in plan groups rather than names such as `volume_noise_map`
+Sampling overrides must return `SampledParams` rather than a flat dictionary (`AXG021`), and must not derive
+target-sensitive values from first-target `params["shape"]` or legacy shape helpers (`AXG022`). Application methods
+use semantic parameter names; target routing belongs in target groups rather than names such as `volume_noise_map`
 (`AXG023`).
 
 #### No `get_transform_init_args_names` Override
@@ -726,14 +729,14 @@ Examples:
     ...         super().__init__(*args, **kwargs)
     ...         # Add custom parameters here
     ...
-    ...     def sample_parameters(self, inputs, sampling):
-    ...         height, width = inputs.require_spatial_frame().spatial_shape_2d
+    ...     def sample_parameters(self, params, data, targets, sampling):
+    ...         height, width = targets.require_spatial_shape(2)
     ...         # Generate distortion maps
     ...         map_x = np.zeros((height, width), dtype=np.float32)
     ...         map_y = np.zeros((height, width), dtype=np.float32)
     ...         # Apply your custom distortion logic here
     ...         # ...
-    ...         return TransformParameterPlan.shared_only({"map_x": map_x, "map_y": map_y})
+    ...         return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
     >>>
     >>> # Prepare sample data
     >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -378,15 +378,15 @@ def sample_parameters(
     sampling: SamplingContext,
 ) -> SampledParams:
     brightness = sampling.py_random.uniform(*self.brightness_range)
-    height, width = targets.require_spatial_shape(2)
+    height, width = targets.require_aligned_spatial_shape(2)
     noise = sampling.random_generator.uniform(-1, 1, size=(height, width))
     sampling.applied_overrides["brightness_range"] = brightness
-    return SampledParams.shared_only({"brightness": brightness, "noise": noise})
+    return SampledParams(params={"brightness": brightness, "noise": noise})
 ```
 
 Use `sampling.py_random` for a few scalar choices. Use `sampling.random_generator` for array-valued draws. Generate
-all stochastic parameters before `apply`, then return a `SampledParams`. Shared values go in
-`SampledParams.shared`; representation-dependent values belong in `TargetParams` entries addressed by actual target key.
+all stochastic parameters before `apply`, then return a `SampledParams`. Values that apply to every target go in
+`SampledParams.params`; representation-dependent values belong in `TargetParams` entries addressed by actual target key.
 Use `targets` and its descriptors for channel, dtype, layout, topology, or target-content decisions. Do not derive
 those decisions from the first-target `params["shape"]` field.
 
@@ -434,7 +434,7 @@ def sample_parameters(
     targets: TargetSet,
     sampling: SamplingContext,
 ) -> SampledParams:
-    height, width = targets.require_spatial_shape(2)
+    height, width = targets.require_aligned_spatial_shape(2)
 
     image = data.get("image")
     mask = data.get("mask")
@@ -446,14 +446,14 @@ def sample_parameters(
     center_x = width // 2
     center_y = height // 2
 
-    return SampledParams.shared_only({"crop_size": crop_size, "center": (center_x, center_y)})
+    return SampledParams(params={"crop_size": crop_size, "center": (center_x, center_y)})
 ```
 
 The method receives:
 
-- `params`: Common execution parameters such as interpolation and fill values
+- `params`: Execution parameters such as interpolation and fill values
 - `data`: The full preprocessed invocation, including auxiliary values outside the active targets
-- `targets`: The ordered `TargetSet`; use `require_spatial_shape(2)` or `require_spatial_shape(3)` for synchronized geometry
+- `targets`: The ordered `TargetSet`; use `require_aligned_spatial_shape(2)` or `require_aligned_spatial_shape(3)` for synchronized geometry
 - `sampling`: Call-local Python and NumPy RNG streams plus the applied-configuration sink
 
 Use this method when you need to:
@@ -538,7 +538,7 @@ they must not introduce new constructor fields.
 
 Sampling overrides must return `SampledParams` rather than a flat dictionary (`AXG021`), and must not derive
 target-sensitive values from first-target `params["shape"]` or legacy shape helpers (`AXG022`). Application methods
-use semantic parameter names; target routing belongs in target groups rather than names such as `volume_noise_map`
+use semantic parameter names; target routing belongs in `TargetParams` entries rather than names such as `volume_noise_map`
 (`AXG023`).
 
 #### No `get_transform_init_args_names` Override
@@ -730,13 +730,13 @@ Examples:
     ...         # Add custom parameters here
     ...
     ...     def sample_parameters(self, params, data, targets, sampling):
-    ...         height, width = targets.require_spatial_shape(2)
+    ...         height, width = targets.require_aligned_spatial_shape(2)
     ...         # Generate distortion maps
     ...         map_x = np.zeros((height, width), dtype=np.float32)
     ...         map_y = np.zeros((height, width), dtype=np.float32)
     ...         # Apply your custom distortion logic here
     ...         # ...
-    ...         return SampledParams.shared_only({"map_x": map_x, "map_y": map_y})
+    ...         return SampledParams(params={"map_x": map_x, "map_y": map_y})
     >>>
     >>> # Prepare sample data
     >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -51,7 +51,7 @@ We use pre-commit hooks to maintain consistent code quality. These hooks automat
 - Pyrefly runs through the official pre-commit hook in system mode, using the same `uv` environment as CI.
 
 The repository-specific deterministic rules run through one package-wide hook:
-`pre-commit run check-ax-coding-guidance --all-files`. It emits `AXG001`–`AXG023` diagnostics for transform API,
+`pre-commit run check-ax-coding-guidance --all-files`. It emits `AXG001`–`AXG024` diagnostics for transform API,
 sampling, schema, naming, performance-shape, documentation, bbox propagation, and target-specific sampling contracts. The public
 `BboxParams.__init__(bbox_type="hbb")` compatibility default is intentional; all internal transform, processor, and
 functional calls must pass `bbox_type` explicitly. Keep design judgment and benchmark interpretation in the relevant
@@ -539,7 +539,8 @@ they must not introduce new constructor fields.
 Sampling overrides must return `SampledParams` rather than a flat dictionary (`AXG021`), and must not derive
 target-sensitive values from first-target `params["shape"]` or legacy shape helpers (`AXG022`). Application methods
 use semantic parameter names; target routing belongs in `TargetParams` entries rather than names such as `volume_noise_map`
-(`AXG023`).
+(`AXG023`). When choosing among canonical image targets, samplers use `TargetSet` rather than selecting `image`,
+`images`, or `volume` from `data` (`AXG024`).
 
 #### No `get_transform_init_args_names` Override
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -55,6 +55,15 @@ sample-dependent work, with separate branch-free executors for ordinary, observe
 
 ## Active Design Work
 
+### [Greenfield Target-Specific Parameter Sampling](target-specific-parameter-sampling.md)
+
+Plan for replacing flat sampled-parameter dictionaries and special `volume_*` fields with shared parameters plus
+actual-target-key parameter groups, including aliases, mixed representations, deterministic execution, and replay.
+
+**Status**: Implemented (greenfield cutover).
+
+The maintained sampler inventory is in [Target-Specific Sampling Inventory](target-specific-parameter-sampling-inventory.md).
+
 ### [Shared CI Foundation](https://github.com/albumentations-team/ci-foundation/blob/main/docs/architecture.md)
 
 The public, SHA-pinned foundation owns Python and uv bootstrap, CPU-only Torch mechanics, and trusted Antigravity

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -57,8 +57,8 @@ sample-dependent work, with separate branch-free executors for ordinary, observe
 
 ### [Greenfield Target-Specific Parameter Sampling](target-specific-parameter-sampling.md)
 
-Plan for replacing flat sampled-parameter dictionaries and special `volume_*` fields with shared parameters plus
-actual-target-key parameter groups, including aliases, mixed representations, deterministic execution, and replay.
+Plan for replacing flat sampled-parameter dictionaries and special `volume_*` fields with parameters plus
+actual-target-key `TargetParams` records, including aliases, mixed representations, deterministic execution, and replay.
 
 **Status**: Implemented (greenfield cutover).
 

--- a/docs/design/compose-greenfield-architecture.md
+++ b/docs/design/compose-greenfield-architecture.md
@@ -43,12 +43,11 @@ Built-in samplers receive randomness explicitly:
 ```python
 def sample_parameters(
     self,
-    params: dict[str, Any],
-    data: dict[str, Any],
+    inputs: TransformSamplingInput,
     sampling: SamplingContext,
-) -> dict[str, Any]:
+) -> TransformParameterPlan:
     value = sampling.py_random.uniform(0.0, 1.0)
-    return {"value": value}
+    return TransformParameterPlan.shared_only({"value": value})
 ```
 
 `SamplingContext` exposes the invocation-local Python and NumPy streams plus `applied_overrides`. Built-in sampler
@@ -56,6 +55,8 @@ code must use these streams, never `self.py_random` or `self.random_generator`. 
 sampling context is pointed at a no-op override sink: samplers can keep the same interface without allocating or
 retaining an applied-configuration dictionary. Observed calls provide a real sink and build the durable replay record.
 `apply_*` receives realized parameters and target data only; it does not generate randomness.
+Target-sensitive samplers use `inputs.targets` and return `TargetParameterGroup` entries keyed by actual target names;
+they must not route through target-named fields such as `volume_noise_map`.
 
 ## Ordinary hot path
 

--- a/docs/design/compose-greenfield-architecture.md
+++ b/docs/design/compose-greenfield-architecture.md
@@ -49,7 +49,7 @@ def sample_parameters(
     sampling: SamplingContext,
 ) -> SampledParams:
     value = sampling.py_random.uniform(0.0, 1.0)
-    return SampledParams.shared_only({"value": value})
+    return SampledParams(params={"value": value})
 ```
 
 `SamplingContext` exposes the invocation-local Python and NumPy streams plus `applied_overrides`. Built-in sampler

--- a/docs/design/compose-greenfield-architecture.md
+++ b/docs/design/compose-greenfield-architecture.md
@@ -43,11 +43,13 @@ Built-in samplers receive randomness explicitly:
 ```python
 def sample_parameters(
     self,
-    inputs: TransformSamplingInput,
+    params: dict[str, Any],
+    data: dict[str, Any],
+    targets: TargetSet,
     sampling: SamplingContext,
-) -> TransformParameterPlan:
+) -> SampledParams:
     value = sampling.py_random.uniform(0.0, 1.0)
-    return TransformParameterPlan.shared_only({"value": value})
+    return SampledParams.shared_only({"value": value})
 ```
 
 `SamplingContext` exposes the invocation-local Python and NumPy streams plus `applied_overrides`. Built-in sampler
@@ -55,7 +57,7 @@ code must use these streams, never `self.py_random` or `self.random_generator`. 
 sampling context is pointed at a no-op override sink: samplers can keep the same interface without allocating or
 retaining an applied-configuration dictionary. Observed calls provide a real sink and build the durable replay record.
 `apply_*` receives realized parameters and target data only; it does not generate randomness.
-Target-sensitive samplers use `inputs.targets` and return `TargetParameterGroup` entries keyed by actual target names;
+Target-sensitive samplers use `targets` and return `TargetParams` entries keyed by actual target names;
 they must not route through target-named fields such as `volume_noise_map`.
 
 ## Ordinary hot path

--- a/docs/design/target-specific-parameter-sampling-inventory.md
+++ b/docs/design/target-specific-parameter-sampling-inventory.md
@@ -36,11 +36,8 @@ it must include every property used to construct the execution value.
 
 - `albumentations/augmentations/blur/transforms.py`: `GaussianBlur`.
 - `albumentations/augmentations/dropout/channel_dropout.py`: `ChannelDropout`.
-- `albumentations/augmentations/dropout/coarse_dropout.py`: `CoarseDropout`, `Erasing`.
-- `albumentations/augmentations/dropout/grid_dropout.py`: `GridDropout`.
-- `albumentations/augmentations/dropout/grid_mask.py`: `GridMask`.
 - `albumentations/augmentations/dropout/transforms.py`: `PixelDropout`.
-- `albumentations/augmentations/dropout/xy_masking.py`: `XYMasking`.
+- `albumentations/augmentations/other/annotation_artifacts.py`: `AnnotationArtifacts`.
 - `albumentations/augmentations/pixel/channel.py`: `ChannelShuffle`.
 - `albumentations/augmentations/pixel/color_advanced.py`: `RGBShift`, `PhotoMetricDistort`.
 - `albumentations/augmentations/pixel/color_basic.py`: `RandomToneCurve`, `ExposureMatching`.
@@ -64,6 +61,10 @@ group key.
   `AtLeastOneBBoxRandomCrop`.
 - `albumentations/augmentations/crops/sized.py`: `RandomSizedCrop`, `RandomResizedCrop`.
 - `albumentations/augmentations/crops/special.py`: `RandomCropNearBBox`, `RandomCropFromBorders`.
+- `albumentations/augmentations/dropout/coarse_dropout.py`: `CoarseDropout`, `Erasing`.
+- `albumentations/augmentations/dropout/grid_dropout.py`: `GridDropout`.
+- `albumentations/augmentations/dropout/grid_mask.py`: `GridMask`.
+- `albumentations/augmentations/dropout/xy_masking.py`: `XYMasking`.
 - `albumentations/augmentations/geometric/distortion.py`: `ElasticTransform`, `PiecewiseAffine`, `OpticalDistortion`,
   `GridDistortion`, `ThinPlateSpline`, `WaterRefraction`, `PixelSpread`.
 - `albumentations/augmentations/geometric/pad.py`: `PadIfNeeded`.
@@ -88,7 +89,6 @@ realized value is consumed by multiple representations, move the materialization
 - `albumentations/augmentations/mixing/domain_adaptation.py`: `HistogramMatching`, `PixelDistributionAdaptation`.
 - `albumentations/augmentations/mixing/mosaic.py`: `Mosaic`.
 - `albumentations/augmentations/mixing/overlay.py`: `OverlayElements`.
-- `albumentations/augmentations/other/annotation_artifacts.py`: `AnnotationArtifacts`.
 - `albumentations/augmentations/pixel/color_advanced.py`: `HEStain`.
 - `albumentations/augmentations/pixel/color_basic.py`: `Equalize`.
 - `albumentations/augmentations/text/transforms.py`: `TextImage`.

--- a/docs/design/target-specific-parameter-sampling-inventory.md
+++ b/docs/design/target-specific-parameter-sampling-inventory.md
@@ -31,7 +31,7 @@ when the sampled value is independent of target representation and content.
 
 ## Grouped by representation or actual target
 
-These samplers materialize one or more `TargetParameterGroup` values. The grouping key is part of each transform's contract;
+These samplers materialize one or more `TargetParams` values. The grouping key is part of each transform's contract;
 it must include every property used to construct the execution value.
 
 - `albumentations/augmentations/blur/transforms.py`: `GaussianBlur`.
@@ -120,7 +120,7 @@ representation test before changing the implementation.
 ## Review requirements for additions
 
 1. Add the sampler to exactly one category and state the sharing key in its docstring or the implementation comment next
-   to the `TargetParameterGroup` construction.
+   to the `TargetParams` construction.
 2. Test at least two actual target keys, including an `additional_targets` alias when the transform supports one.
 3. Vary the representation property that drives materialization: shape, channels, dtype scale, layout, topology, or
    content. A test that only checks output shape does not prove the plan is target-correct.

--- a/docs/design/target-specific-parameter-sampling-inventory.md
+++ b/docs/design/target-specific-parameter-sampling-inventory.md
@@ -26,7 +26,7 @@ PY
 ```
 
 The source hook enforces the boundaries mechanically: `AXG021` rejects flat sampler returns, `AXG022` rejects first-target
-shape helpers, and `AXG023` rejects target-routing names in application parameters. A transform may remain shared-only only
+shape helpers, and `AXG023` rejects target-routing names in application parameters. A transform may return no target-specific parameters
 when the sampled value is independent of target representation and content.
 
 ## Grouped by representation or actual target
@@ -78,7 +78,7 @@ share geometry intentionally; representation-dependent values must not be added 
 ## Content-derived or mixed policy
 
 These samplers read caller content or annotation metadata. They must document which target is the reference and, when the
-realized value is consumed by multiple representations, move the materialization into target groups.
+realized value is consumed by multiple representations, move the materialization into `TargetParams` records.
 
 - `albumentations/augmentations/crops/special.py`: `CropNonEmptyMaskIfExists`.
 - `albumentations/augmentations/dropout/coarse_dropout.py`: `ConstrainedCoarseDropout`.
@@ -92,7 +92,7 @@ realized value is consumed by multiple representations, move the materialization
 - `albumentations/augmentations/pixel/color_basic.py`: `Equalize`.
 - `albumentations/augmentations/text/transforms.py`: `TextImage`.
 
-## Shared-only policy
+## Parameters without target-specific values
 
 These samplers produce values independent of active target representation. If a future change makes one of these values
 depend on shape, channels, dtype, topology, or target content, move it to one of the two sections above and add a mixed

--- a/docs/design/target-specific-parameter-sampling-inventory.md
+++ b/docs/design/target-specific-parameter-sampling-inventory.md
@@ -54,8 +54,9 @@ it must include every property used to construct the execution value.
 
 ## Shared spatial frame
 
-These samplers use `inputs.spatial_frame`, which is validated against every active spatial target before sampling. They
-share geometry intentionally; representation-dependent values must not be added to this category without a group key.
+These samplers call `TargetSet.require_aligned_spatial_shape(...)`, which validates every active spatial target before
+sampling. They share geometry intentionally; representation-dependent values must not be added to this category without a
+group key.
 
 - `albumentations/augmentations/blur/transforms.py`: `GlassBlur`.
 - `albumentations/augmentations/crops/basic.py`: `RandomCrop`, `CenterCrop`, `Crop`, `CropAndPad`.

--- a/docs/design/target-specific-parameter-sampling-inventory.md
+++ b/docs/design/target-specific-parameter-sampling-inventory.md
@@ -1,0 +1,128 @@
+# Target-Specific Sampling Inventory
+
+**Status**: maintained with the greenfield sampling contract
+
+This inventory is the review surface for every built-in `sample_parameters` override. It prevents a new transform from
+silently reintroducing first-target sampling or target names embedded in execution parameters. The inventory is grouped by
+the contract the sampler must keep, not by the transform's public family.
+
+The audit can be regenerated with:
+
+```bash
+uv run python - <<'PY'
+import ast
+from pathlib import Path
+
+for path in sorted(Path("albumentations/augmentations").rglob("*.py")):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and any(
+            isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and member.name == "sample_parameters"
+            for member in node.body
+        ):
+            print(path, node.name)
+PY
+```
+
+The source hook enforces the boundaries mechanically: `AXG021` rejects flat sampler returns, `AXG022` rejects first-target
+shape helpers, and `AXG023` rejects target-routing names in application parameters. A transform may remain shared-only only
+when the sampled value is independent of target representation and content.
+
+## Grouped by representation or actual target
+
+These samplers materialize one or more `TargetParameterGroup` values. The grouping key is part of each transform's contract;
+it must include every property used to construct the execution value.
+
+- `albumentations/augmentations/blur/transforms.py`: `GaussianBlur`.
+- `albumentations/augmentations/dropout/channel_dropout.py`: `ChannelDropout`.
+- `albumentations/augmentations/dropout/coarse_dropout.py`: `CoarseDropout`, `Erasing`.
+- `albumentations/augmentations/dropout/grid_dropout.py`: `GridDropout`.
+- `albumentations/augmentations/dropout/grid_mask.py`: `GridMask`.
+- `albumentations/augmentations/dropout/transforms.py`: `PixelDropout`.
+- `albumentations/augmentations/dropout/xy_masking.py`: `XYMasking`.
+- `albumentations/augmentations/pixel/channel.py`: `ChannelShuffle`.
+- `albumentations/augmentations/pixel/color_advanced.py`: `RGBShift`, `PhotoMetricDistort`.
+- `albumentations/augmentations/pixel/color_basic.py`: `RandomToneCurve`, `ExposureMatching`.
+- `albumentations/augmentations/pixel/color_gray.py`: `FancyPCA`.
+- `albumentations/augmentations/pixel/color_lighting.py`: `PlasmaBrightnessContrast`, `PlasmaShadow`.
+- `albumentations/augmentations/pixel/noise.py`: `GaussNoise`, `MultiplicativeNoise`, `AdditiveNoise`,
+  `SaltAndPepper`, `FilmGrain`, `RicianNoise`.
+- `albumentations/augmentations/pixel/transforms.py`: `Dithering`, `LensFlare`.
+- `albumentations/augmentations/pixel/weather.py`: `RandomSnow`, `RandomGravel`, `RandomRain`, `RandomFog`,
+  `RandomSunFlare`, `RandomShadow`, `Spatter`, `AtmosphericFog`.
+
+## Shared spatial frame
+
+These samplers use `inputs.spatial_frame`, which is validated against every active spatial target before sampling. They
+share geometry intentionally; representation-dependent values must not be added to this category without a group key.
+
+- `albumentations/augmentations/blur/transforms.py`: `GlassBlur`.
+- `albumentations/augmentations/crops/basic.py`: `RandomCrop`, `CenterCrop`, `Crop`, `CropAndPad`.
+- `albumentations/augmentations/crops/bbox_safe.py`: `BBoxSafeRandomCrop`, `BBoxSubsetSafeRandomCrop`,
+  `AtLeastOneBBoxRandomCrop`.
+- `albumentations/augmentations/crops/sized.py`: `RandomSizedCrop`, `RandomResizedCrop`.
+- `albumentations/augmentations/crops/special.py`: `RandomCropNearBBox`, `RandomCropFromBorders`.
+- `albumentations/augmentations/geometric/distortion.py`: `ElasticTransform`, `PiecewiseAffine`, `OpticalDistortion`,
+  `GridDistortion`, `ThinPlateSpline`, `WaterRefraction`, `PixelSpread`.
+- `albumentations/augmentations/geometric/pad.py`: `PadIfNeeded`.
+- `albumentations/augmentations/geometric/resize.py`: `LongestMaxSize`, `SmallestMaxSize`, `LetterBox`.
+- `albumentations/augmentations/geometric/rotate.py`: `Rotate`, `SafeRotate`.
+- `albumentations/augmentations/geometric/transforms.py`: `Perspective`, `Affine`, `GridElasticDeform`,
+  `RandomGridShuffle`.
+- `albumentations/augmentations/mixing/copy_paste.py`: `CopyAndPaste`.
+- `albumentations/augmentations/mixing/domain_adaptation.py`: `FDA`.
+- `albumentations/augmentations/transforms3d/transforms.py`: `Affine3D`, `Anisotropy3D`, `Resize3D`, `PadIfNeeded3D`,
+  `CenterCrop3D`, `RandomCrop3D`, `CoarseDropout3D`, `Flip3D`, `CubicSymmetry`, `RandomRotate90_3D`, `GridShuffle3D`.
+
+## Content-derived or mixed policy
+
+These samplers read caller content or annotation metadata. They must document which target is the reference and, when the
+realized value is consumed by multiple representations, move the materialization into target groups.
+
+- `albumentations/augmentations/crops/special.py`: `CropNonEmptyMaskIfExists`.
+- `albumentations/augmentations/dropout/coarse_dropout.py`: `ConstrainedCoarseDropout`.
+- `albumentations/augmentations/dropout/guided_coarse_dropout.py`: `GuidedCoarseDropout`.
+- `albumentations/augmentations/dropout/mask_dropout.py`: `MaskDropout`.
+- `albumentations/augmentations/mixing/domain_adaptation.py`: `HistogramMatching`, `PixelDistributionAdaptation`.
+- `albumentations/augmentations/mixing/mosaic.py`: `Mosaic`.
+- `albumentations/augmentations/mixing/overlay.py`: `OverlayElements`.
+- `albumentations/augmentations/other/annotation_artifacts.py`: `AnnotationArtifacts`.
+- `albumentations/augmentations/pixel/color_advanced.py`: `HEStain`.
+- `albumentations/augmentations/pixel/color_basic.py`: `Equalize`.
+- `albumentations/augmentations/text/transforms.py`: `TextImage`.
+
+## Shared-only policy
+
+These samplers produce values independent of active target representation. If a future change makes one of these values
+depend on shape, channels, dtype, topology, or target content, move it to one of the two sections above and add a mixed
+representation test before changing the implementation.
+
+- `albumentations/augmentations/blur/transforms.py`: `Blur`, `MotionBlur`, `ModeFilter`, `AdvancedBlur`, `Defocus`,
+  `ZoomBlur`.
+- `albumentations/augmentations/dropout/transforms.py`: `BaseDropout` (abstract contract only).
+- `albumentations/augmentations/geometric/flip.py`: `D4`.
+- `albumentations/augmentations/geometric/pad.py`: `Pad`.
+- `albumentations/augmentations/geometric/resize.py`: `RandomScale`.
+- `albumentations/augmentations/geometric/rotate.py`: `RandomRotate90`.
+- `albumentations/augmentations/geometric/transforms.py`: `Morphological`.
+- `albumentations/augmentations/pixel/color_advanced.py`: `ColorJitter`, `ChromaticAberration`, `PlanckianJitter`.
+- `albumentations/augmentations/pixel/color_basic.py`: `HueSaturationValue`, `Solarize`, `Posterize`,
+  `RandomBrightnessContrast`, `CLAHE`, `RandomGamma`.
+- `albumentations/augmentations/pixel/color_gray.py`: `Colorize`.
+- `albumentations/augmentations/pixel/color_lighting.py`: `Illumination`, `Vignetting`.
+- `albumentations/augmentations/pixel/compression.py`: `ImageCompression`, `Downscale`.
+- `albumentations/augmentations/pixel/noise.py`: `ISONoise`, `ShotNoise`.
+- `albumentations/augmentations/pixel/transforms.py`: `Sharpen`, `Emboss`, `Enhance`, `Superpixels`, `RingingOvershoot`,
+  `UnsharpMask`, `Halftone`.
+- `albumentations/augmentations/transforms3d/transforms.py`: `Pad3D`.
+
+## Review requirements for additions
+
+1. Add the sampler to exactly one category and state the sharing key in its docstring or the implementation comment next
+   to the `TargetParameterGroup` construction.
+2. Test at least two actual target keys, including an `additional_targets` alias when the transform supports one.
+3. Vary the representation property that drives materialization: shape, channels, dtype scale, layout, topology, or
+   content. A test that only checks output shape does not prove the plan is target-correct.
+4. Assert the structured replay payload and verify replay does not sample again.
+5. Run `check-ax-coding-guidance`, the focused transform tests, and the full quality gate.

--- a/docs/design/target-specific-parameter-sampling.md
+++ b/docs/design/target-specific-parameter-sampling.md
@@ -1,12 +1,12 @@
 # Greenfield Target-Specific Parameter Sampling
 
-**Status**: Implemented (greenfield cutover)
+**Status**: Implementation complete; paired base-to-head performance evidence pending before merge
 
 **Owner**: AlbumentationsX core transform maintainers
 
 ## Overview
 
-AlbumentationsX now samples one structured parameter plan for a transform invocation and resolves it for each active target.
+AlbumentationsX now samples structured execution parameters for a transform invocation and resolves them for each active target.
 The old flat dictionary model worked when all targets could consume the same realized parameters. It failed when a parameter depends
 on the actual target's channel count, dtype, shape, batch layout, or volume layout.
 
@@ -29,9 +29,9 @@ The implementation will make these changes as one atomic repository cutover:
 
 1. Build an ordered `TargetSet` for every invocation. Its entries are keyed by the actual input name, including aliases such
    as `image2`, and carry the canonical target type plus representation metadata.
-2. Replace flat dictionaries returned by `sample_parameters` with `TransformParameterPlan`.
-3. Store target-independent values in `TransformParameterPlan.shared`.
-4. Store representation-dependent values in `TargetParameterGroup` objects. Each group names the actual targets that consume
+2. Replace flat dictionaries returned by `sample_parameters` with `SampledParams`.
+3. Store target-independent values in `SampledParams.shared`.
+4. Store representation-dependent values in `TargetParams` objects. Each group names the actual targets that consume
    its parameters. Groups may overlap when different parameters have different sharing domains.
 5. Resolve the relevant group before calling `apply`, `apply_to_images`, `apply_to_volume`, or an alias of those methods.
 6. Persist the same structure in deterministic mode and `ReplayCompose` so replay performs no sampling or rematerialization.
@@ -51,8 +51,8 @@ preserved, while target routing moves into the shared core contract defined here
 `volume_*` fields as part of the cutover.
 
 Because the sampling override and execution-replay schemas are customization contracts, the completed cutover ships as a
-documented breaking change. The implementation PR owns the migration guide, paired performance evidence, and exact-head test
-results.
+documented breaking change. This is a correctness change, not an optimization: it must preserve the shared-only fast path
+and must not claim a speedup without paired base-to-head, full-route evidence.
 
 ## Problem Statement
 
@@ -128,15 +128,15 @@ the required abstraction.
 - Preserve the meaning of one transform invocation as one random augmentation event.
 - Allow exact parameter sharing when targets are semantically compatible.
 - Materialize correct values for targets with different shapes, channel counts, dtypes, layouts, or content.
-- Keep geometric synchronization explicit through a shared spatial frame.
+- Keep geometric synchronization explicit through a common spatial shape obtained from `TargetSet`.
 - Make target routing visible in types and replay data instead of parameter-name conventions.
-- Fail before applying any target when a plan is incomplete, ambiguous, or incompatible with the current invocation.
+- Fail before applying any target when sampled parameters are incomplete, ambiguous, or incompatible with the current invocation.
 - Preserve the fast path for the common single-target, shared-parameter case.
 - Give custom transforms one documented way to express shared and target-specific parameters.
 
 ## Non-Goals
 
-- Supporting different spatial frames for targets that a synchronized geometric transform requires to be aligned.
+- Supporting different spatial shapes for targets that a synchronized geometric transform requires to be aligned.
 - Inferring transform-specific sharing semantics in `BasicTransform`.
 - Changing random-number generators, seed derivation, probability gates, or transform ordering.
 - Moving execution parameters into `applied_config`; constructor replay and execution replay remain separate contracts.
@@ -173,20 +173,21 @@ The framework provides deterministic grouping helpers. Each transform supplies t
 
 ### Spatial synchronization is separate from representation
 
-Geometric transforms need a validated spatial frame shared by aligned targets. Photometric and dense-value transforms need
+Geometric transforms need one validated spatial shape shared by aligned targets. Photometric and dense-value transforms need
 per-target representation metadata. A single global `shape` derived from the first target conflates these concerns.
 
-The sampling input therefore contains both `spatial_frame` and `targets`. Geometry reads the former. Representation-dependent
-sampling reads the latter.
+`TargetSet.require_spatial_shape(2)` provides the common height-width shape for 2D geometry and
+`TargetSet.require_spatial_shape(3)` provides depth-height-width for 3D geometry. Representation-dependent sampling uses
+the same `TargetSet` descriptors. There is no wrapper object that hides `params` or `data`.
 
 ### Replay stores realized execution
 
-Replay records the complete structured plan used by the original call. It does not rerun grouping, rescale values, or draw
+Replay records the complete structured sampled values used by the original call. It does not rerun grouping, rescale values, or draw
 random numbers. Target-specific replay validates the current target schema before any target is mutated.
 
 ### The ordinary path stays small
 
-Shared-only plans use one shared dictionary and no per-target group lookup. Mixed-target calls pay work proportional to the
+Shared-only sampled values use one shared dictionary and no per-target group lookup. Mixed-target calls pay work proportional to the
 number of active targets. Dense arrays are materialized once per compatible group.
 
 ## Terminology
@@ -195,12 +196,12 @@ number of active targets. Dense arrays are materialized once per compatible grou
 - **Active target**: A non-`None` input whose actual key resolves through the transform's target mapping.
 - **Canonical target type**: The built-in role to which a key resolves, such as `image` or `volume`.
 - **Target view**: A read-only invocation-local view of one target and its representation metadata.
-- **Spatial frame**: Validated spatial dimensions and coordinate conventions shared by synchronized targets.
+- **Common spatial shape**: Validated spatial dimensions shared by synchronized targets.
 - **Shared parameter**: A realized value consumed by every applicable target in an invocation.
 - **Target parameter group**: One parameter mapping shared by a named set of compatible actual targets.
 - **Sampling topology**: The semantic layout used to generate a parameter, such as one 2D map, one map per batch item, or
   one full 3D map.
-- **Parameter plan**: The shared parameters and target groups for one transform invocation.
+- **Sampled parameters**: The shared values and target groups for one transform invocation.
 
 ## Implemented Types
 
@@ -239,12 +240,6 @@ class TargetRequirement:
     sampling_topology: str | None = None
 
 
-@dataclass(frozen=True, slots=True)
-class SpatialFrame:
-    rank: int
-    shape: tuple[int, ...]
-
-
 class TargetSet:
     ordered: tuple[TargetView, ...]
 
@@ -253,36 +248,30 @@ class TargetSet:
     def image_like(self) -> tuple[TargetView, ...]: ...
     def primary_image_like(self) -> TargetView: ...
     def group_by(self, key: Callable[[TargetView], Hashable]) -> tuple[tuple[TargetView, ...], ...]: ...
+    def spatial_shape(self, rank: int) -> tuple[int, ...] | None: ...
+    def require_spatial_shape(self, rank: int) -> tuple[int, ...]: ...
 
 
 @dataclass(frozen=True, slots=True)
-class TargetParameterGroup:
+class TargetParams:
     targets: tuple[str, ...]
     params: Mapping[str, Any]
     requirements: Mapping[str, TargetRequirement]
 
 
 @dataclass(frozen=True, slots=True)
-class TransformParameterPlan:
+class SampledParams:
     shared: Mapping[str, Any]
-    groups: tuple[TargetParameterGroup, ...] = ()
+    groups: tuple[TargetParams, ...] = ()
     target_schema: Mapping[str, str] | None = None
 
     @classmethod
-    def shared_only(cls, params: Mapping[str, Any]) -> TransformParameterPlan: ...
+    def shared_only(cls, params: Mapping[str, Any]) -> SampledParams: ...
 
     def params_for(self, target_name: str) -> Mapping[str, Any]: ...
 
 
-class TransformParameterPlanError(ValueError): ...
-
-
-@dataclass(frozen=True, slots=True)
-class TransformSamplingInput:
-    base_params: Mapping[str, Any]
-    spatial_frame: SpatialFrame | None
-    targets: TargetSet
-    data: dict[str, Any]
+class SampledParamsError(ValueError): ...
 ```
 
 `TargetView.value` is a borrowed reference for content-dependent sampling. Constructing a target view does not copy an array;
@@ -290,11 +279,11 @@ sampling code must not mutate the borrowed value. Metadata is derived after inpu
 representation that the application function will receive. Layout and topology are stable strings derived from the canonical
 target type plus the validated value; array rank alone never decides whether a value is a batch or a volume.
 
-`SpatialFrame.rank` is declared by the transform family: 2D transforms consume the aligned height-width frame and 3D
-transforms consume the aligned depth-height-width frame. A transform that has no shared geometric domain can opt out with a
-`None` rank and derive representation-dependent sizes from target descriptors.
+The transform family declares the rank it requires. 2D transforms consume the aligned height-width shape and 3D transforms
+consume the aligned depth-height-width shape. A transform that has no shared geometric domain can opt out and derive
+representation-dependent sizes from target descriptors.
 
-`TargetParameterGroup.params` contains only the group-specific delta. `params_for` builds one keyword dictionary from `shared`
+`TargetParams.params` contains only the group-specific delta. `params_for` builds one keyword dictionary from `shared`
 and every group that contains the actual target; dense arrays are referenced, not copied.
 
 `TargetRequirement` records only the representation properties on which a materialized parameter depends. A dense map may
@@ -304,9 +293,9 @@ permutation may require only channel count. Replay
 uses these declared constraints and does not reject harmless differences. `dtype` and `dtype_scale` are separate constraints:
 some parameters require the exact storage type, while others require only an equivalent numeric range.
 
-## Parameter Plan Invariants
+## Sampled-Parameter Invariants
 
-The core validates a complete plan immediately after sampling:
+The core validates complete sampled parameters immediately after sampling:
 
 1. `shared` and every group parameter mapping are treated as immutable by the execution layer for the rest of the invocation.
 2. A parameter name cannot appear in both `shared` and a group. This prevents silent shadowing.
@@ -322,8 +311,8 @@ The core validates a complete plan immediately after sampling:
 11. Application functions cannot access another target's groups.
 12. Sampling and validation finish before the first application function is called.
 
-The framework raises `TransformParameterPlanError`, a `ValueError` subclass containing the transform name and violated
-invariant (or a `TypeError` when a sampler returns a non-plan). It must not fall through to a NumPy broadcasting error.
+The framework raises `SampledParamsError`, a `ValueError` subclass containing the transform name and violated
+invariant (or a `TypeError` when a sampler returns the wrong type). It must not fall through to a NumPy broadcasting error.
 
 ## Deterministic Target Ordering
 
@@ -343,29 +332,33 @@ for existing mixed-target invocations; after the cutover, the new ordering is st
 ```python
 def sample_parameters(
     self,
-    inputs: TransformSamplingInput,
+    params: dict[str, Any],
+    data: dict[str, Any],
+    targets: TargetSet,
     sampling: SamplingContext,
-) -> TransformParameterPlan: ...
+) -> SampledParams: ...
 ```
 
-The base implementation returns `TransformParameterPlan.shared_only({})`. Shared-only transforms return a plan explicitly:
+`params` contains common execution values, `data` contains the whole preprocessed invocation, and `targets` describes the
+active transform targets. The base implementation returns `SampledParams.shared_only({})`. Shared-only transforms return
+sampled values explicitly:
 
 ```python
-return TransformParameterPlan.shared_only({"angle": angle})
+return SampledParams.shared_only({"angle": angle})
 ```
 
 Target-sensitive transforms return shared policy plus groups:
 
 ```python
-return TransformParameterPlan(
+return SampledParams(
     shared={"distribution": distribution, "intensity": intensity},
     groups=(
-        TargetParameterGroup(
+        TargetParams(
             targets=("image", "image2"),
             params={"noise_map": shared_image_noise},
             requirements=image_noise_requirements,
         ),
-        TargetParameterGroup(
+        TargetParams(
             targets=("volume",),
             params={"noise_map": volume_noise},
             requirements=volume_noise_requirements,
@@ -383,21 +376,21 @@ boundary.
 start of `Compose`, because an earlier transform may change shape, dtype, channels, or content. The stable actual-key ordering
 template can be cached with the configured target mapping; values and descriptors belong to the current transform step.
 
-Only active targets enter the set. Unknown metadata stays in `TransformSamplingInput.data`, and recognized keys with `None`
-values remain inactive. Replay treats missing and `None` target values equivalently for target-schema validation.
+Only active targets enter the set. Unknown metadata stays in `data`, and recognized keys with `None` values remain inactive.
+Replay treats missing and `None` target values equivalently for target-schema validation.
 
 Representation metadata is derived once from the borrowed values for the current transform step. The descriptors do not copy
 arrays, and shared-only samplers take the same fast path as before; target-aware samplers use the already available descriptors.
 
 ### Shared base parameters
 
-Core-derived values such as interpolation, fill values, and annotation processor metadata enter through
-`TransformSamplingInput.base_params`. The core combines them with `plan.shared` after checking for duplicate keys.
+Core-derived values such as interpolation, fill values, and annotation processor metadata enter through `params`. The core
+combines them with `SampledParams.shared` after checking for duplicate keys.
 
-The shared `base_params["shape"]` compatibility field remains for existing geometry and application code. It is normalized
+The shared `params["shape"]` compatibility field remains for existing geometry and application code. It is normalized
 to the canonical 2D shape for batched images, volumes, batched masks, and 3D masks. New target-sensitive sampling must not
-derive representation from that first-target field: geometry reads `spatial_frame`, while target-specific sampling reads the
-relevant descriptor from `inputs.targets`.
+derive representation from that first-target field: geometry reads `targets.require_spatial_shape(...)`, while
+target-specific sampling reads the relevant descriptor from `targets`.
 
 ### Grouping helpers
 
@@ -410,7 +403,7 @@ relevant descriptor from `inputs.targets`.
 | Full 3D value map | `(sampling_topology, spatial_shape, channels, dtype_scale)` |
 | Channel permutation | `(channels,)` |
 | Content-derived reference matching | actual target key |
-| Shared geometry | no target groups; use `spatial_frame` |
+| Shared geometry | no target groups; use `targets.require_spatial_shape(...)` |
 
 `dtype_scale` is a transform-defined semantic value. Raw `dtype` is insufficient when several dtypes share the same value
 range or when a transform operates in normalized floating-point space.
@@ -429,10 +422,10 @@ channels or dtype.
 
 ## Application Dispatch
 
-`apply_with_params` receives the validated plan and keeps two execution paths.
+`apply_with_params` receives validated sampled parameters and keeps two execution paths.
 
-The shared-only path performs the current loop with `plan.shared`. It checks once that `plan.groups` is empty and performs no
-per-target lookup.
+The shared-only path performs the current loop with `sampled_params.shared`. It checks once that `sampled_params.groups` is
+empty and performs no per-target lookup.
 
 The target-aware path resolves by actual key:
 
@@ -440,7 +433,7 @@ The target-aware path resolves by actual key:
 for target_name, value in data.items():
     if target_name in self._key2func and value is not None:
         target_function = self._key2func[target_name]
-        target_params = plan.params_for(target_name)
+        target_params = sampled_params.params_for(target_name)
         result[target_name] = target_function(value, **target_params)
 ```
 
@@ -448,15 +441,15 @@ Application methods use semantic parameter names consistently. `apply`, `apply_t
 accept `noise_map`; dispatch selects the correct value. Fields whose only purpose was target routing are deleted.
 
 Required keyword names for each canonical application function are compiled once from its signature when the transform class
-is prepared. Plan validation resolves those requirements through every actual key before the application loop. Methods that
+is prepared. Validation resolves those requirements through every actual key before the application loop. Methods that
 accept only shared parameters keep the shared-only path.
 
 Annotation postprocessing that needs realized geometry receives the shared geometry parameters. If a future annotation target
-requires its own materialization, it participates through its actual target key under the same plan contract.
+requires its own materialization, it participates through its actual target key under the same sampled-parameter contract.
 
 ## Replay and Deterministic Execution
 
-The in-memory plan is normalized into this replay shape:
+In-memory sampled parameters are normalized into this replay shape:
 
 ```python
 {
@@ -490,9 +483,9 @@ JSON `applied_config` contract.
 
 Replay follows these rules:
 
-1. It reconstructs `TransformParameterPlan` without calling a sampler.
-2. Shared-only plans keep current replay applicability.
-3. A plan with target groups requires the exact recorded set of active actual target keys; extra keys fail as well as missing
+1. It reconstructs `SampledParams` without calling a sampler.
+2. Shared-only sampled values keep current replay applicability.
+3. Sampled values with target groups require the exact recorded set of active actual target keys; extra keys fail as well as missing
    keys because no realized target-specific parameters exist for an added target.
 4. Each current key must resolve to the canonical target type recorded in `target_schema`.
 5. Each current descriptor must satisfy the properties declared by its `TargetRequirement`. Unconstrained properties may
@@ -508,10 +501,10 @@ need a migration note. `applied_config()` remains constructor-valid and unchange
 This is a breaking change for custom transforms that override `sample_parameters` or inspect deterministic execution params.
 The release containing the cutover must include a migration guide with these cases:
 
-- wrap shared dictionaries with `TransformParameterPlan.shared_only`;
+- wrap shared dictionaries with `SampledParams.shared_only`;
 - replace `image_*` and `volume_*` execution fields with groups keyed by actual target names;
-- use `inputs.spatial_frame` for synchronized geometry;
-- use `inputs.targets` for representation metadata and content access;
+- use `targets.require_spatial_shape(2)` or `targets.require_spatial_shape(3)` for synchronized geometry;
+- use `targets` for representation metadata and content access;
 - use a transform-defined `group_by` key when compatible aliases should share parameters; and
 - update deterministic and replay assertions to the structured payload.
 
@@ -546,7 +539,7 @@ The audit must also classify transforms that currently depend on first-target me
 | Noise and color scaling | `AdditiveNoise`, `GaussNoise`, advanced color transforms | Does dtype or channel count change materialization? |
 | Content-derived sampling | `ExposureMatching` and reference-based transforms | Is a sampled value tied to one target's pixels? |
 | Batch and volume sampling | transforms with `apply_to_images` or `apply_to_volume` | Does sampling topology match the application method? |
-| Geometry | all shape-dependent geometric transforms | Can the transform use the validated shared spatial frame exclusively? |
+| Geometry | all shape-dependent geometric transforms | Can the transform use the validated common spatial shape exclusively? |
 | Semantic 3D policy | transforms with volume-specific kernel or sigma policy | Is the difference true transform policy or only dispatch encoded in a name? |
 
 Volume-specific constructor policy may remain when it expresses real 3D semantics. Realized execution values still use the
@@ -568,13 +561,12 @@ classifications and the review hook's coverage.
 **Completion condition**: every built-in sampler has an assigned migration class; no target-sensitive transform remains under
 an implicit first-target assumption.
 
-### Phase 1: Add target and plan types — complete
+### Phase 1: Add target and sampled-parameter types — complete
 
-- Add `TargetView`, `TargetSet`, `SpatialFrame`, `TransformSamplingInput`, `TargetParameterGroup`, and
-  `TransformParameterPlan` in the core transform execution layer.
+- Add `TargetView`, `TargetSet`, `TargetParams`, and `SampledParams` in the core transform execution layer.
 - Derive target views from the post-preprocessing values that application functions receive.
-- Add deterministic target ordering and grouping helpers.
-- Add plan validation and dedicated errors.
+- Add deterministic target ordering, grouping helpers, and `TargetSet.require_spatial_shape`.
+- Add sampled-parameter validation and dedicated errors.
 - Add the shared-only application fast path and actual-key group dispatch.
 
 **Completion condition**: focused core tests prove routing, validation, ordering, and zero application before a validation
@@ -582,9 +574,9 @@ failure.
 
 ### Phase 2: Migrate the sampling boundary — complete
 
-- Change the base sampling signature to accept `TransformSamplingInput` and return `TransformParameterPlan`.
+- Change the base sampling signature to accept `params`, `data`, `targets`, and `sampling`, and return `SampledParams`.
 - Convert every shared-only transform explicitly.
-- Replace global first-target `shape` reads with `spatial_frame` or a specific `TargetView`.
+- Replace global first-target `shape` reads with `targets.require_spatial_shape(...)` or a specific `TargetView`.
 - Reject dictionary returns.
 - Update deterministic state and `get_applied_params()`.
 
@@ -604,7 +596,7 @@ in channel count and dtype.
 
 ### Phase 4: Cut over replay — complete
 
-- Store `parameter_schema: 2` and the normalized plan in deterministic state and `ReplayCompose`.
+- Store `parameter_schema: 2` and normalized sampled parameters in deterministic state and `ReplayCompose`.
 - Validate actual keys, canonical types, and materialized parameter compatibility before replay.
 - Update replay fixtures and tests.
 - Document the intentional incompatibility with flat execution-param payloads.
@@ -626,15 +618,15 @@ materialization code.
 **Completion condition**: a repository search and AST audit find no target-name execution fields or first-target sampling
 dependencies.
 
-### Phase 6: Validate and benchmark the atomic cutover — complete
+### Phase 6: Validate and measure the atomic cutover — pending paired evidence
 
 - Run the focused core and transform matrices described below.
 - Run the full test suite, type checks, documentation checks, and pre-commit hooks.
 - Benchmark the same base commit and exact cutover head in the same environment.
 - Inspect the final diff for duplicate compatibility logic, transitional branches, and obsolete tests.
 
-**Completion condition**: all correctness gates pass, performance stays within budget, and the cutover contains one runtime
-contract.
+**Completion condition**: all correctness gates pass, paired base-to-head measurements satisfy the performance budget, and
+the cutover contains one runtime contract. This phase does not assert an optimization; it detects an unacceptable regression.
 
 ### Merge strategy
 
@@ -659,7 +651,7 @@ Add focused tests for:
 - unknown, repeated, empty, and missing group targets;
 - missing required parameters;
 - validation before any application function runs;
-- read-only plan behavior and no caller-input mutation; and
+- read-only sampled-parameter behavior and no caller-input mutation; and
 - precise diagnostic messages containing transform and target identity.
 
 ### Representation matrix
@@ -698,7 +690,7 @@ shared-policy relationship.
 ### Replay and determinism tests
 
 - Same seed plus the same target set produces identical structured plans and outputs.
-- Permuting call keyword order does not change the plan or outputs.
+- Permuting call keyword order does not change sampled parameters or outputs.
 - Replay produces exact outputs for mixed channel counts and dtypes.
 - Replay performs zero RNG calls and zero materialization calls.
 - Missing or renamed aliases fail before any output is produced.
@@ -762,10 +754,10 @@ policy names containing words such as `volume`.
 
 The implementation is expected to touch these ownership areas:
 
-- `albumentations/core/transforms_interface.py`: sampling boundary, plan validation, actual-key dispatch, deterministic state;
-- core type modules: target views, spatial frame, parameter plans, and errors;
+- `albumentations/core/transforms_interface.py`: sampling boundary, sampled-parameter validation, actual-key dispatch, deterministic state;
+- core type modules: target views, target geometry, sampled parameters, and errors;
 - `albumentations/core/composition.py`: target-set construction, preprocessing boundary, and replay integration;
-- transform modules: explicit plan construction and removal of target-named execution fields;
+- transform modules: explicit sampled-parameter construction and removal of target-named execution fields;
 - `tests/`: core contract, family regressions, aliases, determinism, and replay;
 - `tools/ax_coding_guidance/`: post-cutover deterministic enforcement; and
 - public customization and replay documentation: migration guidance and structured parameter examples;
@@ -792,13 +784,13 @@ The final diff must confirm all of the following:
 
 The class of bugs is resolved when:
 
-1. Every built-in sampler returns `TransformParameterPlan`.
+1. Every built-in sampler returns `SampledParams`.
 2. Every target-sensitive transform addresses parameters by actual target key through groups.
 3. Multiple aliases of the same canonical target type can differ in channels, dtype, shape where allowed, and content without
    misrouting or silent rescaling.
 4. Compatible aliases retain their declared parameter correlation.
 5. Mixed `image`, `images`, and `volume` calls pass the representation matrix.
-6. Replay records and restores the structured plan exactly and rejects incompatible target schemas before applying data.
+6. Replay records and restores structured sampled parameters exactly and rejects incompatible target schemas before applying data.
 7. `applied_config` behavior remains unchanged.
 8. The full transform inventory has no unresolved first-target dependency.
 9. Legacy target-routing fields and adapters are deleted.

--- a/docs/design/target-specific-parameter-sampling.md
+++ b/docs/design/target-specific-parameter-sampling.md
@@ -218,7 +218,7 @@ class TargetDescriptor:
     spatial_shape: tuple[int, ...] | None
     channels: int | None
     dtype: Any
-    dtype_scale: str | None
+    value_scale: float | None
     layout: str
     sampling_topology: str
 
@@ -236,7 +236,7 @@ class TargetRequirement:
     spatial_shape_suffix: tuple[int, ...] | None = None
     channels: int | None = None
     dtype: Any = None
-    dtype_scale: str | None = None
+    value_scale: float | None = None
     layout: str | None = None
     sampling_topology: str | None = None
 
@@ -285,10 +285,10 @@ representation-dependent sizes from target descriptors.
 and every `TargetParams` record that contains the actual target; dense arrays are referenced, not copied.
 
 `TargetRequirement` records only the representation properties on which a materialized parameter depends. A dense map may
-require exact array shape, channels, dtype scale, and topology. A 2D spatial parameter applied slice-wise to a volume can
+require exact array shape, channels, value scale, and topology. A 2D spatial parameter applied slice-wise to a volume can
 declare `spatial_shape_suffix` so replay checks height and width without coupling the parameter to volume depth. A channel
 permutation may require only channel count. Replay
-uses these declared constraints and does not reject harmless differences. `dtype` and `dtype_scale` are separate constraints:
+uses these declared constraints and does not reject harmless differences. `dtype` and `value_scale` are separate constraints:
 some parameters require the exact storage type, while others require only an equivalent numeric range.
 
 ## Sampled-Parameter Invariants
@@ -396,14 +396,14 @@ target-specific sampling reads the relevant descriptor from `targets`.
 
 | Transform behavior | Example sharing key |
 |---|---|
-| Channel scalar or vector | `(channels, dtype_scale)` |
-| Dense 2D value map | `(sampling_topology, spatial_shape, channels, dtype_scale)` |
-| Full 3D value map | `(sampling_topology, spatial_shape, channels, dtype_scale)` |
+| Channel scalar or vector | `(channels, value_scale)` |
+| Dense 2D value map | `(sampling_topology, spatial_shape, channels, value_scale)` |
+| Full 3D value map | `(sampling_topology, spatial_shape, channels, value_scale)` |
 | Channel permutation | `(channels,)` |
 | Content-derived reference matching | actual target key |
 | Aligned geometry | no target-specific parameters; use `targets.require_aligned_spatial_shape(...)` |
 
-`dtype_scale` is a transform-defined semantic value. Raw `dtype` is insufficient when several dtypes share the same value
+`value_scale` is the maximum value represented by the input dtype. Raw `dtype` is insufficient when several dtypes share the same value
 range or when a transform operates in normalized floating-point space.
 
 ### Correlation rules
@@ -790,7 +790,7 @@ The class of bugs is resolved when:
 4. Compatible aliases retain their declared parameter correlation.
 5. Mixed `image`, `images`, and `volume` calls pass the representation matrix.
 6. Replay records and restores structured sampled parameters exactly and rejects incompatible target schemas before applying data.
-7. `applied_config` behavior remains unchanged.
+7. `applied_config` keeps its single-target contract; structured execution replay preserves every target-specific materialization.
 8. The full transform inventory has no unresolved first-target dependency.
 9. Legacy target-routing fields and adapters are deleted.
 10. Focused, full-suite, type, lint, documentation, and coding-guidance gates pass.

--- a/docs/design/target-specific-parameter-sampling.md
+++ b/docs/design/target-specific-parameter-sampling.md
@@ -16,8 +16,8 @@ with different representations. The same defect appears whenever a transform der
 image-like input and reuses it for every other input.
 
 This document defines a greenfield cutover to structured, target-aware execution parameters. Each transform invocation still
-represents one sampled augmentation event. The event can contain shared parameters and one or more materialized parameter
-groups addressed by actual target key. Compatible targets may share a group; incompatible targets receive parameters suited
+represents one sampled augmentation event. The event can contain parameters and one or more materialized `TargetParams`
+records addressed by actual target key. Compatible targets may share a record; incompatible targets receive parameters suited
 to their own representation.
 
 The cutover is complete only when all sampled transforms use the structured contract and target-specific fields are removed.
@@ -30,16 +30,16 @@ The implementation will make these changes as one atomic repository cutover:
 1. Build an ordered `TargetSet` for every invocation. Its entries are keyed by the actual input name, including aliases such
    as `image2`, and carry the canonical target type plus representation metadata.
 2. Replace flat dictionaries returned by `sample_parameters` with `SampledParams`.
-3. Store target-independent values in `SampledParams.shared`.
-4. Store representation-dependent values in `TargetParams` objects. Each group names the actual targets that consume
-   its parameters. Groups may overlap when different parameters have different sharing domains.
-5. Resolve the relevant group before calling `apply`, `apply_to_images`, `apply_to_volume`, or an alias of those methods.
+3. Store target-independent values in `SampledParams.params`.
+4. Store representation-dependent values in `TargetParams` records. Each record names the actual targets that consume
+   its parameters. Records may overlap when different parameters have different sharing domains.
+5. Resolve the relevant target parameters before calling `apply`, `apply_to_images`, `apply_to_volume`, or an alias of those methods.
 6. Persist the same structure in deterministic mode and `ReplayCompose` so replay performs no sampling or rematerialization.
 7. Remove first-target sampling helpers from transform implementations and delete target names embedded in execution
    parameter names.
 
-The core dispatch layer will not guess whether two targets are compatible. The transform defines its sharing key or constructs
-groups directly because compatibility depends on transform semantics.
+The core dispatch layer will not guess whether two targets are compatible. The transform defines its compatibility key or constructs
+`TargetParams` records directly because compatibility depends on transform semantics.
 
 ## Delivery and Dependencies
 
@@ -51,7 +51,7 @@ preserved, while target routing moves into the shared core contract defined here
 `volume_*` fields as part of the cutover.
 
 Because the sampling override and execution-replay schemas are customization contracts, the completed cutover ships as a
-documented breaking change. This is a correctness change, not an optimization: it must preserve the shared-only fast path
+documented breaking change. This is a correctness change, not an optimization: it must preserve the uniform-parameter fast path
 and must not claim a speedup without paired base-to-head, full-route evidence.
 
 ## Problem Statement
@@ -128,10 +128,10 @@ the required abstraction.
 - Preserve the meaning of one transform invocation as one random augmentation event.
 - Allow exact parameter sharing when targets are semantically compatible.
 - Materialize correct values for targets with different shapes, channel counts, dtypes, layouts, or content.
-- Keep geometric synchronization explicit through a common spatial shape obtained from `TargetSet`.
+- Keep geometric synchronization explicit through an aligned spatial shape obtained from `TargetSet`.
 - Make target routing visible in types and replay data instead of parameter-name conventions.
 - Fail before applying any target when sampled parameters are incomplete, ambiguous, or incompatible with the current invocation.
-- Preserve the fast path for the common single-target, shared-parameter case.
+- Preserve the fast path for the single-target path with one parameter mapping.
 - Give custom transforms one documented way to express shared and target-specific parameters.
 
 ## Non-Goals
@@ -154,14 +154,14 @@ canonical target type remains metadata used to select the application function a
 This distinction is essential. Two inputs may both map to `image` while requiring different arrays, scaling, or channel
 indices.
 
-### A shared event may have multiple materializations
+### One event may have multiple materializations
 
-The transform samples one conceptual event. Shared policy values describe that event, while target parameter groups describe
+The transform samples one conceptual event. Target-independent policy values describe that event, while `TargetParams` records describe
 how it is realized for compatible inputs.
 
 For example, additive noise may share distribution parameters and intensity across all image-like targets. Targets with equal
 shape, channel behavior, dtype scale, and sampling topology can share one dense noise map. A volume with a different channel
-count or topology receives another map sampled from the same shared policy.
+count or topology receives another map sampled from the same target-independent policy.
 
 ### Transforms define compatibility
 
@@ -169,15 +169,16 @@ Compatibility is semantic. Equal array shapes do not prove that a batch and a vo
 may matter for one transform and be irrelevant for another. Content-derived transforms may require one group per input even
 when all metadata matches.
 
-The framework provides deterministic grouping helpers. Each transform supplies the grouping key or the groups themselves.
+The framework provides deterministic grouping helpers. Each transform supplies the compatibility key or the `TargetParams`
+records themselves.
 
 ### Spatial synchronization is separate from representation
 
 Geometric transforms need one validated spatial shape shared by aligned targets. Photometric and dense-value transforms need
 per-target representation metadata. A single global `shape` derived from the first target conflates these concerns.
 
-`TargetSet.require_spatial_shape(2)` provides the common height-width shape for 2D geometry and
-`TargetSet.require_spatial_shape(3)` provides depth-height-width for 3D geometry. Representation-dependent sampling uses
+`TargetSet.require_aligned_spatial_shape(2)` provides the aligned height-width shape for 2D geometry and
+`TargetSet.require_aligned_spatial_shape(3)` provides depth-height-width for 3D geometry. Representation-dependent sampling uses
 the same `TargetSet` descriptors. There is no wrapper object that hides `params` or `data`.
 
 ### Replay stores realized execution
@@ -187,8 +188,8 @@ random numbers. Target-specific replay validates the current target schema befor
 
 ### The ordinary path stays small
 
-Shared-only sampled values use one shared dictionary and no per-target group lookup. Mixed-target calls pay work proportional to the
-number of active targets. Dense arrays are materialized once per compatible group.
+When `target_params` is empty, sampled values use one `params` dictionary and no per-target lookup. Mixed-target calls pay work
+proportional to the number of active targets. Dense arrays are materialized once per compatible target set.
 
 ## Terminology
 
@@ -196,12 +197,12 @@ number of active targets. Dense arrays are materialized once per compatible grou
 - **Active target**: A non-`None` input whose actual key resolves through the transform's target mapping.
 - **Canonical target type**: The built-in role to which a key resolves, such as `image` or `volume`.
 - **Target view**: A read-only invocation-local view of one target and its representation metadata.
-- **Common spatial shape**: Validated spatial dimensions shared by synchronized targets.
-- **Shared parameter**: A realized value consumed by every applicable target in an invocation.
-- **Target parameter group**: One parameter mapping shared by a named set of compatible actual targets.
+- **Aligned spatial shape**: Validated spatial dimensions shared by synchronized targets.
+- **Parameter**: A realized value consumed by every applicable target in an invocation.
+- **Target parameters**: One parameter mapping for a named set of compatible actual targets.
 - **Sampling topology**: The semantic layout used to generate a parameter, such as one 2D map, one map per batch item, or
   one full 3D map.
-- **Sampled parameters**: The shared values and target groups for one transform invocation.
+- **Sampled parameters**: The parameters and target-specific parameter records for one transform invocation.
 
 ## Implemented Types
 
@@ -248,8 +249,8 @@ class TargetSet:
     def image_like(self) -> tuple[TargetView, ...]: ...
     def primary_image_like(self) -> TargetView: ...
     def group_by(self, key: Callable[[TargetView], Hashable]) -> tuple[tuple[TargetView, ...], ...]: ...
-    def spatial_shape(self, rank: int) -> tuple[int, ...] | None: ...
-    def require_spatial_shape(self, rank: int) -> tuple[int, ...]: ...
+    def aligned_spatial_shape(self, rank: int) -> tuple[int, ...] | None: ...
+    def require_aligned_spatial_shape(self, rank: int) -> tuple[int, ...]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -261,12 +262,9 @@ class TargetParams:
 
 @dataclass(frozen=True, slots=True)
 class SampledParams:
-    shared: Mapping[str, Any]
-    groups: tuple[TargetParams, ...] = ()
+    params: Mapping[str, Any]
+    target_params: tuple[TargetParams, ...] = ()
     target_schema: Mapping[str, str] | None = None
-
-    @classmethod
-    def shared_only(cls, params: Mapping[str, Any]) -> SampledParams: ...
 
     def params_for(self, target_name: str) -> Mapping[str, Any]: ...
 
@@ -283,8 +281,8 @@ The transform family declares the rank it requires. 2D transforms consume the al
 consume the aligned depth-height-width shape. A transform that has no shared geometric domain can opt out and derive
 representation-dependent sizes from target descriptors.
 
-`TargetParams.params` contains only the group-specific delta. `params_for` builds one keyword dictionary from `shared`
-and every group that contains the actual target; dense arrays are referenced, not copied.
+`TargetParams.params` contains only the target-specific delta. `params_for` builds one keyword dictionary from `params`
+and every `TargetParams` record that contains the actual target; dense arrays are referenced, not copied.
 
 `TargetRequirement` records only the representation properties on which a materialized parameter depends. A dense map may
 require exact array shape, channels, dtype scale, and topology. A 2D spatial parameter applied slice-wise to a volume can
@@ -297,18 +295,18 @@ some parameters require the exact storage type, while others require only an equ
 
 The core validates complete sampled parameters immediately after sampling:
 
-1. `shared` and every group parameter mapping are treated as immutable by the execution layer for the rest of the invocation.
-2. A parameter name cannot appear in both `shared` and a group. This prevents silent shadowing.
-3. Every group contains at least one actual target key.
+1. `params` and every target-specific parameter mapping are treated as immutable by the execution layer for the rest of the invocation.
+2. A parameter name cannot appear in both `params` and `TargetParams.params`. This prevents silent shadowing.
+3. Every `TargetParams` record contains at least one actual target key.
 4. Every named key exists in the invocation and is supported by the transform.
-5. A target key may appear in multiple groups when the groups supply different parameter names.
-6. For any actual target, a parameter name appears in at most one group and never also in `shared`.
-7. Group target names are stored in canonical deterministic order.
-8. Every group declares requirements for each target it names, including an empty requirement when the materialization is
+5. A target key may appear in multiple `TargetParams` records when they supply different parameter names.
+6. For any actual target, a parameter name appears in at most one `TargetParams` record and never also in `params`.
+7. Target names in every `TargetParams` record are stored in canonical deterministic order.
+8. Every `TargetParams` record declares requirements for each target it names, including an empty requirement when the materialization is
    representation-independent.
-9. Parameters required by an application method are present in either `shared` or one of that target's groups.
-10. A target that needs only shared parameters may remain outside all groups.
-11. Application functions cannot access another target's groups.
+9. Parameters required by an application method are present in either `params` or one of that target's `TargetParams` records.
+10. A target that needs no target-specific parameters may remain outside all `TargetParams` records.
+11. Application functions cannot access another target's target-specific parameters.
 12. Sampling and validation finish before the first application function is called.
 
 The framework raises `SampledParamsError`, a `ValueError` subclass containing the transform name and violated
@@ -339,23 +337,23 @@ def sample_parameters(
 ) -> SampledParams: ...
 ```
 
-`params` contains common execution values, `data` contains the whole preprocessed invocation, and `targets` describes the
-active transform targets. The base implementation returns `SampledParams.shared_only({})`. Shared-only transforms return
-sampled values explicitly:
+`params` contains execution values, `data` contains the whole preprocessed invocation, and `targets` describes the
+active transform targets. The base implementation returns `SampledParams(params={})`. Transforms with no target-specific
+parameters return values explicitly:
 
 ```python
-return SampledParams.shared_only({"angle": angle})
+return SampledParams(params={"angle": angle})
 ```
 
-Target-sensitive transforms return shared policy plus groups:
+Target-sensitive transforms return target-independent policy plus target-specific parameters:
 
 ```python
 return SampledParams(
-    shared={"distribution": distribution, "intensity": intensity},
-    groups=(
+    params={"distribution": distribution, "intensity": intensity},
+    target_params=(
         TargetParams(
             targets=("image", "image2"),
-            params={"noise_map": shared_image_noise},
+            params={"noise_map": image_noise},
             requirements=image_noise_requirements,
         ),
         TargetParams(
@@ -380,16 +378,16 @@ Only active targets enter the set. Unknown metadata stays in `data`, and recogni
 Replay treats missing and `None` target values equivalently for target-schema validation.
 
 Representation metadata is derived once from the borrowed values for the current transform step. The descriptors do not copy
-arrays, and shared-only samplers take the same fast path as before; target-aware samplers use the already available descriptors.
+arrays, and samplers with no target-specific parameters take the same fast path as before; target-aware samplers use the already available descriptors.
 
-### Shared base parameters
+### Base parameters
 
 Core-derived values such as interpolation, fill values, and annotation processor metadata enter through `params`. The core
-combines them with `SampledParams.shared` after checking for duplicate keys.
+combines them with `SampledParams.params` after checking for duplicate keys.
 
-The shared `params["shape"]` compatibility field remains for existing geometry and application code. It is normalized
+The existing `params["shape"]` compatibility field remains for existing geometry and application code. It is normalized
 to the canonical 2D shape for batched images, volumes, batched masks, and 3D masks. New target-sensitive sampling must not
-derive representation from that first-target field: geometry reads `targets.require_spatial_shape(...)`, while
+derive representation from that first-target field: geometry reads `targets.require_aligned_spatial_shape(...)`, while
 target-specific sampling reads the relevant descriptor from `targets`.
 
 ### Grouping helpers
@@ -403,7 +401,7 @@ target-specific sampling reads the relevant descriptor from `targets`.
 | Full 3D value map | `(sampling_topology, spatial_shape, channels, dtype_scale)` |
 | Channel permutation | `(channels,)` |
 | Content-derived reference matching | actual target key |
-| Shared geometry | no target groups; use `targets.require_spatial_shape(...)` |
+| Aligned geometry | no target-specific parameters; use `targets.require_aligned_spatial_shape(...)` |
 
 `dtype_scale` is a transform-defined semantic value. Raw `dtype` is insufficient when several dtypes share the same value
 range or when a transform operates in normalized floating-point space.
@@ -424,8 +422,8 @@ channels or dtype.
 
 `apply_with_params` receives validated sampled parameters and keeps two execution paths.
 
-The shared-only path performs the current loop with `sampled_params.shared`. It checks once that `sampled_params.groups` is
-empty and performs no per-target lookup.
+The uniform-parameter path performs the current loop with `sampled_params.params`. It checks once that
+`sampled_params.target_params` is empty and performs no per-target lookup.
 
 The target-aware path resolves by actual key:
 
@@ -442,9 +440,9 @@ accept `noise_map`; dispatch selects the correct value. Fields whose only purpos
 
 Required keyword names for each canonical application function are compiled once from its signature when the transform class
 is prepared. Validation resolves those requirements through every actual key before the application loop. Methods that
-accept only shared parameters keep the shared-only path.
+accept no target-specific parameters keep the uniform-parameter path.
 
-Annotation postprocessing that needs realized geometry receives the shared geometry parameters. If a future annotation target
+Annotation postprocessing that needs realized geometry receives the geometry parameters. If a future annotation target
 requires its own materialization, it participates through its actual target key under the same sampled-parameter contract.
 
 ## Replay and Deterministic Execution
@@ -459,8 +457,8 @@ In-memory sampled parameters are normalized into this replay shape:
         "image2": "image",
         "volume": "volume",
     },
-    "shared": {"distribution": "gaussian", "intensity": 0.1},
-    "groups": [
+    "params": {"distribution": "gaussian", "intensity": 0.1},
+    "target_params": [
         {
             "targets": ["image", "image2"],
             "params": {"noise_map": image_noise},
@@ -484,8 +482,8 @@ JSON `applied_config` contract.
 Replay follows these rules:
 
 1. It reconstructs `SampledParams` without calling a sampler.
-2. Shared-only sampled values keep current replay applicability.
-3. Sampled values with target groups require the exact recorded set of active actual target keys; extra keys fail as well as missing
+2. Sampled values without target-specific parameters keep current replay applicability.
+3. Sampled values with `TargetParams` records require the exact recorded set of active actual target keys; extra keys fail as well as missing
    keys because no realized target-specific parameters exist for an added target.
 4. Each current key must resolve to the canonical target type recorded in `target_schema`.
 5. Each current descriptor must satisfy the properties declared by its `TargetRequirement`. Unconstrained properties may
@@ -501,9 +499,9 @@ need a migration note. `applied_config()` remains constructor-valid and unchange
 This is a breaking change for custom transforms that override `sample_parameters` or inspect deterministic execution params.
 The release containing the cutover must include a migration guide with these cases:
 
-- wrap shared dictionaries with `SampledParams.shared_only`;
-- replace `image_*` and `volume_*` execution fields with groups keyed by actual target names;
-- use `targets.require_spatial_shape(2)` or `targets.require_spatial_shape(3)` for synchronized geometry;
+- return `SampledParams(params={...})` for values used by every target;
+- replace `image_*` and `volume_*` execution fields with `TargetParams` records keyed by actual target names;
+- use `targets.require_aligned_spatial_shape(2)` or `targets.require_aligned_spatial_shape(3)` for synchronized geometry;
 - use `targets` for representation metadata and content access;
 - use a transform-defined `group_by` key when compatible aliases should share parameters; and
 - update deterministic and replay assertions to the structured payload.
@@ -539,11 +537,11 @@ The audit must also classify transforms that currently depend on first-target me
 | Noise and color scaling | `AdditiveNoise`, `GaussNoise`, advanced color transforms | Does dtype or channel count change materialization? |
 | Content-derived sampling | `ExposureMatching` and reference-based transforms | Is a sampled value tied to one target's pixels? |
 | Batch and volume sampling | transforms with `apply_to_images` or `apply_to_volume` | Does sampling topology match the application method? |
-| Geometry | all shape-dependent geometric transforms | Can the transform use the validated common spatial shape exclusively? |
+| Geometry | all shape-dependent geometric transforms | Can the transform use the validated aligned spatial shape exclusively? |
 | Semantic 3D policy | transforms with volume-specific kernel or sigma policy | Is the difference true transform policy or only dispatch encoded in a name? |
 
 Volume-specific constructor policy may remain when it expresses real 3D semantics. Realized execution values still use the
-same semantic parameter names inside target groups.
+same semantic parameter names inside `TargetParams` records.
 
 ## Implementation Plan
 
@@ -551,7 +549,8 @@ same semantic parameter names inside target groups.
 
 - Record every `sample_parameters` override, `get_image_data` call, `_extract_shape_from_data` dependency, and target-specific
   application signature.
-- Assign each transform to shared-only, shared-spatial, grouped-by-representation, grouped-by-content, or mixed.
+- Assign each transform to params-only, aligned-spatial, target-parameters-by-representation,
+  target-parameters-by-content, or mixed.
 - Write the expected grouping and correlation policy beside every target-sensitive transform in the inventory.
 - Confirm which execution-param inspection APIs are public and include them in the migration note.
 
@@ -565,9 +564,9 @@ an implicit first-target assumption.
 
 - Add `TargetView`, `TargetSet`, `TargetParams`, and `SampledParams` in the core transform execution layer.
 - Derive target views from the post-preprocessing values that application functions receive.
-- Add deterministic target ordering, grouping helpers, and `TargetSet.require_spatial_shape`.
+- Add deterministic target ordering, grouping helpers, and `TargetSet.require_aligned_spatial_shape`.
 - Add sampled-parameter validation and dedicated errors.
-- Add the shared-only application fast path and actual-key group dispatch.
+- Add the uniform-parameter application fast path and actual-key target-parameter dispatch.
 
 **Completion condition**: focused core tests prove routing, validation, ordering, and zero application before a validation
 failure.
@@ -575,8 +574,8 @@ failure.
 ### Phase 2: Migrate the sampling boundary — complete
 
 - Change the base sampling signature to accept `params`, `data`, `targets`, and `sampling`, and return `SampledParams`.
-- Convert every shared-only transform explicitly.
-- Replace global first-target `shape` reads with `targets.require_spatial_shape(...)` or a specific `TargetView`.
+- Convert every transform that samples no target-specific parameters explicitly.
+- Replace global first-target `shape` reads with `targets.require_aligned_spatial_shape(...)` or a specific `TargetView`.
 - Reject dictionary returns.
 - Update deterministic state and `get_applied_params()`.
 
@@ -585,7 +584,7 @@ dictionary.
 
 ### Phase 3: Migrate target-sensitive families — complete
 
-- Migrate noise transforms as one family so shared distribution and dtype-scale rules stay consistent.
+- Migrate noise transforms as one family so target-independent distribution and dtype-scale rules stay consistent.
 - Migrate channel transforms and dropout transforms.
 - Migrate content-derived and reference-based transforms.
 - Migrate remaining image, batch, and volume special cases from the inventory.
@@ -642,13 +641,13 @@ Add focused tests for:
 
 - actual-key routing for canonical targets and aliases;
 - deterministic target ordering independent of call keyword order;
-- shared-only fast-path dispatch;
+- uniform-parameter fast-path dispatch;
 - exact sharing of one parameter object by compatible targets;
-- separate groups for incompatible targets;
-- overlapping target groups with disjoint parameter names;
-- duplicate parameter names across overlapping groups;
-- duplicate shared/group keys;
-- unknown, repeated, empty, and missing group targets;
+- separate `TargetParams` records for incompatible targets;
+- overlapping `TargetParams` records with disjoint parameter names;
+- duplicate parameter names across overlapping `TargetParams` records;
+- duplicate parameter/target-specific parameter keys;
+- unknown, repeated, empty, and missing target keys in `TargetParams` records;
 - missing required parameters;
 - validation before any application function runs;
 - read-only sampled-parameter behavior and no caller-input mutation; and
@@ -696,7 +695,7 @@ shared-policy relationship.
 - Missing or renamed aliases fail before any output is produced.
 - Canonical-type changes fail even if the array shapes happen to match.
 - Incompatible shape, channels, dtype scale, or topology fails with the recorded and current descriptors.
-- Shared-only replay retains existing behavior.
+- Replay of values with no target-specific parameters retains existing behavior.
 - `applied_config` remains constructor-valid and strict-JSON serializable.
 
 ### Negative controls
@@ -716,8 +715,8 @@ Each negative control must fail on the pre-cutover base or demonstrate the wrong
 Measure base and exact head in the same process environment with identical inputs, seeds, warmup, and repetitions. Report
 median and dispersion for these cells:
 
-- cheap shared-only transform on one image;
-- cheap shared-only transform inside `Compose`;
+- cheap transform with no target-specific parameters on one image;
+- cheap transform with no target-specific parameters inside `Compose`;
 - target-sensitive transform on one image;
 - compatible `image` plus alias;
 - incompatible `image` plus alias;
@@ -727,11 +726,11 @@ median and dispersion for these cells:
 
 The implementation must satisfy these budgets:
 
-- shared-only application performs one empty-group branch per transform and no per-target group lookup;
+- uniform-parameter application performs one empty-target-parameters branch per transform and no per-target lookup;
 - target view construction is allocation-light and does not copy arrays;
 - target-aware dispatch is `O(T)` in active targets;
-- dense parameters are materialized once per compatible group;
-- ordinary single-target and shared-only representative cells regress by no more than 5%; and
+- dense parameters are materialized once per compatible target set;
+- ordinary single-target and uniform-parameter representative cells regress by no more than 5%; and
 - a larger regression blocks the cutover unless the implementation removes equivalent work elsewhere and provides measured
   full-route evidence.
 
@@ -776,7 +775,7 @@ The final diff must confirm all of the following:
 - [x] No `volume_*`, `image_*`, or alias-specific execution field exists solely for dispatch.
 - [x] No compatibility decoder accepts parameter schema 1.
 - [x] No temporary dual dispatch path remains.
-- [x] No dense parameter is duplicated across compatible groups.
+- [x] No dense parameter is duplicated across compatible target sets.
 - [x] No tests assert legacy target-specific field names.
 - [x] No documentation teaches the legacy sampling signature.
 
@@ -785,7 +784,7 @@ The final diff must confirm all of the following:
 The class of bugs is resolved when:
 
 1. Every built-in sampler returns `SampledParams`.
-2. Every target-sensitive transform addresses parameters by actual target key through groups.
+2. Every target-sensitive transform addresses parameters by actual target key through `TargetParams` records.
 3. Multiple aliases of the same canonical target type can differ in channels, dtype, shape where allowed, and content without
    misrouting or silent rescaling.
 4. Compatible aliases retain their declared parameter correlation.

--- a/docs/design/target-specific-parameter-sampling.md
+++ b/docs/design/target-specific-parameter-sampling.md
@@ -1,0 +1,816 @@
+# Greenfield Target-Specific Parameter Sampling
+
+**Status**: Implemented (greenfield cutover)
+
+**Owner**: AlbumentationsX core transform maintainers
+
+## Overview
+
+AlbumentationsX now samples one structured parameter plan for a transform invocation and resolves it for each active target.
+The old flat dictionary model worked when all targets could consume the same realized parameters. It failed when a parameter depends
+on the actual target's channel count, dtype, shape, batch layout, or volume layout.
+
+Several transforms compensate by adding fields such as `volume_noise_map`, `volume_multiplier`, and `image_gains`. Those
+fields solve individual branches, but they encode target routing in parameter names and cannot represent two image aliases
+with different representations. The same defect appears whenever a transform derives an execution parameter from the first
+image-like input and reuses it for every other input.
+
+This document defines a greenfield cutover to structured, target-aware execution parameters. Each transform invocation still
+represents one sampled augmentation event. The event can contain shared parameters and one or more materialized parameter
+groups addressed by actual target key. Compatible targets may share a group; incompatible targets receive parameters suited
+to their own representation.
+
+The cutover is complete only when all sampled transforms use the structured contract and target-specific fields are removed.
+There is no permanent compatibility path for flat sampled-parameter dictionaries.
+
+## Decision Summary
+
+The implementation will make these changes as one atomic repository cutover:
+
+1. Build an ordered `TargetSet` for every invocation. Its entries are keyed by the actual input name, including aliases such
+   as `image2`, and carry the canonical target type plus representation metadata.
+2. Replace flat dictionaries returned by `sample_parameters` with `TransformParameterPlan`.
+3. Store target-independent values in `TransformParameterPlan.shared`.
+4. Store representation-dependent values in `TargetParameterGroup` objects. Each group names the actual targets that consume
+   its parameters. Groups may overlap when different parameters have different sharing domains.
+5. Resolve the relevant group before calling `apply`, `apply_to_images`, `apply_to_volume`, or an alias of those methods.
+6. Persist the same structure in deterministic mode and `ReplayCompose` so replay performs no sampling or rematerialization.
+7. Remove first-target sampling helpers from transform implementations and delete target names embedded in execution
+   parameter names.
+
+The core dispatch layer will not guess whether two targets are compatible. The transform defines its sharing key or constructs
+groups directly because compatibility depends on transform semantics.
+
+## Delivery and Dependencies
+
+The cutover depends only on existing AlbumentationsX execution components: `SamplingContext`, `BasicTransform`, `Compose`,
+`ReplayCompose`, target preprocessing, and the generated target-contract suite. It introduces no external runtime dependency.
+
+PR #462 remains the motivating contribution. Its regression cases and valid transform-specific sampling behavior are
+preserved, while target routing moves into the shared core contract defined here. The implementation removes the special
+`volume_*` fields as part of the cutover.
+
+Because the sampling override and execution-replay schemas are customization contracts, the completed cutover ships as a
+documented breaking change. The implementation PR owns the migration guide, paired performance evidence, and exact-head test
+results.
+
+## Problem Statement
+
+### Current execution model
+
+`BasicTransform` currently performs these operations:
+
+1. Derive shared metadata, including `shape`, from the first recognized target.
+2. Call `sample_parameters` once and merge the result into one flat dictionary.
+3. Save that dictionary for deterministic execution or replay.
+4. Pass the same dictionary to every function in `_key2func`.
+
+`add_targets` maps an alias to a canonical target function, but the actual input key is not part of parameter selection. A
+transform therefore knows that it is applying an image function, yet cannot select parameters specifically sampled for
+`image2`.
+
+### Failure class
+
+The defect is broader than volume noise. It occurs when all of the following are true:
+
+- one invocation contains multiple image-like targets;
+- a sampled parameter depends on a target property such as shape, channels, dtype, layout, or content;
+- the transform derives that parameter from one target or from global metadata; and
+- the same realized value is applied to another target with a different representation.
+
+Observable failures include:
+
+- broadcasting errors when a three-channel multiplier is applied to a five-channel volume;
+- incorrect scaling when a value derived for `uint8` is applied to `float32`;
+- invalid channel indices or permutations when channel counts differ;
+- masks or dense noise maps with the wrong spatial shape;
+- incomplete support for multiple aliases of the same canonical target type; and
+- replay data whose field names encode only the built-in `image` and `volume` cases.
+
+The bug can remain silent. A parameter may broadcast successfully while producing the wrong magnitude or correlation, so
+shape-only tests do not provide sufficient coverage.
+
+### Motivating regressions
+
+[PR #462](https://github.com/albumentations-team/AlbumentationsX/pull/462) exposes both the immediate defect and the limit of
+the local-field approach:
+
+- `MultiplicativeNoise(elementwise=False, per_channel=False)` can still derive a three-value multiplier from `image` and apply
+  it to a five-channel `volume`, producing a broadcasting error;
+- the same representation mismatch is possible between `image`, `images`, and aliases mapped through
+  `additional_targets`; and
+- constant `AdditiveNoise` sampled from a `uint8` primary image can use the wrong scale for a `float32` secondary image even
+  when broadcasting succeeds.
+
+These cases require a single architectural fix because they differ only in which representation property invalidates a shared
+materialization.
+
+### Why local fields do not close the issue
+
+A field such as `volume_noise_map` adds one second route. It cannot express all of these inputs in the same call:
+
+```python
+transform(
+    image=image_rgb_uint8,
+    image2=image_gray_float32,
+    images=batch_rgba_float32,
+    volume=volume_five_channel_uint8,
+)
+```
+
+Adding `image2_noise_map`, `images_noise_map`, and similar fields would couple transform internals to caller-selected names,
+duplicate application methods, and keep the first-target assumption in the sampling API. A structured actual-key mapping is
+the required abstraction.
+
+## Goals
+
+- Support target-specific sampling for every canonical target and every `additional_targets` alias.
+- Preserve the meaning of one transform invocation as one random augmentation event.
+- Allow exact parameter sharing when targets are semantically compatible.
+- Materialize correct values for targets with different shapes, channel counts, dtypes, layouts, or content.
+- Keep geometric synchronization explicit through a shared spatial frame.
+- Make target routing visible in types and replay data instead of parameter-name conventions.
+- Fail before applying any target when a plan is incomplete, ambiguous, or incompatible with the current invocation.
+- Preserve the fast path for the common single-target, shared-parameter case.
+- Give custom transforms one documented way to express shared and target-specific parameters.
+
+## Non-Goals
+
+- Supporting different spatial frames for targets that a synchronized geometric transform requires to be aligned.
+- Inferring transform-specific sharing semantics in `BasicTransform`.
+- Changing random-number generators, seed derivation, probability gates, or transform ordering.
+- Moving execution parameters into `applied_config`; constructor replay and execution replay remain separate contracts.
+- Preserving old `ReplayCompose` payloads across this greenfield schema cutover.
+- Adding a second runtime route that permanently accepts legacy flat dictionaries.
+- Optimizing image-processing kernels unrelated to parameter sampling and dispatch.
+
+## Design Principles
+
+### Actual keys own target-specific state
+
+The routing identity is the actual key present in the call: `image`, `volume`, `image2`, or another configured alias. The
+canonical target type remains metadata used to select the application function and interpret layout.
+
+This distinction is essential. Two inputs may both map to `image` while requiring different arrays, scaling, or channel
+indices.
+
+### A shared event may have multiple materializations
+
+The transform samples one conceptual event. Shared policy values describe that event, while target parameter groups describe
+how it is realized for compatible inputs.
+
+For example, additive noise may share distribution parameters and intensity across all image-like targets. Targets with equal
+shape, channel behavior, dtype scale, and sampling topology can share one dense noise map. A volume with a different channel
+count or topology receives another map sampled from the same shared policy.
+
+### Transforms define compatibility
+
+Compatibility is semantic. Equal array shapes do not prove that a batch and a volume should share the same dense map. Dtype
+may matter for one transform and be irrelevant for another. Content-derived transforms may require one group per input even
+when all metadata matches.
+
+The framework provides deterministic grouping helpers. Each transform supplies the grouping key or the groups themselves.
+
+### Spatial synchronization is separate from representation
+
+Geometric transforms need a validated spatial frame shared by aligned targets. Photometric and dense-value transforms need
+per-target representation metadata. A single global `shape` derived from the first target conflates these concerns.
+
+The sampling input therefore contains both `spatial_frame` and `targets`. Geometry reads the former. Representation-dependent
+sampling reads the latter.
+
+### Replay stores realized execution
+
+Replay records the complete structured plan used by the original call. It does not rerun grouping, rescale values, or draw
+random numbers. Target-specific replay validates the current target schema before any target is mutated.
+
+### The ordinary path stays small
+
+Shared-only plans use one shared dictionary and no per-target group lookup. Mixed-target calls pay work proportional to the
+number of active targets. Dense arrays are materialized once per compatible group.
+
+## Terminology
+
+- **Actual target key**: The key supplied by the caller, such as `image2`.
+- **Active target**: A non-`None` input whose actual key resolves through the transform's target mapping.
+- **Canonical target type**: The built-in role to which a key resolves, such as `image` or `volume`.
+- **Target view**: A read-only invocation-local view of one target and its representation metadata.
+- **Spatial frame**: Validated spatial dimensions and coordinate conventions shared by synchronized targets.
+- **Shared parameter**: A realized value consumed by every applicable target in an invocation.
+- **Target parameter group**: One parameter mapping shared by a named set of compatible actual targets.
+- **Sampling topology**: The semantic layout used to generate a parameter, such as one 2D map, one map per batch item, or
+  one full 3D map.
+- **Parameter plan**: The shared parameters and target groups for one transform invocation.
+
+## Implemented Types
+
+The implementation types live in a new `albumentations/core/transform_params.py` module. Custom transforms import the public
+sampling contract from that module. The root package does not re-export these advanced customization types.
+
+```python
+@dataclass(frozen=True, slots=True)
+class TargetDescriptor:
+    name: str
+    canonical_type: str
+    shape: tuple[int, ...] | None
+    spatial_shape: tuple[int, ...] | None
+    channels: int | None
+    dtype: Any
+    dtype_scale: str | None
+    layout: str
+    sampling_topology: str
+
+
+@dataclass(frozen=True, slots=True)
+class TargetView:
+    descriptor: TargetDescriptor
+    value: Any
+
+
+@dataclass(frozen=True, slots=True)
+class TargetRequirement:
+    shape: tuple[int, ...] | None = None
+    spatial_shape: tuple[int, ...] | None = None
+    spatial_shape_suffix: tuple[int, ...] | None = None
+    channels: int | None = None
+    dtype: Any = None
+    dtype_scale: str | None = None
+    layout: str | None = None
+    sampling_topology: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SpatialFrame:
+    rank: int
+    shape: tuple[int, ...]
+
+
+class TargetSet:
+    ordered: tuple[TargetView, ...]
+
+    def by_name(self, name: str) -> TargetView: ...
+    def by_canonical_type(self, target_type: Targets | str) -> tuple[TargetView, ...]: ...
+    def image_like(self) -> tuple[TargetView, ...]: ...
+    def primary_image_like(self) -> TargetView: ...
+    def group_by(self, key: Callable[[TargetView], Hashable]) -> tuple[tuple[TargetView, ...], ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class TargetParameterGroup:
+    targets: tuple[str, ...]
+    params: Mapping[str, Any]
+    requirements: Mapping[str, TargetRequirement]
+
+
+@dataclass(frozen=True, slots=True)
+class TransformParameterPlan:
+    shared: Mapping[str, Any]
+    groups: tuple[TargetParameterGroup, ...] = ()
+    target_schema: Mapping[str, str] | None = None
+
+    @classmethod
+    def shared_only(cls, params: Mapping[str, Any]) -> TransformParameterPlan: ...
+
+    def params_for(self, target_name: str) -> Mapping[str, Any]: ...
+
+
+class TransformParameterPlanError(ValueError): ...
+
+
+@dataclass(frozen=True, slots=True)
+class TransformSamplingInput:
+    base_params: Mapping[str, Any]
+    spatial_frame: SpatialFrame | None
+    targets: TargetSet
+    data: dict[str, Any]
+```
+
+`TargetView.value` is a borrowed reference for content-dependent sampling. Constructing a target view does not copy an array;
+sampling code must not mutate the borrowed value. Metadata is derived after input preprocessing has established the
+representation that the application function will receive. Layout and topology are stable strings derived from the canonical
+target type plus the validated value; array rank alone never decides whether a value is a batch or a volume.
+
+`SpatialFrame.rank` is declared by the transform family: 2D transforms consume the aligned height-width frame and 3D
+transforms consume the aligned depth-height-width frame. A transform that has no shared geometric domain can opt out with a
+`None` rank and derive representation-dependent sizes from target descriptors.
+
+`TargetParameterGroup.params` contains only the group-specific delta. `params_for` builds one keyword dictionary from `shared`
+and every group that contains the actual target; dense arrays are referenced, not copied.
+
+`TargetRequirement` records only the representation properties on which a materialized parameter depends. A dense map may
+require exact array shape, channels, dtype scale, and topology. A 2D spatial parameter applied slice-wise to a volume can
+declare `spatial_shape_suffix` so replay checks height and width without coupling the parameter to volume depth. A channel
+permutation may require only channel count. Replay
+uses these declared constraints and does not reject harmless differences. `dtype` and `dtype_scale` are separate constraints:
+some parameters require the exact storage type, while others require only an equivalent numeric range.
+
+## Parameter Plan Invariants
+
+The core validates a complete plan immediately after sampling:
+
+1. `shared` and every group parameter mapping are treated as immutable by the execution layer for the rest of the invocation.
+2. A parameter name cannot appear in both `shared` and a group. This prevents silent shadowing.
+3. Every group contains at least one actual target key.
+4. Every named key exists in the invocation and is supported by the transform.
+5. A target key may appear in multiple groups when the groups supply different parameter names.
+6. For any actual target, a parameter name appears in at most one group and never also in `shared`.
+7. Group target names are stored in canonical deterministic order.
+8. Every group declares requirements for each target it names, including an empty requirement when the materialization is
+   representation-independent.
+9. Parameters required by an application method are present in either `shared` or one of that target's groups.
+10. A target that needs only shared parameters may remain outside all groups.
+11. Application functions cannot access another target's groups.
+12. Sampling and validation finish before the first application function is called.
+
+The framework raises `TransformParameterPlanError`, a `ValueError` subclass containing the transform name and violated
+invariant (or a `TypeError` when a sampler returns a non-plan). It must not fall through to a NumPy broadcasting error.
+
+## Deterministic Target Ordering
+
+Parameter sampling must not depend on keyword argument order. `TargetSet` uses this order:
+
+1. canonical target priority defined once in core;
+2. the canonical key before its aliases; and
+3. aliases in lexical order within a canonical type.
+
+Grouping preserves that order. Random draws for multiple groups occur in group order. The cutover may change seeded results
+for existing mixed-target invocations; after the cutover, the new ordering is stable and covered by tests.
+
+## Sampling API
+
+`BasicTransform.sample_parameters` becomes a typed greenfield contract:
+
+```python
+def sample_parameters(
+    self,
+    inputs: TransformSamplingInput,
+    sampling: SamplingContext,
+) -> TransformParameterPlan: ...
+```
+
+The base implementation returns `TransformParameterPlan.shared_only({})`. Shared-only transforms return a plan explicitly:
+
+```python
+return TransformParameterPlan.shared_only({"angle": angle})
+```
+
+Target-sensitive transforms return shared policy plus groups:
+
+```python
+return TransformParameterPlan(
+    shared={"distribution": distribution, "intensity": intensity},
+    groups=(
+        TargetParameterGroup(
+            targets=("image", "image2"),
+            params={"noise_map": shared_image_noise},
+            requirements=image_noise_requirements,
+        ),
+        TargetParameterGroup(
+            targets=("volume",),
+            params={"noise_map": volume_noise},
+            requirements=volume_noise_requirements,
+        ),
+    ),
+)
+```
+
+Returning a plain dictionary is a type error after the cutover. This rule makes incomplete migrations fail at the sampling
+boundary.
+
+### Target-set lifetime
+
+`TargetSet` wraps the current data immediately before one transform samples parameters. It cannot be constructed once at the
+start of `Compose`, because an earlier transform may change shape, dtype, channels, or content. The stable actual-key ordering
+template can be cached with the configured target mapping; values and descriptors belong to the current transform step.
+
+Only active targets enter the set. Unknown metadata stays in `TransformSamplingInput.data`, and recognized keys with `None`
+values remain inactive. Replay treats missing and `None` target values equivalently for target-schema validation.
+
+Representation metadata is derived once from the borrowed values for the current transform step. The descriptors do not copy
+arrays, and shared-only samplers take the same fast path as before; target-aware samplers use the already available descriptors.
+
+### Shared base parameters
+
+Core-derived values such as interpolation, fill values, and annotation processor metadata enter through
+`TransformSamplingInput.base_params`. The core combines them with `plan.shared` after checking for duplicate keys.
+
+The shared `base_params["shape"]` compatibility field remains for existing geometry and application code. It is normalized
+to the canonical 2D shape for batched images, volumes, batched masks, and 3D masks. New target-sensitive sampling must not
+derive representation from that first-target field: geometry reads `spatial_frame`, while target-specific sampling reads the
+relevant descriptor from `inputs.targets`.
+
+### Grouping helpers
+
+`TargetSet.group_by` creates deterministic compatible groups without imposing a global policy. Typical keys include:
+
+| Transform behavior | Example sharing key |
+|---|---|
+| Channel scalar or vector | `(channels, dtype_scale)` |
+| Dense 2D value map | `(sampling_topology, spatial_shape, channels, dtype_scale)` |
+| Full 3D value map | `(sampling_topology, spatial_shape, channels, dtype_scale)` |
+| Channel permutation | `(channels,)` |
+| Content-derived reference matching | actual target key |
+| Shared geometry | no target groups; use `spatial_frame` |
+
+`dtype_scale` is a transform-defined semantic value. Raw `dtype` is insufficient when several dtypes share the same value
+range or when a transform operates in normalized floating-point space.
+
+### Correlation rules
+
+Every migrated target-sensitive transform documents and tests its correlation policy:
+
+- compatible targets in one group consume the exact same realized parameters;
+- different groups share policy parameters and draw separate representation-specific values;
+- a transform may share a normalized latent program and materialize it per group when that preserves stronger alignment;
+- batches and volumes remain different topologies unless the transform explicitly defines them as compatible.
+
+This preserves the usual `additional_targets` expectation for compatible aligned images while supporting aliases that differ in
+channels or dtype.
+
+## Application Dispatch
+
+`apply_with_params` receives the validated plan and keeps two execution paths.
+
+The shared-only path performs the current loop with `plan.shared`. It checks once that `plan.groups` is empty and performs no
+per-target lookup.
+
+The target-aware path resolves by actual key:
+
+```python
+for target_name, value in data.items():
+    if target_name in self._key2func and value is not None:
+        target_function = self._key2func[target_name]
+        target_params = plan.params_for(target_name)
+        result[target_name] = target_function(value, **target_params)
+```
+
+Application methods use semantic parameter names consistently. `apply`, `apply_to_images`, and `apply_to_volume` may all
+accept `noise_map`; dispatch selects the correct value. Fields whose only purpose was target routing are deleted.
+
+Required keyword names for each canonical application function are compiled once from its signature when the transform class
+is prepared. Plan validation resolves those requirements through every actual key before the application loop. Methods that
+accept only shared parameters keep the shared-only path.
+
+Annotation postprocessing that needs realized geometry receives the shared geometry parameters. If a future annotation target
+requires its own materialization, it participates through its actual target key under the same plan contract.
+
+## Replay and Deterministic Execution
+
+The in-memory plan is normalized into this replay shape:
+
+```python
+{
+    "parameter_schema": 2,
+    "target_schema": {
+        "image": "image",
+        "image2": "image",
+        "volume": "volume",
+    },
+    "shared": {"distribution": "gaussian", "intensity": 0.1},
+    "groups": [
+        {
+            "targets": ["image", "image2"],
+            "params": {"noise_map": image_noise},
+            "requirements": {
+                "image": image_requirement,
+                "image2": image2_requirement,
+            },
+        },
+        {
+            "targets": ["volume"],
+            "params": {"noise_map": volume_noise},
+            "requirements": {"volume": volume_requirement},
+        },
+    ],
+}
+```
+
+The execution-parameter payload retains the existing support for arrays and other runtime values. It is not part of the strict
+JSON `applied_config` contract.
+
+Replay follows these rules:
+
+1. It reconstructs `TransformParameterPlan` without calling a sampler.
+2. Shared-only plans keep current replay applicability.
+3. A plan with target groups requires the exact recorded set of active actual target keys; extra keys fail as well as missing
+   keys because no realized target-specific parameters exist for an added target.
+4. Each current key must resolve to the canonical target type recorded in `target_schema`.
+5. Each current descriptor must satisfy the properties declared by its `TargetRequirement`. Unconstrained properties may
+   differ.
+6. Missing, extra, renamed, duplicated, or incompatible targets fail before any transform is applied.
+7. A legacy flat parameter dictionary is rejected with a schema-version error.
+
+`get_applied_params()` returns the normalized structured payload. Existing consumers that inspect flat execution parameters
+need a migration note. `applied_config()` remains constructor-valid and unchanged.
+
+## Custom Transform Contract
+
+This is a breaking change for custom transforms that override `sample_parameters` or inspect deterministic execution params.
+The release containing the cutover must include a migration guide with these cases:
+
+- wrap shared dictionaries with `TransformParameterPlan.shared_only`;
+- replace `image_*` and `volume_*` execution fields with groups keyed by actual target names;
+- use `inputs.spatial_frame` for synchronized geometry;
+- use `inputs.targets` for representation metadata and content access;
+- use a transform-defined `group_by` key when compatible aliases should share parameters; and
+- update deterministic and replay assertions to the structured payload.
+
+No deprecation shim will accept both return types. A clear boundary error is safer than silently routing a partially migrated
+custom transform through the old semantics.
+
+## Transform Inventory and Migration Classes
+
+The implementation begins with an AST-assisted inventory of every `sample_parameters` override and every application method
+whose required parameters differ by canonical target. The current tree has more than one hundred sampling overrides, so the
+inventory is a required artifact of the implementation PR.
+
+Known target-name workarounds include:
+
+| Transform | Current target-specific fields | Required migration |
+|---|---|---|
+| `MultiplicativeNoise` | `volume_multiplier` (removed) | Group `multiplier` by channel, topology, shape, and mode |
+| `AdditiveNoise` | `volume_noise_map` (removed) | Group `noise_map` by topology, shape, channels, and dtype scale |
+| `GaussNoise` | `volume_noise_map` (removed) | Group `noise_map` with the same explicit correlation rules |
+| `SaltAndPepper` | `volume_salt_mask`, `volume_pepper_mask` (removed) | Group `salt_mask` and `pepper_mask` |
+| `FilmGrain` | `volume_grain` (removed) | Group `grain` by sampling topology and representation |
+| `RicianNoise` | `volume_real_noise`, `volume_imaginary_noise` (removed) | Group both components together |
+| `ExposureMatching` | `image_gains`, `volume_gains` (removed) | Group one semantic `gain` value per compatible actual target set |
+| `GaussianBlur` | `volume_sigma`, `volume_kernel_size` (removed) | Keep the 3D sampling policy; route semantic `sigma` and `kernel_size` through a volume group |
+
+The audit must also classify transforms that currently depend on first-target metadata without target-named fields:
+
+| Class | Representative transforms | Audit question |
+|---|---|---|
+| Channel selection and permutation | `ChannelDropout`, `ChannelShuffle` | Does every target receive valid indices with the intended correlation? |
+| Dense dropout and replacement | `PixelDropout` | Are mask shape, channel sharing, dtype scale, and replacement values target-correct? |
+| Noise and color scaling | `AdditiveNoise`, `GaussNoise`, advanced color transforms | Does dtype or channel count change materialization? |
+| Content-derived sampling | `ExposureMatching` and reference-based transforms | Is a sampled value tied to one target's pixels? |
+| Batch and volume sampling | transforms with `apply_to_images` or `apply_to_volume` | Does sampling topology match the application method? |
+| Geometry | all shape-dependent geometric transforms | Can the transform use the validated shared spatial frame exclusively? |
+| Semantic 3D policy | transforms with volume-specific kernel or sigma policy | Is the difference true transform policy or only dispatch encoded in a name? |
+
+Volume-specific constructor policy may remain when it expresses real 3D semantics. Realized execution values still use the
+same semantic parameter names inside target groups.
+
+## Implementation Plan
+
+### Phase 0: Freeze the contract and inventory — complete
+
+- Record every `sample_parameters` override, `get_image_data` call, `_extract_shape_from_data` dependency, and target-specific
+  application signature.
+- Assign each transform to shared-only, shared-spatial, grouped-by-representation, grouped-by-content, or mixed.
+- Write the expected grouping and correlation policy beside every target-sensitive transform in the inventory.
+- Confirm which execution-param inspection APIs are public and include them in the migration note.
+
+The resulting [inventory](target-specific-parameter-sampling-inventory.md) is the durable source of truth for these
+classifications and the review hook's coverage.
+
+**Completion condition**: every built-in sampler has an assigned migration class; no target-sensitive transform remains under
+an implicit first-target assumption.
+
+### Phase 1: Add target and plan types — complete
+
+- Add `TargetView`, `TargetSet`, `SpatialFrame`, `TransformSamplingInput`, `TargetParameterGroup`, and
+  `TransformParameterPlan` in the core transform execution layer.
+- Derive target views from the post-preprocessing values that application functions receive.
+- Add deterministic target ordering and grouping helpers.
+- Add plan validation and dedicated errors.
+- Add the shared-only application fast path and actual-key group dispatch.
+
+**Completion condition**: focused core tests prove routing, validation, ordering, and zero application before a validation
+failure.
+
+### Phase 2: Migrate the sampling boundary — complete
+
+- Change the base sampling signature to accept `TransformSamplingInput` and return `TransformParameterPlan`.
+- Convert every shared-only transform explicitly.
+- Replace global first-target `shape` reads with `spatial_frame` or a specific `TargetView`.
+- Reject dictionary returns.
+- Update deterministic state and `get_applied_params()`.
+
+**Completion condition**: all repository samplers type-check against the new signature and no built-in sampler returns a flat
+dictionary.
+
+### Phase 3: Migrate target-sensitive families — complete
+
+- Migrate noise transforms as one family so shared distribution and dtype-scale rules stay consistent.
+- Migrate channel transforms and dropout transforms.
+- Migrate content-derived and reference-based transforms.
+- Migrate remaining image, batch, and volume special cases from the inventory.
+- Give every migrated transform explicit compatibility keys and correlation tests.
+
+**Completion condition**: every known target-sensitive transform works with canonical targets and multiple aliases that differ
+in channel count and dtype.
+
+### Phase 4: Cut over replay — complete
+
+- Store `parameter_schema: 2` and the normalized plan in deterministic state and `ReplayCompose`.
+- Validate actual keys, canonical types, and materialized parameter compatibility before replay.
+- Update replay fixtures and tests.
+- Document the intentional incompatibility with flat execution-param payloads.
+
+**Completion condition**: replay reproduces exact outputs for mixed representations without invoking random sampling or
+materialization code.
+
+### Phase 5: Delete legacy machinery — complete
+
+- Delete target-routing fields such as `volume_noise_map`, `volume_multiplier`, `volume_sigma`, `image_gains`, and
+  `volume_gains`.
+- Delete application arguments that exist only to receive those fields.
+- Remove `get_image_data(data)` and first-target shape extraction from transform sampling paths.
+- Remove legacy replay decoding and any temporary migration adapters used on the development branch.
+- Add a deterministic source check that rejects new application parameters whose only purpose is encoding a target name.
+  Legitimate constructor policies such as 3D mode selection remain outside this rule.
+- Update custom-transform and replay documentation.
+
+**Completion condition**: a repository search and AST audit find no target-name execution fields or first-target sampling
+dependencies.
+
+### Phase 6: Validate and benchmark the atomic cutover — complete
+
+- Run the focused core and transform matrices described below.
+- Run the full test suite, type checks, documentation checks, and pre-commit hooks.
+- Benchmark the same base commit and exact cutover head in the same environment.
+- Inspect the final diff for duplicate compatibility logic, transitional branches, and obsolete tests.
+
+**Completion condition**: all correctness gates pass, performance stays within budget, and the cutover contains one runtime
+contract.
+
+### Merge strategy
+
+Implementation may use staged commits on one feature branch. The repository merges the work only after every built-in
+transform and replay consumer has migrated. Intermediate commits are development checkpoints, not supported mixed-schema
+releases.
+
+## Testing Strategy
+
+### Core contract tests
+
+Add focused tests for:
+
+- actual-key routing for canonical targets and aliases;
+- deterministic target ordering independent of call keyword order;
+- shared-only fast-path dispatch;
+- exact sharing of one parameter object by compatible targets;
+- separate groups for incompatible targets;
+- overlapping target groups with disjoint parameter names;
+- duplicate parameter names across overlapping groups;
+- duplicate shared/group keys;
+- unknown, repeated, empty, and missing group targets;
+- missing required parameters;
+- validation before any application function runs;
+- read-only plan behavior and no caller-input mutation; and
+- precise diagnostic messages containing transform and target identity.
+
+### Representation matrix
+
+Use a pairwise matrix that covers the failure dimensions without creating a full Cartesian test suite:
+
+| Profile | Targets | Representation difference |
+|---|---|---|
+| Shared compatible aliases | `image`, `image2` | Same shape, channels, dtype, and topology |
+| Channel mismatch | `image`, `image2` | Three and five channels |
+| Dtype mismatch | `image`, `image2` | `uint8` and `float32` |
+| Combined mismatch | `image`, `volume` | Channels, dtype, spatial rank, and topology |
+| Batch mismatch | `image`, `images` | Single item and batch layout |
+| Multiple aliases | `image`, `image2`, `image3` | One compatible pair and one incompatible target |
+| Canonical mixture | `image`, `images`, `volume` | All built-in image-like routes in one invocation |
+
+Use one-, three-, four-, and five-channel examples across the matrix. Include different spatial shapes only where the public
+shape-check contract allows them.
+
+### Transform-family tests
+
+At minimum, add public `Compose` coverage for:
+
+- `MultiplicativeNoise` across all `elementwise` and `per_channel` combinations;
+- `AdditiveNoise` across constant, uniform, Gaussian, Laplace, and beta distributions;
+- `GaussNoise`, `RicianNoise`, `SaltAndPepper`, and `FilmGrain`;
+- `ChannelShuffle` and `ChannelDropout` with different channel counts;
+- `PixelDropout` with per-channel masks, shared masks, and replacement values;
+- `ExposureMatching` with canonical and aliased inputs; and
+- every additional transform identified by the inventory.
+
+Assertions must cover values and correlation, not only output shape and dtype. For a fixed seed, compatible targets should
+prove exact parameter sharing where declared. Incompatible targets should prove valid target-scaled outputs and the intended
+shared-policy relationship.
+
+### Replay and determinism tests
+
+- Same seed plus the same target set produces identical structured plans and outputs.
+- Permuting call keyword order does not change the plan or outputs.
+- Replay produces exact outputs for mixed channel counts and dtypes.
+- Replay performs zero RNG calls and zero materialization calls.
+- Missing or renamed aliases fail before any output is produced.
+- Canonical-type changes fail even if the array shapes happen to match.
+- Incompatible shape, channels, dtype scale, or topology fails with the recorded and current descriptors.
+- Shared-only replay retains existing behavior.
+- `applied_config` remains constructor-valid and strict-JSON serializable.
+
+### Negative controls
+
+Keep explicit regressions for the known silent and loud failures:
+
+- a non-elementwise, non-per-channel multiplier sampled from a three-channel image and applied to a five-channel volume;
+- constant additive noise with `uint8` primary data and `float32` secondary data;
+- a channel permutation sampled for three channels and applied to a five-channel alias;
+- a dense dropout mask whose source and destination spatial shapes differ; and
+- two aliases of canonical type `image` that require separate materializations.
+
+Each negative control must fail on the pre-cutover base or demonstrate the wrong value, then pass on the exact cutover head.
+
+## Performance Budget
+
+Measure base and exact head in the same process environment with identical inputs, seeds, warmup, and repetitions. Report
+median and dispersion for these cells:
+
+- cheap shared-only transform on one image;
+- cheap shared-only transform inside `Compose`;
+- target-sensitive transform on one image;
+- compatible `image` plus alias;
+- incompatible `image` plus alias;
+- `image`, `images`, and `volume` together;
+- deterministic capture; and
+- replay.
+
+The implementation must satisfy these budgets:
+
+- shared-only application performs one empty-group branch per transform and no per-target group lookup;
+- target view construction is allocation-light and does not copy arrays;
+- target-aware dispatch is `O(T)` in active targets;
+- dense parameters are materialized once per compatible group;
+- ordinary single-target and shared-only representative cells regress by no more than 5%; and
+- a larger regression blocks the cutover unless the implementation removes equivalent work elsewhere and provides measured
+  full-route evidence.
+
+Microbenchmarks support diagnosis. The acceptance decision uses representative `Compose` routes because parameter setup,
+dispatch, and application all contribute to user-visible cost.
+
+## Source Enforcement
+
+The implemented `check-ax-coding-guidance` rules protect the architectural boundary.
+The rule should detect:
+
+- a `sample_parameters` override returning a plain dictionary;
+- transform sampling code deriving representation from `get_image_data(data)` or another first-target helper; and
+- parameters required only by one `apply_to_*` method whose names encode the target solely for routing.
+
+The checks use AST structure and a narrow semantic allowlist. A broad text search would incorrectly reject legitimate public
+policy names containing words such as `volume`.
+
+## Files and Ownership
+
+The implementation is expected to touch these ownership areas:
+
+- `albumentations/core/transforms_interface.py`: sampling boundary, plan validation, actual-key dispatch, deterministic state;
+- core type modules: target views, spatial frame, parameter plans, and errors;
+- `albumentations/core/composition.py`: target-set construction, preprocessing boundary, and replay integration;
+- transform modules: explicit plan construction and removal of target-named execution fields;
+- `tests/`: core contract, family regressions, aliases, determinism, and replay;
+- `tools/ax_coding_guidance/`: post-cutover deterministic enforcement; and
+- public customization and replay documentation: migration guidance and structured parameter examples;
+- `docs/design/target-specific-parameter-sampling-inventory.md`: durable sampler classification and review surface.
+
+The inventory is public design documentation because it is part of the maintained source contract. Scratch benchmark
+artifacts may live under `_internal/`, but durable performance conclusions belong in the PR description or public design
+documentation before merge.
+
+## Deletion Checklist
+
+The final diff must confirm all of the following:
+
+- [x] No built-in `sample_parameters` returns a flat dictionary.
+- [x] No sampled representation is derived implicitly from the first image-like target.
+- [x] No `volume_*`, `image_*`, or alias-specific execution field exists solely for dispatch.
+- [x] No compatibility decoder accepts parameter schema 1.
+- [x] No temporary dual dispatch path remains.
+- [x] No dense parameter is duplicated across compatible groups.
+- [x] No tests assert legacy target-specific field names.
+- [x] No documentation teaches the legacy sampling signature.
+
+## Acceptance Criteria
+
+The class of bugs is resolved when:
+
+1. Every built-in sampler returns `TransformParameterPlan`.
+2. Every target-sensitive transform addresses parameters by actual target key through groups.
+3. Multiple aliases of the same canonical target type can differ in channels, dtype, shape where allowed, and content without
+   misrouting or silent rescaling.
+4. Compatible aliases retain their declared parameter correlation.
+5. Mixed `image`, `images`, and `volume` calls pass the representation matrix.
+6. Replay records and restores the structured plan exactly and rejects incompatible target schemas before applying data.
+7. `applied_config` behavior remains unchanged.
+8. The full transform inventory has no unresolved first-target dependency.
+9. Legacy target-routing fields and adapters are deleted.
+10. Focused, full-suite, type, lint, documentation, and coding-guidance gates pass.
+11. Paired base-to-head benchmarks satisfy the performance budget.
+12. The custom-transform migration guidance is published in the coding guidelines and add-transform skill.
+
+## References
+
+- [Greenfield Compose Architecture](compose-greenfield-architecture.md)
+- [Generated Transform Target Contracts](transform-target-contracts.md)
+- [Applied Configuration Replay Contracts](applied-config-replay-contracts.md)
+- [Coding Guidelines](../contributing/coding_guidelines.md)
+- [Testing Conventions](../../.codex/rules/testing-conventions.md)
+- [Performance and Benchmarking Rules](../../.codex/rules/benchmarking.md)

--- a/tests/contracts/test_contract_harness.py
+++ b/tests/contracts/test_contract_harness.py
@@ -8,7 +8,7 @@ from pydantic import model_validator
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 from tests.helpers.applied_config import (
@@ -43,11 +43,13 @@ class CrossFieldConflict(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides["choice"] = "a"
-        return TransformParameterPlan.shared_only({})
+        return SampledParams.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -56,11 +58,13 @@ class CrossFieldConflict(ImageOnlyTransform):
 class UnknownEmittedKey(ImageOnlyTransform):
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides["unknown_key"] = 137
-        return TransformParameterPlan.shared_only({})
+        return SampledParams.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -76,11 +80,13 @@ class NonJsonValue(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides["payload"] = {1, 2}
-        return TransformParameterPlan.shared_only({})
+        return SampledParams.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -96,12 +102,14 @@ class MutatesPreviousRecord(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         self.history.append(len(self.history) + 1)
         sampling.applied_overrides["history"] = self.history
-        return TransformParameterPlan.shared_only({})
+        return SampledParams.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -117,11 +125,13 @@ class ReconstructsButCannotRun(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides["mode"] = "replay"
-        return TransformParameterPlan.shared_only({})
+        return SampledParams.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if self.mode == "replay":
@@ -139,11 +149,13 @@ class ReconstructsWithDifferentOutput(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         sampling.applied_overrides["mode"] = "replay"
-        return TransformParameterPlan.shared_only({})
+        return SampledParams.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return np.zeros_like(img) if self.mode == "replay" else img

--- a/tests/contracts/test_contract_harness.py
+++ b/tests/contracts/test_contract_harness.py
@@ -49,7 +49,7 @@ class CrossFieldConflict(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         sampling.applied_overrides["choice"] = "a"
-        return SampledParams.shared_only({})
+        return SampledParams(params={})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -64,7 +64,7 @@ class UnknownEmittedKey(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         sampling.applied_overrides["unknown_key"] = 137
-        return SampledParams.shared_only({})
+        return SampledParams(params={})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -86,7 +86,7 @@ class NonJsonValue(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         sampling.applied_overrides["payload"] = {1, 2}
-        return SampledParams.shared_only({})
+        return SampledParams(params={})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -109,7 +109,7 @@ class MutatesPreviousRecord(ImageOnlyTransform):
     ) -> SampledParams:
         self.history.append(len(self.history) + 1)
         sampling.applied_overrides["history"] = self.history
-        return SampledParams.shared_only({})
+        return SampledParams(params={})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -131,7 +131,7 @@ class ReconstructsButCannotRun(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         sampling.applied_overrides["mode"] = "replay"
-        return SampledParams.shared_only({})
+        return SampledParams(params={})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if self.mode == "replay":
@@ -155,7 +155,7 @@ class ReconstructsWithDifferentOutput(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         sampling.applied_overrides["mode"] = "replay"
-        return SampledParams.shared_only({})
+        return SampledParams(params={})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return np.zeros_like(img) if self.mode == "replay" else img

--- a/tests/contracts/test_contract_harness.py
+++ b/tests/contracts/test_contract_harness.py
@@ -8,6 +8,7 @@ from pydantic import model_validator
 from typing_extensions import Self
 
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import BaseTransformInitSchema, ImageOnlyTransform
 from albumentations.core.type_definitions import ImageType
 from tests.helpers.applied_config import (
@@ -42,12 +43,11 @@ class CrossFieldConflict(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         sampling.applied_overrides["choice"] = "a"
-        return {}
+        return TransformParameterPlan.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -56,12 +56,11 @@ class CrossFieldConflict(ImageOnlyTransform):
 class UnknownEmittedKey(ImageOnlyTransform):
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         sampling.applied_overrides["unknown_key"] = 137
-        return {}
+        return TransformParameterPlan.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -77,12 +76,11 @@ class NonJsonValue(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         sampling.applied_overrides["payload"] = {1, 2}
-        return {}
+        return TransformParameterPlan.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -98,13 +96,12 @@ class MutatesPreviousRecord(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         self.history.append(len(self.history) + 1)
         sampling.applied_overrides["history"] = self.history
-        return {}
+        return TransformParameterPlan.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return img
@@ -120,12 +117,11 @@ class ReconstructsButCannotRun(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         sampling.applied_overrides["mode"] = "replay"
-        return {}
+        return TransformParameterPlan.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         if self.mode == "replay":
@@ -143,12 +139,11 @@ class ReconstructsWithDifferentOutput(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         sampling.applied_overrides["mode"] = "replay"
-        return {}
+        return TransformParameterPlan.shared_only({})
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return np.zeros_like(img) if self.mode == "replay" else img

--- a/tests/test_annotation_artifacts.py
+++ b/tests/test_annotation_artifacts.py
@@ -5,6 +5,7 @@ import albumentations as A
 from albumentations.augmentations.other import annotation_artifacts_functional as fannotation
 from albumentations.core.invocation import SamplingContext
 from tests.helpers import TestDataFactory
+from tests.utils import get_resolved_applied_params, make_sampling_input
 
 
 @pytest.mark.parametrize("element_type", ["text", "rectangle", "arrow", "line", "callout"])
@@ -50,11 +51,11 @@ def test_annotation_artifacts_default_sampling_sequence_is_unchanged() -> None:
     )
     transform.set_random_seed(137)
 
+    data = {"image": np.empty((160, 160, 3), dtype=np.uint8)}
     artifacts = transform.sample_parameters(
-        {"shape": (160, 160, 3)},
-        {"image": np.empty((160, 160, 3), dtype=np.uint8)},
+        make_sampling_input(transform, data),
         SamplingContext.from_owner(transform, {}),
-    )["artifacts"]
+    ).shared["artifacts"]
 
     assert artifacts == [
         {
@@ -147,7 +148,7 @@ def test_annotation_artifacts_direct_grayscale_inputs(target: str, shape: tuple[
 
     assert result.shape == data.shape
     assert result.dtype == data.dtype
-    assert all(len(artifact["color"]) == 1 for artifact in transform.params["artifacts"])
+    assert all(len(artifact["color"]) == 1 for artifact in get_resolved_applied_params(transform)["artifacts"])
     assert not np.array_equal(result, data)
 
 
@@ -213,10 +214,9 @@ def test_annotation_artifacts_line_length_range_controls_lines() -> None:
     transform.set_random_seed(137)
 
     artifacts = transform.sample_parameters(
-        {"shape": image.shape},
-        {"image": image},
+        make_sampling_input(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
-    )["artifacts"]
+    ).shared["artifacts"]
     lengths = np.array(
         [
             int(np.hypot(artifact["end"][0] - artifact["start"][0], artifact["end"][1] - artifact["start"][1]))
@@ -239,7 +239,7 @@ def test_annotation_artifacts_random_endpoints_are_replayable() -> None:
     pipeline = A.ReplayCompose([transform], seed=137)
 
     result = pipeline(image=image)
-    artifacts = transform.params["artifacts"]
+    artifacts = get_resolved_applied_params(transform)["artifacts"]
     replayed = A.ReplayCompose.replay(result["replay"], image=image)
 
     assert any(
@@ -268,7 +268,7 @@ def test_annotation_artifacts_line_style_policy_applies_to_all_styled_elements(e
 
     A.Compose([transform], save_applied_params=True, seed=137, strict=True)(image=image)
 
-    assert {artifact["style"] for artifact in transform.params["artifacts"]} == {"dotted"}
+    assert {artifact["style"] for artifact in get_resolved_applied_params(transform)["artifacts"]} == {"dotted"}
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
@@ -288,7 +288,7 @@ def test_annotation_artifacts_random_colors_match_image_channels(
     )
 
     result = A.Compose([transform], save_applied_params=True, seed=137, strict=True)(image=image)["image"]
-    colors = [artifact["color"] for artifact in transform.params["artifacts"]]
+    colors = [artifact["color"] for artifact in get_resolved_applied_params(transform)["artifacts"]]
 
     assert all(len(color) == num_channels for color in colors)
     assert all(0 <= value <= 255 for color in colors for value in color)
@@ -310,7 +310,9 @@ def test_annotation_artifacts_weighted_color_palette() -> None:
 
     A.Compose([transform], save_applied_params=True, seed=137, strict=True)(image=image)
 
-    assert {artifact["color"] for artifact in transform.params["artifacts"]} == {(10, 20, 30, 40, 50)}
+    assert {artifact["color"] for artifact in get_resolved_applied_params(transform)["artifacts"]} == {
+        (10, 20, 30, 40, 50),
+    }
 
 
 def test_annotation_artifacts_fixed_palette_extends_to_extra_channels() -> None:
@@ -348,7 +350,7 @@ def test_annotation_artifacts_random_angle_supports_pixel_lengths() -> None:
             artifact["end"][0] - artifact["start"][0],
             artifact["end"][1] - artifact["start"][1],
         )
-        for artifact in transform.params["artifacts"]
+        for artifact in get_resolved_applied_params(transform)["artifacts"]
     ]
 
     assert all(18.5 <= length <= 21.5 for length in lengths)
@@ -367,7 +369,7 @@ def test_annotation_artifacts_random_angle_has_nonzero_relative_length() -> None
 
     A.Compose([transform], save_applied_params=True, seed=137, strict=True)(image=image)
 
-    assert all(artifact["start"] != artifact["end"] for artifact in transform.params["artifacts"])
+    assert all(artifact["start"] != artifact["end"] for artifact in get_resolved_applied_params(transform)["artifacts"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_annotation_artifacts.py
+++ b/tests/test_annotation_artifacts.py
@@ -4,6 +4,7 @@ import pytest
 import albumentations as A
 from albumentations.augmentations.other import annotation_artifacts_functional as fannotation
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import SampledParams
 from tests.helpers import TestDataFactory
 from tests.utils import get_resolved_applied_params, make_sampling_args
 
@@ -40,6 +41,28 @@ def test_annotation_artifacts_deterministic_with_compose_seed() -> None:
     same_seed_result = same_seed_transform(image=image)["image"]
 
     np.testing.assert_array_equal(result, same_seed_result)
+
+
+def test_annotation_artifacts_materializes_artifacts_per_target_representation() -> None:
+    image = np.full((32, 40, 3), 137, dtype=np.uint8)
+    image2 = np.full((24, 28, 5), 137, dtype=np.uint8)
+    transform = A.AnnotationArtifacts(
+        element_types=("line",),
+        element_probabilities=(1.0,),
+        count_range=(1, 1),
+        random_color_prob=1.0,
+        p=1.0,
+    )
+    transform.add_targets({"image2": "image"})
+
+    result = transform(image=image, image2=image2)
+    sampled_params = SampledParams.from_dict(transform.get_applied_params())
+
+    assert {target_params.targets for target_params in sampled_params.target_params} == {("image",), ("image2",)}
+    assert len(sampled_params.params_for("image")["artifacts"][0]["color"]) == 3
+    assert len(sampled_params.params_for("image2")["artifacts"][0]["color"]) == 5
+    assert result["image"].shape == image.shape
+    assert result["image2"].shape == image2.shape
 
 
 def test_annotation_artifacts_default_sampling_sequence_is_unchanged() -> None:

--- a/tests/test_annotation_artifacts.py
+++ b/tests/test_annotation_artifacts.py
@@ -55,7 +55,7 @@ def test_annotation_artifacts_default_sampling_sequence_is_unchanged() -> None:
     artifacts = transform.sample_parameters(
         *make_sampling_args(transform, data),
         SamplingContext.from_owner(transform, {}),
-    ).shared["artifacts"]
+    ).params["artifacts"]
 
     assert artifacts == [
         {
@@ -216,7 +216,7 @@ def test_annotation_artifacts_line_length_range_controls_lines() -> None:
     artifacts = transform.sample_parameters(
         *make_sampling_args(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
-    ).shared["artifacts"]
+    ).params["artifacts"]
     lengths = np.array(
         [
             int(np.hypot(artifact["end"][0] - artifact["start"][0], artifact["end"][1] - artifact["start"][1]))

--- a/tests/test_annotation_artifacts.py
+++ b/tests/test_annotation_artifacts.py
@@ -5,7 +5,7 @@ import albumentations as A
 from albumentations.augmentations.other import annotation_artifacts_functional as fannotation
 from albumentations.core.invocation import SamplingContext
 from tests.helpers import TestDataFactory
-from tests.utils import get_resolved_applied_params, make_sampling_input
+from tests.utils import get_resolved_applied_params, make_sampling_args
 
 
 @pytest.mark.parametrize("element_type", ["text", "rectangle", "arrow", "line", "callout"])
@@ -53,7 +53,7 @@ def test_annotation_artifacts_default_sampling_sequence_is_unchanged() -> None:
 
     data = {"image": np.empty((160, 160, 3), dtype=np.uint8)}
     artifacts = transform.sample_parameters(
-        make_sampling_input(transform, data),
+        *make_sampling_args(transform, data),
         SamplingContext.from_owner(transform, {}),
     ).shared["artifacts"]
 
@@ -214,7 +214,7 @@ def test_annotation_artifacts_line_length_range_controls_lines() -> None:
     transform.set_random_seed(137)
 
     artifacts = transform.sample_parameters(
-        make_sampling_input(transform, {"image": image}),
+        *make_sampling_args(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
     ).shared["artifacts"]
     lengths = np.array(

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -23,7 +23,7 @@ from .utils import (
     get_primary_dual_transform_params,
     get_primary_image_only_transform_params,
     get_resolved_applied_params,
-    make_sampling_input,
+    make_sampling_args,
     set_seed,
 )
 
@@ -1111,7 +1111,7 @@ def test_constrained_coarse_dropout_with_mask():
 
     # Get holes
     params = transform.sample_parameters(
-        make_sampling_input(transform, {"image": image, "mask": mask}),
+        *make_sampling_args(transform, {"image": image, "mask": mask}),
         SamplingContext.from_owner(transform, {}),
     ).shared
     holes = params["holes"]
@@ -1636,7 +1636,7 @@ def test_random_rain_slant(slant_range, expected_slant_range):
         transform.set_random_seed(137 + iteration)
         # Get params without actually applying transform
         params = transform.sample_parameters(
-            make_sampling_input(transform, {"image": image}),
+            *make_sampling_args(transform, {"image": image}),
             SamplingContext.from_owner(transform, {}),
         ).shared
         slants.append(params["slant"])

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -22,6 +22,8 @@ from .utils import (
     get_primary_2d_transform_params,
     get_primary_dual_transform_params,
     get_primary_image_only_transform_params,
+    get_resolved_applied_params,
+    make_sampling_input,
     set_seed,
 )
 
@@ -1109,10 +1111,9 @@ def test_constrained_coarse_dropout_with_mask():
 
     # Get holes
     params = transform.sample_parameters(
-        {},
-        {"image": image, "mask": mask},
+        make_sampling_input(transform, {"image": image, "mask": mask}),
         SamplingContext.from_owner(transform, {}),
-    )
+    ).shared
     holes = params["holes"]
 
     # Verify number of holes (2 per object, 3 objects)
@@ -1176,7 +1177,7 @@ def test_constrained_coarse_dropout_with_bboxes(bbox_labels, bboxes, expected_nu
     # Apply transform
     transform(image=image, bboxes=bboxes_without_labels, class_labels=labels)
 
-    holes = ccd.params["holes"]
+    holes = get_resolved_applied_params(ccd)["holes"]
 
     # Verify number of holes (2 per object)
     assert len(holes) == expected_num_objects * 2, (
@@ -1635,10 +1636,9 @@ def test_random_rain_slant(slant_range, expected_slant_range):
         transform.set_random_seed(137 + iteration)
         # Get params without actually applying transform
         params = transform.sample_parameters(
-            {"shape": image.shape},
-            {"image": image},
+            make_sampling_input(transform, {"image": image}),
             SamplingContext.from_owner(transform, {}),
-        )
+        ).shared
         slants.append(params["slant"])
 
     # Assert all slants are within the expected range
@@ -2125,7 +2125,7 @@ def test_random_shadow_batch_compose_routes_match_per_image_results(target_name,
     compose = A.Compose([transform], seed=seed, strict=True, save_applied_params=True)
 
     actual = compose(**{target_name: data})[target_name]
-    params = transform.get_applied_params()
+    params = get_resolved_applied_params(transform, target_name)
     expected = np.stack([transform.apply(image, **params) for image in data])
 
     np.testing.assert_array_equal(data, data_before)
@@ -2178,7 +2178,7 @@ def test_spatter_apply_to_images_matches_inherited_fallback(mode, dtype, seed, b
     images_before = images.copy()
     transform = A.Spatter(mode=mode, color=(137, 89, 211), p=1.0)
     compose_result = A.Compose([transform], save_applied_params=True, seed=seed, strict=True)(images=images)["images"]
-    params = transform.get_applied_params()
+    params = get_resolved_applied_params(transform, target="images")
     expected = ImageOnlyTransform.apply_to_images(transform, images, **params)
     direct_result = transform.apply_to_images(images, **params)
 
@@ -2341,7 +2341,7 @@ def test_spatter_batch_path_preserves_volume_routing(mode, dtype):
     transform = A.Spatter(mode=mode, p=1.0)
 
     actual = A.Compose([transform], save_applied_params=True, seed=137, strict=True)(volume=volume)["volume"]
-    params = transform.get_applied_params()
+    params = get_resolved_applied_params(transform, "volume")
     expected = ImageOnlyTransform.apply_to_images(transform, volume, **params)
 
     if dtype == np.uint8:

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1113,7 +1113,7 @@ def test_constrained_coarse_dropout_with_mask():
     params = transform.sample_parameters(
         *make_sampling_args(transform, {"image": image, "mask": mask}),
         SamplingContext.from_owner(transform, {}),
-    ).shared
+    ).params
     holes = params["holes"]
 
     # Verify number of holes (2 per object, 3 objects)
@@ -1638,7 +1638,7 @@ def test_random_rain_slant(slant_range, expected_slant_range):
         params = transform.sample_parameters(
             *make_sampling_args(transform, {"image": image}),
             SamplingContext.from_owner(transform, {}),
-        ).shared
+        ).params
         slants.append(params["slant"])
 
     # Assert all slants are within the expected range

--- a/tests/test_ax_coding_guidance.py
+++ b/tests/test_ax_coding_guidance.py
@@ -59,7 +59,7 @@ class DualTransform: pass
 class RandomNew(DualTransform):
     def apply(self, image, value=1):
         return sampling.py_random.random()
-    def sample_parameters(self, self2, params, data, sampling):
+    def sample_parameters(self, self2, inputs, sampling):
         return {'x': np.random.uniform(0, 1), 'y': random.random(), 'z': sampling.py_random.random()}
 """,
         },
@@ -150,8 +150,8 @@ from random import randint
 
 class DualTransform: pass
 class Example(DualTransform):
-    def sample_parameters(self, params, data, sampling: SamplingContext, /):
-        return {"x": uniform(), "y": randint(0, 1), "image": resize(data["image"], (4, 4))}
+    def sample_parameters(self, inputs, sampling: SamplingContext, /):
+        return {"x": uniform(), "y": randint(0, 1), "image": resize(inputs.data["image"], (4, 4))}
 """,
         },
     )
@@ -220,6 +220,45 @@ class Child(Parent):
 class BasicTransform: pass
 class Child(BasicTransform):
     def __init__(self, transpose: bool = False, p: float = 1.0): super().__init__(p=p)
+""",
+        },
+    )
+
+
+def test_sampling_plan_rules_reject_flat_returns_and_first_target_shape() -> None:
+    ids = rule_ids(
+        {
+            "albumentations/augmentations/example.py": """
+class DualTransform: pass
+class Example(DualTransform):
+    def sample_parameters(self, inputs, sampling: SamplingContext):
+        shape = inputs.base_params["shape"]
+        return {"shape": shape}
+""",
+        },
+    )
+    assert {"AXG021", "AXG022"} <= set(ids)
+
+
+def test_target_plan_rule_rejects_target_routing_parameter_names() -> None:
+    ids = rule_ids(
+        {
+            "albumentations/augmentations/example.py": """
+class DualTransform: pass
+class Example(DualTransform):
+    def apply(self, image, volume_noise_map):
+        return image
+""",
+        },
+    )
+    assert "AXG023" in ids
+    assert "AXG023" not in rule_ids(
+        {
+            "albumentations/augmentations/example.py": """
+class DualTransform: pass
+class Example(DualTransform):
+    def apply(self, image, image_type):
+        return image
 """,
         },
     )

--- a/tests/test_ax_coding_guidance.py
+++ b/tests/test_ax_coding_guidance.py
@@ -233,7 +233,8 @@ class DualTransform: pass
 class Example(DualTransform):
     def sample_parameters(self, params, data, targets, sampling: SamplingContext):
         shape = params["shape"]
-        return {"shape": shape}
+        alternate_shape = params.get("shape")
+        return {"shape": alternate_shape}
 """,
         },
     )

--- a/tests/test_ax_coding_guidance.py
+++ b/tests/test_ax_coding_guidance.py
@@ -150,8 +150,8 @@ from random import randint
 
 class DualTransform: pass
 class Example(DualTransform):
-    def sample_parameters(self, inputs, sampling: SamplingContext, /):
-        return {"x": uniform(), "y": randint(0, 1), "image": resize(inputs.data["image"], (4, 4))}
+    def sample_parameters(self, params, data, targets, sampling: SamplingContext, /):
+        return {"x": uniform(), "y": randint(0, 1), "image": resize(data["image"], (4, 4))}
 """,
         },
     )
@@ -231,8 +231,8 @@ def test_sampling_plan_rules_reject_flat_returns_and_first_target_shape() -> Non
             "albumentations/augmentations/example.py": """
 class DualTransform: pass
 class Example(DualTransform):
-    def sample_parameters(self, inputs, sampling: SamplingContext):
-        shape = inputs.base_params["shape"]
+    def sample_parameters(self, params, data, targets, sampling: SamplingContext):
+        shape = params["shape"]
         return {"shape": shape}
 """,
         },

--- a/tests/test_ax_coding_guidance.py
+++ b/tests/test_ax_coding_guidance.py
@@ -241,6 +241,23 @@ class Example(DualTransform):
     assert {"AXG021", "AXG022"} <= set(ids)
 
 
+def test_sampling_plan_rules_reject_direct_canonical_target_selection() -> None:
+    ids = rule_ids(
+        {
+            "albumentations/augmentations/example.py": """
+class DualTransform: pass
+class Example(DualTransform):
+    def sample_parameters(self, params, data, targets, sampling: SamplingContext):
+        image = data["image"]
+        images = data.get("images")
+        has_volume = "volume" in data
+        return SampledParams(params={"image": image, "images": images, "has_volume": has_volume})
+""",
+        },
+    )
+    assert ids.count("AXG024") == 1
+
+
 def test_target_plan_rule_rejects_target_routing_parameter_names() -> None:
     ids = rule_ids(
         {

--- a/tests/test_compose_reentrancy.py
+++ b/tests/test_compose_reentrancy.py
@@ -16,7 +16,7 @@ import albumentations as A
 import albumentations.core.composition as composition_module
 import albumentations.core.invocation as invocation_module
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import ImageOnlyTransform
 
 T = TypeVar("T")
@@ -34,12 +34,14 @@ class _BlockingNumpyOnlyProbe(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        marker = int(inputs.data["image"][0, 0, 0])
+    ) -> SampledParams:
+        marker = int(data["image"][0, 0, 0])
         sampling.applied_overrides["marker_range"] = (marker, marker)
-        return TransformParameterPlan.shared_only({"marker": marker})
+        return SampledParams.shared_only({"marker": marker})
 
     def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
         if marker == 1:
@@ -60,12 +62,14 @@ class _BlockingRandomProbe(_BlockingNumpyOnlyProbe):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
+    ) -> SampledParams:
         with self._ids_lock:
             self.py_random_ids.append(id(sampling.py_random))
-        return super().sample_parameters(inputs, sampling)
+        return super().sample_parameters(params, data, targets, sampling)
 
 
 class _NumpyRandomMarker(ImageOnlyTransform):
@@ -73,11 +77,13 @@ class _NumpyRandomMarker(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        del inputs
-        return TransformParameterPlan.shared_only(
+    ) -> SampledParams:
+        del params, data, targets
+        return SampledParams.shared_only(
             {"marker": int(sampling.random_generator.integers(np.iinfo(np.int64).max, dtype=np.int64))},
         )
 
@@ -112,11 +118,13 @@ class _ExplicitExternalSampler(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        del inputs
-        return TransformParameterPlan.shared_only({"offset": sampling.py_random.randint(1, 7)})
+    ) -> SampledParams:
+        del params, data, targets
+        return SampledParams.shared_only({"offset": sampling.py_random.randint(1, 7)})
 
     def apply(self, image: np.ndarray, offset: int, **params: Any) -> np.ndarray:
         del params
@@ -158,12 +166,14 @@ class _FailAfterSampling(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        del inputs
+    ) -> SampledParams:
+        del params, data, targets
         sampling.applied_overrides["marker"] = self.marker
-        return TransformParameterPlan.shared_only({"marker": self.marker})
+        return SampledParams.shared_only({"marker": self.marker})
 
     def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
         del image, marker, params

--- a/tests/test_compose_reentrancy.py
+++ b/tests/test_compose_reentrancy.py
@@ -41,7 +41,7 @@ class _BlockingNumpyOnlyProbe(ImageOnlyTransform):
     ) -> SampledParams:
         marker = int(data["image"][0, 0, 0])
         sampling.applied_overrides["marker_range"] = (marker, marker)
-        return SampledParams.shared_only({"marker": marker})
+        return SampledParams(params={"marker": marker})
 
     def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
         if marker == 1:
@@ -83,8 +83,8 @@ class _NumpyRandomMarker(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         del params, data, targets
-        return SampledParams.shared_only(
-            {"marker": int(sampling.random_generator.integers(np.iinfo(np.int64).max, dtype=np.int64))},
+        return SampledParams(
+            params={"marker": int(sampling.random_generator.integers(np.iinfo(np.int64).max, dtype=np.int64))},
         )
 
     def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
@@ -124,7 +124,7 @@ class _ExplicitExternalSampler(ImageOnlyTransform):
         sampling: SamplingContext,
     ) -> SampledParams:
         del params, data, targets
-        return SampledParams.shared_only({"offset": sampling.py_random.randint(1, 7)})
+        return SampledParams(params={"offset": sampling.py_random.randint(1, 7)})
 
     def apply(self, image: np.ndarray, offset: int, **params: Any) -> np.ndarray:
         del params
@@ -173,7 +173,7 @@ class _FailAfterSampling(ImageOnlyTransform):
     ) -> SampledParams:
         del params, data, targets
         sampling.applied_overrides["marker"] = self.marker
-        return SampledParams.shared_only({"marker": self.marker})
+        return SampledParams(params={"marker": self.marker})
 
     def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
         del image, marker, params
@@ -259,7 +259,7 @@ def test_deterministic_direct_transform_keeps_caller_local_observation() -> None
 
     def run(image: np.ndarray) -> tuple[tuple[int, ...], np.ndarray]:
         result = transform(image=image)
-        return transform.get_applied_params()["shared"]["shape"], result["image"]
+        return transform.get_applied_params()["params"]["shape"], result["image"]
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         first_future = _submit(executor, lambda: run(first_image))

--- a/tests/test_compose_reentrancy.py
+++ b/tests/test_compose_reentrancy.py
@@ -16,6 +16,7 @@ import albumentations as A
 import albumentations.core.composition as composition_module
 import albumentations.core.invocation as invocation_module
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import ImageOnlyTransform
 
 T = TypeVar("T")
@@ -33,13 +34,12 @@ class _BlockingNumpyOnlyProbe(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        marker = int(data["image"][0, 0, 0])
+    ) -> TransformParameterPlan:
+        marker = int(inputs.data["image"][0, 0, 0])
         sampling.applied_overrides["marker_range"] = (marker, marker)
-        return {"marker": marker}
+        return TransformParameterPlan.shared_only({"marker": marker})
 
     def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
         if marker == 1:
@@ -60,13 +60,12 @@ class _BlockingRandomProbe(_BlockingNumpyOnlyProbe):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
         with self._ids_lock:
             self.py_random_ids.append(id(sampling.py_random))
-        return super().sample_parameters(params, data, sampling)
+        return super().sample_parameters(inputs, sampling)
 
 
 class _NumpyRandomMarker(ImageOnlyTransform):
@@ -74,12 +73,13 @@ class _NumpyRandomMarker(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        del params, data
-        return {"marker": int(sampling.random_generator.integers(np.iinfo(np.int64).max, dtype=np.int64))}
+    ) -> TransformParameterPlan:
+        del inputs
+        return TransformParameterPlan.shared_only(
+            {"marker": int(sampling.random_generator.integers(np.iinfo(np.int64).max, dtype=np.int64))},
+        )
 
     def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
         del params
@@ -112,12 +112,11 @@ class _ExplicitExternalSampler(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        del params, data
-        return {"offset": sampling.py_random.randint(1, 7)}
+    ) -> TransformParameterPlan:
+        del inputs
+        return TransformParameterPlan.shared_only({"offset": sampling.py_random.randint(1, 7)})
 
     def apply(self, image: np.ndarray, offset: int, **params: Any) -> np.ndarray:
         del params
@@ -159,12 +158,12 @@ class _FailAfterSampling(ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
+    ) -> TransformParameterPlan:
+        del inputs
         sampling.applied_overrides["marker"] = self.marker
-        return {"marker": self.marker}
+        return TransformParameterPlan.shared_only({"marker": self.marker})
 
     def apply(self, image: np.ndarray, marker: int, **params: Any) -> np.ndarray:
         del image, marker, params
@@ -250,7 +249,7 @@ def test_deterministic_direct_transform_keeps_caller_local_observation() -> None
 
     def run(image: np.ndarray) -> tuple[tuple[int, ...], np.ndarray]:
         result = transform(image=image)
-        return transform.get_applied_params()["shape"], result["image"]
+        return transform.get_applied_params()["shared"]["shape"], result["image"]
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         first_future = _submit(executor, lambda: run(first_image))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,7 +22,7 @@ from albumentations.core.composition import (
     SomeOf,
 )
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from albumentations.core.transforms_interface import DualTransform, ImageOnlyTransform, NoOp
 from tests.conftest import (
     IMAGES,
@@ -124,7 +124,7 @@ def test_image_only_transform(image):
         with mock.patch.object(
             ImageOnlyTransform,
             "sample_parameters",
-            return_value=TransformParameterPlan.shared_only({"interpolation": cv2.INTER_LINEAR}),
+            return_value=SampledParams.shared_only({"interpolation": cv2.INTER_LINEAR}),
         ):
             aug = ImageOnlyTransform(p=1)
             data = aug(image=image, mask=mask)
@@ -141,7 +141,7 @@ def test_dual_transform(image):
     mask = image.copy()
 
     with mock.patch.object(DualTransform, "apply") as mocked_apply:
-        with mock.patch.object(DualTransform, "sample_parameters", return_value=TransformParameterPlan.shared_only({})):
+        with mock.patch.object(DualTransform, "sample_parameters", return_value=SampledParams.shared_only({})):
             aug = DualTransform(p=1)
             aug(image=image, mask=mask)
 
@@ -179,7 +179,7 @@ def test_additional_targets(image):
         with mock.patch.object(
             DualTransform,
             "sample_parameters",
-            return_value=TransformParameterPlan.shared_only({"interpolation": cv2.INTER_LINEAR}),
+            return_value=SampledParams.shared_only({"interpolation": cv2.INTER_LINEAR}),
         ):
             aug = DualTransform(p=1)
             aug.add_targets({"image2": "image"})
@@ -2860,10 +2860,14 @@ def test_user_data_targets_as_params() -> None:
         targets_as_params = ("user_data",)
 
         def sample_parameters(
-            self, inputs: TransformSamplingInput, sampling: SamplingContext
-        ) -> TransformParameterPlan:
-            ud = inputs.data.get("user_data")
-            return TransformParameterPlan.shared_only({"seen_user_data": ud is not None, "ud_value": ud})
+            self,
+            params: dict[str, Any],
+            data: dict[str, Any],
+            targets: TargetSet,
+            sampling: SamplingContext,
+        ) -> SampledParams:
+            ud = data.get("user_data")
+            return SampledParams.shared_only({"seen_user_data": ud is not None, "ud_value": ud})
 
         def apply_to_user_data(self, data: Any, **params: Any) -> Any:
             return {**data, "seen": params.get("seen_user_data", False)}
@@ -2928,9 +2932,15 @@ def test_applied_config_invalid_key_raises():
     """Transforms that set invalid applied_config keys must raise ValueError."""
 
     class BadTransform(A.NoOp):
-        def sample_parameters(self, inputs: TransformSamplingInput, sampling: SamplingContext):
+        def sample_parameters(
+            self,
+            params: dict[str, Any],
+            data: dict[str, Any],
+            targets: TargetSet,
+            sampling: SamplingContext,
+        ) -> SampledParams:
             sampling.applied_overrides["not_a_real_constructor_param_xyz"] = 42
-            return TransformParameterPlan.shared_only({})
+            return SampledParams.shared_only({})
 
     aug = BadTransform(p=1.0)
     with pytest.raises(ValueError, match="not_a_real_constructor_param_xyz"):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -124,7 +124,7 @@ def test_image_only_transform(image):
         with mock.patch.object(
             ImageOnlyTransform,
             "sample_parameters",
-            return_value=SampledParams.shared_only({"interpolation": cv2.INTER_LINEAR}),
+            return_value=SampledParams(params={"interpolation": cv2.INTER_LINEAR}),
         ):
             aug = ImageOnlyTransform(p=1)
             data = aug(image=image, mask=mask)
@@ -141,7 +141,7 @@ def test_dual_transform(image):
     mask = image.copy()
 
     with mock.patch.object(DualTransform, "apply") as mocked_apply:
-        with mock.patch.object(DualTransform, "sample_parameters", return_value=SampledParams.shared_only({})):
+        with mock.patch.object(DualTransform, "sample_parameters", return_value=SampledParams(params={})):
             aug = DualTransform(p=1)
             aug(image=image, mask=mask)
 
@@ -179,7 +179,7 @@ def test_additional_targets(image):
         with mock.patch.object(
             DualTransform,
             "sample_parameters",
-            return_value=SampledParams.shared_only({"interpolation": cv2.INTER_LINEAR}),
+            return_value=SampledParams(params={"interpolation": cv2.INTER_LINEAR}),
         ):
             aug = DualTransform(p=1)
             aug.add_targets({"image2": "image"})
@@ -1487,7 +1487,7 @@ def test_mask_interpolation_someof(interpolation, compose):
 
 
 @pytest.mark.parametrize(
-    ["transform", "expected_shared_keys"],
+    ["transform", "expected_params_keys"],
     [
         (A.HorizontalFlip(p=1), {"shape"}),
         (A.VerticalFlip(p=1), {"shape"}),
@@ -1512,13 +1512,13 @@ def test_mask_interpolation_someof(interpolation, compose):
         ),
     ],
 )
-def test_transform_returns_params(transform, expected_shared_keys):
+def test_transform_returns_params(transform, expected_params_keys):
     image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
     transform(image=image)
     params = transform.get_applied_params()
     assert isinstance(params, dict)
-    assert set(params) == {"parameter_schema", "target_schema", "shared", "groups"}
-    assert expected_shared_keys.issubset(params["shared"])
+    assert set(params) == {"parameter_schema", "target_schema", "params", "target_params"}
+    assert expected_params_keys.issubset(params["params"])
 
 
 @pytest.mark.parametrize(
@@ -2867,7 +2867,7 @@ def test_user_data_targets_as_params() -> None:
             sampling: SamplingContext,
         ) -> SampledParams:
             ud = data.get("user_data")
-            return SampledParams.shared_only({"seen_user_data": ud is not None, "ud_value": ud})
+            return SampledParams(params={"seen_user_data": ud is not None, "ud_value": ud})
 
         def apply_to_user_data(self, data: Any, **params: Any) -> Any:
             return {**data, "seen": params.get("seen_user_data", False)}
@@ -2940,7 +2940,7 @@ def test_applied_config_invalid_key_raises():
             sampling: SamplingContext,
         ) -> SampledParams:
             sampling.applied_overrides["not_a_real_constructor_param_xyz"] = 42
-            return SampledParams.shared_only({})
+            return SampledParams(params={})
 
     aug = BadTransform(p=1.0)
     with pytest.raises(ValueError, match="not_a_real_constructor_param_xyz"):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,7 @@ from albumentations.core.composition import (
     SomeOf,
 )
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from albumentations.core.transforms_interface import DualTransform, ImageOnlyTransform, NoOp
 from tests.conftest import (
     IMAGES,
@@ -123,7 +124,7 @@ def test_image_only_transform(image):
         with mock.patch.object(
             ImageOnlyTransform,
             "sample_parameters",
-            return_value={"interpolation": cv2.INTER_LINEAR},
+            return_value=TransformParameterPlan.shared_only({"interpolation": cv2.INTER_LINEAR}),
         ):
             aug = ImageOnlyTransform(p=1)
             data = aug(image=image, mask=mask)
@@ -140,7 +141,7 @@ def test_dual_transform(image):
     mask = image.copy()
 
     with mock.patch.object(DualTransform, "apply") as mocked_apply:
-        with mock.patch.object(DualTransform, "sample_parameters", return_value={}):
+        with mock.patch.object(DualTransform, "sample_parameters", return_value=TransformParameterPlan.shared_only({})):
             aug = DualTransform(p=1)
             aug(image=image, mask=mask)
 
@@ -178,7 +179,7 @@ def test_additional_targets(image):
         with mock.patch.object(
             DualTransform,
             "sample_parameters",
-            return_value={"interpolation": cv2.INTER_LINEAR},
+            return_value=TransformParameterPlan.shared_only({"interpolation": cv2.INTER_LINEAR}),
         ):
             aug = DualTransform(p=1)
             aug.add_targets({"image2": "image"})
@@ -1486,7 +1487,7 @@ def test_mask_interpolation_someof(interpolation, compose):
 
 
 @pytest.mark.parametrize(
-    ["transform", "expected_param_keys"],
+    ["transform", "expected_shared_keys"],
     [
         (A.HorizontalFlip(p=1), {"shape"}),
         (A.VerticalFlip(p=1), {"shape"}),
@@ -1511,12 +1512,13 @@ def test_mask_interpolation_someof(interpolation, compose):
         ),
     ],
 )
-def test_transform_returns_params(transform, expected_param_keys):
+def test_transform_returns_params(transform, expected_shared_keys):
     image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
     transform(image=image)
     params = transform.get_applied_params()
     assert isinstance(params, dict)
-    assert set(params.keys()) == expected_param_keys
+    assert set(params) == {"parameter_schema", "target_schema", "shared", "groups"}
+    assert expected_shared_keys.issubset(params["shared"])
 
 
 @pytest.mark.parametrize(
@@ -2857,9 +2859,11 @@ def test_user_data_targets_as_params() -> None:
     class UserDataAwareTransform(A.NoOp):
         targets_as_params = ("user_data",)
 
-        def sample_parameters(self, params: dict, data: dict, sampling: SamplingContext) -> dict:
-            ud = data.get("user_data")
-            return {"seen_user_data": ud is not None, "ud_value": ud}
+        def sample_parameters(
+            self, inputs: TransformSamplingInput, sampling: SamplingContext
+        ) -> TransformParameterPlan:
+            ud = inputs.data.get("user_data")
+            return TransformParameterPlan.shared_only({"seen_user_data": ud is not None, "ud_value": ud})
 
         def apply_to_user_data(self, data: Any, **params: Any) -> Any:
             return {**data, "seen": params.get("seen_user_data", False)}
@@ -2924,9 +2928,9 @@ def test_applied_config_invalid_key_raises():
     """Transforms that set invalid applied_config keys must raise ValueError."""
 
     class BadTransform(A.NoOp):
-        def sample_parameters(self, params, data, sampling: SamplingContext):
+        def sample_parameters(self, inputs: TransformSamplingInput, sampling: SamplingContext):
             sampling.applied_overrides["not_a_real_constructor_param_xyz"] = 42
-            return {}
+            return TransformParameterPlan.shared_only({})
 
     aug = BadTransform(p=1.0)
     with pytest.raises(ValueError, match="not_a_real_constructor_param_xyz"):

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -10,6 +10,7 @@ from albumentations.augmentations.crops.functional import crop_bboxes_by_coords
 from albumentations.core.invocation import SamplingContext
 
 from .conftest import IMAGES, RECTANGULAR_UINT8_IMAGE
+from .utils import make_sampling_input
 
 
 def test_random_crop_vs_crop(bboxes, keypoints):
@@ -456,7 +457,8 @@ def test_bbox_subset_safe_random_crop_selects_valid_subset_size():
     for seed in range(40):
         transform.set_random_seed(seed)
         sampling = SamplingContext.from_owner(transform, {})
-        result = transform.sample_parameters({"shape": (400, 400, 3)}, {"bboxes": bboxes}, sampling)
+        data = {"image": np.zeros((400, 400, 3), dtype=np.uint8), "bboxes": bboxes}
+        result = transform.sample_parameters(make_sampling_input(transform, data), sampling).shared
         selected = result["bbox_indices"]
 
         assert min_subset_size <= len(selected) <= max_subset_size
@@ -480,7 +482,8 @@ def test_bbox_subset_safe_random_crop_preserves_selected_boxes_without_erosion()
     for seed in range(40):
         transform.set_random_seed(seed)
         sampling = SamplingContext.from_owner(transform, {})
-        result = transform.sample_parameters({"shape": (*image_shape, 3)}, {"bboxes": bboxes}, sampling)
+        data = {"image": np.zeros((*image_shape, 3), dtype=np.uint8), "bboxes": bboxes}
+        result = transform.sample_parameters(make_sampling_input(transform, data), sampling).shared
         selected = result["bbox_indices"]
         crop_x_min, crop_y_min, crop_x_max, crop_y_max = result["crop_coords"]
 
@@ -508,9 +511,10 @@ def test_bbox_subset_safe_random_crop_enforces_feasible_aspect_ratio():
     for seed in range(20):
         transform.set_random_seed(seed)
         sampling = SamplingContext.from_owner(transform, {})
+        data = {"image": np.zeros((320, 640, 3), dtype=np.uint8), "bboxes": bboxes}
         crop_x_min, crop_y_min, crop_x_max, crop_y_max = transform.sample_parameters(
-            {"shape": (320, 640, 3)}, {"bboxes": bboxes}, sampling
-        )["crop_coords"]
+            make_sampling_input(transform, data), sampling
+        ).shared["crop_coords"]
         assert (crop_y_max - crop_y_min) / (crop_x_max - crop_x_min) == 0.2
 
 
@@ -522,9 +526,13 @@ def test_bbox_subset_safe_random_crop_applies_aspect_ratio_without_protected_box
         p=1.0,
     )
     sampling = SamplingContext.from_owner(transform, {})
+    data = {
+        "image": np.zeros((320, 640, 3), dtype=np.uint8),
+        "bboxes": np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32),
+    }
     crop_x_min, crop_y_min, crop_x_max, crop_y_max = transform.sample_parameters(
-        {"shape": (320, 640, 3)}, {"bboxes": np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32)}, sampling
-    )["crop_coords"]
+        make_sampling_input(transform, data), sampling
+    ).shared["crop_coords"]
 
     assert (crop_y_max - crop_y_min) / (crop_x_max - crop_x_min) == 0.2
 
@@ -536,8 +544,10 @@ def test_bbox_subset_safe_random_crop_returns_full_image_when_aspect_ratio_is_in
         p=1.0,
     )
     sampling = SamplingContext.from_owner(transform, {})
-    result = transform.sample_parameters(
-        {"shape": (100, 200, 3)}, {"bboxes": np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32)}, sampling
-    )
+    data = {
+        "image": np.zeros((100, 200, 3), dtype=np.uint8),
+        "bboxes": np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32),
+    }
+    result = transform.sample_parameters(make_sampling_input(transform, data), sampling).shared
 
     assert result == {"crop_coords": (0, 0, 200, 100), "bbox_indices": (0,)}

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -10,7 +10,7 @@ from albumentations.augmentations.crops.functional import crop_bboxes_by_coords
 from albumentations.core.invocation import SamplingContext
 
 from .conftest import IMAGES, RECTANGULAR_UINT8_IMAGE
-from .utils import make_sampling_input
+from .utils import make_sampling_args
 
 
 def test_random_crop_vs_crop(bboxes, keypoints):
@@ -458,7 +458,7 @@ def test_bbox_subset_safe_random_crop_selects_valid_subset_size():
         transform.set_random_seed(seed)
         sampling = SamplingContext.from_owner(transform, {})
         data = {"image": np.zeros((400, 400, 3), dtype=np.uint8), "bboxes": bboxes}
-        result = transform.sample_parameters(make_sampling_input(transform, data), sampling).shared
+        result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).shared
         selected = result["bbox_indices"]
 
         assert min_subset_size <= len(selected) <= max_subset_size
@@ -483,7 +483,7 @@ def test_bbox_subset_safe_random_crop_preserves_selected_boxes_without_erosion()
         transform.set_random_seed(seed)
         sampling = SamplingContext.from_owner(transform, {})
         data = {"image": np.zeros((*image_shape, 3), dtype=np.uint8), "bboxes": bboxes}
-        result = transform.sample_parameters(make_sampling_input(transform, data), sampling).shared
+        result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).shared
         selected = result["bbox_indices"]
         crop_x_min, crop_y_min, crop_x_max, crop_y_max = result["crop_coords"]
 
@@ -513,7 +513,7 @@ def test_bbox_subset_safe_random_crop_enforces_feasible_aspect_ratio():
         sampling = SamplingContext.from_owner(transform, {})
         data = {"image": np.zeros((320, 640, 3), dtype=np.uint8), "bboxes": bboxes}
         crop_x_min, crop_y_min, crop_x_max, crop_y_max = transform.sample_parameters(
-            make_sampling_input(transform, data), sampling
+            *make_sampling_args(transform, data), sampling
         ).shared["crop_coords"]
         assert (crop_y_max - crop_y_min) / (crop_x_max - crop_x_min) == 0.2
 
@@ -531,7 +531,7 @@ def test_bbox_subset_safe_random_crop_applies_aspect_ratio_without_protected_box
         "bboxes": np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32),
     }
     crop_x_min, crop_y_min, crop_x_max, crop_y_max = transform.sample_parameters(
-        make_sampling_input(transform, data), sampling
+        *make_sampling_args(transform, data), sampling
     ).shared["crop_coords"]
 
     assert (crop_y_max - crop_y_min) / (crop_x_max - crop_x_min) == 0.2
@@ -548,6 +548,6 @@ def test_bbox_subset_safe_random_crop_returns_full_image_when_aspect_ratio_is_in
         "image": np.zeros((100, 200, 3), dtype=np.uint8),
         "bboxes": np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32),
     }
-    result = transform.sample_parameters(make_sampling_input(transform, data), sampling).shared
+    result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).shared
 
     assert result == {"crop_coords": (0, 0, 200, 100), "bbox_indices": (0,)}

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -458,7 +458,7 @@ def test_bbox_subset_safe_random_crop_selects_valid_subset_size():
         transform.set_random_seed(seed)
         sampling = SamplingContext.from_owner(transform, {})
         data = {"image": np.zeros((400, 400, 3), dtype=np.uint8), "bboxes": bboxes}
-        result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).shared
+        result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).params
         selected = result["bbox_indices"]
 
         assert min_subset_size <= len(selected) <= max_subset_size
@@ -483,7 +483,7 @@ def test_bbox_subset_safe_random_crop_preserves_selected_boxes_without_erosion()
         transform.set_random_seed(seed)
         sampling = SamplingContext.from_owner(transform, {})
         data = {"image": np.zeros((*image_shape, 3), dtype=np.uint8), "bboxes": bboxes}
-        result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).shared
+        result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).params
         selected = result["bbox_indices"]
         crop_x_min, crop_y_min, crop_x_max, crop_y_max = result["crop_coords"]
 
@@ -514,7 +514,7 @@ def test_bbox_subset_safe_random_crop_enforces_feasible_aspect_ratio():
         data = {"image": np.zeros((320, 640, 3), dtype=np.uint8), "bboxes": bboxes}
         crop_x_min, crop_y_min, crop_x_max, crop_y_max = transform.sample_parameters(
             *make_sampling_args(transform, data), sampling
-        ).shared["crop_coords"]
+        ).params["crop_coords"]
         assert (crop_y_max - crop_y_min) / (crop_x_max - crop_x_min) == 0.2
 
 
@@ -532,7 +532,7 @@ def test_bbox_subset_safe_random_crop_applies_aspect_ratio_without_protected_box
     }
     crop_x_min, crop_y_min, crop_x_max, crop_y_max = transform.sample_parameters(
         *make_sampling_args(transform, data), sampling
-    ).shared["crop_coords"]
+    ).params["crop_coords"]
 
     assert (crop_y_max - crop_y_min) / (crop_x_max - crop_x_min) == 0.2
 
@@ -548,6 +548,6 @@ def test_bbox_subset_safe_random_crop_returns_full_image_when_aspect_ratio_is_in
         "image": np.zeros((100, 200, 3), dtype=np.uint8),
         "bboxes": np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float32),
     }
-    result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).shared
+    result = transform.sample_parameters(*make_sampling_args(transform, data), sampling).params
 
     assert result == {"crop_coords": (0, 0, 200, 100), "bbox_indices": (0,)}

--- a/tests/test_custom_transform_apply.py
+++ b/tests/test_custom_transform_apply.py
@@ -11,6 +11,7 @@ import pytest
 
 import albumentations as A
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Fixtures
@@ -51,11 +52,10 @@ class BrightnessWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        return {"factor": 0.5}
+    ) -> TransformParameterPlan:
+        return TransformParameterPlan.shared_only({"factor": 0.5})
 
     def apply(self, img: np.ndarray, factor: float = 1.0, **p) -> np.ndarray:
         return np.clip(img.astype(np.float32) * factor, 0, 255).astype(img.dtype)
@@ -82,11 +82,10 @@ class RotateWithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        return {"factor": 1}  # fixed for deterministic tests
+    ) -> TransformParameterPlan:
+        return TransformParameterPlan.shared_only({"factor": 1})
 
     def apply(self, img: np.ndarray, factor: int = 0, **p) -> np.ndarray:
         return np.rot90(img, factor)
@@ -103,11 +102,10 @@ class MultiTargetDual(A.CustomTransformsApplyMixin, A.DualTransform):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        return {"factor": 2}
+    ) -> TransformParameterPlan:
+        return TransformParameterPlan.shared_only({"factor": 2})
 
     def apply(self, img: np.ndarray, **p) -> np.ndarray:
         return img
@@ -127,11 +125,10 @@ class VolumeWithLabel(A.CustomTransformsApplyMixin, A.Transform3D):
 
     def sample_parameters(
         self,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        return {"factor": 1}
+    ) -> TransformParameterPlan:
+        return TransformParameterPlan.shared_only({"factor": 1})
 
     def apply(self, img: np.ndarray, **p) -> np.ndarray:
         return img
@@ -453,8 +450,8 @@ class TestParamsPassthrough:
         received = {}
 
         class _Capture(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def sample_parameters(self, params, data, sampling: SamplingContext):
-                return {"factor": 7}
+            def sample_parameters(self, inputs: TransformSamplingInput, sampling: SamplingContext):
+                return TransformParameterPlan.shared_only({"factor": 7})
 
             def apply(self, img, factor=0, **p):
                 received["apply_factor"] = factor
@@ -473,8 +470,8 @@ class TestParamsPassthrough:
         received = {}
 
         class _CaptureMulti(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def sample_parameters(self, params, data, sampling: SamplingContext):
-                return {"alpha": 3, "beta": 9}
+            def sample_parameters(self, inputs: TransformSamplingInput, sampling: SamplingContext):
+                return TransformParameterPlan.shared_only({"alpha": 3, "beta": 9})
 
             def apply(self, img, **p):
                 return img
@@ -586,12 +583,11 @@ class TestGetParamsDependentOnData:
 
             def sample_parameters(
                 self,
-                params: dict[str, Any],
-                data: dict[str, Any],
+                inputs: TransformSamplingInput,
                 sampling: SamplingContext,
-            ) -> dict[str, Any]:
-                label = data.get("label", 0)
-                return {"base": 10, "offset": label * 2}
+            ) -> TransformParameterPlan:
+                label = inputs.data.get("label", 0)
+                return TransformParameterPlan.shared_only({"base": 10, "offset": label * 2})
 
             def apply(self, img: np.ndarray, base: int = 0, offset: int = 0, **p) -> np.ndarray:
                 return img
@@ -610,11 +606,10 @@ class TestGetParamsDependentOnData:
 
             def sample_parameters(
                 self,
-                params: dict[str, Any],
-                data: dict[str, Any],
+                inputs: TransformSamplingInput,
                 sampling: SamplingContext,
-            ) -> dict[str, Any]:
-                return {}
+            ) -> TransformParameterPlan:
+                return TransformParameterPlan.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -636,11 +631,10 @@ class TestAddTargetsWithCustomKeys:
         class TransformWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                params: dict[str, Any],
-                data: dict[str, Any],
+                inputs: TransformSamplingInput,
                 sampling: SamplingContext,
-            ) -> dict[str, Any]:
-                return {}
+            ) -> TransformParameterPlan:
+                return TransformParameterPlan.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -661,11 +655,10 @@ class TestAddTargetsWithCustomKeys:
         class TransformWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                params: dict[str, Any],
-                data: dict[str, Any],
+                inputs: TransformSamplingInput,
                 sampling: SamplingContext,
-            ) -> dict[str, Any]:
-                return {}
+            ) -> TransformParameterPlan:
+                return TransformParameterPlan.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -749,11 +742,10 @@ class TestAvailableKeysAndComposition:
         class AddOne(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                params: dict[str, Any],
-                data: dict[str, Any],
+                inputs: TransformSamplingInput,
                 sampling: SamplingContext,
-            ) -> dict[str, Any]:
-                return {}
+            ) -> TransformParameterPlan:
+                return TransformParameterPlan.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -764,11 +756,10 @@ class TestAvailableKeysAndComposition:
         class MulTwo(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                params: dict[str, Any],
-                data: dict[str, Any],
+                inputs: TransformSamplingInput,
                 sampling: SamplingContext,
-            ) -> dict[str, Any]:
-                return {}
+            ) -> TransformParameterPlan:
+                return TransformParameterPlan.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -786,11 +777,10 @@ class TestAvailableKeysAndComposition:
         class BaseWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                params: dict[str, Any],
-                data: dict[str, Any],
+                inputs: TransformSamplingInput,
                 sampling: SamplingContext,
-            ) -> dict[str, Any]:
-                return {}
+            ) -> TransformParameterPlan:
+                return TransformParameterPlan.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img

--- a/tests/test_custom_transform_apply.py
+++ b/tests/test_custom_transform_apply.py
@@ -11,7 +11,7 @@ import pytest
 
 import albumentations as A
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Fixtures
@@ -52,10 +52,12 @@ class BrightnessWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        return TransformParameterPlan.shared_only({"factor": 0.5})
+    ) -> SampledParams:
+        return SampledParams.shared_only({"factor": 0.5})
 
     def apply(self, img: np.ndarray, factor: float = 1.0, **p) -> np.ndarray:
         return np.clip(img.astype(np.float32) * factor, 0, 255).astype(img.dtype)
@@ -82,10 +84,12 @@ class RotateWithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        return TransformParameterPlan.shared_only({"factor": 1})
+    ) -> SampledParams:
+        return SampledParams.shared_only({"factor": 1})
 
     def apply(self, img: np.ndarray, factor: int = 0, **p) -> np.ndarray:
         return np.rot90(img, factor)
@@ -102,10 +106,12 @@ class MultiTargetDual(A.CustomTransformsApplyMixin, A.DualTransform):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        return TransformParameterPlan.shared_only({"factor": 2})
+    ) -> SampledParams:
+        return SampledParams.shared_only({"factor": 2})
 
     def apply(self, img: np.ndarray, **p) -> np.ndarray:
         return img
@@ -125,10 +131,12 @@ class VolumeWithLabel(A.CustomTransformsApplyMixin, A.Transform3D):
 
     def sample_parameters(
         self,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> TransformParameterPlan:
-        return TransformParameterPlan.shared_only({"factor": 1})
+    ) -> SampledParams:
+        return SampledParams.shared_only({"factor": 1})
 
     def apply(self, img: np.ndarray, **p) -> np.ndarray:
         return img
@@ -450,8 +458,14 @@ class TestParamsPassthrough:
         received = {}
 
         class _Capture(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def sample_parameters(self, inputs: TransformSamplingInput, sampling: SamplingContext):
-                return TransformParameterPlan.shared_only({"factor": 7})
+            def sample_parameters(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
+                sampling: SamplingContext,
+            ) -> SampledParams:
+                return SampledParams.shared_only({"factor": 7})
 
             def apply(self, img, factor=0, **p):
                 received["apply_factor"] = factor
@@ -470,8 +484,14 @@ class TestParamsPassthrough:
         received = {}
 
         class _CaptureMulti(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
-            def sample_parameters(self, inputs: TransformSamplingInput, sampling: SamplingContext):
-                return TransformParameterPlan.shared_only({"alpha": 3, "beta": 9})
+            def sample_parameters(
+                self,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
+                sampling: SamplingContext,
+            ) -> SampledParams:
+                return SampledParams.shared_only({"alpha": 3, "beta": 9})
 
             def apply(self, img, **p):
                 return img
@@ -583,11 +603,13 @@ class TestGetParamsDependentOnData:
 
             def sample_parameters(
                 self,
-                inputs: TransformSamplingInput,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
                 sampling: SamplingContext,
-            ) -> TransformParameterPlan:
-                label = inputs.data.get("label", 0)
-                return TransformParameterPlan.shared_only({"base": 10, "offset": label * 2})
+            ) -> SampledParams:
+                label = data.get("label", 0)
+                return SampledParams.shared_only({"base": 10, "offset": label * 2})
 
             def apply(self, img: np.ndarray, base: int = 0, offset: int = 0, **p) -> np.ndarray:
                 return img
@@ -606,10 +628,12 @@ class TestGetParamsDependentOnData:
 
             def sample_parameters(
                 self,
-                inputs: TransformSamplingInput,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
                 sampling: SamplingContext,
-            ) -> TransformParameterPlan:
-                return TransformParameterPlan.shared_only({})
+            ) -> SampledParams:
+                return SampledParams.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -631,10 +655,12 @@ class TestAddTargetsWithCustomKeys:
         class TransformWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                inputs: TransformSamplingInput,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
                 sampling: SamplingContext,
-            ) -> TransformParameterPlan:
-                return TransformParameterPlan.shared_only({})
+            ) -> SampledParams:
+                return SampledParams.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -655,10 +681,12 @@ class TestAddTargetsWithCustomKeys:
         class TransformWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                inputs: TransformSamplingInput,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
                 sampling: SamplingContext,
-            ) -> TransformParameterPlan:
-                return TransformParameterPlan.shared_only({})
+            ) -> SampledParams:
+                return SampledParams.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -742,10 +770,12 @@ class TestAvailableKeysAndComposition:
         class AddOne(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                inputs: TransformSamplingInput,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
                 sampling: SamplingContext,
-            ) -> TransformParameterPlan:
-                return TransformParameterPlan.shared_only({})
+            ) -> SampledParams:
+                return SampledParams.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -756,10 +786,12 @@ class TestAvailableKeysAndComposition:
         class MulTwo(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                inputs: TransformSamplingInput,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
                 sampling: SamplingContext,
-            ) -> TransformParameterPlan:
-                return TransformParameterPlan.shared_only({})
+            ) -> SampledParams:
+                return SampledParams.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -777,10 +809,12 @@ class TestAvailableKeysAndComposition:
         class BaseWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
             def sample_parameters(
                 self,
-                inputs: TransformSamplingInput,
+                params: dict[str, Any],
+                data: dict[str, Any],
+                targets: TargetSet,
                 sampling: SamplingContext,
-            ) -> TransformParameterPlan:
-                return TransformParameterPlan.shared_only({})
+            ) -> SampledParams:
+                return SampledParams.shared_only({})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img

--- a/tests/test_custom_transform_apply.py
+++ b/tests/test_custom_transform_apply.py
@@ -57,7 +57,7 @@ class BrightnessWithLabel(A.CustomTransformsApplyMixin, A.ImageOnlyTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        return SampledParams.shared_only({"factor": 0.5})
+        return SampledParams(params={"factor": 0.5})
 
     def apply(self, img: np.ndarray, factor: float = 1.0, **p) -> np.ndarray:
         return np.clip(img.astype(np.float32) * factor, 0, 255).astype(img.dtype)
@@ -89,7 +89,7 @@ class RotateWithLabel(A.CustomTransformsApplyMixin, A.DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        return SampledParams.shared_only({"factor": 1})
+        return SampledParams(params={"factor": 1})
 
     def apply(self, img: np.ndarray, factor: int = 0, **p) -> np.ndarray:
         return np.rot90(img, factor)
@@ -111,7 +111,7 @@ class MultiTargetDual(A.CustomTransformsApplyMixin, A.DualTransform):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        return SampledParams.shared_only({"factor": 2})
+        return SampledParams(params={"factor": 2})
 
     def apply(self, img: np.ndarray, **p) -> np.ndarray:
         return img
@@ -136,7 +136,7 @@ class VolumeWithLabel(A.CustomTransformsApplyMixin, A.Transform3D):
         targets: TargetSet,
         sampling: SamplingContext,
     ) -> SampledParams:
-        return SampledParams.shared_only({"factor": 1})
+        return SampledParams(params={"factor": 1})
 
     def apply(self, img: np.ndarray, **p) -> np.ndarray:
         return img
@@ -465,7 +465,7 @@ class TestParamsPassthrough:
                 targets: TargetSet,
                 sampling: SamplingContext,
             ) -> SampledParams:
-                return SampledParams.shared_only({"factor": 7})
+                return SampledParams(params={"factor": 7})
 
             def apply(self, img, factor=0, **p):
                 received["apply_factor"] = factor
@@ -491,7 +491,7 @@ class TestParamsPassthrough:
                 targets: TargetSet,
                 sampling: SamplingContext,
             ) -> SampledParams:
-                return SampledParams.shared_only({"alpha": 3, "beta": 9})
+                return SampledParams(params={"alpha": 3, "beta": 9})
 
             def apply(self, img, **p):
                 return img
@@ -609,7 +609,7 @@ class TestGetParamsDependentOnData:
                 sampling: SamplingContext,
             ) -> SampledParams:
                 label = data.get("label", 0)
-                return SampledParams.shared_only({"base": 10, "offset": label * 2})
+                return SampledParams(params={"base": 10, "offset": label * 2})
 
             def apply(self, img: np.ndarray, base: int = 0, offset: int = 0, **p) -> np.ndarray:
                 return img
@@ -633,7 +633,7 @@ class TestGetParamsDependentOnData:
                 targets: TargetSet,
                 sampling: SamplingContext,
             ) -> SampledParams:
-                return SampledParams.shared_only({})
+                return SampledParams(params={})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -660,7 +660,7 @@ class TestAddTargetsWithCustomKeys:
                 targets: TargetSet,
                 sampling: SamplingContext,
             ) -> SampledParams:
-                return SampledParams.shared_only({})
+                return SampledParams(params={})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -686,7 +686,7 @@ class TestAddTargetsWithCustomKeys:
                 targets: TargetSet,
                 sampling: SamplingContext,
             ) -> SampledParams:
-                return SampledParams.shared_only({})
+                return SampledParams(params={})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -775,7 +775,7 @@ class TestAvailableKeysAndComposition:
                 targets: TargetSet,
                 sampling: SamplingContext,
             ) -> SampledParams:
-                return SampledParams.shared_only({})
+                return SampledParams(params={})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -791,7 +791,7 @@ class TestAvailableKeysAndComposition:
                 targets: TargetSet,
                 sampling: SamplingContext,
             ) -> SampledParams:
-                return SampledParams.shared_only({})
+                return SampledParams(params={})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img
@@ -814,7 +814,7 @@ class TestAvailableKeysAndComposition:
                 targets: TargetSet,
                 sampling: SamplingContext,
             ) -> SampledParams:
-                return SampledParams.shared_only({})
+                return SampledParams(params={})
 
             def apply(self, img: np.ndarray, **p) -> np.ndarray:
                 return img

--- a/tests/test_distortion_map_resolution.py
+++ b/tests/test_distortion_map_resolution.py
@@ -6,7 +6,7 @@ import pytest
 import albumentations as A
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.core.invocation import SamplingContext
-from tests.utils import make_sampling_input
+from tests.utils import make_sampling_args
 
 DISTORTION_TRANSFORMS = [
     pytest.param(A.GridDistortion, {"num_steps": 5, "distort_range": (-0.2, 0.2)}, id="GridDistortion"),
@@ -60,7 +60,7 @@ def test_low_map_resolution_returns_full_size_maps(transform_cls, params):
     transform.set_random_seed(137)
 
     result = transform.sample_parameters(
-        make_sampling_input(transform, {"image": image}),
+        *make_sampling_args(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
     ).shared
 
@@ -78,7 +78,7 @@ def test_low_map_resolution_returns_full_size_maps_for_tiny_images(transform_cls
     transform.set_random_seed(137)
 
     result = transform.sample_parameters(
-        make_sampling_input(transform, {"image": image}),
+        *make_sampling_args(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
     ).shared
 

--- a/tests/test_distortion_map_resolution.py
+++ b/tests/test_distortion_map_resolution.py
@@ -6,6 +6,7 @@ import pytest
 import albumentations as A
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.core.invocation import SamplingContext
+from tests.utils import make_sampling_input
 
 DISTORTION_TRANSFORMS = [
     pytest.param(A.GridDistortion, {"num_steps": 5, "distort_range": (-0.2, 0.2)}, id="GridDistortion"),
@@ -59,10 +60,9 @@ def test_low_map_resolution_returns_full_size_maps(transform_cls, params):
     transform.set_random_seed(137)
 
     result = transform.sample_parameters(
-        {"shape": image.shape},
-        {"image": image},
+        make_sampling_input(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
-    )
+    ).shared
 
     assert result["map_x"].shape == image.shape[:2]
     assert result["map_y"].shape == image.shape[:2]
@@ -78,10 +78,9 @@ def test_low_map_resolution_returns_full_size_maps_for_tiny_images(transform_cls
     transform.set_random_seed(137)
 
     result = transform.sample_parameters(
-        {"shape": image.shape},
-        {"image": image},
+        make_sampling_input(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
-    )
+    ).shared
 
     assert result["map_x"].shape == image.shape[:2]
     assert result["map_y"].shape == image.shape[:2]

--- a/tests/test_distortion_map_resolution.py
+++ b/tests/test_distortion_map_resolution.py
@@ -62,7 +62,7 @@ def test_low_map_resolution_returns_full_size_maps(transform_cls, params):
     result = transform.sample_parameters(
         *make_sampling_args(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
-    ).shared
+    ).params
 
     assert result["map_x"].shape == image.shape[:2]
     assert result["map_y"].shape == image.shape[:2]
@@ -80,7 +80,7 @@ def test_low_map_resolution_returns_full_size_maps_for_tiny_images(transform_cls
     result = transform.sample_parameters(
         *make_sampling_args(transform, {"image": image}),
         SamplingContext.from_owner(transform, {}),
-    ).shared
+    ).params
 
     assert result["map_x"].shape == image.shape[:2]
     assert result["map_y"].shape == image.shape[:2]

--- a/tests/test_domain_adaptation.py
+++ b/tests/test_domain_adaptation.py
@@ -551,6 +551,32 @@ def test_fda_transform_5plus_channels(num_channels):
     assert result.dtype == image.dtype
 
 
+def test_fda_materializes_reference_images_for_unaligned_aliases():
+    rng = np.random.default_rng(137)
+    image = rng.integers(0, 256, (17, 23, 3), dtype=np.uint8)
+    image2 = rng.integers(0, 256, (29, 31, 3), dtype=np.uint8)
+    reference = rng.integers(0, 256, (11, 13, 3), dtype=np.uint8)
+    transform = A.FDA(beta_range=(0.05, 0.05), p=1.0)
+    transform.add_targets({"image2": "image"})
+
+    result = transform(image=image, image2=image2, fda_metadata=[reference])
+
+    assert result["image"].shape == image.shape
+    assert result["image2"].shape == image2.shape
+
+
+def test_fda_rejects_aliases_with_channels_incompatible_with_reference():
+    rng = np.random.default_rng(137)
+    image = rng.integers(0, 256, (17, 23, 3), dtype=np.uint8)
+    image2 = rng.integers(0, 256, (17, 23, 5), dtype=np.uint8)
+    reference = rng.integers(0, 256, (11, 13, 3), dtype=np.uint8)
+    transform = A.FDA(beta_range=(0.05, 0.05), p=1.0)
+    transform.add_targets({"image2": "image"})
+
+    with pytest.raises(ValueError, match="reference image has 3 channels; target 'image2' has 5"):
+        transform(image=image, image2=image2, fda_metadata=[reference])
+
+
 @pytest.mark.parametrize("num_channels", [5, 6])
 @pytest.mark.parametrize("transform_type", ["pca", "standard", "minmax"])
 def test_pixel_distribution_adaptation_transform_5plus_channels(num_channels, transform_type):

--- a/tests/test_elastic_transform.py
+++ b/tests/test_elastic_transform.py
@@ -128,7 +128,7 @@ def test_sampled_control_coefficients_are_bounded_and_replayable() -> None:
         seed=137,
     )
     result = transform(image=image)
-    params = result["replay"]["transforms"][0]["params"]["shared"]
+    params = result["replay"]["transforms"][0]["params"]["params"]
     coefficients = np.asarray(params["control_coefficients"], dtype=np.float32)
     radius = 0.05 * min(image.shape[0] - 1, image.shape[1] - 1)
 
@@ -258,7 +258,7 @@ def test_zero_spatial_extent_does_not_sample_coefficients() -> None:
     params = transform.sample_parameters(
         *make_sampling_args(transform, data),
         SamplingContext.from_owner(transform, {}),
-    ).shared
+    ).params
 
     assert params["control_coefficients"] == []
 

--- a/tests/test_elastic_transform.py
+++ b/tests/test_elastic_transform.py
@@ -10,7 +10,7 @@ import pytest
 import albumentations as A
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.core.invocation import SamplingContext
-from tests.utils import make_sampling_input
+from tests.utils import make_sampling_args
 
 
 class _LabelMappingElasticTransform(A.ElasticTransform):
@@ -256,7 +256,7 @@ def test_zero_spatial_extent_does_not_sample_coefficients() -> None:
 
     data = {"image": np.empty((0, 10, 3), dtype=np.float32)}
     params = transform.sample_parameters(
-        make_sampling_input(transform, data),
+        *make_sampling_args(transform, data),
         SamplingContext.from_owner(transform, {}),
     ).shared
 

--- a/tests/test_elastic_transform.py
+++ b/tests/test_elastic_transform.py
@@ -10,6 +10,7 @@ import pytest
 import albumentations as A
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.core.invocation import SamplingContext
+from tests.utils import make_sampling_input
 
 
 class _LabelMappingElasticTransform(A.ElasticTransform):
@@ -127,7 +128,7 @@ def test_sampled_control_coefficients_are_bounded_and_replayable() -> None:
         seed=137,
     )
     result = transform(image=image)
-    params = result["replay"]["transforms"][0]["params"]
+    params = result["replay"]["transforms"][0]["params"]["shared"]
     coefficients = np.asarray(params["control_coefficients"], dtype=np.float32)
     radius = 0.05 * min(image.shape[0] - 1, image.shape[1] - 1)
 
@@ -253,11 +254,11 @@ def test_keypoint_inverse_marks_divergent_iterations_invalid() -> None:
 def test_zero_spatial_extent_does_not_sample_coefficients() -> None:
     transform = A.ElasticTransform(displacement_range=(0.01, 0.01), p=1.0)
 
+    data = {"image": np.empty((0, 10, 3), dtype=np.float32)}
     params = transform.sample_parameters(
-        {"shape": (0, 10, 3)},
-        {},
+        make_sampling_input(transform, data),
         SamplingContext.from_owner(transform, {}),
-    )
+    ).shared
 
     assert params["control_coefficients"] == []
 

--- a/tests/test_exposure_matching.py
+++ b/tests/test_exposure_matching.py
@@ -178,12 +178,12 @@ def test_exposure_matching_records_sampled_target_and_gains_for_replay() -> None
     applied_transforms = json.loads(json.dumps(result["applied_transforms"], allow_nan=False))
     _, applied_config = applied_transforms[0]
 
-    assert 0.3 <= params.shared["target_mean"] <= 0.5
+    assert 0.3 <= params.params["target_mean"] <= 0.5
     np.testing.assert_allclose(
         params.params_for("images")["gain"],
-        [params.shared["target_mean"] / 0.2, params.shared["target_mean"] / 0.8],
+        [params.params["target_mean"] / 0.2, params.params["target_mean"] / 0.8],
     )
-    assert applied_config["target_mean_range"] == params.shared["target_mean"]
+    assert applied_config["target_mean_range"] == params.params["target_mean"]
     assert applied_config["gain_range"] == [0.25, 3.0]
 
     replay = A.Compose.from_applied_transforms(applied_transforms)
@@ -206,7 +206,7 @@ def test_exposure_matching_replay_compose_reuses_applied_gains(target: str) -> N
     replay_params = SampledParams.from_dict(result["replay"]["transforms"][0]["params"])
     replayed = A.ReplayCompose.replay(result["replay"], **{target: data})
 
-    assert 0.3 <= replay_params.shared["target_mean"] <= 0.5
+    assert 0.3 <= replay_params.params["target_mean"] <= 0.5
     assert len(replay_params.params_for(target)["gain"]) == len(data)
     np.testing.assert_array_equal(replayed[target], result[target])
 

--- a/tests/test_exposure_matching.py
+++ b/tests/test_exposure_matching.py
@@ -5,6 +5,9 @@ import pytest
 
 import albumentations as A
 from albumentations.augmentations.pixel import functional as fpixel
+from albumentations.core.transform_params import TransformParameterPlan
+
+from .utils import get_resolved_applied_params
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
@@ -65,7 +68,7 @@ def test_exposure_matching_handles_zero_and_near_zero_means(
     result = transform(image=image)["image"]
 
     np.testing.assert_allclose(result, expected_value, rtol=1e-6, atol=1e-12)
-    np.testing.assert_allclose(transform.get_applied_params()["gain"], expected_gain, rtol=1e-6)
+    np.testing.assert_allclose(get_resolved_applied_params(transform)["gain"], expected_gain, rtol=1e-6)
 
 
 def test_exposure_matching_clips_saturated_pixels_without_compensation() -> None:
@@ -98,7 +101,7 @@ def test_exposure_matching_clips_derived_gain(
     result = transform(image=image)["image"]
 
     np.testing.assert_allclose(result, expected_value, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(transform.get_applied_params()["gain"], expected_gain)
+    np.testing.assert_allclose(get_resolved_applied_params(transform)["gain"], expected_gain)
 
 
 @pytest.mark.parametrize("target", ["images", "volume"])
@@ -115,8 +118,7 @@ def test_exposure_matching_derives_one_gain_per_image_or_slice(
 
     expected_value = 102 if dtype == np.uint8 else 0.4
     np.testing.assert_allclose(result, expected_value, rtol=0, atol=1e-6)
-    gains_key = "image_gains" if target == "images" else "volume_gains"
-    np.testing.assert_allclose(transform.get_applied_params()[gains_key], [2.0, 1.0, 0.5])
+    np.testing.assert_allclose(get_resolved_applied_params(transform, target)["gain"], [2.0, 1.0, 0.5])
 
 
 def test_exposure_matching_keeps_gains_separate_for_simultaneous_target_routes() -> None:
@@ -126,13 +128,13 @@ def test_exposure_matching_keeps_gains_separate_for_simultaneous_target_routes()
     transform = A.ExposureMatching(target_mean_range=(0.4, 0.4), p=1.0)
 
     result = transform(image=image, images=images, volume=volume)
-    params = transform.get_applied_params()
+    params = TransformParameterPlan.from_dict(transform.get_applied_params())
 
     for target in ("image", "images", "volume"):
         np.testing.assert_allclose(result[target], 0.4, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(params["gain"], 2.0)
-    np.testing.assert_allclose(params["image_gains"], [2.0, 1.0])
-    np.testing.assert_allclose(params["volume_gains"], [2.0, 0.5, 1.0])
+    np.testing.assert_allclose(params.params_for("image")["gain"], 2.0)
+    np.testing.assert_allclose(params.params_for("images")["gain"], [2.0, 1.0])
+    np.testing.assert_allclose(params.params_for("volume")["gain"], [2.0, 0.5, 1.0])
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
@@ -172,16 +174,16 @@ def test_exposure_matching_records_sampled_target_and_gains_for_replay() -> None
     pipeline = A.Compose([transform], save_applied_params=True, seed=137)
 
     result = pipeline(images=images)
-    params = transform.get_applied_params()
+    params = TransformParameterPlan.from_dict(transform.get_applied_params())
     applied_transforms = json.loads(json.dumps(result["applied_transforms"], allow_nan=False))
     _, applied_config = applied_transforms[0]
 
-    assert 0.3 <= params["target_mean"] <= 0.5
+    assert 0.3 <= params.shared["target_mean"] <= 0.5
     np.testing.assert_allclose(
-        params["image_gains"],
-        [params["target_mean"] / 0.2, params["target_mean"] / 0.8],
+        params.params_for("images")["gain"],
+        [params.shared["target_mean"] / 0.2, params.shared["target_mean"] / 0.8],
     )
-    assert applied_config["target_mean_range"] == params["target_mean"]
+    assert applied_config["target_mean_range"] == params.shared["target_mean"]
     assert applied_config["gain_range"] == [0.25, 3.0]
 
     replay = A.Compose.from_applied_transforms(applied_transforms)
@@ -189,11 +191,8 @@ def test_exposure_matching_records_sampled_target_and_gains_for_replay() -> None
     np.testing.assert_array_equal(replayed["images"], result["images"])
 
 
-@pytest.mark.parametrize(
-    ("target", "gains_key"),
-    [("images", "image_gains"), ("volume", "volume_gains")],
-)
-def test_exposure_matching_replay_compose_reuses_applied_gains(target: str, gains_key: str) -> None:
+@pytest.mark.parametrize("target", ["images", "volume"])
+def test_exposure_matching_replay_compose_reuses_applied_gains(target: str) -> None:
     images = np.stack(
         [
             np.full((4, 6, 3), 0.2, dtype=np.float32),
@@ -204,11 +203,11 @@ def test_exposure_matching_replay_compose_reuses_applied_gains(target: str, gain
     pipeline = A.ReplayCompose([A.ExposureMatching(target_mean_range=(0.3, 0.5), p=1.0)], seed=137)
 
     result = pipeline(**{target: data})
-    replay_params = result["replay"]["transforms"][0]["params"]
+    replay_params = TransformParameterPlan.from_dict(result["replay"]["transforms"][0]["params"])
     replayed = A.ReplayCompose.replay(result["replay"], **{target: data})
 
-    assert 0.3 <= replay_params["target_mean"] <= 0.5
-    assert len(replay_params[gains_key]) == len(data)
+    assert 0.3 <= replay_params.shared["target_mean"] <= 0.5
+    assert len(replay_params.params_for(target)["gain"]) == len(data)
     np.testing.assert_array_equal(replayed[target], result[target])
 
 

--- a/tests/test_exposure_matching.py
+++ b/tests/test_exposure_matching.py
@@ -5,7 +5,7 @@ import pytest
 
 import albumentations as A
 from albumentations.augmentations.pixel import functional as fpixel
-from albumentations.core.transform_params import TransformParameterPlan
+from albumentations.core.transform_params import SampledParams
 
 from .utils import get_resolved_applied_params
 
@@ -128,7 +128,7 @@ def test_exposure_matching_keeps_gains_separate_for_simultaneous_target_routes()
     transform = A.ExposureMatching(target_mean_range=(0.4, 0.4), p=1.0)
 
     result = transform(image=image, images=images, volume=volume)
-    params = TransformParameterPlan.from_dict(transform.get_applied_params())
+    params = SampledParams.from_dict(transform.get_applied_params())
 
     for target in ("image", "images", "volume"):
         np.testing.assert_allclose(result[target], 0.4, rtol=0, atol=1e-6)
@@ -174,7 +174,7 @@ def test_exposure_matching_records_sampled_target_and_gains_for_replay() -> None
     pipeline = A.Compose([transform], save_applied_params=True, seed=137)
 
     result = pipeline(images=images)
-    params = TransformParameterPlan.from_dict(transform.get_applied_params())
+    params = SampledParams.from_dict(transform.get_applied_params())
     applied_transforms = json.loads(json.dumps(result["applied_transforms"], allow_nan=False))
     _, applied_config = applied_transforms[0]
 
@@ -203,7 +203,7 @@ def test_exposure_matching_replay_compose_reuses_applied_gains(target: str) -> N
     pipeline = A.ReplayCompose([A.ExposureMatching(target_mean_range=(0.3, 0.5), p=1.0)], seed=137)
 
     result = pipeline(**{target: data})
-    replay_params = TransformParameterPlan.from_dict(result["replay"]["transforms"][0]["params"])
+    replay_params = SampledParams.from_dict(result["replay"]["transforms"][0]["params"])
     replayed = A.ReplayCompose.replay(result["replay"], **{target: data})
 
     assert 0.3 <= replay_params.shared["target_mean"] <= 0.5

--- a/tests/test_hestain.py
+++ b/tests/test_hestain.py
@@ -5,6 +5,7 @@ import pytest
 
 import albumentations as A
 from albumentations.augmentations.pixel import functional as fpixel
+from albumentations.core.transform_params import TransformParameterPlan
 from tests.helpers import TestDataFactory
 
 CUSTOM_STAIN_MATRIX = np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32)
@@ -76,7 +77,7 @@ def test_hestain_augment_residual_matches_full_basis_reference(dtype: type[np.ge
     )
 
     result = transform(image=image)["image"]
-    params = transform.get_applied_params()
+    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
 
     assert params["scale_factors"].shape == (3,)
     assert params["shift_values"].shape == (3,)
@@ -103,7 +104,7 @@ def test_hestain_preserve_residual_reconstructs_identity() -> None:
     )
 
     result = transform(image=image)["image"]
-    params = transform.get_applied_params()
+    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
 
     np.testing.assert_array_equal(params["scale_factors"], np.array([1.0, 1.0, 1.0]))
     np.testing.assert_array_equal(params["shift_values"], np.array([0.0, 0.0, 0.0]))
@@ -115,7 +116,7 @@ def test_hestain_default_project_mode_does_not_consume_a_root_probability_draw()
     transform = A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, p=1.0)
 
     result = A.Compose([transform], save_applied_params=True, seed=137, strict=True)(image=image)["image"]
-    params = transform.get_applied_params()
+    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
     explicit_project = A.Compose(
         [A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, residual_mode="project", p=1.0)],
         seed=137,
@@ -223,7 +224,7 @@ def test_hestain_project_mode_stays_within_accepted_legacy_tolerance(
     )
 
     result = transform(image=data)["image"]
-    params = transform.get_applied_params()
+    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
     expected = _apply_he_project_legacy_reference(
         data,
         CUSTOM_STAIN_MATRIX,
@@ -263,7 +264,7 @@ def test_hestain_augment_residual_replay_reuses_all_sampled_parameters(
     )
 
     result = pipeline(**{target: data})
-    replay_params = result["replay"]["transforms"][0]["params"]
+    replay_params = TransformParameterPlan.from_dict(result["replay"]["transforms"][0]["params"]).shared
     replayed = A.ReplayCompose.replay(result["replay"], **{target: data})
 
     assert len(replay_params["scale_factors"]) == 3
@@ -312,7 +313,8 @@ def test_hestain_uses_custom_stain_matrix() -> None:
 
     result = transform(image=image)
 
-    np.testing.assert_array_equal(transform.get_applied_params()["stain_matrix"], CUSTOM_STAIN_MATRIX)
+    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
+    np.testing.assert_array_equal(params["stain_matrix"], CUSTOM_STAIN_MATRIX)
     expected = fpixel.apply_he_stain_augmentation(
         img=image,
         stain_matrix=CUSTOM_STAIN_MATRIX,

--- a/tests/test_hestain.py
+++ b/tests/test_hestain.py
@@ -5,7 +5,7 @@ import pytest
 
 import albumentations as A
 from albumentations.augmentations.pixel import functional as fpixel
-from albumentations.core.transform_params import TransformParameterPlan
+from albumentations.core.transform_params import SampledParams
 from tests.helpers import TestDataFactory
 
 CUSTOM_STAIN_MATRIX = np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32)
@@ -77,7 +77,7 @@ def test_hestain_augment_residual_matches_full_basis_reference(dtype: type[np.ge
     )
 
     result = transform(image=image)["image"]
-    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).shared
 
     assert params["scale_factors"].shape == (3,)
     assert params["shift_values"].shape == (3,)
@@ -104,7 +104,7 @@ def test_hestain_preserve_residual_reconstructs_identity() -> None:
     )
 
     result = transform(image=image)["image"]
-    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).shared
 
     np.testing.assert_array_equal(params["scale_factors"], np.array([1.0, 1.0, 1.0]))
     np.testing.assert_array_equal(params["shift_values"], np.array([0.0, 0.0, 0.0]))
@@ -116,7 +116,7 @@ def test_hestain_default_project_mode_does_not_consume_a_root_probability_draw()
     transform = A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, p=1.0)
 
     result = A.Compose([transform], save_applied_params=True, seed=137, strict=True)(image=image)["image"]
-    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).shared
     explicit_project = A.Compose(
         [A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, residual_mode="project", p=1.0)],
         seed=137,
@@ -224,7 +224,7 @@ def test_hestain_project_mode_stays_within_accepted_legacy_tolerance(
     )
 
     result = transform(image=data)["image"]
-    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).shared
     expected = _apply_he_project_legacy_reference(
         data,
         CUSTOM_STAIN_MATRIX,
@@ -264,7 +264,7 @@ def test_hestain_augment_residual_replay_reuses_all_sampled_parameters(
     )
 
     result = pipeline(**{target: data})
-    replay_params = TransformParameterPlan.from_dict(result["replay"]["transforms"][0]["params"]).shared
+    replay_params = SampledParams.from_dict(result["replay"]["transforms"][0]["params"]).shared
     replayed = A.ReplayCompose.replay(result["replay"], **{target: data})
 
     assert len(replay_params["scale_factors"]) == 3
@@ -313,7 +313,7 @@ def test_hestain_uses_custom_stain_matrix() -> None:
 
     result = transform(image=image)
 
-    params = TransformParameterPlan.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).shared
     np.testing.assert_array_equal(params["stain_matrix"], CUSTOM_STAIN_MATRIX)
     expected = fpixel.apply_he_stain_augmentation(
         img=image,

--- a/tests/test_hestain.py
+++ b/tests/test_hestain.py
@@ -77,7 +77,7 @@ def test_hestain_augment_residual_matches_full_basis_reference(dtype: type[np.ge
     )
 
     result = transform(image=image)["image"]
-    params = SampledParams.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).params
 
     assert params["scale_factors"].shape == (3,)
     assert params["shift_values"].shape == (3,)
@@ -104,7 +104,7 @@ def test_hestain_preserve_residual_reconstructs_identity() -> None:
     )
 
     result = transform(image=image)["image"]
-    params = SampledParams.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).params
 
     np.testing.assert_array_equal(params["scale_factors"], np.array([1.0, 1.0, 1.0]))
     np.testing.assert_array_equal(params["shift_values"], np.array([0.0, 0.0, 0.0]))
@@ -116,7 +116,7 @@ def test_hestain_default_project_mode_does_not_consume_a_root_probability_draw()
     transform = A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, p=1.0)
 
     result = A.Compose([transform], save_applied_params=True, seed=137, strict=True)(image=image)["image"]
-    params = SampledParams.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).params
     explicit_project = A.Compose(
         [A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, residual_mode="project", p=1.0)],
         seed=137,
@@ -224,7 +224,7 @@ def test_hestain_project_mode_stays_within_accepted_legacy_tolerance(
     )
 
     result = transform(image=data)["image"]
-    params = SampledParams.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).params
     expected = _apply_he_project_legacy_reference(
         data,
         CUSTOM_STAIN_MATRIX,
@@ -264,7 +264,7 @@ def test_hestain_augment_residual_replay_reuses_all_sampled_parameters(
     )
 
     result = pipeline(**{target: data})
-    replay_params = SampledParams.from_dict(result["replay"]["transforms"][0]["params"]).shared
+    replay_params = SampledParams.from_dict(result["replay"]["transforms"][0]["params"]).params
     replayed = A.ReplayCompose.replay(result["replay"], **{target: data})
 
     assert len(replay_params["scale_factors"]) == 3
@@ -313,7 +313,7 @@ def test_hestain_uses_custom_stain_matrix() -> None:
 
     result = transform(image=image)
 
-    params = SampledParams.from_dict(transform.get_applied_params()).shared
+    params = SampledParams.from_dict(transform.get_applied_params()).params
     np.testing.assert_array_equal(params["stain_matrix"], CUSTOM_STAIN_MATRIX)
     expected = fpixel.apply_he_stain_augmentation(
         img=image,

--- a/tests/test_sampled_params.py
+++ b/tests/test_sampled_params.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import torch
 
 import albumentations as A
 from albumentations.core.transform_params import (
@@ -11,7 +12,7 @@ from albumentations.core.transform_params import (
 )
 
 
-def test_multiplicative_noise_groups_channel_vectors_by_actual_target_representation() -> None:
+def test_multiplicative_noise_shares_a_scalar_across_target_representations() -> None:
     image = np.ones((6, 7, 3), dtype=np.float32)
     volume = np.ones((2, 6, 7, 5), dtype=np.float32)
     transform = A.MultiplicativeNoise(multiplier=(0.5, 0.5), p=1.0)
@@ -19,11 +20,29 @@ def test_multiplicative_noise_groups_channel_vectors_by_actual_target_representa
     result = transform(image=image, volume=volume)
     sampled_params = SampledParams.from_dict(transform.get_applied_params())
 
-    assert {tuple(target_params.targets) for target_params in sampled_params.target_params} == {("image",), ("volume",)}
+    assert sampled_params.target_params == ()
+    assert sampled_params.params["multiplier"] == 0.5
     assert result["image"].shape == image.shape
     assert result["volume"].shape == volume.shape
     np.testing.assert_allclose(result["image"], 0.5)
     np.testing.assert_allclose(result["volume"], 0.5)
+
+
+def test_multiplicative_noise_elementwise_shared_channels_share_one_map() -> None:
+    image = np.ones((6, 7, 3), dtype=np.float32)
+    image2 = np.ones((6, 7, 5), dtype=np.float32)
+    transform = A.MultiplicativeNoise(elementwise=True, per_channel=False, p=1.0)
+    transform.add_targets({"image2": "image"})
+
+    result = transform(image=image, image2=image2)
+    sampled_params = SampledParams.from_dict(transform.get_applied_params())
+
+    assert [target_params.targets for target_params in sampled_params.target_params] == [("image", "image2")]
+    assert sampled_params.params_for("image")["multiplier"].shape == (6, 7, 1)
+    np.testing.assert_array_equal(result["image"][:, :, 0], result["image"][:, :, 1])
+    np.testing.assert_array_equal(result["image"][:, :, 0], result["image"][:, :, 2])
+    np.testing.assert_array_equal(result["image2"][:, :, 0], result["image2"][:, :, 4])
+    np.testing.assert_array_equal(result["image"][:, :, 0], result["image2"][:, :, 0])
 
 
 def test_additive_noise_scales_materialized_maps_per_dtype_and_alias() -> None:
@@ -125,6 +144,55 @@ def test_aligned_spatial_shape_rejects_unaligned_targets_before_application() ->
 
     with pytest.raises(SampledParamsError, match="requires aligned spatial targets"):
         transform(image=image, image2=image2)
+
+
+def test_image_only_sampling_allows_unaligned_aliases() -> None:
+    image = np.zeros((4, 5, 3), dtype=np.uint8)
+    image2 = np.zeros((3, 5, 3), dtype=np.uint8)
+    transform = A.Compose(
+        [
+            A.AdditiveNoise(
+                noise_type="uniform",
+                spatial_mode="per_pixel",
+                noise_params={"ranges": [(0.1, 0.1)]},
+                p=1.0,
+            ),
+        ],
+        additional_targets={"image2": "image"},
+        is_check_shapes=False,
+        strict=True,
+    )
+
+    result = transform(image=image, image2=image2)
+
+    assert result["image"].shape == image.shape
+    assert result["image2"].shape == image2.shape
+    assert np.any(result["image"])
+    assert np.any(result["image2"])
+
+
+def test_channel_dropout_ignores_user_data_during_sampling() -> None:
+    image = np.full((4, 5, 3), 255, dtype=np.uint8)
+    user_data = {"source": "fixture"}
+    transform = A.ChannelDropout(channel_drop_range=(1, 1), fill=0, p=1.0)
+
+    result = transform(image=image, user_data=user_data)
+
+    assert result["user_data"] == user_data
+    assert sum(np.all(result["image"][:, :, channel] == 0) for channel in range(3)) == 1
+
+
+def test_tensor_image_sequence_descriptor_uses_channel_first_sequence_layout() -> None:
+    targets = TargetSet.from_data(
+        {"images": torch.zeros((3, 5, 11, 13), dtype=torch.uint8)},
+        {"images": "images"},
+    )
+
+    descriptor = targets.by_name("images").descriptor
+
+    assert descriptor.layout == "images_clhw"
+    assert descriptor.channels == 3
+    assert descriptor.spatial_shape == (11, 13)
 
 
 def test_sampled_params_reject_duplicate_keys_and_invalid_target_params() -> None:

--- a/tests/test_sampled_params.py
+++ b/tests/test_sampled_params.py
@@ -19,7 +19,7 @@ def test_multiplicative_noise_groups_channel_vectors_by_actual_target_representa
     result = transform(image=image, volume=volume)
     sampled_params = SampledParams.from_dict(transform.get_applied_params())
 
-    assert {tuple(group.targets) for group in sampled_params.groups} == {("image",), ("volume",)}
+    assert {tuple(target_params.targets) for target_params in sampled_params.target_params} == {("image",), ("volume",)}
     assert result["image"].shape == image.shape
     assert result["volume"].shape == volume.shape
     np.testing.assert_allclose(result["image"], 0.5)
@@ -40,7 +40,7 @@ def test_additive_noise_scales_materialized_maps_per_dtype_and_alias() -> None:
     result = transform(image=image, image2=image2)
     sampled_params = SampledParams.from_dict(transform.get_applied_params())
 
-    assert {tuple(group.targets) for group in sampled_params.groups} == {("image",), ("image2",)}
+    assert {tuple(target_params.targets) for target_params in sampled_params.target_params} == {("image",), ("image2",)}
     assert result["image"].dtype == image.dtype
     assert result["image2"].dtype == image2.dtype
     assert not np.array_equal(
@@ -58,8 +58,8 @@ def test_sampled_params_are_deterministically_ordered_and_schema_versioned() -> 
     assert [view.name for view in targets.ordered] == ["image", "image2", "volume"]
 
     sampled_params = SampledParams(
-        shared={"shared": 1},
-        groups=(
+        params={"value": 1},
+        target_params=(
             TargetParams(
                 targets=("image",),
                 params={"specific": 2},
@@ -68,13 +68,22 @@ def test_sampled_params_are_deterministically_ordered_and_schema_versioned() -> 
         ),
         target_schema=targets.schema(),
     )
-    assert sampled_params.to_dict()["parameter_schema"] == 2
-    assert sampled_params.params_for("image") == {"shared": 1, "specific": 2}
+    serialized = sampled_params.to_dict()
+    assert set(serialized) == {"parameter_schema", "target_schema", "params", "target_params"}
+    assert serialized["parameter_schema"] == 2
+    assert sampled_params.params_for("image") == {"value": 1, "specific": 2}
 
 
 def test_legacy_flat_parameter_payload_is_rejected() -> None:
     with pytest.raises(ValueError, match="unsupported or legacy"):
         SampledParams.from_dict({"shape": (4, 5, 3), "noise_map": np.zeros((4, 5, 3))})
+
+
+def test_structured_payload_with_retired_field_names_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unsupported or legacy"):
+        SampledParams.from_dict(
+            {"parameter_schema": 2, "target_schema": None, "common": {}, "target_params": []},
+        )
 
 
 def test_replay_preserves_mixed_target_materialization() -> None:
@@ -101,14 +110,14 @@ def test_pixel_dropout_routes_mixed_alias_representations_by_actual_key() -> Non
     result = transform(image=image, image2=image2)
     sampled_params = SampledParams.from_dict(transform.get_applied_params())
 
-    assert {tuple(group.targets) for group in sampled_params.groups} == {("image",), ("image2",)}
+    assert {tuple(target_params.targets) for target_params in sampled_params.target_params} == {("image",), ("image2",)}
     assert result["image"].shape == image.shape
     assert result["image2"].shape == image2.shape
     np.testing.assert_array_equal(result["image"], 0)
     np.testing.assert_array_equal(result["image2"], 0)
 
 
-def test_common_spatial_shape_rejects_unaligned_targets_before_application() -> None:
+def test_aligned_spatial_shape_rejects_unaligned_targets_before_application() -> None:
     image = np.zeros((4, 5, 3), dtype=np.uint8)
     image2 = np.zeros((3, 5, 3), dtype=np.uint8)
     transform = A.Rotate(limit=(0, 0), p=1.0)
@@ -118,7 +127,7 @@ def test_common_spatial_shape_rejects_unaligned_targets_before_application() -> 
         transform(image=image, image2=image2)
 
 
-def test_sampled_params_reject_duplicate_keys_and_invalid_groups() -> None:
+def test_sampled_params_reject_duplicate_keys_and_invalid_target_params() -> None:
     targets = TargetSet.from_data({"image": np.zeros((2, 2, 1), dtype=np.uint8)}, {"image": "image"})
 
     with pytest.raises(SampledParamsError, match="cannot repeat"):
@@ -129,8 +138,8 @@ def test_sampled_params_reject_duplicate_keys_and_invalid_groups() -> None:
         )
 
     sampled_params = SampledParams(
-        shared={"value": 1},
-        groups=(
+        params={"value": 1},
+        target_params=(
             TargetParams(
                 targets=("image",),
                 params={"value": 2},

--- a/tests/test_sampled_params.py
+++ b/tests/test_sampled_params.py
@@ -294,6 +294,107 @@ def test_tensor_samplers_use_descriptor_value_scale(transform, parameter_name: s
     assert parameter_name in sampled_params.params_for("image")
 
 
+@pytest.mark.parametrize(
+    ("transform", "reference_parameter"),
+    [
+        (A.FDA(beta_range=(0.1, 0.1), metadata_key="reference", p=1.0), "target_image"),
+        (A.HistogramMatching(blend_ratio=(1.0, 1.0), metadata_key="reference", p=1.0), "reference_image"),
+        (
+            A.PixelDistributionAdaptation(
+                blend_ratio=(1.0, 1.0),
+                transform_type="standard",
+                metadata_key="reference",
+                p=1.0,
+            ),
+            "reference_image",
+        ),
+    ],
+)
+def test_domain_adaptation_materializes_references_for_each_target_representation(
+    transform, reference_parameter: str
+) -> None:
+    image = np.full((8, 9, 3), 137, dtype=np.uint8)
+    image2 = np.full((5, 6, 3), 0.5, dtype=np.float32)
+    reference = np.full((7, 11, 3), 200, dtype=np.uint8)
+    transform.add_targets({"image2": "image"})
+    data = {"image": image, "image2": image2, "reference": [reference]}
+
+    sampled_params = transform.sample_parameters(
+        *make_sampling_args(transform, data),
+        SamplingContext.from_owner(transform, {}),
+    )
+    result = transform(**data)
+
+    assert sampled_params.params_for("image")[reference_parameter].shape == (8, 9, 3)
+    image2_reference = sampled_params.params_for("image2")[reference_parameter]
+    assert image2_reference.shape == (5, 6, 3)
+    assert image2_reference.dtype == np.float32
+    assert result["image"].shape == image.shape
+    assert result["image2"].shape == image2.shape
+
+
+@pytest.mark.parametrize("target_name", ["images", "volume"])
+def test_dithering_tensor_sampler_counts_channel_first_items(target_name: str) -> None:
+    transform = A.Dithering(method="random", color_mode="per_channel", p=1.0)
+    data = {target_name: torch.zeros((3, 5, 7, 9), dtype=torch.uint8)}
+
+    sampled_params = transform.sample_parameters(
+        *make_sampling_args(transform, data),
+        SamplingContext.from_owner(transform, {}),
+    )
+
+    random_noise = sampled_params.params_for(target_name)["random_noise"]
+    assert random_noise.shape == (5, 7, 9, 3)
+    assert random_noise.dtype == np.int16
+
+
+def test_he_stain_extracts_a_matrix_for_each_image_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    transform = A.HEStain(method="macenko", p=1.0)
+    transform.add_targets({"image2": "image"})
+    image = np.full((8, 9, 3), 25, dtype=np.uint8)
+    image2 = np.full((8, 9, 3), 200, dtype=np.uint8)
+    images_used_for_extraction: list[np.ndarray] = []
+
+    def extract_stain_matrix(image: np.ndarray | None, sampling: SamplingContext) -> np.ndarray:
+        assert image is not None
+        images_used_for_extraction.append(image)
+        return np.full((2, 3), image.mean(), dtype=np.float32)
+
+    monkeypatch.setattr(transform, "_get_stain_matrix", extract_stain_matrix)
+    sampled_params = transform.sample_parameters(
+        *make_sampling_args(transform, {"image": image, "image2": image2}),
+        SamplingContext.from_owner(transform, {}),
+    )
+
+    assert images_used_for_extraction[0] is image
+    assert images_used_for_extraction[1] is image2
+    assert {params.targets for params in sampled_params.target_params} == {("image",), ("image2",)}
+    assert sampled_params.params_for("image")["stain_matrix"][0, 0] == 25
+    assert sampled_params.params_for("image2")["stain_matrix"][0, 0] == 200
+
+
+def test_text_image_materializes_normalized_bboxes_for_each_target_shape() -> None:
+    transform = A.TextImage(
+        font_path="./tests/files/LiberationSerif-Bold.ttf",
+        font_size_fraction_range=(0.5, 0.5),
+        p=1.0,
+    )
+    transform.add_targets({"image2": "image"})
+    data = {
+        "image": np.zeros((20, 30, 3), dtype=np.uint8),
+        "image2": np.zeros((10, 12, 3), dtype=np.uint8),
+        "textimage_metadata": {"bbox": (0.1, 0.2, 0.5, 0.7), "text": "target-aware"},
+    }
+
+    sampled_params = transform.sample_parameters(
+        *make_sampling_args(transform, data),
+        SamplingContext.from_owner(transform, {}),
+    )
+
+    assert sampled_params.params_for("image")["overlay_data"][0]["bbox_coords"] == (3, 4, 15, 14)
+    assert sampled_params.params_for("image2")["overlay_data"][0]["bbox_coords"] == (1, 2, 6, 7)
+
+
 def test_rgb_shift_replay_rejects_changed_channel_count() -> None:
     recorded = A.ReplayCompose([A.RGBShift(p=1.0)], seed=137)(
         image=np.zeros((8, 9, 3), dtype=np.uint8),

--- a/tests/test_sampled_params.py
+++ b/tests/test_sampled_params.py
@@ -3,11 +3,11 @@ import pytest
 
 import albumentations as A
 from albumentations.core.transform_params import (
-    TargetParameterGroup,
+    SampledParams,
+    SampledParamsError,
+    TargetParams,
     TargetRequirement,
     TargetSet,
-    TransformParameterPlan,
-    TransformParameterPlanError,
 )
 
 
@@ -17,9 +17,9 @@ def test_multiplicative_noise_groups_channel_vectors_by_actual_target_representa
     transform = A.MultiplicativeNoise(multiplier=(0.5, 0.5), p=1.0)
 
     result = transform(image=image, volume=volume)
-    plan = TransformParameterPlan.from_dict(transform.get_applied_params())
+    sampled_params = SampledParams.from_dict(transform.get_applied_params())
 
-    assert {tuple(group.targets) for group in plan.groups} == {("image",), ("volume",)}
+    assert {tuple(group.targets) for group in sampled_params.groups} == {("image",), ("volume",)}
     assert result["image"].shape == image.shape
     assert result["volume"].shape == volume.shape
     np.testing.assert_allclose(result["image"], 0.5)
@@ -38,15 +38,17 @@ def test_additive_noise_scales_materialized_maps_per_dtype_and_alias() -> None:
     transform.add_targets({"image2": "image"})
 
     result = transform(image=image, image2=image2)
-    plan = TransformParameterPlan.from_dict(transform.get_applied_params())
+    sampled_params = SampledParams.from_dict(transform.get_applied_params())
 
-    assert {tuple(group.targets) for group in plan.groups} == {("image",), ("image2",)}
+    assert {tuple(group.targets) for group in sampled_params.groups} == {("image",), ("image2",)}
     assert result["image"].dtype == image.dtype
     assert result["image2"].dtype == image2.dtype
-    assert not np.array_equal(plan.params_for("image")["noise_map"], plan.params_for("image2")["noise_map"])
+    assert not np.array_equal(
+        sampled_params.params_for("image")["noise_map"], sampled_params.params_for("image2")["noise_map"]
+    )
 
 
-def test_target_parameter_plan_is_deterministically_ordered_and_schema_versioned() -> None:
+def test_sampled_params_are_deterministically_ordered_and_schema_versioned() -> None:
     data = {
         "volume": np.zeros((2, 4, 5, 1), dtype=np.float32),
         "image2": np.zeros((4, 5, 1), dtype=np.float32),
@@ -55,10 +57,10 @@ def test_target_parameter_plan_is_deterministically_ordered_and_schema_versioned
     targets = TargetSet.from_data(data, {"image": "image", "image2": "image", "volume": "volume"})
     assert [view.name for view in targets.ordered] == ["image", "image2", "volume"]
 
-    plan = TransformParameterPlan(
+    sampled_params = SampledParams(
         shared={"shared": 1},
         groups=(
-            TargetParameterGroup(
+            TargetParams(
                 targets=("image",),
                 params={"specific": 2},
                 requirements={"image": TargetRequirement()},
@@ -66,13 +68,13 @@ def test_target_parameter_plan_is_deterministically_ordered_and_schema_versioned
         ),
         target_schema=targets.schema(),
     )
-    assert plan.to_dict()["parameter_schema"] == 2
-    assert plan.params_for("image") == {"shared": 1, "specific": 2}
+    assert sampled_params.to_dict()["parameter_schema"] == 2
+    assert sampled_params.params_for("image") == {"shared": 1, "specific": 2}
 
 
 def test_legacy_flat_parameter_payload_is_rejected() -> None:
     with pytest.raises(ValueError, match="unsupported or legacy"):
-        TransformParameterPlan.from_dict({"shape": (4, 5, 3), "noise_map": np.zeros((4, 5, 3))})
+        SampledParams.from_dict({"shape": (4, 5, 3), "noise_map": np.zeros((4, 5, 3))})
 
 
 def test_replay_preserves_mixed_target_materialization() -> None:
@@ -97,44 +99,44 @@ def test_pixel_dropout_routes_mixed_alias_representations_by_actual_key() -> Non
     transform.add_targets({"image2": "image"})
 
     result = transform(image=image, image2=image2)
-    plan = TransformParameterPlan.from_dict(transform.get_applied_params())
+    sampled_params = SampledParams.from_dict(transform.get_applied_params())
 
-    assert {tuple(group.targets) for group in plan.groups} == {("image",), ("image2",)}
+    assert {tuple(group.targets) for group in sampled_params.groups} == {("image",), ("image2",)}
     assert result["image"].shape == image.shape
     assert result["image2"].shape == image2.shape
     np.testing.assert_array_equal(result["image"], 0)
     np.testing.assert_array_equal(result["image2"], 0)
 
 
-def test_spatial_frame_rejects_unaligned_targets_before_application() -> None:
+def test_common_spatial_shape_rejects_unaligned_targets_before_application() -> None:
     image = np.zeros((4, 5, 3), dtype=np.uint8)
     image2 = np.zeros((3, 5, 3), dtype=np.uint8)
     transform = A.Rotate(limit=(0, 0), p=1.0)
     transform.add_targets({"image2": "image"})
 
-    with pytest.raises(TransformParameterPlanError, match="requires aligned spatial targets"):
+    with pytest.raises(SampledParamsError, match="requires aligned spatial targets"):
         transform(image=image, image2=image2)
 
 
-def test_parameter_plan_rejects_duplicate_keys_and_invalid_groups() -> None:
+def test_sampled_params_reject_duplicate_keys_and_invalid_groups() -> None:
     targets = TargetSet.from_data({"image": np.zeros((2, 2, 1), dtype=np.uint8)}, {"image": "image"})
 
-    with pytest.raises(TransformParameterPlanError, match="cannot repeat"):
-        TargetParameterGroup(
+    with pytest.raises(SampledParamsError, match="cannot repeat"):
+        TargetParams(
             targets=("image", "image"),
             params={"value": 1},
             requirements={"image": TargetRequirement()},
         )
 
-    plan = TransformParameterPlan(
+    sampled_params = SampledParams(
         shared={"value": 1},
         groups=(
-            TargetParameterGroup(
+            TargetParams(
                 targets=("image",),
                 params={"value": 2},
                 requirements={"image": TargetRequirement()},
             ),
         ),
     )
-    with pytest.raises(TransformParameterPlanError, match="duplicate keys"):
-        plan.validate(targets, {}, "Example")
+    with pytest.raises(SampledParamsError, match="duplicate keys"):
+        sampled_params.validate(targets, {}, "Example")

--- a/tests/test_sampled_params.py
+++ b/tests/test_sampled_params.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 import albumentations as A
+from albumentations.core.invocation import SamplingContext
 from albumentations.core.transform_params import (
     SampledParams,
     SampledParamsError,
@@ -10,6 +11,7 @@ from albumentations.core.transform_params import (
     TargetRequirement,
     TargetSet,
 )
+from tests.utils import make_sampling_args
 
 
 def test_multiplicative_noise_shares_a_scalar_across_target_representations() -> None:
@@ -270,6 +272,59 @@ def test_tensor_image_sequence_descriptor_uses_channel_first_sequence_layout() -
     assert descriptor.channels == 3
     assert descriptor.spatial_shape == (11, 13)
     assert descriptor.value_scale == 255
+
+
+@pytest.mark.parametrize(
+    ("transform", "parameter_name"),
+    [
+        (A.GaussNoise(p=1.0), "noise_map"),
+        (A.AdditiveNoise(p=1.0), "noise_map"),
+        (A.RGBShift(p=1.0), "noise_map"),
+        (A.AtmosphericFog(p=1.0), "depth_map"),
+    ],
+)
+def test_tensor_samplers_use_descriptor_value_scale(transform, parameter_name: str) -> None:
+    data = {"image": torch.zeros((3, 5, 7), dtype=torch.uint8)}
+
+    sampled_params = transform.sample_parameters(
+        *make_sampling_args(transform, data),
+        SamplingContext.from_owner(transform, {}),
+    )
+
+    assert parameter_name in sampled_params.params_for("image")
+
+
+def test_rgb_shift_replay_rejects_changed_channel_count() -> None:
+    recorded = A.ReplayCompose([A.RGBShift(p=1.0)], seed=137)(
+        image=np.zeros((8, 9, 3), dtype=np.uint8),
+    )["replay"]
+
+    with pytest.raises(SampledParamsError, match="requirements do not match target 'image'"):
+        A.ReplayCompose.replay(recorded, image=np.zeros((8, 9, 1), dtype=np.uint8))
+
+
+def test_exposure_matching_replay_rejects_changed_batch_size() -> None:
+    recorded = A.ReplayCompose([A.ExposureMatching(p=1.0)], seed=137)(
+        images=np.zeros((2, 8, 9, 3), dtype=np.uint8),
+    )["replay"]
+
+    with pytest.raises(SampledParamsError, match="requirements do not match target 'images'"):
+        A.ReplayCompose.replay(recorded, images=np.zeros((3, 8, 9, 3), dtype=np.uint8))
+
+
+def test_pixel_dropout_attaches_bboxes_to_a_mask_group_without_an_image() -> None:
+    transform = A.PixelDropout(mask_drop_value=0, p=1.0)
+    data = {
+        "mask": np.ones((5, 7), dtype=np.uint8),
+        "bboxes": np.array([[0.1, 0.1, 0.9, 0.9]], dtype=np.float32),
+    }
+
+    sampled_params = transform.sample_parameters(
+        *make_sampling_args(transform, data),
+        SamplingContext.from_owner(transform, {}),
+    )
+
+    assert "drop_mask" in sampled_params.params_for("bboxes")
 
 
 def test_sampled_params_reject_duplicate_keys_and_invalid_target_params() -> None:

--- a/tests/test_sampled_params.py
+++ b/tests/test_sampled_params.py
@@ -333,6 +333,22 @@ def test_domain_adaptation_materializes_references_for_each_target_representatio
     assert result["image2"].shape == image2.shape
 
 
+def test_domain_adaptation_rejects_reference_with_incompatible_channels() -> None:
+    transform = A.HistogramMatching(blend_ratio=(1.0, 1.0), metadata_key="reference", p=1.0)
+    transform.add_targets({"image2": "image"})
+    data = {
+        "image": np.zeros((8, 9, 3), dtype=np.uint8),
+        "image2": np.zeros((5, 6), dtype=np.uint8),
+        "reference": [np.zeros((7, 11, 3), dtype=np.uint8)],
+    }
+
+    with pytest.raises(ValueError, match="reference image has 3 channels; target 'image2' has 1"):
+        transform.sample_parameters(
+            *make_sampling_args(transform, data),
+            SamplingContext.from_owner(transform, {}),
+        )
+
+
 @pytest.mark.parametrize("target_name", ["images", "volume"])
 def test_dithering_tensor_sampler_counts_channel_first_items(target_name: str) -> None:
     transform = A.Dithering(method="random", color_mode="per_channel", p=1.0)

--- a/tests/test_sampled_params.py
+++ b/tests/test_sampled_params.py
@@ -120,6 +120,36 @@ def test_replay_preserves_mixed_target_materialization() -> None:
     assert first["replay"]["transforms"][0]["params"]["parameter_schema"] == 2
 
 
+def test_structured_payload_with_retired_requirement_fields_is_rejected() -> None:
+    with pytest.raises(SampledParamsError, match="unsupported target parameter requirement"):
+        SampledParams.from_dict(
+            {
+                "parameter_schema": 2,
+                "target_schema": {"image": "image"},
+                "params": {},
+                "target_params": [
+                    {
+                        "targets": ["image"],
+                        "params": {"noise_map": [1]},
+                        "requirements": {
+                            "image": {
+                                "shape": None,
+                                "spatial_shape": None,
+                                "spatial_shape_suffix": None,
+                                "channels": None,
+                                "dtype": None,
+                                "value_scale": None,
+                                "layout": None,
+                                "sampling_topology": None,
+                                "dtype_scale": "uint8",
+                            },
+                        },
+                    },
+                ],
+            },
+        )
+
+
 def test_pixel_dropout_routes_mixed_alias_representations_by_actual_key() -> None:
     image = np.full((4, 5, 3), 255, dtype=np.uint8)
     image2 = np.full((4, 5, 5), 1.0, dtype=np.float32)
@@ -134,6 +164,52 @@ def test_pixel_dropout_routes_mixed_alias_representations_by_actual_key() -> Non
     assert result["image2"].shape == image2.shape
     np.testing.assert_array_equal(result["image"], 0)
     np.testing.assert_array_equal(result["image2"], 0)
+
+
+def test_equalize_materializes_callable_masks_for_each_alias() -> None:
+    image = np.full((4, 5, 3), 137, dtype=np.uint8)
+    image2 = np.full((6, 7, 3), 137, dtype=np.uint8)
+    volume = np.full((2, 8, 9, 3), 137, dtype=np.uint8)
+    sampled_shapes: list[tuple[int, ...]] = []
+
+    def mask_for(image: np.ndarray) -> np.ndarray:
+        sampled_shapes.append(image.shape)
+        return np.ones((*image.shape[:2], 1), dtype=np.uint8)
+
+    transform = A.Equalize(mask=mask_for, p=1.0)
+    transform.add_targets({"image2": "image"})
+
+    result = transform(image=image, image2=image2, volume=volume)
+    sampled_params = SampledParams.from_dict(transform.get_applied_params())
+
+    assert sampled_shapes == [image.shape, image2.shape, volume[0].shape]
+    assert {target_params.targets for target_params in sampled_params.target_params} == {
+        ("image",),
+        ("image2",),
+        ("volume",),
+    }
+    assert result["image"].shape == image.shape
+    assert result["image2"].shape == image2.shape
+    assert result["volume"].shape == volume.shape
+
+
+def test_replay_rejects_target_specific_spatial_parameters_for_changed_alias_shape() -> None:
+    transform = A.ReplayCompose(
+        [A.PlasmaShadow(plasma_size=4, roughness=1.0, p=1.0)],
+        additional_targets={"image2": "image"},
+        is_check_shapes=False,
+    )
+    image = np.full((10, 12, 3), 120, dtype=np.uint8)
+    image2 = np.full((8, 9, 3), 120, dtype=np.uint8)
+
+    recorded = transform(image=image, image2=image2)["replay"]
+
+    with pytest.raises(SampledParamsError, match="requirements do not match target 'image2'"):
+        A.ReplayCompose.replay(
+            recorded,
+            image=image,
+            image2=np.full((7, 9, 3), 120, dtype=np.uint8),
+        )
 
 
 def test_aligned_spatial_shape_rejects_unaligned_targets_before_application() -> None:
@@ -193,6 +269,7 @@ def test_tensor_image_sequence_descriptor_uses_channel_first_sequence_layout() -
     assert descriptor.layout == "images_clhw"
     assert descriptor.channels == 3
     assert descriptor.spatial_shape == (11, 13)
+    assert descriptor.value_scale == 255
 
 
 def test_sampled_params_reject_duplicate_keys_and_invalid_target_params() -> None:

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 import albumentations as A
+from albumentations.core.transform_params import TransformParameterPlan
 
 
 class _ApplyWithParamsTrackingFlip(A.HorizontalFlip):
@@ -134,11 +135,10 @@ def test_semantic_mask_label_mapping_follows_realized_cubic_symmetry_operation(
 
     def fixed_index(
         self: A.CubicSymmetry,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: Any,
         sampling: Any,
-    ) -> dict[str, Any]:
-        return {"index": index, "volume_shape": data["volume"].shape}
+    ) -> TransformParameterPlan:
+        return TransformParameterPlan.shared_only({"index": index, "volume_shape": inputs.data["volume"].shape})
 
     monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
     result = A.Compose(

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -141,7 +141,7 @@ def test_semantic_mask_label_mapping_follows_realized_cubic_symmetry_operation(
         sampling: Any,
     ) -> SampledParams:
         del self, params, targets, sampling
-        return SampledParams.shared_only({"index": index, "volume_shape": data["volume"].shape})
+        return SampledParams(params={"index": index, "volume_shape": data["volume"].shape})
 
     monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
     result = A.Compose(

--- a/tests/test_semantic_mask_label_mapping.py
+++ b/tests/test_semantic_mask_label_mapping.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import albumentations as A
-from albumentations.core.transform_params import TransformParameterPlan
+from albumentations.core.transform_params import SampledParams, TargetSet
 
 
 class _ApplyWithParamsTrackingFlip(A.HorizontalFlip):
@@ -135,10 +135,13 @@ def test_semantic_mask_label_mapping_follows_realized_cubic_symmetry_operation(
 
     def fixed_index(
         self: A.CubicSymmetry,
-        inputs: Any,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: Any,
-    ) -> TransformParameterPlan:
-        return TransformParameterPlan.shared_only({"index": index, "volume_shape": inputs.data["volume"].shape})
+    ) -> SampledParams:
+        del self, params, targets, sampling
+        return SampledParams.shared_only({"index": index, "volume_shape": data["volume"].shape})
 
     monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
     result = A.Compose(

--- a/tests/test_transform_parameter_plan.py
+++ b/tests/test_transform_parameter_plan.py
@@ -1,0 +1,140 @@
+import numpy as np
+import pytest
+
+import albumentations as A
+from albumentations.core.transform_params import (
+    TargetParameterGroup,
+    TargetRequirement,
+    TargetSet,
+    TransformParameterPlan,
+    TransformParameterPlanError,
+)
+
+
+def test_multiplicative_noise_groups_channel_vectors_by_actual_target_representation() -> None:
+    image = np.ones((6, 7, 3), dtype=np.float32)
+    volume = np.ones((2, 6, 7, 5), dtype=np.float32)
+    transform = A.MultiplicativeNoise(multiplier=(0.5, 0.5), p=1.0)
+
+    result = transform(image=image, volume=volume)
+    plan = TransformParameterPlan.from_dict(transform.get_applied_params())
+
+    assert {tuple(group.targets) for group in plan.groups} == {("image",), ("volume",)}
+    assert result["image"].shape == image.shape
+    assert result["volume"].shape == volume.shape
+    np.testing.assert_allclose(result["image"], 0.5)
+    np.testing.assert_allclose(result["volume"], 0.5)
+
+
+def test_additive_noise_scales_materialized_maps_per_dtype_and_alias() -> None:
+    image = np.zeros((5, 6, 3), dtype=np.uint8)
+    image2 = np.zeros((5, 6, 3), dtype=np.float32)
+    transform = A.AdditiveNoise(
+        noise_type="uniform",
+        spatial_mode="per_pixel",
+        noise_params={"ranges": [(0.1, 0.1)]},
+        p=1.0,
+    )
+    transform.add_targets({"image2": "image"})
+
+    result = transform(image=image, image2=image2)
+    plan = TransformParameterPlan.from_dict(transform.get_applied_params())
+
+    assert {tuple(group.targets) for group in plan.groups} == {("image",), ("image2",)}
+    assert result["image"].dtype == image.dtype
+    assert result["image2"].dtype == image2.dtype
+    assert not np.array_equal(plan.params_for("image")["noise_map"], plan.params_for("image2")["noise_map"])
+
+
+def test_target_parameter_plan_is_deterministically_ordered_and_schema_versioned() -> None:
+    data = {
+        "volume": np.zeros((2, 4, 5, 1), dtype=np.float32),
+        "image2": np.zeros((4, 5, 1), dtype=np.float32),
+        "image": np.zeros((4, 5, 1), dtype=np.float32),
+    }
+    targets = TargetSet.from_data(data, {"image": "image", "image2": "image", "volume": "volume"})
+    assert [view.name for view in targets.ordered] == ["image", "image2", "volume"]
+
+    plan = TransformParameterPlan(
+        shared={"shared": 1},
+        groups=(
+            TargetParameterGroup(
+                targets=("image",),
+                params={"specific": 2},
+                requirements={"image": TargetRequirement()},
+            ),
+        ),
+        target_schema=targets.schema(),
+    )
+    assert plan.to_dict()["parameter_schema"] == 2
+    assert plan.params_for("image") == {"shared": 1, "specific": 2}
+
+
+def test_legacy_flat_parameter_payload_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unsupported or legacy"):
+        TransformParameterPlan.from_dict({"shape": (4, 5, 3), "noise_map": np.zeros((4, 5, 3))})
+
+
+def test_replay_preserves_mixed_target_materialization() -> None:
+    image = np.ones((6, 7, 3), dtype=np.float32)
+    volume = np.ones((2, 6, 7, 5), dtype=np.float32)
+    transform = A.ReplayCompose(
+        [A.MultiplicativeNoise(multiplier=(0.8, 1.2), p=1.0)],
+        seed=137,
+    )
+    first = transform(image=image, volume=volume)
+    replayed = A.ReplayCompose.replay(first["replay"], image=image.copy(), volume=volume.copy())
+
+    np.testing.assert_array_equal(first["image"], replayed["image"])
+    np.testing.assert_array_equal(first["volume"], replayed["volume"])
+    assert first["replay"]["transforms"][0]["params"]["parameter_schema"] == 2
+
+
+def test_pixel_dropout_routes_mixed_alias_representations_by_actual_key() -> None:
+    image = np.full((4, 5, 3), 255, dtype=np.uint8)
+    image2 = np.full((4, 5, 5), 1.0, dtype=np.float32)
+    transform = A.PixelDropout(dropout_prob=1.0, drop_value=0, p=1.0)
+    transform.add_targets({"image2": "image"})
+
+    result = transform(image=image, image2=image2)
+    plan = TransformParameterPlan.from_dict(transform.get_applied_params())
+
+    assert {tuple(group.targets) for group in plan.groups} == {("image",), ("image2",)}
+    assert result["image"].shape == image.shape
+    assert result["image2"].shape == image2.shape
+    np.testing.assert_array_equal(result["image"], 0)
+    np.testing.assert_array_equal(result["image2"], 0)
+
+
+def test_spatial_frame_rejects_unaligned_targets_before_application() -> None:
+    image = np.zeros((4, 5, 3), dtype=np.uint8)
+    image2 = np.zeros((3, 5, 3), dtype=np.uint8)
+    transform = A.Rotate(limit=(0, 0), p=1.0)
+    transform.add_targets({"image2": "image"})
+
+    with pytest.raises(TransformParameterPlanError, match="requires aligned spatial targets"):
+        transform(image=image, image2=image2)
+
+
+def test_parameter_plan_rejects_duplicate_keys_and_invalid_groups() -> None:
+    targets = TargetSet.from_data({"image": np.zeros((2, 2, 1), dtype=np.uint8)}, {"image": "image"})
+
+    with pytest.raises(TransformParameterPlanError, match="cannot repeat"):
+        TargetParameterGroup(
+            targets=("image", "image"),
+            params={"value": 1},
+            requirements={"image": TargetRequirement()},
+        )
+
+    plan = TransformParameterPlan(
+        shared={"value": 1},
+        groups=(
+            TargetParameterGroup(
+                targets=("image",),
+                params={"value": 2},
+                requirements={"image": TargetRequirement()},
+            ),
+        ),
+    )
+    with pytest.raises(TransformParameterPlanError, match="duplicate keys"):
+        plan.validate(targets, {}, "Example")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -678,9 +678,9 @@ def test_multiplicative_noise_rgb(image, elementwise):
     mul = sampled_params.params_for("image")["multiplier"]
 
     if elementwise:
-        assert mul.shape == image.shape
+        assert mul.shape == (*image.shape[:2], 1)
     else:
-        assert mul.shape == (image.shape[-1],)
+        assert np.isscalar(mul)
 
     result = aug.apply(image, mul)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1050,7 +1050,7 @@ def test_affine_scale_ratio(params):
     apply_params = aug.sample_parameters(
         *make_sampling_args(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
-    ).shared
+    ).params
 
     if "keep_ratio" not in params:
         # Default keep_ratio is True
@@ -1087,7 +1087,7 @@ def test_affine_default_keep_ratio_behavior():
     apply_params = transform.sample_parameters(
         *make_sampling_args(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
-    ).shared
+    ).params
 
     assert apply_params["scale"]["x"] == apply_params["scale"]["y"], (
         f"With default keep_ratio=True, scales should be equal "
@@ -1106,7 +1106,7 @@ def test_affine_explicit_keep_ratio_false():
     apply_params = transform.sample_parameters(
         *make_sampling_args(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
-    ).shared
+    ).params
 
     # With keep_ratio=False, x and y can be different (not always will be, but can be)
     # Let's test multiple seeds to ensure we get different values at least once
@@ -1116,7 +1116,7 @@ def test_affine_explicit_keep_ratio_false():
         apply_params = transform.sample_parameters(
             *make_sampling_args(transform, data),
             sampling=SamplingContext.from_owner(transform, {}),
-        ).shared
+        ).params
         if apply_params["scale"]["x"] != apply_params["scale"]["y"]:
             found_different = True
             break
@@ -1137,7 +1137,7 @@ def test_affine_with_dict_scale_keep_ratio_true():
     apply_params = transform.sample_parameters(
         *make_sampling_args(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
-    ).shared
+    ).params
 
     assert apply_params["scale"]["x"] == apply_params["scale"]["y"], (
         "With keep_ratio=True and dict scale, x and y should be equal"
@@ -1160,7 +1160,7 @@ def test_affine_keep_ratio_with_single_scale_value():
     apply_params = transform.sample_parameters(
         *make_sampling_args(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
-    ).shared
+    ).params
 
     # With a single scale value, both x and y should be that value
     assert apply_params["scale"]["x"] == 1.5, f"Expected scale_x=1.5 but got {apply_params['scale']['x']}"
@@ -1422,7 +1422,7 @@ def test_motion_blur_allow_shifted():
     kernel = transform.sample_parameters(
         *make_sampling_args(transform, {}),
         sampling=SamplingContext.from_owner(transform, {}),
-    ).shared["kernel"]
+    ).params["kernel"]
 
     center = kernel.shape[0] / 2 - 0.5
 
@@ -1461,7 +1461,7 @@ def test_motion_blur_allow_shifted_true():
         kernel = transform.sample_parameters(
             *make_sampling_args(transform, {}),
             sampling=SamplingContext.from_owner(transform, {}),
-        ).shared["kernel"]
+        ).params["kernel"]
         kernels.append(kernel)
 
     # Check that not all kernels are identical (shifting should cause variation)
@@ -2118,7 +2118,7 @@ def test_additive_noise_patch_changes_only_sampled_rectangle() -> None:
     )
 
     result = transform(image=image)
-    patch = result["replay"]["transforms"][0]["params"]["groups"][0]["params"]["patches"][0]
+    patch = result["replay"]["transforms"][0]["params"]["target_params"][0]["params"]["patches"][0]
     x_min, y_min, x_max, y_max = patch
     expected_changed = np.zeros(image.shape[:2], dtype=bool)
     expected_changed[y_min:y_max, x_min:x_max] = True
@@ -2266,7 +2266,7 @@ def test_additive_noise_patch_handles_single_pixel_grayscale() -> None:
     result = transform(image=image)
 
     np.testing.assert_array_equal(
-        result["replay"]["transforms"][0]["params"]["groups"][0]["params"]["patches"],
+        result["replay"]["transforms"][0]["params"]["target_params"][0]["params"]["patches"],
         [[0, 0, 1, 1]],
     )
     np.testing.assert_equal(result["image"].shape, image.shape)
@@ -2309,7 +2309,7 @@ def test_additive_noise_patch_distributions_preserve_outside_pixels(
     )
 
     result = transform(image=image)
-    patches = result["replay"]["transforms"][0]["params"]["groups"][0]["params"]["patches"]
+    patches = result["replay"]["transforms"][0]["params"]["target_params"][0]["params"]["patches"]
     patch_mask = np.zeros(image.shape[:2], dtype=bool)
     for x_min, y_min, x_max, y_max in patches:
         patch_mask[y_min:y_max, x_min:x_max] = True

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -27,7 +27,7 @@ from .utils import (
     get_primary_2d_transform_params,
     get_primary_dual_transform_params,
     get_primary_image_only_transform_params,
-    make_sampling_input,
+    make_sampling_args,
 )
 
 
@@ -633,11 +633,11 @@ def test_multiplicative_noise_grayscale(image):
     m = 0.5
     aug = A.MultiplicativeNoise((m, m), elementwise=False, p=1)
     data = {"image": image}
-    plan = aug.sample_parameters(
-        inputs=make_sampling_input(aug, data),
+    sampled_params = aug.sample_parameters(
+        *make_sampling_args(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
     )
-    params = plan.params_for("image")
+    params = sampled_params.params_for("image")
     assert m == params["multiplier"]
     result_e = aug(image=image)["image"]
 
@@ -646,11 +646,11 @@ def test_multiplicative_noise_grayscale(image):
     np.testing.assert_allclose(clip(expected, image.dtype), result_e, rtol=1e-5, atol=1e-8, equal_nan=False)
 
     aug = A.MultiplicativeNoise((m, m), elementwise=True, p=1)
-    plan = aug.sample_parameters(
-        inputs=make_sampling_input(aug, data),
+    sampled_params = aug.sample_parameters(
+        *make_sampling_args(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
     )
-    params = plan.params_for("image")
+    params = sampled_params.params_for("image")
     result_ne = aug.apply(image, params["multiplier"])
 
     expected = image.astype(np.float32) * params["multiplier"]
@@ -671,11 +671,11 @@ def test_multiplicative_noise_rgb(image, elementwise):
 
     aug = A.MultiplicativeNoise(multiplier=(0.9, 1.1), elementwise=elementwise, p=1)
     data = {"image": image}
-    plan = aug.sample_parameters(
-        inputs=make_sampling_input(aug, data),
+    sampled_params = aug.sample_parameters(
+        *make_sampling_args(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
     )
-    mul = plan.params_for("image")["multiplier"]
+    mul = sampled_params.params_for("image")["multiplier"]
 
     if elementwise:
         assert mul.shape == image.shape
@@ -1048,7 +1048,7 @@ def test_affine_scale_ratio(params):
 
     data = {"image": image}
     apply_params = aug.sample_parameters(
-        inputs=make_sampling_input(aug, data),
+        *make_sampling_args(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
     ).shared
 
@@ -1085,7 +1085,7 @@ def test_affine_default_keep_ratio_behavior():
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
     apply_params = transform.sample_parameters(
-        inputs=make_sampling_input(transform, data),
+        *make_sampling_args(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
     ).shared
 
@@ -1104,7 +1104,7 @@ def test_affine_explicit_keep_ratio_false():
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
     apply_params = transform.sample_parameters(
-        inputs=make_sampling_input(transform, data),
+        *make_sampling_args(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
     ).shared
 
@@ -1114,7 +1114,7 @@ def test_affine_explicit_keep_ratio_false():
     for seed in range(10):
         transform.set_random_seed(seed)
         apply_params = transform.sample_parameters(
-            inputs=make_sampling_input(transform, data),
+            *make_sampling_args(transform, data),
             sampling=SamplingContext.from_owner(transform, {}),
         ).shared
         if apply_params["scale"]["x"] != apply_params["scale"]["y"]:
@@ -1135,7 +1135,7 @@ def test_affine_with_dict_scale_keep_ratio_true():
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
     apply_params = transform.sample_parameters(
-        inputs=make_sampling_input(transform, data),
+        *make_sampling_args(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
     ).shared
 
@@ -1158,7 +1158,7 @@ def test_affine_keep_ratio_with_single_scale_value():
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
     apply_params = transform.sample_parameters(
-        inputs=make_sampling_input(transform, data),
+        *make_sampling_args(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
     ).shared
 
@@ -1420,7 +1420,7 @@ def test_motion_blur_allow_shifted():
         blur_range=(7, 7),  # Fixed kernel size
     )
     kernel = transform.sample_parameters(
-        inputs=make_sampling_input(transform, {}),
+        *make_sampling_args(transform, {}),
         sampling=SamplingContext.from_owner(transform, {}),
     ).shared["kernel"]
 
@@ -1459,7 +1459,7 @@ def test_motion_blur_allow_shifted_true():
     kernels = []
     for _ in range(10):
         kernel = transform.sample_parameters(
-            inputs=make_sampling_input(transform, {}),
+            *make_sampling_args(transform, {}),
             sampling=SamplingContext.from_owner(transform, {}),
         ).shared["kernel"]
         kernels.append(kernel)
@@ -2056,11 +2056,11 @@ def test_gauss_noise(mean, image):
     aug = A.GaussNoise(p=1, mean_range=(mean, mean))
     aug.set_random_seed(42)
 
-    plan = aug.sample_parameters(
-        inputs=make_sampling_input(aug, {"image": image}),
+    sampled_params = aug.sample_parameters(
+        *make_sampling_args(aug, {"image": image}),
         sampling=SamplingContext.from_owner(aug, {}),
     )
-    apply_params = plan.params_for("image")
+    apply_params = sampled_params.params_for("image")
 
     assert (
         np.abs(
@@ -2093,7 +2093,7 @@ def test_additive_noise_spatial_map_is_float32(noise_type, noise_params, spatial
     )
 
     apply_params = aug.sample_parameters(
-        inputs=make_sampling_input(aug, {"image": image}),
+        *make_sampling_args(aug, {"image": image}),
         sampling=SamplingContext.from_owner(aug, {}),
     ).params_for("image")
 
@@ -2222,7 +2222,7 @@ def test_additive_noise_uniform_rejects_too_few_channel_ranges_before_sampling(
     numpy_random_state = copy.deepcopy(sampling.random_generator.bit_generator.state)
 
     with pytest.raises(ValueError, match="Not enough ranges provided"):
-        transform.sample_parameters(inputs=make_sampling_input(transform, {"image": image}), sampling=sampling)
+        transform.sample_parameters(*make_sampling_args(transform, {"image": image}), sampling=sampling)
 
     np.testing.assert_equal(sampling.py_random.getstate(), py_random_state)
     np.testing.assert_equal(sampling.random_generator.bit_generator.state, numpy_random_state)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -27,6 +27,7 @@ from .utils import (
     get_primary_2d_transform_params,
     get_primary_dual_transform_params,
     get_primary_image_only_transform_params,
+    make_sampling_input,
 )
 
 
@@ -631,11 +632,12 @@ def test_batched_multiplicative_noise(images: np.ndarray):
 def test_multiplicative_noise_grayscale(image):
     m = 0.5
     aug = A.MultiplicativeNoise((m, m), elementwise=False, p=1)
-    params = aug.sample_parameters(
-        params={"shape": image.shape},
-        data={"image": image},
+    data = {"image": image}
+    plan = aug.sample_parameters(
+        inputs=make_sampling_input(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
     )
+    params = plan.params_for("image")
     assert m == params["multiplier"]
     result_e = aug(image=image)["image"]
 
@@ -644,11 +646,11 @@ def test_multiplicative_noise_grayscale(image):
     np.testing.assert_allclose(clip(expected, image.dtype), result_e, rtol=1e-5, atol=1e-8, equal_nan=False)
 
     aug = A.MultiplicativeNoise((m, m), elementwise=True, p=1)
-    params = aug.sample_parameters(
-        params={"shape": image.shape},
-        data={"image": image},
+    plan = aug.sample_parameters(
+        inputs=make_sampling_input(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
     )
+    params = plan.params_for("image")
     result_ne = aug.apply(image, params["multiplier"])
 
     expected = image.astype(np.float32) * params["multiplier"]
@@ -668,12 +670,12 @@ def test_multiplicative_noise_rgb(image, elementwise):
     dtype = image.dtype
 
     aug = A.MultiplicativeNoise(multiplier=(0.9, 1.1), elementwise=elementwise, p=1)
-    params = aug.sample_parameters(
-        params={"shape": image.shape},
-        data={"image": image},
+    data = {"image": image}
+    plan = aug.sample_parameters(
+        inputs=make_sampling_input(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
     )
-    mul = params["multiplier"]
+    mul = plan.params_for("image")["multiplier"]
 
     if elementwise:
         assert mul.shape == image.shape
@@ -1045,13 +1047,10 @@ def test_affine_scale_ratio(params):
     image = SQUARE_UINT8_IMAGE
 
     data = {"image": image}
-    call_params = aug.update_transform_params({}, data)
-
     apply_params = aug.sample_parameters(
-        params=call_params,
-        data=data,
+        inputs=make_sampling_input(aug, data),
         sampling=SamplingContext.from_owner(aug, {}),
-    )
+    ).shared
 
     if "keep_ratio" not in params:
         # Default keep_ratio is True
@@ -1085,12 +1084,10 @@ def test_affine_default_keep_ratio_behavior():
     transform.set_random_seed(137)
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
-    params = transform.update_transform_params({}, data)
     apply_params = transform.sample_parameters(
-        params=params,
-        data=data,
+        inputs=make_sampling_input(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
-    )
+    ).shared
 
     assert apply_params["scale"]["x"] == apply_params["scale"]["y"], (
         f"With default keep_ratio=True, scales should be equal "
@@ -1106,24 +1103,20 @@ def test_affine_explicit_keep_ratio_false():
     transform.set_random_seed(137)
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
-    params = transform.update_transform_params({}, data)
     apply_params = transform.sample_parameters(
-        params=params,
-        data=data,
+        inputs=make_sampling_input(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
-    )
+    ).shared
 
     # With keep_ratio=False, x and y can be different (not always will be, but can be)
     # Let's test multiple seeds to ensure we get different values at least once
     found_different = False
     for seed in range(10):
         transform.set_random_seed(seed)
-        params = transform.update_transform_params({}, data)
         apply_params = transform.sample_parameters(
-            params=params,
-            data=data,
+            inputs=make_sampling_input(transform, data),
             sampling=SamplingContext.from_owner(transform, {}),
-        )
+        ).shared
         if apply_params["scale"]["x"] != apply_params["scale"]["y"]:
             found_different = True
             break
@@ -1141,12 +1134,10 @@ def test_affine_with_dict_scale_keep_ratio_true():
     transform.set_random_seed(137)
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
-    params = transform.update_transform_params({}, data)
     apply_params = transform.sample_parameters(
-        params=params,
-        data=data,
+        inputs=make_sampling_input(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
-    )
+    ).shared
 
     assert apply_params["scale"]["x"] == apply_params["scale"]["y"], (
         "With keep_ratio=True and dict scale, x and y should be equal"
@@ -1166,12 +1157,10 @@ def test_affine_keep_ratio_with_single_scale_value():
     transform.set_random_seed(137)
     image = SQUARE_UINT8_IMAGE
     data = {"image": image}
-    params = transform.update_transform_params({}, data)
     apply_params = transform.sample_parameters(
-        params=params,
-        data=data,
+        inputs=make_sampling_input(transform, data),
         sampling=SamplingContext.from_owner(transform, {}),
-    )
+    ).shared
 
     # With a single scale value, both x and y should be that value
     assert apply_params["scale"]["x"] == 1.5, f"Expected scale_x=1.5 but got {apply_params['scale']['x']}"
@@ -1431,10 +1420,9 @@ def test_motion_blur_allow_shifted():
         blur_range=(7, 7),  # Fixed kernel size
     )
     kernel = transform.sample_parameters(
-        params={},
-        data={},
+        inputs=make_sampling_input(transform, {}),
         sampling=SamplingContext.from_owner(transform, {}),
-    )["kernel"]
+    ).shared["kernel"]
 
     center = kernel.shape[0] / 2 - 0.5
 
@@ -1471,10 +1459,9 @@ def test_motion_blur_allow_shifted_true():
     kernels = []
     for _ in range(10):
         kernel = transform.sample_parameters(
-            params={},
-            data={},
+            inputs=make_sampling_input(transform, {}),
             sampling=SamplingContext.from_owner(transform, {}),
-        )["kernel"]
+        ).shared["kernel"]
         kernels.append(kernel)
 
     # Check that not all kernels are identical (shifting should cause variation)
@@ -2069,11 +2056,11 @@ def test_gauss_noise(mean, image):
     aug = A.GaussNoise(p=1, mean_range=(mean, mean))
     aug.set_random_seed(42)
 
-    apply_params = aug.sample_parameters(
-        params={"shape": image.shape},
-        data={"image": image},
+    plan = aug.sample_parameters(
+        inputs=make_sampling_input(aug, {"image": image}),
         sampling=SamplingContext.from_owner(aug, {}),
     )
+    apply_params = plan.params_for("image")
 
     assert (
         np.abs(
@@ -2106,10 +2093,9 @@ def test_additive_noise_spatial_map_is_float32(noise_type, noise_params, spatial
     )
 
     apply_params = aug.sample_parameters(
-        params={"shape": image.shape},
-        data={"image": image},
+        inputs=make_sampling_input(aug, {"image": image}),
         sampling=SamplingContext.from_owner(aug, {}),
-    )
+    ).params_for("image")
 
     np.testing.assert_equal(apply_params["noise_map"].dtype, np.float32)
 
@@ -2132,7 +2118,7 @@ def test_additive_noise_patch_changes_only_sampled_rectangle() -> None:
     )
 
     result = transform(image=image)
-    patch = result["replay"]["transforms"][0]["params"]["patches"][0]
+    patch = result["replay"]["transforms"][0]["params"]["groups"][0]["params"]["patches"][0]
     x_min, y_min, x_max, y_max = patch
     expected_changed = np.zeros(image.shape[:2], dtype=bool)
     expected_changed[y_min:y_max, x_min:x_max] = True
@@ -2236,7 +2222,7 @@ def test_additive_noise_uniform_rejects_too_few_channel_ranges_before_sampling(
     numpy_random_state = copy.deepcopy(sampling.random_generator.bit_generator.state)
 
     with pytest.raises(ValueError, match="Not enough ranges provided"):
-        transform.sample_parameters(params={}, data={"image": image}, sampling=sampling)
+        transform.sample_parameters(inputs=make_sampling_input(transform, {"image": image}), sampling=sampling)
 
     np.testing.assert_equal(sampling.py_random.getstate(), py_random_state)
     np.testing.assert_equal(sampling.random_generator.bit_generator.state, numpy_random_state)
@@ -2279,7 +2265,10 @@ def test_additive_noise_patch_handles_single_pixel_grayscale() -> None:
 
     result = transform(image=image)
 
-    np.testing.assert_array_equal(result["replay"]["transforms"][0]["params"]["patches"], [[0, 0, 1, 1]])
+    np.testing.assert_array_equal(
+        result["replay"]["transforms"][0]["params"]["groups"][0]["params"]["patches"],
+        [[0, 0, 1, 1]],
+    )
     np.testing.assert_equal(result["image"].shape, image.shape)
     np.testing.assert_array_less(image, result["image"])
 
@@ -2320,7 +2309,7 @@ def test_additive_noise_patch_distributions_preserve_outside_pixels(
     )
 
     result = transform(image=image)
-    patches = result["replay"]["transforms"][0]["params"]["patches"]
+    patches = result["replay"]["transforms"][0]["params"]["groups"][0]["params"]["patches"]
     patch_mask = np.zeros(image.shape[:2], dtype=bool)
     for x_min, y_min, x_max, y_max in patches:
         patch_mask[y_min:y_max, x_min:x_max] = True

--- a/tests/test_xy_masking.py
+++ b/tests/test_xy_masking.py
@@ -4,11 +4,11 @@ import numpy as np
 import pytest
 
 import albumentations as A
-from albumentations.core.transform_params import TransformParameterPlan
+from albumentations.core.transform_params import SampledParams
 
 
 def _applied_shared(transform: A.XYMasking) -> dict:
-    return dict(TransformParameterPlan.from_dict(transform.get_applied_params()).params_for("image"))
+    return dict(SampledParams.from_dict(transform.get_applied_params()).params_for("image"))
 
 
 def _sample_holes(transform: A.XYMasking, shape: tuple[int, int, int], seed: int = 137) -> np.ndarray:

--- a/tests/test_xy_masking.py
+++ b/tests/test_xy_masking.py
@@ -4,12 +4,17 @@ import numpy as np
 import pytest
 
 import albumentations as A
+from albumentations.core.transform_params import TransformParameterPlan
+
+
+def _applied_shared(transform: A.XYMasking) -> dict:
+    return dict(TransformParameterPlan.from_dict(transform.get_applied_params()).params_for("image"))
 
 
 def _sample_holes(transform: A.XYMasking, shape: tuple[int, int, int], seed: int = 137) -> np.ndarray:
     pipeline = A.Compose([transform], save_applied_params=True, seed=seed, strict=True)
     pipeline(image=np.ones(shape, dtype=np.uint8))
-    return transform.get_applied_params()["holes"]
+    return _applied_shared(transform)["holes"]
 
 
 def _assert_canonical_empty_holes(holes: np.ndarray) -> None:
@@ -107,7 +112,7 @@ def test_fractional_zero_length_is_noop_for_every_supported_target() -> None:
         mask3d=mask3d,
     )
 
-    _assert_canonical_empty_holes(transform.get_applied_params()["holes"])
+    _assert_canonical_empty_holes(_applied_shared(transform)["holes"])
     np.testing.assert_array_equal(result["image"], image)
     np.testing.assert_array_equal(result["mask"], mask)
     np.testing.assert_array_equal(result["bboxes"], bboxes)
@@ -184,7 +189,7 @@ def test_fractional_zero_length_is_noop_for_float32_inpainting() -> None:
 
     result = A.Compose([transform], save_applied_params=True, seed=137, strict=True)(image=image)
 
-    _assert_canonical_empty_holes(transform.get_applied_params()["holes"])
+    _assert_canonical_empty_holes(_applied_shared(transform)["holes"])
     np.testing.assert_array_equal(result["image"], image)
 
 
@@ -197,7 +202,7 @@ def test_fractional_zero_length_keeps_rng_order_for_later_masks() -> None:
     transform.set_random_seed(137)
 
     transform(image=np.ones((7, 5, 1), dtype=np.uint8))
-    holes = transform.get_applied_params()["holes"]
+    holes = _applied_shared(transform)["holes"]
 
     np.testing.assert_array_equal(holes, [[1, 0, 2, 7], [0, 0, 1, 7]])
 
@@ -336,7 +341,7 @@ def test_float_range_transport_preserves_integral_valued_float_identity(value: o
     restored = A.from_dict(transported)
     restored_transform = restored.transforms[0]
     restored(image=np.ones((7, 11, 1), dtype=np.uint8))
-    holes = restored_transform.get_applied_params()["holes"]
+    holes = _applied_shared(restored_transform)["holes"]
 
     assert transform.mask_x_length_range == (1.0, 1.0)
     assert all(type(element) is float for element in transform.mask_x_length_range)
@@ -408,16 +413,16 @@ def test_integer_dimension_error_does_not_advance_rng(invalid_axis: str) -> None
         retried(image=invalid_image)
 
     retried_result = retried(image=valid_image)
-    retried_holes = retried.get_applied_params()["holes"]
+    retried_holes = _applied_shared(retried)["holes"]
     fresh_result = fresh(image=valid_image)
-    fresh_holes = fresh.get_applied_params()["holes"]
+    fresh_holes = _applied_shared(fresh)["holes"]
     np.testing.assert_array_equal(retried_holes, fresh_holes)
     np.testing.assert_array_equal(retried_result["image"], fresh_result["image"])
 
     retried(image=valid_image)
-    retried_holes = retried.get_applied_params()["holes"]
+    retried_holes = _applied_shared(retried)["holes"]
     fresh(image=valid_image)
-    np.testing.assert_array_equal(retried_holes, fresh.get_applied_params()["holes"])
+    np.testing.assert_array_equal(retried_holes, _applied_shared(fresh)["holes"])
 
 
 def test_integer_dimension_preflight_checks_x_before_y() -> None:
@@ -468,7 +473,7 @@ def test_strict_json_applied_configuration_reconstructs_runnable_policy_at_new_r
     reconstructed = A.Compose.from_applied_transforms(transported, save_applied_params=True, seed=151)
     reconstructed_transform = reconstructed.transforms[0]
     reconstructed(image=np.ones((24, 40, 1), dtype=np.uint8))
-    holes = reconstructed_transform.get_applied_params()["holes"]
+    holes = _applied_shared(reconstructed_transform)["holes"]
 
     assert reconstructed_transform.mask_x_length_range == (0.25, 0.25)
     assert reconstructed_transform.mask_y_length_range == (3, 3)
@@ -501,9 +506,9 @@ def test_one_serialized_relative_pipeline_scales_across_resolutions() -> None:
     transform = pipeline.transforms[0]
 
     pipeline(image=np.ones((7, 10, 1), dtype=np.uint8))
-    first_holes = transform.get_applied_params()["holes"]
+    first_holes = _applied_shared(transform)["holes"]
     pipeline(image=np.ones((7, 20, 1), dtype=np.uint8))
-    second_holes = transform.get_applied_params()["holes"]
+    second_holes = _applied_shared(transform)["holes"]
 
     np.testing.assert_array_equal(first_holes[:, 2] - first_holes[:, 0], [5])
     np.testing.assert_array_equal(second_holes[:, 2] - second_holes[:, 0], [10])
@@ -597,7 +602,7 @@ def test_integer_sampling_matches_permanent_baseline_golden_vectors(
     transform = A.XYMasking(**kwargs, p=1)
     transform.set_random_seed(seed)
     transform(image=np.ones(shape, dtype=np.uint8))
-    holes = transform.get_applied_params()["holes"]
+    holes = _applied_shared(transform)["holes"]
 
     np.testing.assert_array_equal(holes, expected)
 
@@ -620,4 +625,4 @@ def test_integer_sampling_preserves_sequential_rng_progression() -> None:
 
     for expected in expected_calls:
         transform(image=image)
-        np.testing.assert_array_equal(transform.get_applied_params()["holes"], expected)
+        np.testing.assert_array_equal(_applied_shared(transform)["holes"], expected)

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -9,11 +9,13 @@ import torch.nn.functional as torch_f
 import albumentations as A
 from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
 from tests.conftest import RECTANGULAR_UINT8_IMAGE
 from tests.utils import (
     get_primary_2d_transform_params,
     get_primary_3d_transform_params,
     get_primary_dual_transform_params,
+    make_sampling_input,
 )
 
 
@@ -1422,12 +1424,11 @@ def test_cubic_symmetry_remaps_keypoint_labels_without_reordering_transformed_ro
 
     def fixed_index(
         self: A.CubicSymmetry,
-        params: dict[str, Any],
-        data: dict[str, Any],
+        inputs: TransformSamplingInput,
         sampling: Any,
-    ) -> dict[str, Any]:
-        del self, params, sampling
-        return {"index": index, "volume_shape": data["volume"].shape}
+    ) -> TransformParameterPlan:
+        del self, sampling
+        return TransformParameterPlan.shared_only({"index": index, "volume_shape": inputs.data["volume"].shape})
 
     monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
     result = A.Compose(
@@ -1522,7 +1523,10 @@ def test_flip3d_random_mode_samples_the_full_reflection_group() -> None:
     volume = np.zeros((2, 3, 5, 1), dtype=np.uint8)
 
     sampled_axes = {
-        transform.sample_parameters({}, {"volume": volume}, SamplingContext.from_owner(transform, {}))["flip_axes"]
+        transform.sample_parameters(
+            make_sampling_input(transform, {"volume": volume}),
+            SamplingContext.from_owner(transform, {}),
+        ).shared["flip_axes"]
         for _ in range(64)
     }
 

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1430,7 +1430,7 @@ def test_cubic_symmetry_remaps_keypoint_labels_without_reordering_transformed_ro
         sampling: Any,
     ) -> SampledParams:
         del self, params, targets, sampling
-        return SampledParams.shared_only({"index": index, "volume_shape": data["volume"].shape})
+        return SampledParams(params={"index": index, "volume_shape": data["volume"].shape})
 
     monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
     result = A.Compose(
@@ -1528,7 +1528,7 @@ def test_flip3d_random_mode_samples_the_full_reflection_group() -> None:
         transform.sample_parameters(
             *make_sampling_args(transform, {"volume": volume}),
             SamplingContext.from_owner(transform, {}),
-        ).shared["flip_axes"]
+        ).params["flip_axes"]
         for _ in range(64)
     }
 

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -9,13 +9,13 @@ import torch.nn.functional as torch_f
 import albumentations as A
 from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core.invocation import SamplingContext
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams, TargetSet
 from tests.conftest import RECTANGULAR_UINT8_IMAGE
 from tests.utils import (
     get_primary_2d_transform_params,
     get_primary_3d_transform_params,
     get_primary_dual_transform_params,
-    make_sampling_input,
+    make_sampling_args,
 )
 
 
@@ -1424,11 +1424,13 @@ def test_cubic_symmetry_remaps_keypoint_labels_without_reordering_transformed_ro
 
     def fixed_index(
         self: A.CubicSymmetry,
-        inputs: TransformSamplingInput,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
         sampling: Any,
-    ) -> TransformParameterPlan:
-        del self, sampling
-        return TransformParameterPlan.shared_only({"index": index, "volume_shape": inputs.data["volume"].shape})
+    ) -> SampledParams:
+        del self, params, targets, sampling
+        return SampledParams.shared_only({"index": index, "volume_shape": data["volume"].shape})
 
     monkeypatch.setattr(A.CubicSymmetry, "sample_parameters", fixed_index)
     result = A.Compose(
@@ -1524,7 +1526,7 @@ def test_flip3d_random_mode_samples_the_full_reflection_group() -> None:
 
     sampled_axes = {
         transform.sample_parameters(
-            make_sampling_input(transform, {"volume": volume}),
+            *make_sampling_args(transform, {"volume": volume}),
             SamplingContext.from_owner(transform, {}),
         ).shared["flip_axes"]
         for _ in range(64)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,23 @@ from io import StringIO
 import numpy as np
 
 import albumentations
+from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+
+
+def make_sampling_input(transform, data):
+    """Build the public sampler input used by direct sampler regression tests."""
+    targets = transform._build_target_set(data)
+    return TransformSamplingInput(
+        base_params=transform.update_transform_params({}, data, targets=targets),
+        spatial_frame=transform._build_spatial_frame(targets),
+        targets=targets,
+        data=data,
+    )
+
+
+def get_resolved_applied_params(transform, target="image"):
+    """Resolve one target's parameters from a recorded structured plan."""
+    return TransformParameterPlan.from_dict(transform.get_applied_params()).params_for(target)
 
 
 class FrozenParams(dict):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,23 +7,22 @@ from io import StringIO
 import numpy as np
 
 import albumentations
-from albumentations.core.transform_params import TransformParameterPlan, TransformSamplingInput
+from albumentations.core.transform_params import SampledParams
 
 
-def make_sampling_input(transform, data):
-    """Build the public sampler input used by direct sampler regression tests."""
+def make_sampling_args(transform, data):
+    """Build explicit sampler arguments for direct sampler regression tests."""
     targets = transform._build_target_set(data)
-    return TransformSamplingInput(
-        base_params=transform.update_transform_params({}, data, targets=targets),
-        spatial_frame=transform._build_spatial_frame(targets),
-        targets=targets,
-        data=data,
+    return (
+        transform.update_transform_params({}, data, targets=targets),
+        data,
+        targets,
     )
 
 
 def get_resolved_applied_params(transform, target="image"):
-    """Resolve one target's parameters from a recorded structured plan."""
-    return TransformParameterPlan.from_dict(transform.get_applied_params()).params_for(target)
+    """Resolve one target's parameters from recorded structured sampled parameters."""
+    return SampledParams.from_dict(transform.get_applied_params()).params_for(target)
 
 
 class FrozenParams(dict):

--- a/tools/ax_coding_guidance/rules.py
+++ b/tools/ax_coding_guidance/rules.py
@@ -398,7 +398,7 @@ def rule_target_routing_parameters(index: SourceIndex) -> list[Diagnostic]:
                             arg,
                             (
                                 "application parameters must use semantic names; target-specific routing belongs "
-                                "in SampledParams groups"
+                                "in SampledParams.target_params"
                             ),
                             f"{info.name}.{name}",
                         )

--- a/tools/ax_coding_guidance/rules.py
+++ b/tools/ax_coding_guidance/rules.py
@@ -52,6 +52,8 @@ LEGACY_RANDOM_TRANSFORM_NAMES = frozenset(
     },
 )
 RANGE_ALIASES = frozenset({"AxisRanges3D", "MaskLengthRange", "PixelLengthRange", "PositiveAxisRanges3D"})
+TARGET_ROUTING_PREFIXES = ("image_", "images_", "volume_", "mask_", "masks_", "mask3d_")
+TARGET_ROUTING_PARAMETER_ALLOWLIST = frozenset({"image_type", "volume_shape"})
 NUMPY_MATH_TO_MATH = {
     "arccos": "acos",
     "arccosh": "acosh",
@@ -252,13 +254,13 @@ def rule_sampling_signature(index: SourceIndex) -> list[Diagnostic]:
             continue
         args = node.args
         names = [arg.arg for arg in [*args.posonlyargs, *args.args]]
-        if names != ["self", "params", "data", "sampling"] or args.kwonlyargs or args.vararg or args.kwarg:
+        if names != ["self", "inputs", "sampling"] or args.kwonlyargs or args.vararg or args.kwarg:
             result.append(
                 _d(
                     "AXG004",
                     info,
                     node,
-                    "sample_parameters must have exactly self, params, data, sampling",
+                    "sample_parameters must have exactly self, inputs, sampling",
                     f"{info.name}.sample_parameters",
                 )
             )
@@ -275,6 +277,132 @@ def rule_sampling_signature(index: SourceIndex) -> list[Diagnostic]:
                     f"{info.name}.sample_parameters",
                 )
             )
+    return result
+
+
+def _plain_plan_dict_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Assign) and isinstance(child.value, (ast.Dict, ast.Call)):
+            if isinstance(child.value, ast.Call) and dotted(child.value.func) != "dict":
+                continue
+            for target in child.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(child, ast.AnnAssign) and isinstance(child.value, (ast.Dict, ast.Call)):
+            if isinstance(child.value, ast.Call) and dotted(child.value.func) != "dict":
+                continue
+            if isinstance(child.target, ast.Name):
+                names.add(child.target.id)
+    return names
+
+
+class _DirectSamplerReturnVisitor(ast.NodeVisitor):
+    def __init__(self, root: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self.root = root
+        self.returns: list[ast.Return] = []
+
+    def visit_Return(self, returned: ast.Return) -> None:
+        if returned.value is not None:
+            self.returns.append(returned)
+
+    def visit_FunctionDef(self, function: ast.FunctionDef) -> None:
+        if function is self.root:
+            self.generic_visit(function)
+
+    def visit_AsyncFunctionDef(self, function: ast.AsyncFunctionDef) -> None:
+        if function is self.root:
+            self.generic_visit(function)
+
+
+def _direct_sampler_returns(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.Return]:
+    visitor = _DirectSamplerReturnVisitor(node)
+    visitor.visit(node)
+    return visitor.returns
+
+
+def _is_first_target_shape_access(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Subscript)
+        and ast.unparse(node.value) == "inputs.base_params"
+        and (ast.unparse(node.slice).strip("\"'") == "shape")
+    )
+
+
+def _is_legacy_shape_helper_call(node: ast.AST) -> bool:
+    return isinstance(node, ast.Call) and dotted(node.func) in {
+        "get_image_data",
+        "self.get_image_data",
+        "_extract_shape_from_data",
+        "self._extract_shape_from_data",
+        "_extract_shared_shape_from_data",
+        "self._extract_shared_shape_from_data",
+    }
+
+
+def rule_sampling_plan_contract(index: SourceIndex) -> list[Diagnostic]:
+    result: list[Diagnostic] = []
+    for info in index.concrete_transforms():
+        node = info.methods.get("sample_parameters")
+        if node is None:
+            continue
+        plain_names = _plain_plan_dict_names(node)
+        for returned in _direct_sampler_returns(node):
+            value = returned.value
+            is_plain_dict = (
+                isinstance(value, ast.Dict)
+                or (isinstance(value, ast.Call) and dotted(value.func) == "dict")
+                or (isinstance(value, ast.Name) and value.id in plain_names)
+            )
+            if is_plain_dict:
+                result.append(
+                    _d(
+                        "AXG021",
+                        info,
+                        returned,
+                        "sample_parameters must return TransformParameterPlan, not a plain dictionary",
+                        f"{info.name}.sample_parameters",
+                    )
+                )
+        for child in ast.walk(node):
+            if _is_first_target_shape_access(child) or _is_legacy_shape_helper_call(child):
+                detail = (
+                    "instead of first-target base_params['shape']"
+                    if _is_first_target_shape_access(child)
+                    else "instead of a first-target helper"
+                )
+                result.append(
+                    _d(
+                        "AXG022",
+                        info,
+                        child,
+                        (f"sample_parameters must use TransformSamplingInput.targets or spatial_frame {detail}"),
+                        f"{info.name}.sample_parameters",
+                    )
+                )
+    return result
+
+
+def rule_target_routing_parameters(index: SourceIndex) -> list[Diagnostic]:
+    result: list[Diagnostic] = []
+    for info in index.concrete_transforms():
+        for name, node in _method_targets(info):
+            for arg in argument_nodes(node)[1:]:
+                if arg.arg in TARGET_ROUTING_PARAMETER_ALLOWLIST:
+                    continue
+                if arg.arg.startswith(TARGET_ROUTING_PREFIXES):
+                    result.append(
+                        _d(
+                            "AXG023",
+                            info,
+                            arg,
+                            (
+                                "application parameters must use semantic names; target-specific routing belongs "
+                                "in TransformParameterPlan groups"
+                            ),
+                            f"{info.name}.{name}",
+                        )
+                    )
     return result
 
 
@@ -488,7 +616,7 @@ def rule_removed_sampling(index: SourceIndex) -> list[Diagnostic]:
                 "AXG010",
                 info,
                 info.methods[name],
-                f"{info.name}.{name} was removed; implement sample_parameters(params, data, sampling) instead",
+                f"{info.name}.{name} was removed; implement sample_parameters(inputs, sampling) instead",
                 f"{info.name}.{name}",
             )
             for name in ("get_params", "get_params_dependent_on_data")
@@ -1126,6 +1254,7 @@ def run_all(index: SourceIndex) -> list[Diagnostic]:
         rule_apply_defaults,
         rule_apply_length,
         rule_sampling_signature,
+        rule_sampling_plan_contract,
         rule_random_usage,
         rule_sampling_rng,
         rule_transform_names,
@@ -1142,6 +1271,7 @@ def run_all(index: SourceIndex) -> list[Diagnostic]:
         rule_method_docstrings,
         rule_apply_docstrings,
         rule_constructor_schema,
+        rule_target_routing_parameters,
     )
     diagnostics: list[Diagnostic] = []
     for check in checks:

--- a/tools/ax_coding_guidance/rules.py
+++ b/tools/ax_coding_guidance/rules.py
@@ -336,6 +336,33 @@ def _is_first_target_shape_access(node: ast.AST) -> bool:
     )
 
 
+def _direct_canonical_target_name(node: ast.AST) -> str | None:
+    target_names = {"image", "images", "volume"}
+    if (
+        isinstance(node, ast.Subscript)
+        and ast.unparse(node.value) == "data"
+        and ast.unparse(node.slice).strip("\"'") in target_names
+    ):
+        return ast.unparse(node.slice).strip("\"'")
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and ast.unparse(node.func.value) == "data"
+        and node.func.attr == "get"
+        and node.args
+        and ast.unparse(node.args[0]).strip("\"'") in target_names
+    ):
+        return ast.unparse(node.args[0]).strip("\"'")
+    if (
+        isinstance(node, ast.Compare)
+        and any(isinstance(operator, ast.In) for operator in node.ops)
+        and any(ast.unparse(comparator) == "data" for comparator in node.comparators)
+        and ast.unparse(node.left).strip("\"'") in target_names
+    ):
+        return ast.unparse(node.left).strip("\"'")
+    return None
+
+
 def _is_legacy_shape_helper_call(node: ast.AST) -> bool:
     return isinstance(node, ast.Call) and dotted(node.func) in {
         "get_image_data",
@@ -371,6 +398,11 @@ def rule_sampling_plan_contract(index: SourceIndex) -> list[Diagnostic]:
                         f"{info.name}.sample_parameters",
                     )
                 )
+        direct_target_accesses = [
+            (child, target_name)
+            for child in ast.walk(node)
+            if (target_name := _direct_canonical_target_name(child)) is not None
+        ]
         for child in ast.walk(node):
             if _is_first_target_shape_access(child) or _is_legacy_shape_helper_call(child):
                 detail = (
@@ -387,6 +419,16 @@ def rule_sampling_plan_contract(index: SourceIndex) -> list[Diagnostic]:
                         f"{info.name}.sample_parameters",
                     )
                 )
+        if len({target_name for _, target_name in direct_target_accesses}) > 1:
+            result.append(
+                _d(
+                    "AXG024",
+                    info,
+                    direct_target_accesses[0][0],
+                    "sample_parameters must use TargetSet instead of selecting among image, images, and volume",
+                    f"{info.name}.sample_parameters",
+                )
+            )
     return result
 
 

--- a/tools/ax_coding_guidance/rules.py
+++ b/tools/ax_coding_guidance/rules.py
@@ -326,6 +326,13 @@ def _is_first_target_shape_access(node: ast.AST) -> bool:
         isinstance(node, ast.Subscript)
         and ast.unparse(node.value) == "params"
         and (ast.unparse(node.slice).strip("\"'") == "shape")
+    ) or (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and ast.unparse(node.func.value) == "params"
+        and node.func.attr == "get"
+        and len(node.args) == 1
+        and ast.unparse(node.args[0]).strip("\"'") == "shape"
     )
 
 
@@ -367,7 +374,7 @@ def rule_sampling_plan_contract(index: SourceIndex) -> list[Diagnostic]:
         for child in ast.walk(node):
             if _is_first_target_shape_access(child) or _is_legacy_shape_helper_call(child):
                 detail = (
-                    "instead of first-target params['shape']"
+                    "instead of first-target params shape access"
                     if _is_first_target_shape_access(child)
                     else "instead of a first-target helper"
                 )

--- a/tools/ax_coding_guidance/rules.py
+++ b/tools/ax_coding_guidance/rules.py
@@ -254,13 +254,13 @@ def rule_sampling_signature(index: SourceIndex) -> list[Diagnostic]:
             continue
         args = node.args
         names = [arg.arg for arg in [*args.posonlyargs, *args.args]]
-        if names != ["self", "inputs", "sampling"] or args.kwonlyargs or args.vararg or args.kwarg:
+        if names != ["self", "params", "data", "targets", "sampling"] or args.kwonlyargs or args.vararg or args.kwarg:
             result.append(
                 _d(
                     "AXG004",
                     info,
                     node,
-                    "sample_parameters must have exactly self, inputs, sampling",
+                    "sample_parameters must have exactly self, params, data, targets, sampling",
                     f"{info.name}.sample_parameters",
                 )
             )
@@ -324,7 +324,7 @@ def _direct_sampler_returns(node: ast.FunctionDef | ast.AsyncFunctionDef) -> lis
 def _is_first_target_shape_access(node: ast.AST) -> bool:
     return (
         isinstance(node, ast.Subscript)
-        and ast.unparse(node.value) == "inputs.base_params"
+        and ast.unparse(node.value) == "params"
         and (ast.unparse(node.slice).strip("\"'") == "shape")
     )
 
@@ -360,14 +360,14 @@ def rule_sampling_plan_contract(index: SourceIndex) -> list[Diagnostic]:
                         "AXG021",
                         info,
                         returned,
-                        "sample_parameters must return TransformParameterPlan, not a plain dictionary",
+                        "sample_parameters must return SampledParams, not a plain dictionary",
                         f"{info.name}.sample_parameters",
                     )
                 )
         for child in ast.walk(node):
             if _is_first_target_shape_access(child) or _is_legacy_shape_helper_call(child):
                 detail = (
-                    "instead of first-target base_params['shape']"
+                    "instead of first-target params['shape']"
                     if _is_first_target_shape_access(child)
                     else "instead of a first-target helper"
                 )
@@ -376,7 +376,7 @@ def rule_sampling_plan_contract(index: SourceIndex) -> list[Diagnostic]:
                         "AXG022",
                         info,
                         child,
-                        (f"sample_parameters must use TransformSamplingInput.targets or spatial_frame {detail}"),
+                        f"sample_parameters must use TargetSet metadata {detail}",
                         f"{info.name}.sample_parameters",
                     )
                 )
@@ -398,7 +398,7 @@ def rule_target_routing_parameters(index: SourceIndex) -> list[Diagnostic]:
                             arg,
                             (
                                 "application parameters must use semantic names; target-specific routing belongs "
-                                "in TransformParameterPlan groups"
+                                "in SampledParams groups"
                             ),
                             f"{info.name}.{name}",
                         )

--- a/tools/ax_coding_guidance/rules.py
+++ b/tools/ax_coding_guidance/rules.py
@@ -616,7 +616,7 @@ def rule_removed_sampling(index: SourceIndex) -> list[Diagnostic]:
                 "AXG010",
                 info,
                 info.methods[name],
-                f"{info.name}.{name} was removed; implement sample_parameters(inputs, sampling) instead",
+                f"{info.name}.{name} was removed; implement sample_parameters(params, data, targets, sampling) instead",
                 f"{info.name}.{name}",
             )
             for name in ("get_params", "get_params_dependent_on_data")


### PR DESCRIPTION
## What changes

`sample_parameters` now makes its inputs explicit:

```python
def sample_parameters(self, params, data, targets, sampling) -> SampledParams:
```

- `params` contains execution values; `data` is the preprocessed invocation; `targets` describes active actual keys.
- `SampledParams(params=...)` holds values used for every applicable target. `TargetParams` holds values materialized for compatible actual targets.
- `TargetSet.require_aligned_spatial_shape(2)` and `(3)` make the alignment guarantee explicit for geometry.
- Replay stores only `parameter_schema`, `target_schema`, `params`, and `target_params`. Flat payloads and structured payloads with retired fields are rejected.
- All built-in samplers, replay, custom-transform guidance, tests, and source enforcement use this contract.

## Why

PR #462 exposed a mixed image/volume failure, but the underlying bug is broader: a sampled value derived from one target can be invalid for an alias, batch, mask, or volume with different channels, dtype scaling, shape, layout, topology, or content. Actual target keys now select the materialized value without encoding routing in names such as `volume_noise_map`.

## Compatibility

This is a greenfield execution/replay schema cutover. There is no dual decoder for earlier sampled-parameter payloads.

## Performance scope

This is a correctness and API-clarity change, not an optimization. The path with no target-specific values applies one parameter mapping to every target without a per-target lookup. The design records paired base-to-head full-route measurement as merge evidence; this PR makes no speedup claim.

## Validation

- Focused core, replay, 3D, and coding-guidance tests: `1861 passed, 17 skipped`.
- Full `uv run pytest -qq` completed successfully.
- Full `pre-commit run --all-files` passed, including Ruff, mypy, Pyrefly, documentation, integrity, and the target-sampling guidance checks.

Design: `docs/design/target-specific-parameter-sampling.md`.