### PR TITLE
feat(geometric): add direct tensor volume square symmetry

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,7 +91,7 @@ jobs:
         numpy==2.2.6
         scipy==1.15.3
         pydantic==2.12.4
-        albucore==0.2.13
+        albucore==0.2.14
         opencv-python-headless==5.0.0.93
         hypothesis
         pytest

--- a/albumentations/augmentations/geometric/flip.py
+++ b/albumentations/augmentations/geometric/flip.py
@@ -27,7 +27,7 @@ from typing import Any, Literal, cast
 
 import numpy as np
 import torch
-from albucore import hflip, vflip
+from albucore import flip_volume, hflip, rot90_volume, transpose_volume, vflip
 
 from albumentations.core.invocation import SamplingContext
 from albumentations.core.transform_params import SampledParams, TargetSet
@@ -53,6 +53,30 @@ __all__ = [
     "Transpose",
     "VerticalFlip",
 ]
+
+
+def _apply_d4_to_tensor_volume(
+    volume: torch.Tensor,
+    group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
+) -> torch.Tensor:
+    match group_element:
+        case "e":
+            result = volume
+        case "r90":
+            result = rot90_volume(volume, 1, (-2, -1))
+        case "r180":
+            result = rot90_volume(volume, 2, (-2, -1))
+        case "r270":
+            result = rot90_volume(volume, 3, (-2, -1))
+        case "v":
+            result = flip_volume(volume, -2)
+        case "hvt":
+            result = transpose_volume(flip_volume(volume, (-2, -1)), -2, -1)
+        case "h":
+            result = flip_volume(volume, -1)
+        case "t":
+            result = transpose_volume(volume, -2, -1)
+    return result
 
 
 class VerticalFlip(DualTransform):
@@ -473,6 +497,8 @@ class D4(DualTransform):
 
     _targets = ALL_TARGETS
     _supported_bbox_types: frozenset[str] = frozenset({"hbb", "obb"})
+    _supports_cpu_tensor = True
+    _cpu_tensor_targets = frozenset({"volume", "mask3d"})
 
     class InitSchema(BaseTransformInitSchema):
         group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"] | None
@@ -546,6 +572,8 @@ class D4(DualTransform):
         group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
         **params: Any,
     ) -> ImageType:
+        if isinstance(images, torch.Tensor):
+            return cast("ImageType", _apply_d4_to_tensor_volume(images, group_element))
         return fgeometric.d4_images(images, group_element)
 
     def apply_to_mask3d(
@@ -554,6 +582,11 @@ class D4(DualTransform):
         group_element: Literal["e", "r90", "r180", "r270", "v", "hvt", "h", "t"],
         **params: Any,
     ) -> VolumeType:
+        if isinstance(mask3d, torch.Tensor):
+            return cast(
+                "VolumeType",
+                _apply_d4_to_tensor_volume(mask3d.unsqueeze(0), group_element).squeeze(0),
+            )
         if mask3d.size == 0:
             # Group elements that transpose dimensions: "r90", "r270", "t", "hvt"
             # Assume mask3d shape is (D, H, W, C)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=5.0.0.93
-    - albucore==0.2.13
+    - albucore==0.2.14
     - numkong>=7.8.0
 
 suggests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "albucore==0.2.13",
+  "albucore==0.2.14",
   "numkong>=7.8.0",
   "numpy>=2.2.6",
   "pydantic>=2.12.4",

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 import albumentations as A
+from albumentations.core import composition
 from albumentations.core.transforms_interface import ImageOnlyTransform
 from albumentations.core.utils import get_image_data, get_shape, get_volume_shape
 
@@ -274,6 +275,63 @@ def test_flip3d_tensor_compose_preserves_volume_mask_and_semantic_mapping() -> N
     assert result["mask3d"].dtype == mask3d.dtype
     torch.testing.assert_close(result["volume"], torch.flip(volume, dims=(3,)))
     torch.testing.assert_close(result["mask3d"], expected_mask3d)
+
+
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
+@pytest.mark.parametrize("group_element", ["e", "r90", "r180", "r270", "v", "hvt", "h", "t"])
+@pytest.mark.parametrize("strided", [False, True])
+def test_square_symmetry_volume_tensor_compose_stays_on_direct_route(
+    monkeypatch: pytest.MonkeyPatch,
+    dtype: torch.dtype,
+    group_element: str,
+    strided: bool,
+) -> None:
+    volume = torch.arange(2 * 3 * 5 * 5, dtype=dtype).reshape(2, 3, 5, 5)
+    mask3d = torch.arange(3 * 5 * 5, dtype=torch.uint8).reshape(3, 5, 5)
+    if strided:
+        volume = volume.transpose(-2, -1)
+        mask3d = mask3d.transpose(-2, -1)
+
+    def fail_on_numpy_bridge(*args: object, **kwargs: object) -> None:
+        raise AssertionError("SquareSymmetry volume Tensor route entered the NumPy bridge")
+
+    monkeypatch.setattr(composition, "tensor_to_numpy_spatial", fail_on_numpy_bridge)
+    result = A.Compose([A.SquareSymmetry(group_element=group_element, p=1.0)], strict=True)(
+        volume=volume,
+        mask3d=mask3d,
+    )
+
+    expected_volume = _d4_tensor_reference(volume, group_element)
+    expected_mask3d = _d4_tensor_reference(mask3d, group_element)
+    assert result["volume"].dtype == volume.dtype
+    assert result["mask3d"].dtype == mask3d.dtype
+    assert result["volume"].stride() == expected_volume.stride()
+    assert result["mask3d"].stride() == expected_mask3d.stride()
+    torch.testing.assert_close(result["volume"], expected_volume)
+    torch.testing.assert_close(result["mask3d"], expected_mask3d)
+
+
+def _d4_tensor_reference(value: torch.Tensor, group_element: str) -> torch.Tensor:
+    match group_element:
+        case "e":
+            result = value
+        case "r90":
+            result = torch.rot90(value, 1, (-2, -1))
+        case "r180":
+            result = torch.rot90(value, 2, (-2, -1))
+        case "r270":
+            result = torch.rot90(value, 3, (-2, -1))
+        case "v":
+            result = torch.flip(value, (-2,))
+        case "hvt":
+            result = torch.transpose(torch.flip(value, (-2, -1)), -2, -1)
+        case "h":
+            result = torch.flip(value, (-1,))
+        case "t":
+            result = torch.transpose(value, -2, -1)
+        case _:
+            raise AssertionError(f"Unexpected D4 group element: {group_element}")
+    return result
 
 
 def test_tensor_compose_combines_3d_transforms() -> None:

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -88,7 +88,7 @@ LOWER_BOUND_REQUIREMENTS = (
     "numpy==2.2.6",
     "scipy==1.15.3",
     "pydantic==2.12.4",
-    "albucore==0.2.13",
+    "albucore==0.2.14",
     "opencv-python-headless==5.0.0.93",
 )
 CI_DEPENDENCY_GROUPS = {

--- a/uv.lock
+++ b/uv.lock
@@ -29,7 +29,7 @@ wheels = [
 
 [[package]]
 name = "albucore"
-version = "0.2.13"
+version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numkong" },
@@ -38,9 +38,9 @@ dependencies = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "stringzilla" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/7b/a7018a715bda30e37b0a584bd1e7a9c084b8063308a150a490887ab39532/albucore-0.2.13.tar.gz", hash = "sha256:0afb83ea8ad73d799370cb45c8c26e739becccbe1cdf3e3fe11594907c2eb622", size = 196407, upload-time = "2026-08-13T11:36:57.103Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/f6/18f42af5549decff159bddfb4d8eb4de01f6f1527905c39fe7d032008654/albucore-0.2.14.tar.gz", hash = "sha256:701d2081b61ae20e874a4c52fb54d573cb0ad4227853178f499436ba4a4496f2", size = 195862, upload-time = "2026-08-24T18:15:04.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/41/1c6374737bf1033455a351a26bd6d04e6c2cbc8d27353153f6aa3da7e16c/albucore-0.2.13-py3-none-any.whl", hash = "sha256:a2d4d049a4cb1b2f0a52874b9d6ec109947661718112e34923d72cc90a701021", size = 57248, upload-time = "2026-08-13T11:36:55.716Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/9f/41eaa6cd4e4ccb2e1758a1ed0355d6b2753c8f4f9bf641a074e35f5e2a93/albucore-0.2.14-py3-none-any.whl", hash = "sha256:38d60ead2380d91bbed68e55e20d6437aa2a006798b70a0723a713fd3a3e634e", size = 57794, upload-time = "2026-08-24T18:15:03.064Z" },
 ]
 
 [[package]]
@@ -212,7 +212,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "albucore", specifier = "==0.2.13" },
+    { name = "albucore", specifier = "==0.2.14" },
     { name = "huggingface-hub", marker = "extra == 'hub'" },
     { name = "numkong", specifier = ">=7.8.0" },
     { name = "numpy", specifier = ">=2.2.6" },


### PR DESCRIPTION
## Result

This PR routes CPU Tensor volume and mask3d targets for SquareSymmetry and D4 through Albucore 0.2.14 volume primitives. It removes the two full-volume Tensor to NumPy representation bridges from the augmentation path. The transform preserves native PyTorch layout and does not force contiguity; collation owns any later materialization.

## Representative DoseRAD benchmark

Same macOS arm64 host, PyTorch 2.13.0, Albucore 0.2.14, one Torch native thread, and the median of 12 Compose calls. Inputs were a volume of shape (7, 384, 160, 160) with its aligned mask3d. Baseline is main's generic Tensor to NumPy to Tensor route. PR is this branch's direct route. Values are milliseconds per call; no caller-controlled contiguous call is timed.

| D4 element | uint8 main | uint8 PR | uint8 speedup | float32 main | float32 PR | float32 speedup |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| e | 27.425 | 0.029 | 945.7x | 48.757 | 0.025 | 1950.3x |
| r90 | 73.318 | 1.698 | 43.2x | 150.102 | 25.798 | 5.8x |
| r180 | 53.156 | 2.663 | 20.0x | 93.209 | 23.375 | 4.0x |
| r270 | 75.176 | 2.864 | 26.2x | 140.833 | 25.631 | 5.5x |
| v | 54.328 | 2.908 | 18.7x | 100.590 | 23.954 | 4.2x |
| hvt | 72.132 | 2.979 | 24.2x | 148.376 | 23.152 | 6.4x |
| h | 59.483 | 1.708 | 34.8x | 104.602 | 25.621 | 4.1x |
| t | 30.851 | 0.020 | 1542.6x | 48.025 | 0.032 | 1500.8x |

The identity and transpose cells return native strided Tensor layouts, so their large factors quantify the avoided bridge. The remaining six spatial operations improve by 18.7x to 43.2x for uint8 and 4.0x to 6.4x for float32. No benchmarked cell regressed.

## Correctness and validation

- Exact parity for all eight D4 elements on uint8 and float32 volume and mask3d Tensor inputs, including strided inputs.
- The direct-route test fails if Compose enters the Tensor to NumPy bridge.
- Full pytest suite: 14072 passed, 32 skipped, 9 xfailed, 3 xpassed.
- Full pre-commit run: passed.

Closes #465