### PR TITLE
chore(release): bump version to 2.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.4.2"
+version = "2.4.3"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.4.2"
+version = "2.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## Summary

- Bump AlbumentationsX from 2.4.2 to 2.4.3.
- Refresh the editable package version in uv.lock.

## Validation

- uv lock --check
- uv run pytest -n auto -q: 14072 passed, 32 skipped, 9 xfailed, 3 xpassed
- pre-commit run --all-files: passed

## Summary by Sourcery

Build:
- Bump the AlbumentationsX package version to 2.4.3 and refresh the locked editable package version.