### PR TITLE
feat(pixel): add StochasticConvolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [SaltAndPepper](https://albumentations.ai/explore/transform/SaltAndPepper/?utm_source=github&utm_medium=referral&utm_campaign=readme)
 - [Sharpen](https://albumentations.ai/explore/transform/Sharpen/?utm_source=github&utm_medium=referral&utm_campaign=readme)
 - [ShotNoise](https://albumentations.ai/explore/transform/ShotNoise/?utm_source=github&utm_medium=referral&utm_campaign=readme)
+- [StochasticConvolution](https://albumentations.ai/explore/transform/StochasticConvolution/?utm_source=github&utm_medium=referral&utm_campaign=readme)
 - [Solarize](https://albumentations.ai/explore/transform/Solarize/?utm_source=github&utm_medium=referral&utm_campaign=readme)
 - [Spatter](https://albumentations.ai/explore/transform/Spatter/?utm_source=github&utm_medium=referral&utm_campaign=readme)
 - [Superpixels](https://albumentations.ai/explore/transform/Superpixels/?utm_source=github&utm_medium=referral&utm_campaign=readme)

--- a/albumentations/augmentations/pixel/_functional_sharpness.py
+++ b/albumentations/augmentations/pixel/_functional_sharpness.py
@@ -358,7 +358,11 @@ def planckian_jitter(
 
 @clipped
 @preserve_channel_dim
-def convolve(img: ImageType, kernel: np.ndarray) -> ImageType:
+def convolve(
+    img: ImageType,
+    kernel: np.ndarray,
+    border_mode: int = cv2.BORDER_DEFAULT,
+) -> ImageType:
     """Convolve image with 2D kernel via cv2.filter2D. Any channel count. Use for custom blur,
     sharpen, or edge kernels. Clipped.
 
@@ -366,15 +370,76 @@ def convolve(img: ImageType, kernel: np.ndarray) -> ImageType:
 
     Args:
         img (ImageType): Input image.
-        kernel (np.ndarray): Kernel.
+        kernel (np.ndarray): A 2D kernel shared across channels, or a stack of 2D kernels with
+            shape `(channels, height, width)`.
+        border_mode (int): OpenCV border mode used for pixels outside the image.
 
     Returns:
         ImageType: Convolved image.
 
     """
     img = cast("ImageType", np.array(img, copy=True, order="C"))
-    cv2.filter2D(img, ddepth=-1, kernel=kernel, dst=img)
+    if kernel.ndim == 2:
+        cv2.filter2D(img, ddepth=-1, kernel=kernel, dst=img, borderType=border_mode)
+        return img
+
+    if kernel.ndim != 3:
+        raise ValueError(f"kernel must have 2 or 3 dimensions, got {kernel.ndim}")
+
+    channels = 1 if img.ndim == 2 else img.shape[-1]
+    if kernel.shape[0] != channels:
+        raise ValueError(f"Expected one kernel per channel ({channels}), got {kernel.shape[0]}")
+
+    if img.ndim == 2:
+        cv2.filter2D(img, ddepth=-1, kernel=kernel[0], dst=img, borderType=border_mode)
+    else:
+        for channel, channel_kernel in enumerate(kernel):
+            filtered_channel = cv2.filter2D(
+                img[..., channel],
+                ddepth=-1,
+                kernel=channel_kernel,
+                borderType=border_mode,
+            )
+            img[..., channel] = filtered_channel
     return img
+
+
+def create_stochastic_convolution_kernel(
+    random_field: np.ndarray,
+    strength: float,
+) -> np.ndarray:
+    """Create an identity-centered stochastic convolution kernel from a sampled field.
+
+    The field contains either one `(K, K)` kernel or one `(C, K, K)` kernel per channel. The
+    random component is scaled by `strength / K` so its expected energy is independent of the
+    selected kernel side length. The identity impulse is added without normalizing the result;
+    signed weights and realized DC gain are therefore preserved.
+
+    Args:
+        random_field (np.ndarray): Float random field with shape `(K, K)` or `(C, K, K)`.
+        strength (float): Non-negative perturbation strength.
+
+    Returns:
+        np.ndarray: Float32 kernel with the same rank as `random_field`.
+
+    Raises:
+        ValueError: If the field is not square or has an unsupported rank.
+
+    """
+    if random_field.ndim not in {2, 3}:
+        raise ValueError(f"random_field must have 2 or 3 dimensions, got {random_field.ndim}")
+    kernel_size = random_field.shape[-1]
+    if random_field.shape[-2] != kernel_size or kernel_size % 2 == 0:
+        raise ValueError("random_field must contain odd square kernels")
+
+    kernel = np.array(random_field, dtype=np.float32, copy=True, order="C")
+    np.multiply(kernel, np.float32(strength / kernel_size), out=kernel)
+    center = kernel_size // 2
+    if kernel.ndim == 2:
+        kernel[center, center] += 1.0
+    else:
+        kernel[:, center, center] += 1.0
+    return kernel
 
 
 @clipped
@@ -404,6 +469,7 @@ __all__ = [
     "_get_planckian_coeffs",
     "chromatic_aberration",
     "convolve",
+    "create_stochastic_convolution_kernel",
     "pixel_dropout",
     "planckian_jitter",
     "separable_convolve",

--- a/albumentations/augmentations/pixel/_functional_sharpness.py
+++ b/albumentations/augmentations/pixel/_functional_sharpness.py
@@ -428,6 +428,8 @@ def create_stochastic_convolution_kernel(
     """
     if random_field.ndim not in {2, 3}:
         raise ValueError(f"random_field must have 2 or 3 dimensions, got {random_field.ndim}")
+    if not np.isfinite(strength) or strength < 0:
+        raise ValueError("strength must be finite and non-negative")
     kernel_size = random_field.shape[-1]
     if random_field.shape[-2] != kernel_size or kernel_size % 2 == 0:
         raise ValueError("random_field must contain odd square kernels")

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -115,16 +115,6 @@ class _FullVolumeNoiseTransform(ImageOnlyTransform):
     _volume_sampling_is_slice_wise: ClassVar[bool] = False
 
 
-_STOCHASTIC_CONVOLUTION_BORDER_MODES = frozenset(
-    {
-        cv2.BORDER_CONSTANT,
-        cv2.BORDER_REPLICATE,
-        cv2.BORDER_REFLECT,
-        cv2.BORDER_REFLECT_101,
-    },
-)
-
-
 class StochasticConvolution(_FullVolumeNoiseTransform):
     """Apply a stochastic identity-centered convolution kernel with configurable spectral strength and channel sharing
     for images and volumes.
@@ -204,23 +194,13 @@ class StochasticConvolution(_FullVolumeNoiseTransform):
             AfterValidator(nondecreasing),
         ]
         per_channel: bool
-        border_mode: BorderModeType
+        border_mode: Literal[0, 1, 2, 4]
 
         @field_validator("kernel_range")
         @classmethod
         def _check_odd_kernel_range(cls, value: tuple[int, int]) -> tuple[int, int]:
             if any(size % 2 == 0 for size in value):
                 raise ValueError(f"kernel_range values must be odd, got {value}")
-            return value
-
-        @field_validator("border_mode")
-        @classmethod
-        def _check_border_mode(cls, value: BorderModeType) -> BorderModeType:
-            if value not in _STOCHASTIC_CONVOLUTION_BORDER_MODES:
-                raise ValueError(
-                    "border_mode must be one of cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, "
-                    "cv2.BORDER_REFLECT, or cv2.BORDER_REFLECT_101",
-                )
             return value
 
     def __init__(

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -32,7 +32,12 @@ from albumentations.core.transforms_interface import (
     BaseTransformInitSchema,
     ImageOnlyTransform,
 )
-from albumentations.core.type_definitions import PAIR, ImageType
+from albumentations.core.type_definitions import (
+    CV2_BORDER_REFLECT_101,
+    PAIR,
+    BorderModeType,
+    ImageType,
+)
 
 __all__ = [
     "AdditiveNoise",
@@ -43,6 +48,7 @@ __all__ = [
     "RicianNoise",
     "SaltAndPepper",
     "ShotNoise",
+    "StochasticConvolution",
 ]
 
 
@@ -60,6 +66,161 @@ def _get_noise_map_shape(
 
 class _FullVolumeNoiseTransform(ImageOnlyTransform):
     _volume_sampling_is_slice_wise: ClassVar[bool] = False
+
+
+class StochasticConvolution(_FullVolumeNoiseTransform):
+    """Apply a stochastic identity-centered convolution kernel with configurable spectral strength and channel sharing
+    for images and volumes.
+
+    The kernel is a discrete impulse plus a zero-mean Gaussian field. `kernel_range` controls the
+    odd side length `K` (the spectral resolution in PRIME), while `strength_range` controls the
+    perturbation energy. The random field is scaled by `strength / K` so the expected perturbation
+    energy remains comparable across kernel sizes.
+
+    Args:
+        kernel_range (tuple[int, int]): Inclusive odd range for the square kernel side length. Values must be
+            greater than or equal to 3. Default: (3, 7).
+        strength_range (tuple[float, float]): Non-negative range for the random field strength. Zero is an exact
+            identity. Default: (0.0, 1.0).
+        per_channel (bool): If True, sample an independent kernel for each channel. If False, share one kernel
+            across all channels. Default: False.
+        border_mode (BorderModeType): OpenCV border policy. Supported values are constant, replicate, reflect,
+            and reflect-101; wrap is rejected because it is not supported by the convolution backend. Default:
+            `cv2.BORDER_REFLECT_101`.
+        p (float): Probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image, volume
+
+    Image types:
+        uint8, float32
+
+    Number of channels:
+        Any
+
+    Notes:
+        - The random weights are not normalized or mean-subtracted. They may be signed, and the realized DC gain
+          is the sampled kernel sum (with expected gain 1).
+        - `cv2.BORDER_CONSTANT` uses zero padding, matching the PRIME reference implementation. The default
+          reflect-101 border is the project-wide image-friendly choice.
+        - One kernel realization is sampled per transform invocation and reused for every image in a batch and every
+          depth slice in a volume.
+        - Applied configuration records the sampled scalar values for the range fields and remains runnable after JSON
+          transport. The in-memory replay path retains the realized kernel through transform parameters.
+
+    Examples:
+        >>> import numpy as np
+        >>> import albumentations as A
+        >>> import cv2
+        >>> image = np.random.default_rng(137).random((128, 128, 3), dtype=np.float32)
+        >>> transform = A.Compose(
+        ...     [
+        ...         A.StochasticConvolution(
+        ...             kernel_range=(3, 7),
+        ...             strength_range=(0.05, 0.25),
+        ...             border_mode=cv2.BORDER_REFLECT_101,
+        ...             p=1.0,
+        ...         ),
+        ...     ],
+        ...     seed=137,
+        ... )
+        >>> transformed = transform(image=image)["image"]
+
+        Use `per_channel=True` for independent spectral perturbations, or `strength_range=(0.0, 0.0)` for an
+        exact identity while keeping the transform in a pipeline.
+
+    References:
+        - PRIME issue: https://github.com/albumentations-team/AlbumentationsX/issues/330
+        - PRIME randomized-filter construction: https://github.com/amodas/PRIME-augmentations/blob/main/utils/rand_filter.py
+
+    """
+
+    class InitSchema(BaseTransformInitSchema):
+        kernel_range: Annotated[
+            tuple[int, int],
+            AfterValidator(check_range_bounds(3)),
+            AfterValidator(nondecreasing),
+        ]
+        strength_range: Annotated[
+            tuple[float, float],
+            AfterValidator(check_range_bounds(0)),
+            AfterValidator(nondecreasing),
+        ]
+        per_channel: bool
+        border_mode: BorderModeType
+
+        @field_validator("kernel_range")
+        @classmethod
+        def _check_odd_kernel_range(cls, value: tuple[int, int]) -> tuple[int, int]:
+            if any(size % 2 == 0 for size in value):
+                raise ValueError(f"kernel_range values must be odd, got {value}")
+            return value
+
+        @field_validator("border_mode")
+        @classmethod
+        def _check_border_mode(cls, value: BorderModeType) -> BorderModeType:
+            if value == cv2.BORDER_WRAP:
+                raise ValueError("border_mode=cv2.BORDER_WRAP is not supported for StochasticConvolution")
+            return value
+
+    def __init__(
+        self,
+        *,
+        kernel_range: tuple[int, int] = (3, 7),
+        strength_range: tuple[float, float] = (0.0, 1.0),
+        per_channel: bool = False,
+        border_mode: BorderModeType = CV2_BORDER_REFLECT_101,
+        p: float = 0.5,
+    ):
+        super().__init__(p=p)
+        self.kernel_range = kernel_range
+        self.strength_range = strength_range
+        self.per_channel = per_channel
+        self.border_mode = border_mode
+
+    @staticmethod
+    def _channel_count(value: Any, target: str) -> int:
+        if value.ndim == 2 or (target in {"images", "volume"} and value.ndim == 3):
+            return 1
+        return int(value.shape[-1])
+
+    def apply(self, img: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
+        return fpixel.convolve(img, kernel=kernel, border_mode=self.border_mode)
+
+    def sample_parameters(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        sampling: SamplingContext,
+    ) -> dict[str, Any]:
+        del params
+        metadata = self.get_image_data(data)
+        kernel_size = sampling.py_random.randrange(self.kernel_range[0], self.kernel_range[1] + 1, 2)
+        strength = sampling.py_random.uniform(*self.strength_range)
+        sampling.applied_overrides.update({"kernel_range": kernel_size, "strength_range": strength})
+
+        if self.per_channel:
+            channel_counts = {
+                target: self._channel_count(value, target)
+                for target in ("image", "images", "volume")
+                if (value := data.get(target)) is not None
+            }
+            if len(set(channel_counts.values())) > 1:
+                raise ValueError(
+                    "per_channel=True requires image, images, and volume targets to have the same channel count; "
+                    f"got {channel_counts}",
+                )
+            field_shape: tuple[int, ...] = (metadata["num_channels"], kernel_size, kernel_size)
+        else:
+            field_shape = (kernel_size, kernel_size)
+
+        random_field: np.ndarray
+        if strength == 0:
+            random_field = np.zeros(field_shape, dtype=np.float32)
+        else:
+            random_field = sampling.random_generator.standard_normal(field_shape, dtype=np.float32)
+        kernel = fpixel.create_stochastic_convolution_kernel(random_field, strength)
+        return {"kernel": kernel}
 
 
 class GaussNoise(_FullVolumeNoiseTransform):
@@ -1124,8 +1285,8 @@ class SaltAndPepper(_FullVolumeNoiseTransform):
         num_pixels = int(area * total_amount)
         num_salt = int(num_pixels * salt_ratio)
         noise_positions = sampling.random_generator.choice(area, size=num_pixels, replace=False)
-        salt_mask = np.zeros(area, dtype=bool)
-        pepper_mask = np.zeros(area, dtype=bool)
+        salt_mask: np.ndarray = np.zeros(area, dtype=bool)
+        pepper_mask: np.ndarray = np.zeros(area, dtype=bool)
         salt_mask[noise_positions[:num_salt]] = True
         pepper_mask[noise_positions[num_salt:]] = True
         return salt_mask.reshape(spatial_shape), pepper_mask.reshape(spatial_shape)

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -238,49 +238,46 @@ class StochasticConvolution(_FullVolumeNoiseTransform):
         self.per_channel = per_channel
         self.border_mode = border_mode
 
-    @staticmethod
-    def _channel_count(value: Any, target: str) -> int:
-        if value.ndim == 2 or (target in {"images", "volume"} and value.ndim == 3):
-            return 1
-        return int(value.shape[-1])
-
     def apply(self, img: ImageType, kernel: np.ndarray, **params: Any) -> ImageType:
         return fpixel.convolve(img, kernel=kernel, border_mode=self.border_mode)
+
+    @staticmethod
+    def _sample_kernel(
+        kernel_shape: tuple[int, ...],
+        strength: float,
+        sampling: SamplingContext,
+    ) -> np.ndarray:
+        random_field = (
+            np.zeros(kernel_shape, dtype=np.float32)
+            if strength == 0
+            else sampling.random_generator.standard_normal(kernel_shape, dtype=np.float32)
+        )
+        return fpixel.create_stochastic_convolution_kernel(random_field, strength)
 
     def sample_parameters(
         self,
         params: dict[str, Any],
         data: dict[str, Any],
+        targets: TargetSet,
         sampling: SamplingContext,
-    ) -> dict[str, Any]:
-        del params
+    ) -> SampledParams:
+        del params, data
         kernel_size = sampling.py_random.randrange(self.kernel_range[0], self.kernel_range[1] + 1, 2)
         strength = sampling.py_random.uniform(*self.strength_range)
         sampling.applied_overrides.update({"kernel_range": kernel_size, "strength_range": strength})
 
-        if self.per_channel:
-            channel_counts = {
-                target: self._channel_count(value, target)
-                for target in ("image", "images", "volume")
-                if (value := data.get(target)) is not None
-            }
-            if len(set(channel_counts.values())) > 1:
-                raise ValueError(
-                    "per_channel=True requires image, images, and volume targets to have the same channel count; "
-                    f"got {channel_counts}",
-                )
-            channel_count = next(iter(channel_counts.values()))
-            field_shape: tuple[int, ...] = (channel_count, kernel_size, kernel_size)
-        else:
-            field_shape = (kernel_size, kernel_size)
+        if not self.per_channel:
+            kernel = self._sample_kernel((kernel_size, kernel_size), strength, sampling)
+            return SampledParams(params={"kernel": kernel})
 
-        random_field: np.ndarray
-        if strength == 0:
-            random_field = np.zeros(field_shape, dtype=np.float32)
-        else:
-            random_field = sampling.random_generator.standard_normal(field_shape, dtype=np.float32)
-        kernel = fpixel.create_stochastic_convolution_kernel(random_field, strength)
-        return {"kernel": kernel}
+        groups: list[TargetParams] = []
+        for views in targets.group_image_like_by(lambda view: view.descriptor.channels):
+            channel_count = views[0].descriptor.channels
+            if channel_count is None:
+                raise ValueError("StochasticConvolution requires image-like targets with a known channel count")
+            kernel = self._sample_kernel((channel_count, kernel_size, kernel_size), strength, sampling)
+            groups.append(_target_parameter_group(views, "kernel", kernel, channels=True))
+        return SampledParams(params={}, target_params=tuple(groups))
 
 
 class GaussNoise(_FullVolumeNoiseTransform):

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -36,7 +36,6 @@ from albumentations.core.transforms_interface import (
 from albumentations.core.type_definitions import (
     CV2_BORDER_REFLECT_101,
     PAIR,
-    BorderModeType,
     ImageType,
 )
 
@@ -209,7 +208,7 @@ class StochasticConvolution(_FullVolumeNoiseTransform):
         kernel_range: tuple[int, int] = (3, 7),
         strength_range: tuple[float, float] = (0.0, 1.0),
         per_channel: bool = False,
-        border_mode: BorderModeType = CV2_BORDER_REFLECT_101,
+        border_mode: Literal[0, 1, 2, 4] = CV2_BORDER_REFLECT_101,
         p: float = 0.5,
     ):
         super().__init__(p=p)

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -68,6 +68,16 @@ class _FullVolumeNoiseTransform(ImageOnlyTransform):
     _volume_sampling_is_slice_wise: ClassVar[bool] = False
 
 
+_STOCHASTIC_CONVOLUTION_BORDER_MODES = frozenset(
+    {
+        cv2.BORDER_CONSTANT,
+        cv2.BORDER_REPLICATE,
+        cv2.BORDER_REFLECT,
+        cv2.BORDER_REFLECT_101,
+    },
+)
+
+
 class StochasticConvolution(_FullVolumeNoiseTransform):
     """Apply a stochastic identity-centered convolution kernel with configurable spectral strength and channel sharing
     for images and volumes.
@@ -159,8 +169,11 @@ class StochasticConvolution(_FullVolumeNoiseTransform):
         @field_validator("border_mode")
         @classmethod
         def _check_border_mode(cls, value: BorderModeType) -> BorderModeType:
-            if value == cv2.BORDER_WRAP:
-                raise ValueError("border_mode=cv2.BORDER_WRAP is not supported for StochasticConvolution")
+            if value not in _STOCHASTIC_CONVOLUTION_BORDER_MODES:
+                raise ValueError(
+                    "border_mode must be one of cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, "
+                    "cv2.BORDER_REFLECT, or cv2.BORDER_REFLECT_101",
+                )
             return value
 
     def __init__(
@@ -194,7 +207,6 @@ class StochasticConvolution(_FullVolumeNoiseTransform):
         sampling: SamplingContext,
     ) -> dict[str, Any]:
         del params
-        metadata = self.get_image_data(data)
         kernel_size = sampling.py_random.randrange(self.kernel_range[0], self.kernel_range[1] + 1, 2)
         strength = sampling.py_random.uniform(*self.strength_range)
         sampling.applied_overrides.update({"kernel_range": kernel_size, "strength_range": strength})
@@ -210,7 +222,8 @@ class StochasticConvolution(_FullVolumeNoiseTransform):
                     "per_channel=True requires image, images, and volume targets to have the same channel count; "
                     f"got {channel_counts}",
                 )
-            field_shape: tuple[int, ...] = (metadata["num_channels"], kernel_size, kernel_size)
+            channel_count = next(iter(channel_counts.values()))
+            field_shape: tuple[int, ...] = (channel_count, kernel_size, kernel_size)
         else:
             field_shape = (kernel_size, kernel_size)
 

--- a/benchmark/benchmarks/test_batch_matrix.py
+++ b/benchmark/benchmarks/test_batch_matrix.py
@@ -77,6 +77,13 @@ IMAGE_BATCH_TRANSFORMS: Mapping[str, BatchSpec] = {
     "random_tone_curve_per_channel": BatchSpec(
         lambda: albumentations.RandomToneCurve(per_channel=True, p=1.0),
     ),
+    "stochastic_convolution": BatchSpec(
+        lambda: albumentations.StochasticConvolution(
+            kernel_range=(3, 3),
+            strength_range=(0.1, 0.1),
+            p=1.0,
+        ),
+    ),
     "resize": BatchSpec(lambda: albumentations.Resize(height=128, width=128, p=1.0)),
     "spatter_mud": BatchSpec(
         lambda: albumentations.Spatter(mode="mud", p=1.0),

--- a/benchmark/benchmarks/test_family_matrix.py
+++ b/benchmark/benchmarks/test_family_matrix.py
@@ -155,6 +155,13 @@ PIXEL_TRANSFORMS: Mapping[str, PixelSpec] = {
     "noop": PixelSpec(lambda: albumentations.NoOp(p=1.0)),
     "shot_noise": PixelSpec(lambda: albumentations.ShotNoise(p=1.0), dtypes=("uint8",)),
     "rician_noise": PixelSpec(lambda: albumentations.RicianNoise(p=1.0)),
+    "stochastic_convolution": PixelSpec(
+        lambda: albumentations.StochasticConvolution(
+            kernel_range=(3, 3),
+            strength_range=(0.1, 0.1),
+            p=1.0,
+        ),
+    ),
     "normalize": PixelSpec(lambda: albumentations.Normalize(p=1.0)),
     "photometric_distort": PixelSpec(lambda: albumentations.PhotoMetricDistort(p=1.0), channels=(1, 3)),
     "pixel_dropout": PixelSpec(lambda: albumentations.PixelDropout(dropout_prob=0.05, p=1.0)),
@@ -299,6 +306,11 @@ VOLUME_TRANSFORMS: Mapping[str, Factory] = {
     "random_rotate90_3d": lambda: albumentations.RandomRotate90_3D(axis_pair=(0, 2), group_element="r90", p=1.0),
     "resize3d": lambda: albumentations.Resize3D(size=(12, 96, 96), p=1.0),
     "rician_noise": lambda: albumentations.RicianNoise(std_range=(0.1, 0.1), p=1.0),
+    "stochastic_convolution": lambda: albumentations.StochasticConvolution(
+        kernel_range=(3, 3),
+        strength_range=(0.1, 0.1),
+        p=1.0,
+    ),
 }
 
 REFERENCE_TRANSFORMS = (

--- a/benchmark/benchmarks/test_functional_kernels.py
+++ b/benchmark/benchmarks/test_functional_kernels.py
@@ -105,6 +105,8 @@ FUNCTIONAL_BLUR_KERNELS: Mapping[str, KernelSupport] = {
     "zoom_blur": KernelSupport(),
     "mode_filter": KernelSupport(),
     "glass_blur": KernelSupport(channels=(1, 3), sizes=("small", "medium")),
+    "stochastic_convolve_shared": KernelSupport(),
+    "stochastic_convolve_per_channel": KernelSupport(),
     **{name: KernelSupport() for name, _ in MEDIAN_BLUR_FUNCTIONAL_CASES},
 }
 
@@ -415,6 +417,14 @@ def _call_glass_blur(benchmark: Any) -> np.ndarray:
     return fblur.glass_blur(benchmark.image, 0.7, 2, benchmark.glass_iterations, benchmark.dxy, "fast")
 
 
+def _call_stochastic_convolve_shared(benchmark: Any) -> np.ndarray:
+    return fpixel.convolve(benchmark.image, benchmark.stochastic_kernel)
+
+
+def _call_stochastic_convolve_per_channel(benchmark: Any) -> np.ndarray:
+    return fpixel.convolve(benchmark.image, benchmark.stochastic_per_channel_kernel)
+
+
 def _make_median_blur_call(kernel_size: int) -> ImageKernelCall:
     def call(benchmark: Any) -> np.ndarray:
         return median_blur(benchmark.image, kernel_size)
@@ -429,6 +439,8 @@ BLUR_CALLS: Mapping[str, ImageKernelCall] = {
     "zoom_blur": _call_zoom_blur,
     "mode_filter": _call_mode_filter,
     "glass_blur": _call_glass_blur,
+    "stochastic_convolve_shared": _call_stochastic_convolve_shared,
+    "stochastic_convolve_per_channel": _call_stochastic_convolve_per_channel,
     **{name: _make_median_blur_call(kernel_size) for name, kernel_size in MEDIAN_BLUR_FUNCTIONAL_CASES},
 }
 
@@ -600,6 +612,10 @@ class TimeFunctionalBlurKernels:
         self.name = name
         self.image = make_image(size_name, channels, dtype_from_name(dtype_name))
         self.kernel = np.ones((3, 3), dtype=np.float32) / 9
+        random_field = np.random.default_rng(137).standard_normal((3, 3), dtype=np.float32)
+        per_channel_field = np.random.default_rng(138).standard_normal((channels, 3, 3), dtype=np.float32)
+        self.stochastic_kernel = fpixel.create_stochastic_convolution_kernel(random_field, 0.1)
+        self.stochastic_per_channel_kernel = fpixel.create_stochastic_convolution_kernel(per_channel_field, 0.1)
         self.zoom_factors = np.array([1.0, 1.02, 1.04], dtype=np.float32)
         self.glass_iterations = 1
         max_delta = 2

--- a/tests/files/public_transform_positional_parameters.json
+++ b/tests/files/public_transform_positional_parameters.json
@@ -121,6 +121,7 @@
   "Sharpen": ["alpha_range", "lightness_range", "method", "kernel_size", "sigma", "p"],
   "ShiftScaleRotate": ["shift_range", "scale_range", "rotate_range", "interpolation", "border_mode", "shift_range_x", "shift_range_y", "rotate_method", "mask_interpolation", "fill", "fill_mask", "p"],
   "ShotNoise": ["scale_range", "p"],
+  "StochasticConvolution": [],
   "SmallestMaxSize": ["max_size", "max_size_hw", "interpolation", "mask_interpolation", "area_for_downscale", "p"],
   "Solarize": ["threshold_range", "p"],
   "Spatter": ["mean_range", "std_range", "gauss_sigma_range", "cutout_threshold_range", "intensity_range", "mode", "color", "p"],

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -564,6 +564,15 @@ _BASE_CASE_SPECS: list[list[Any]] = [
     [A.GridElasticDeform, {"num_grid_xy": (10, 10), "magnitude": 10}],
     [A.ShotNoise, {"scale_range": (0.1, 0.3)}],
     [A.RicianNoise, {"std_range": (0.05, 0.15)}],
+    [
+        A.StochasticConvolution,
+        {
+            "kernel_range": (3, 7),
+            "strength_range": (0.1, 0.3),
+            "per_channel": True,
+            "border_mode": cv2.BORDER_REFLECT,
+        },
+    ],
     [A.TimeReverse, {}],
     [A.TimeMasking, {"time_mask_param": 10}],
     [A.FrequencyMasking, {"freq_mask_param": 30}],
@@ -1173,6 +1182,16 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
     ("stronger", A.ShotNoise, {"scale_range": (0.2, 0.4)}),
     ("stronger", A.RicianNoise, {"std_range": (0.1, 0.3)}),
     ("per-channel", A.RicianNoise, {"std_range": (0.05, 0.15), "per_channel": True}),
+    (
+        "constant-border",
+        A.StochasticConvolution,
+        {
+            "kernel_range": (5, 5),
+            "strength_range": (0.2, 0.2),
+            "per_channel": False,
+            "border_mode": cv2.BORDER_CONSTANT,
+        },
+    ),
     (
         "max-size-hw-downscale",
         A.SmallestMaxSize,

--- a/tests/test_stochastic_convolution.py
+++ b/tests/test_stochastic_convolution.py
@@ -1,0 +1,262 @@
+import cv2
+import numpy as np
+import pytest
+
+import albumentations as A
+from albumentations.augmentations.pixel import functional as fpixel
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("channels", [1, 3, 5])
+def test_stochastic_convolution_preserves_shape_dtype_and_range(dtype: np.dtype, channels: int) -> None:
+    rng = np.random.default_rng(137)
+    image = (
+        rng.integers(0, 256, (23, 19, channels), dtype=np.uint8)
+        if dtype == np.uint8
+        else rng.random((23, 19, channels), dtype=np.float32)
+    )
+    transform = A.Compose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(3, 3),
+                strength_range=(0.15, 0.15),
+                per_channel=channels != 1,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    result = transform(image=image)["image"]
+
+    assert result.shape == image.shape
+    assert result.dtype == image.dtype
+    assert np.isfinite(result).all()
+    if dtype == np.uint8:
+        assert result.min() >= 0
+        assert result.max() <= 255
+    else:
+        assert result.min() >= 0
+        assert result.max() <= 1
+
+
+@pytest.mark.parametrize("channels", [1, 3, 5])
+def test_zero_strength_is_an_exact_identity(channels: int) -> None:
+    image = np.random.default_rng(137).random((17, 13, channels), dtype=np.float32)
+    transform = A.Compose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(3, 7),
+                strength_range=(0.0, 0.0),
+                per_channel=True,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    result = transform(image=image)["image"]
+
+    np.testing.assert_array_equal(result, image)
+
+
+def test_shared_and_per_channel_kernels_have_distinct_channel_semantics() -> None:
+    image = np.zeros((31, 29, 3), dtype=np.float32)
+    image[15, 14] = 1.0
+
+    shared = A.Compose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(5, 5),
+                strength_range=(0.25, 0.25),
+                per_channel=False,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )(image=image)["image"]
+    per_channel = A.Compose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(5, 5),
+                strength_range=(0.25, 0.25),
+                per_channel=True,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )(image=image)["image"]
+
+    np.testing.assert_array_equal(shared[..., 0], shared[..., 1])
+    assert not np.array_equal(per_channel[..., 0], per_channel[..., 1])
+
+
+def test_batch_and_volume_reuse_one_kernel_realization() -> None:
+    image = np.random.default_rng(137).random((13, 17, 3), dtype=np.float32)
+    images = np.stack([image, image], axis=0)
+    volume = np.stack([image, image], axis=0)
+    transform = A.Compose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(3, 3),
+                strength_range=(0.2, 0.2),
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    result = transform(images=images, volume=volume)
+
+    np.testing.assert_array_equal(result["images"][0], result["images"][1])
+    np.testing.assert_array_equal(result["volume"][0], result["volume"][1])
+
+
+def test_per_channel_rejects_mismatched_image_and_volume_channels() -> None:
+    image = np.zeros((11, 13, 3), dtype=np.float32)
+    volume = np.zeros((2, 11, 13, 5), dtype=np.float32)
+    transform = A.Compose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(3, 3),
+                strength_range=(0.1, 0.1),
+                per_channel=True,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    with pytest.raises(ValueError, match="same channel count"):
+        transform(image=image, volume=volume)
+
+
+def test_stochastic_convolution_is_seed_reproducible() -> None:
+    image = np.random.default_rng(137).random((19, 23, 3), dtype=np.float32)
+    transform_kwargs = {
+        "kernel_range": (3, 7),
+        "strength_range": (0.1, 0.3),
+        "per_channel": True,
+        "p": 1.0,
+    }
+
+    first = A.Compose([A.StochasticConvolution(**transform_kwargs)], seed=137)(image=image)["image"]
+    second = A.Compose([A.StochasticConvolution(**transform_kwargs)], seed=137)(image=image)["image"]
+
+    np.testing.assert_array_equal(first, second)
+
+
+def test_stochastic_convolution_replay_reuses_realized_kernel() -> None:
+    image = np.random.default_rng(137).random((19, 23, 3), dtype=np.float32)
+    pipeline = A.ReplayCompose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(3, 3),
+                strength_range=(0.2, 0.2),
+                per_channel=True,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    original = pipeline(image=image)
+    replayed = A.ReplayCompose.replay(original["replay"], image=image)
+
+    np.testing.assert_array_equal(replayed["image"], original["image"])
+
+
+def test_stochastic_convolution_records_constructor_valid_realized_ranges() -> None:
+    image = np.random.default_rng(137).random((19, 23, 3), dtype=np.float32)
+    transform = A.Compose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(3, 7),
+                strength_range=(0.1, 0.3),
+                per_channel=True,
+                border_mode=cv2.BORDER_REFLECT,
+                p=1.0,
+            ),
+        ],
+        save_applied_params=True,
+        seed=137,
+    )
+
+    result = transform(image=image)
+    applied = result["applied_transforms"][0][1]
+
+    assert applied["kernel_range"] in {3, 5, 7}
+    assert 0.1 <= applied["strength_range"] <= 0.3
+    assert applied["border_mode"] == cv2.BORDER_REFLECT
+    assert applied["per_channel"] is True
+
+
+def test_convolve_accepts_per_channel_kernels_and_explicit_border_mode() -> None:
+    image = np.arange(25, dtype=np.float32).reshape(5, 5, 1) / 25
+    random_field = np.zeros((1, 3, 3), dtype=np.float32)
+    random_field[0, 1, 0] = 1.0
+    kernel = fpixel.create_stochastic_convolution_kernel(random_field, strength=1.0)
+
+    result = fpixel.convolve(image, kernel, border_mode=cv2.BORDER_CONSTANT)
+    expected = cv2.filter2D(image[..., 0], -1, kernel[0], borderType=cv2.BORDER_CONSTANT)[..., None]
+
+    np.testing.assert_array_equal(result, np.clip(expected, 0, 1))
+
+
+def test_kernel_strength_is_normalized_by_side_length_without_dc_normalization() -> None:
+    field_3 = np.ones((3, 3), dtype=np.float32)
+    field_5 = np.ones((5, 5), dtype=np.float32)
+
+    kernel_3 = fpixel.create_stochastic_convolution_kernel(field_3, strength=1.5)
+    kernel_5 = fpixel.create_stochastic_convolution_kernel(field_5, strength=1.5)
+
+    np.testing.assert_allclose(kernel_3[0, 0], 0.5)
+    np.testing.assert_allclose(kernel_5[0, 0], 0.3)
+    np.testing.assert_allclose(kernel_3.sum(), 1.0 + 1.5 * 3.0)
+    np.testing.assert_allclose(kernel_5.sum(), 1.0 + 1.5 * 5.0)
+
+
+def test_constant_input_follows_realized_kernel_dc_gain() -> None:
+    field = np.zeros((3, 3), dtype=np.float32)
+    field[0, 0] = 1.0
+    field[1, 2] = -2.0
+    kernel = fpixel.create_stochastic_convolution_kernel(field, strength=1.0)
+    image = np.full((11, 13, 1), 0.25, dtype=np.float32)
+
+    result = fpixel.convolve(image, kernel, border_mode=cv2.BORDER_REFLECT)
+
+    expected_value = np.float32(0.25 * kernel.sum())
+    np.testing.assert_allclose(result, expected_value)
+
+
+def test_extreme_strength_stays_finite_and_clipped() -> None:
+    image = np.full((17, 19, 5), 0.5, dtype=np.float32)
+    transform = A.Compose(
+        [
+            A.StochasticConvolution(
+                kernel_range=(7, 7),
+                strength_range=(100.0, 100.0),
+                per_channel=True,
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    result = transform(image=image)["image"]
+
+    assert result.dtype == np.float32
+    assert np.isfinite(result).all()
+    assert result.min() >= 0
+    assert result.max() <= 1
+
+
+@pytest.mark.parametrize("invalid_range", [(2, 5), (3, 6), (4, 6)])
+def test_stochastic_convolution_rejects_even_kernel_sizes(invalid_range: tuple[int, int]) -> None:
+    with pytest.raises(ValueError):
+        A.StochasticConvolution(kernel_range=invalid_range)
+
+
+def test_stochastic_convolution_rejects_wrap_border() -> None:
+    with pytest.raises(ValueError, match="BORDER_WRAP"):
+        A.StochasticConvolution(border_mode=cv2.BORDER_WRAP)

--- a/tests/test_stochastic_convolution.py
+++ b/tests/test_stochastic_convolution.py
@@ -257,6 +257,18 @@ def test_stochastic_convolution_rejects_even_kernel_sizes(invalid_range: tuple[i
         A.StochasticConvolution(kernel_range=invalid_range)
 
 
-def test_stochastic_convolution_rejects_wrap_border() -> None:
-    with pytest.raises(ValueError, match="BORDER_WRAP"):
-        A.StochasticConvolution(border_mode=cv2.BORDER_WRAP)
+@pytest.mark.parametrize(
+    "border_mode",
+    [cv2.BORDER_WRAP, cv2.BORDER_TRANSPARENT, cv2.BORDER_ISOLATED],
+)
+def test_stochastic_convolution_rejects_unsupported_border_modes(border_mode: int) -> None:
+    with pytest.raises(ValueError, match="border_mode"):
+        A.StochasticConvolution(border_mode=border_mode)
+
+
+@pytest.mark.parametrize("strength", [-0.1, float("inf"), float("nan")])
+def test_stochastic_convolution_kernel_rejects_invalid_strength(strength: float) -> None:
+    random_field = np.zeros((3, 3), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="strength"):
+        fpixel.create_stochastic_convolution_kernel(random_field, strength)

--- a/tests/test_stochastic_convolution.py
+++ b/tests/test_stochastic_convolution.py
@@ -4,6 +4,7 @@ import pytest
 
 import albumentations as A
 from albumentations.augmentations.pixel import functional as fpixel
+from albumentations.core.transform_params import SampledParams, SampledParamsError
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
@@ -112,10 +113,12 @@ def test_batch_and_volume_reuse_one_kernel_realization() -> None:
     np.testing.assert_array_equal(result["volume"][0], result["volume"][1])
 
 
-def test_per_channel_rejects_mismatched_image_and_volume_channels() -> None:
-    image = np.zeros((11, 13, 3), dtype=np.float32)
-    volume = np.zeros((2, 11, 13, 5), dtype=np.float32)
-    transform = A.Compose(
+def test_per_channel_groups_compatible_targets_and_replays() -> None:
+    image = np.random.default_rng(137).random((11, 13, 3), dtype=np.float32)
+    image2 = image.copy()
+    volume_image = np.concatenate((image, np.zeros((11, 13, 2), dtype=np.float32)), axis=-1)
+    volume = np.stack((volume_image, volume_image), axis=0)
+    pipeline = A.ReplayCompose(
         [
             A.StochasticConvolution(
                 kernel_range=(3, 3),
@@ -124,11 +127,36 @@ def test_per_channel_rejects_mismatched_image_and_volume_channels() -> None:
                 p=1.0,
             ),
         ],
+        additional_targets={"image2": "image"},
+        is_check_shapes=False,
         seed=137,
     )
 
-    with pytest.raises(ValueError, match="same channel count"):
-        transform(image=image, volume=volume)
+    original = pipeline(image=image, image2=image2, volume=volume)
+    sampled_params = SampledParams.from_dict(original["replay"]["transforms"][0]["params"])
+    replayed = A.ReplayCompose.replay(original["replay"], image=image, image2=image2, volume=volume)
+
+    assert {params.targets for params in sampled_params.target_params} == {("image", "image2"), ("volume",)}
+    assert sampled_params.params_for("image")["kernel"].shape == (3, 3, 3)
+    assert sampled_params.params_for("volume")["kernel"].shape == (5, 3, 3)
+    np.testing.assert_array_equal(original["image"], original["image2"])
+    for target in ("image", "image2", "volume"):
+        np.testing.assert_array_equal(replayed[target], original[target])
+
+
+def test_per_channel_replay_rejects_changed_channel_count() -> None:
+    image = np.zeros((11, 13, 3), dtype=np.float32)
+    pipeline = A.ReplayCompose(
+        [A.StochasticConvolution(kernel_range=(3, 3), strength_range=(0.1, 0.1), per_channel=True, p=1.0)],
+        additional_targets={"image2": "image"},
+        is_check_shapes=False,
+        seed=137,
+    )
+
+    recorded = pipeline(image=image, image2=image.copy())["replay"]
+
+    with pytest.raises(SampledParamsError, match="requirements do not match target 'image2'"):
+        A.ReplayCompose.replay(recorded, image=image, image2=np.zeros((11, 13, 5), dtype=np.float32))
 
 
 def test_stochastic_convolution_is_seed_reproducible() -> None:

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -310,6 +310,7 @@ DIRECT_KERNEL_TRANSFORMS = frozenset(
         "Resize",
         "Resize3D",
         "Solarize",
+        "StochasticConvolution",
         "ToGray",
         "Transpose",
         "VerticalFlip",

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -187,6 +187,7 @@ PIXEL_ALIAS_TO_TRANSFORM = {
     "sharpen": "Sharpen",
     "shot_noise": "ShotNoise",
     "rician_noise": "RicianNoise",
+    "stochastic_convolution": "StochasticConvolution",
     "posterize": "Posterize",
     "solarize": "Solarize",
     "spatter": "Spatter",
@@ -243,6 +244,7 @@ VOLUME_ALIAS_TO_TRANSFORM = {
     "random_rotate90_3d": "RandomRotate90_3D",
     "resize3d": "Resize3D",
     "rician_noise": "RicianNoise",
+    "stochastic_convolution": "StochasticConvolution",
 }
 
 BATCH_ALIAS_TO_TRANSFORM = {
@@ -262,6 +264,7 @@ BATCH_ALIAS_TO_TRANSFORM = {
     "random_shadow": "RandomShadow",
     "random_tone_curve": "RandomToneCurve",
     "random_tone_curve_per_channel": "RandomToneCurve",
+    "stochastic_convolution": "StochasticConvolution",
     "resize": "Resize",
     "spatter_mud": "Spatter",
     "spatter_rain": "Spatter",
@@ -388,6 +391,7 @@ DIRECT_KERNEL_CASE_PREFIXES_BY_TRANSFORM = {
     "PixelDropout": ("pixel_dropout",),
     "Posterize": ("posterize",),
     "RicianNoise": ("rician_noise",),
+    "StochasticConvolution": ("stochastic_convolve_shared", "stochastic_convolve_per_channel"),
     "RandomGamma": ("gamma_transform",),
     "RandomToneCurve": ("move_tone_curve_shared", "move_tone_curve_per_channel"),
     "Resize": ("resize", "resize_bboxes"),


### PR DESCRIPTION
Closes #330

## Summary

Adds `A.StochasticConvolution`, a focused randomized convolution transform based on an identity impulse plus a signed Gaussian field.

- Supports odd kernel-side ranges and PRIME-style spectral resolution control.
- Scales the random field by `strength / K`, keeping expected perturbation energy comparable across kernel sizes.
- Supports shared kernels and independent per-channel kernels for arbitrary channel counts.
- Supports explicit OpenCV border modes with `BORDER_WRAP` rejected.
- Samples one kernel realization per invocation and reuses it across image batches and volume depth slices.
- Keeps sampling in the invocation `SamplingContext` for seeded determinism and replay.

The kernel is intentionally not normalized or mean-subtracted. Signed weights and realized DC gain are preserved and documented; clipping remains explicit for `uint8` and `float32` outputs.

## Coverage

- Focused transform tests cover identity strength zero, impulse and constant inputs, signed/DC-gain behavior, extreme strengths, shared/per-channel semantics, arbitrary channels, dtype/range preservation, batch and volume reuse, channel mismatch validation, seeded reproducibility, replay, and border validation.
- Transform contract and strict JSON applied-configuration coverage are registered for the public constructor.
- README and public docstring metadata are updated.

## Benchmarks

- Direct OpenCV-backed convolution covers shared and per-channel kernels.
- Compose image matrix covers `256`, `512`, and `1024` square inputs, `1/3/5` channels, and `uint8`/`float32`.
- Volume matrix covers the public volume route, and the batch matrix covers `images` batch dispatch.
- Local candidate checks compared the OpenCV convolution route with a naive NumPy window implementation and NumPy versus OpenCV random-field generation while preserving AlbumentationsX seeded RNG semantics.
- A small fixed-image clean-versus-corruption sanity run measured monotonic perturbation as strength increased for both supported dtypes. This repository has no model/dataset accuracy harness, so the result is image-level corruption evidence rather than an accuracy claim.

## Validation

- `tests/test_stochastic_convolution.py`: 23 passed
- `tests/contracts`: 1850 passed, 6 skipped
- Target-cluster contracts: 1011 passed
- Serialization, docstring, and functional convolution focused suites passed
- Ruff, mypy, Pyrefly, AX guidance, benchmark coverage, CI/shard, performance budget, legal, regression, and full UTF-8-enabled fast quality gate passed

## Summary by Sourcery

Add stochastic identity-centered convolution augmentation with configurable spectral perturbations for images and volumes.

New Features:
- Add the public `StochasticConvolution` transform for randomized identity-centered convolution on images and volumes, with configurable kernel size, strength, channel sharing, and border behavior.

Enhancements:
- Extend functional convolution to support per-channel kernels and explicit OpenCV border modes while preserving clipping and channel handling.
- Preserve seeded sampling, batch and volume kernel reuse, applied-configuration serialization, and replay behavior.

Documentation:
- Document `StochasticConvolution` in the README and public transform metadata.

Tests:
- Add focused coverage for stochastic convolution semantics, validation, dtype and range preservation, reproducibility, replay, and multi-target behavior.
- Add stochastic convolution cases to functional, family, batch, and benchmark coverage matrices.