### PR TITLE
fix(ci): scope performance comparisons to STF evidence profiles

### DIFF
--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -93,6 +93,24 @@ for size_name, (h, w) in SIZES.items():
 3. **Compare**: load both JSON files, compute speedup = old_time / new_time for each transform/size combo
 4. **Report** results in the PR/commit message body
 
+## Repository CI Profiles
+
+AlbumentationsX keeps benchmark definitions catalog-wide, but times only the
+profile that answers the current evidence question:
+
+- `pr-core`: `TimeCorePipeline` and its target-processor/tracing variants for
+  every runtime pull request;
+- `stf-core`: catalog smoke, core pipeline, and selected peak-memory sentinels
+  for the weekly schedule and release preflight;
+- `changed`: affected-family patterns selected from changed files for a
+  `run-performance` PR label or a maintainer-requested deep comparison.
+
+Resolve profiles with `tools/select_benchmark_filters.py`. Timed CI evidence
+must compare an explicit baseline ref with an explicit candidate ref using ASV
+`continuous`. Do not use a single-revision snapshot or treat an empty filter
+as permission to run the entire catalog. A full-family run requires an
+explicit regex so its cost is visible before execution.
+
 ### JSON Output Format
 
 Save benchmark results as JSON for automated comparison:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -151,15 +151,15 @@ jobs:
       working-directory: benchmark
       env:
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_CANDIDATE_SHA: ${{ github.sha }}
       run: |
         BASELINE_SHA="$(git rev-parse "$PR_BASE_SHA")"
-        CANDIDATE_SHA="$(git rev-parse "$PR_HEAD_SHA")"
+        CANDIDATE_SHA="$(git rev-parse "$PR_CANDIDATE_SHA")"
         FILTER="$(python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" --profile pr-core)"
         mkdir -p "$GITHUB_WORKSPACE/pr-core-performance-evidence"
         printf '%s\n' "$PR_BASE_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-baseline-ref.txt"
         printf '%s\n' "$BASELINE_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-baseline-sha.txt"
-        printf '%s\n' "$PR_HEAD_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-candidate-ref.txt"
+        printf '%s\n' "$PR_CANDIDATE_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-candidate-ref.txt"
         printf '%s\n' "$CANDIDATE_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-candidate-sha.txt"
         printf '%s\n' "$FILTER" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-filter.txt"
         set -o pipefail
@@ -167,7 +167,7 @@ jobs:
         asv --config asv.conf.json continuous \
           --factor 1.05 --split --show-stderr \
           --attribute repeat=1 --attribute number=1 \
-          --bench "$FILTER" "$PR_BASE_SHA" "$PR_HEAD_SHA" \
+          --bench "$FILTER" "$PR_BASE_SHA" "$PR_CANDIDATE_SHA" \
           2>&1 | tee "$GITHUB_WORKSPACE/pr-core-performance-evidence/asv-continuous.txt" || ASV_EXIT_CODE=$?
         printf '%s\n' "$ASV_EXIT_CODE" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/asv-continuous-exit-code.txt"
     - name: Summarize PR core comparison
@@ -253,11 +253,11 @@ jobs:
             --profile changed \
             --changed-files "$GITHUB_WORKSPACE/targeted-performance-evidence/changed-files.txt")"
         else
+          CANDIDATE_REF="${INPUT_CANDIDATE_REF:-HEAD}"
           BASELINE_REF="$INPUT_BASELINE_REF"
           if [ -z "$BASELINE_REF" ]; then
-            BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' HEAD^)"
+            BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' "$CANDIDATE_REF^")"
           fi
-          CANDIDATE_REF="${INPUT_CANDIDATE_REF:-HEAD}"
           BENCH_FILTER="${INPUT_BENCH_FILTER:-}"
           if [ -z "$BENCH_FILTER" ]; then
             BENCH_FILTER="$(python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" --profile stf-core)"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,14 +2,8 @@ name: Performance
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - labeled
-    branches:
-      - main
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    branches: [main]
     paths:
       - "albumentations/**"
       - "benchmark/**"
@@ -23,15 +17,15 @@ on:
   workflow_dispatch:
     inputs:
       baseline_ref:
-        description: "Optional git ref/SHA for the before baseline. Leave empty to run evidence for the selected ref only."
+        description: "Optional git ref/SHA for the before baseline. Leave empty to use the previous release tag."
         required: false
         type: string
       candidate_ref:
-        description: "Optional git ref/SHA for the after candidate. Defaults to the selected workflow ref."
+        description: "Optional git ref/SHA for the after candidate. Defaults to HEAD."
         required: false
         type: string
       bench_filter:
-        description: "Optional ASV --bench regex for manual baseline/candidate comparisons. Leave empty for the full suite."
+        description: "Optional ASV --bench regex. Leave empty to run the bounded stf-core profile."
         required: false
         type: string
 
@@ -45,6 +39,7 @@ concurrency:
 jobs:
   benchmark_evidence:
     name: ASV benchmark evidence
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 10
@@ -71,26 +66,26 @@ jobs:
         python -m tools.benchmark_coverage details \
           --output benchmark-evidence/benchmark-coverage-detail.json
     - name: Compare benchmark coverage with baseline
-      if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.baseline_ref != '')
       env:
-        EVENT_NAME: ${{ github.event_name }}
-        INPUT_BASELINE_REF: ${{ inputs.baseline_ref }}
         PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
-        write_unavailable_diff() {
-          python - "$1" "$2" <<'PY'
+        BASE_WORKTREE="$RUNNER_TEMP/benchmark-coverage-base"
+        git worktree add --detach "$BASE_WORKTREE" "$PR_BASE_SHA"
+        if PYTHONPATH="$BASE_WORKTREE:$BASE_WORKTREE/benchmark" python "$BASE_WORKTREE/tools/benchmark_coverage.py" details \
+          --output "$GITHUB_WORKSPACE/benchmark-evidence/benchmark-coverage-detail-base.json"; then
+          python -m tools.benchmark_coverage diff \
+            --base-detail benchmark-evidence/benchmark-coverage-detail-base.json \
+            --output benchmark-evidence/benchmark-coverage-diff.json
+        else
+          python - <<'PY'
         import json
-        import sys
         from pathlib import Path
 
-        output = Path(sys.argv[1])
-        reason = sys.argv[2]
-        output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(
+        Path("benchmark-evidence/benchmark-coverage-diff.json").write_text(
             json.dumps(
                 {
                     "kind": "benchmark-coverage-diff",
-                    "reason": reason,
+                    "reason": "baseline benchmark coverage detail could not be generated",
                     "schema_version": 1,
                     "summary": {"status": "unavailable"},
                 },
@@ -100,33 +95,8 @@ jobs:
             + "\n",
         )
         PY
-        }
-
-        if [ "$EVENT_NAME" = "pull_request" ]; then
-          BASELINE_REF="$PR_BASE_SHA"
-        else
-          BASELINE_REF="$INPUT_BASELINE_REF"
         fi
-
-        if git cat-file -e "$BASELINE_REF:tools/benchmark_coverage.py"; then
-          BASE_WORKTREE="$RUNNER_TEMP/benchmark-coverage-base"
-          git worktree add --detach "$BASE_WORKTREE" "$BASELINE_REF"
-          if PYTHONPATH="$BASE_WORKTREE:$BASE_WORKTREE/benchmark" python "$BASE_WORKTREE/tools/benchmark_coverage.py" details \
-            --output "$GITHUB_WORKSPACE/benchmark-evidence/benchmark-coverage-detail-base.json"; then
-            python -m tools.benchmark_coverage diff \
-              --base-detail benchmark-evidence/benchmark-coverage-detail-base.json \
-              --output benchmark-evidence/benchmark-coverage-diff.json
-          else
-            write_unavailable_diff \
-              benchmark-evidence/benchmark-coverage-diff.json \
-              "baseline benchmark coverage detail could not be generated"
-          fi
-          git worktree remove --force "$BASE_WORKTREE"
-        else
-          write_unavailable_diff \
-            benchmark-evidence/benchmark-coverage-diff.json \
-            "baseline ref does not include tools/benchmark_coverage.py"
-        fi
+        git worktree remove --force "$BASE_WORKTREE"
     - name: Register ASV machine profile
       working-directory: benchmark
       run: asv --config asv.conf.json machine --yes
@@ -149,10 +119,87 @@ jobs:
         path: benchmark-evidence/
         if-no-files-found: ignore
 
+  pr_core_comparison:
+    name: PR core performance smoke
+    needs: benchmark_evidence
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 0
+    - name: Download benchmark contract evidence
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: benchmark-evidence
+        path: benchmark-evidence
+    - name: Set up benchmark environment
+      uses: ./.github/actions/setup-ci
+      with:
+        python-version: "3.12"
+        dependency-group: ci-benchmark
+        runtime-profile: torch-cpu
+    - name: Collect comparison environment evidence
+      run: >
+        python tools/collect_test_environment.py
+        --output pr-core-performance-evidence/environment-pr-core.json
+        --command "PR core ASV comparison"
+    - name: Resolve PR core comparison
+      working-directory: benchmark
+      env:
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        BASELINE_SHA="$(git rev-parse "$PR_BASE_SHA")"
+        CANDIDATE_SHA="$(git rev-parse "$PR_HEAD_SHA")"
+        FILTER="$(python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" --profile pr-core)"
+        mkdir -p "$GITHUB_WORKSPACE/pr-core-performance-evidence"
+        printf '%s\n' "$PR_BASE_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-baseline-ref.txt"
+        printf '%s\n' "$BASELINE_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-baseline-sha.txt"
+        printf '%s\n' "$PR_HEAD_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-candidate-ref.txt"
+        printf '%s\n' "$CANDIDATE_SHA" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-candidate-sha.txt"
+        printf '%s\n' "$FILTER" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/benchmark-filter.txt"
+        set -o pipefail
+        ASV_EXIT_CODE=0
+        asv --config asv.conf.json continuous \
+          --factor 1.05 --split --show-stderr \
+          --attribute repeat=1 --attribute number=1 \
+          --bench "$FILTER" "$PR_BASE_SHA" "$PR_HEAD_SHA" \
+          2>&1 | tee "$GITHUB_WORKSPACE/pr-core-performance-evidence/asv-continuous.txt" || ASV_EXIT_CODE=$?
+        printf '%s\n' "$ASV_EXIT_CODE" > "$GITHUB_WORKSPACE/pr-core-performance-evidence/asv-continuous-exit-code.txt"
+    - name: Summarize PR core comparison
+      if: always()
+      run: |
+        ASV_EXIT_CODE="$(cat pr-core-performance-evidence/asv-continuous-exit-code.txt 2>/dev/null || true)"
+        python tools/asv_summary.py \
+          --input pr-core-performance-evidence/asv-continuous.txt \
+          --output pr-core-performance-evidence/benchmark-asv-summary.json \
+          --asv-exit-code "${ASV_EXIT_CODE:-1}" --allow-missing
+    - name: Classify PR core performance budget
+      if: always()
+      run: >
+        python -m tools.performance_budget summarize
+        --coverage-summary benchmark-evidence/benchmark-coverage.json
+        --coverage-detail benchmark-evidence/benchmark-coverage-detail.json
+        --asv-summary pr-core-performance-evidence/benchmark-asv-summary.json
+        --core-only
+        --output pr-core-performance-evidence/benchmark-performance-budget.json
+    - name: Upload PR core performance evidence
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: pr-core-performance-evidence
+        path: |
+          pr-core-performance-evidence/
+          benchmark/.asv/results/
+        if-no-files-found: ignore
+
   asv_comparison:
-    name: ASV comparison evidence
+    name: Targeted ASV comparison
     if: >
-      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
       contains(github.event.pull_request.labels.*.name, 'run-performance'))
@@ -173,22 +220,21 @@ jobs:
     - name: Collect ASV environment evidence
       run: >
         python tools/collect_test_environment.py
-        --output benchmark-asv-evidence/environment-asv.json
-        --command "ASV timing evidence"
+        --output targeted-performance-evidence/environment-asv.json
+        --command "targeted ASV comparison"
     - name: Collect benchmark coverage evidence
       run: |
         python -m tools.benchmark_coverage summary \
-          --output benchmark-asv-evidence/benchmark-coverage.json
+          --output targeted-performance-evidence/benchmark-coverage.json
         python -m tools.benchmark_coverage details \
-          --output benchmark-asv-evidence/benchmark-coverage-detail.json
+          --output targeted-performance-evidence/benchmark-coverage-detail.json
     - name: Register ASV machine profile
       working-directory: benchmark
       run: asv --config asv.conf.json machine --yes
     - name: Check benchmark suite importability
       working-directory: benchmark
       run: asv --config asv.conf.json check --verbose
-    - name: Compare baseline and candidate benchmarks
-      if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.baseline_ref != '')
+    - name: Compare targeted benchmarks
       working-directory: benchmark
       env:
         EVENT_NAME: ${{ github.event_name }}
@@ -202,99 +248,140 @@ jobs:
         if [ "$EVENT_NAME" = "pull_request" ]; then
           BASELINE_REF="$PR_BASE_SHA"
           CANDIDATE_REF="$PR_HEAD_SHA"
-          git diff --name-only "$BASELINE_REF" "$CANDIDATE_REF" > "$GITHUB_WORKSPACE/benchmark-asv-evidence/changed-files.txt"
-          BENCH_FILTER="$(
-            python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" \
-              --changed-files "$GITHUB_WORKSPACE/benchmark-asv-evidence/changed-files.txt"
-          )"
+          git diff --name-only "$BASELINE_REF" "$CANDIDATE_REF" > "$GITHUB_WORKSPACE/targeted-performance-evidence/changed-files.txt"
+          BENCH_FILTER="$(python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" \
+            --profile changed \
+            --changed-files "$GITHUB_WORKSPACE/targeted-performance-evidence/changed-files.txt")"
         else
           BASELINE_REF="$INPUT_BASELINE_REF"
-          CANDIDATE_REF="$INPUT_CANDIDATE_REF"
-          BENCH_FILTER="$INPUT_BENCH_FILTER"
-          if [ -z "$CANDIDATE_REF" ]; then
-            CANDIDATE_REF="HEAD"
+          if [ -z "$BASELINE_REF" ]; then
+            BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' HEAD^)"
+          fi
+          CANDIDATE_REF="${INPUT_CANDIDATE_REF:-HEAD}"
+          BENCH_FILTER="${INPUT_BENCH_FILTER:-}"
+          if [ -z "$BENCH_FILTER" ]; then
+            BENCH_FILTER="$(python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" --profile stf-core)"
           fi
         fi
-        echo "$BENCH_FILTER" > "$GITHUB_WORKSPACE/benchmark-asv-evidence/benchmark-filter.txt"
+        BASELINE_SHA="$(git rev-parse "$BASELINE_REF")"
+        CANDIDATE_SHA="$(git rev-parse "$CANDIDATE_REF")"
+        printf '%s\n' "$BASELINE_REF" > "$GITHUB_WORKSPACE/targeted-performance-evidence/benchmark-baseline-ref.txt"
+        printf '%s\n' "$BASELINE_SHA" > "$GITHUB_WORKSPACE/targeted-performance-evidence/benchmark-baseline-sha.txt"
+        printf '%s\n' "$CANDIDATE_REF" > "$GITHUB_WORKSPACE/targeted-performance-evidence/benchmark-candidate-ref.txt"
+        printf '%s\n' "$CANDIDATE_SHA" > "$GITHUB_WORKSPACE/targeted-performance-evidence/benchmark-candidate-sha.txt"
+        printf '%s\n' "$BENCH_FILTER" > "$GITHUB_WORKSPACE/targeted-performance-evidence/benchmark-filter.txt"
         ASV_EXIT_CODE=0
-        ASV_COMMAND=(
-          asv --config asv.conf.json continuous
-          --factor 1.05
-          --split
-          --show-stderr
-          --attribute repeat=1
-          --attribute number=1
-        )
-        if [ -n "$BENCH_FILTER" ]; then
-          ASV_COMMAND+=(--bench "$BENCH_FILTER")
-        fi
-        ASV_COMMAND+=("$BASELINE_REF" "$CANDIDATE_REF")
-        "${ASV_COMMAND[@]}" 2>&1 | tee "$GITHUB_WORKSPACE/benchmark-asv-evidence/asv-continuous.txt" || ASV_EXIT_CODE=$?
-        echo "$ASV_EXIT_CODE" > "$GITHUB_WORKSPACE/benchmark-asv-evidence/asv-continuous-exit-code.txt"
-        if [ "$ASV_EXIT_CODE" -ne 0 ]; then
-          echo "::warning::ASV comparison reported performance changes. See benchmark-asv-evidence/asv-continuous.txt and benchmark-asv-summary.json."
-        fi
-    - name: Summarize ASV comparison evidence
-      if: >
-        always() &&
-        (github.event_name == 'pull_request' ||
-        (github.event_name == 'workflow_dispatch' && inputs.baseline_ref != ''))
+        asv --config asv.conf.json continuous \
+          --factor 1.05 --split --show-stderr \
+          --attribute repeat=1 --attribute number=1 \
+          --bench "$BENCH_FILTER" "$BASELINE_REF" "$CANDIDATE_REF" \
+          2>&1 | tee "$GITHUB_WORKSPACE/targeted-performance-evidence/asv-continuous.txt" || ASV_EXIT_CODE=$?
+        printf '%s\n' "$ASV_EXIT_CODE" > "$GITHUB_WORKSPACE/targeted-performance-evidence/asv-continuous-exit-code.txt"
+    - name: Summarize targeted comparison
+      if: always()
       run: |
-        ASV_EXIT_CODE="$(cat benchmark-asv-evidence/asv-continuous-exit-code.txt 2>/dev/null || true)"
-        if [ -n "$ASV_EXIT_CODE" ]; then
-          python tools/asv_summary.py \
-            --input benchmark-asv-evidence/asv-continuous.txt \
-            --output benchmark-asv-evidence/benchmark-asv-summary.json \
-            --asv-exit-code "$ASV_EXIT_CODE"
-        else
-          python tools/asv_summary.py \
-            --input benchmark-asv-evidence/asv-continuous.txt \
-            --output benchmark-asv-evidence/benchmark-asv-summary.json \
-            --allow-missing
-        fi
-    - name: Classify ASV comparison budget evidence
-      if: >
-        always() &&
-        (github.event_name == 'pull_request' ||
-        (github.event_name == 'workflow_dispatch' && inputs.baseline_ref != ''))
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        INPUT_BASELINE_REF: ${{ inputs.baseline_ref }}
-      run: |
-        BUDGET_COMMAND=(
-          python -m tools.performance_budget summarize
-          --coverage-summary benchmark-asv-evidence/benchmark-coverage.json
-          --coverage-detail benchmark-asv-evidence/benchmark-coverage-detail.json
-          --output benchmark-asv-evidence/benchmark-performance-budget.json
-          --core-only
-        )
-        if [ -f benchmark-asv-evidence/benchmark-asv-summary.json ]; then
-          BUDGET_COMMAND+=(--asv-summary benchmark-asv-evidence/benchmark-asv-summary.json)
-        fi
-        if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_BASELINE_REF" ]; then
-          BUDGET_COMMAND+=(--require-comparison --fail-on-release-blockers)
-        fi
-        "${BUDGET_COMMAND[@]}"
-    - name: Run scheduled benchmark evidence
-      if: >
-        github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' && inputs.baseline_ref == '')
-      working-directory: benchmark
-      run: |
-        set -o pipefail
-        asv --config asv.conf.json run \
-          --show-stderr \
-          --durations 20 \
-          --attribute repeat=1 \
-          --attribute number=1 \
-          'HEAD^!' \
-          2>&1 | tee "$GITHUB_WORKSPACE/benchmark-asv-evidence/asv-run.txt"
-    - name: Upload ASV artifacts
+        ASV_EXIT_CODE="$(cat targeted-performance-evidence/asv-continuous-exit-code.txt 2>/dev/null || true)"
+        python tools/asv_summary.py \
+          --input targeted-performance-evidence/asv-continuous.txt \
+          --output targeted-performance-evidence/benchmark-asv-summary.json \
+          --asv-exit-code "${ASV_EXIT_CODE:-1}" --allow-missing
+    - name: Classify targeted performance budget
+      if: always()
+      run: >
+        python -m tools.performance_budget summarize
+        --coverage-summary targeted-performance-evidence/benchmark-coverage.json
+        --coverage-detail targeted-performance-evidence/benchmark-coverage-detail.json
+        --asv-summary targeted-performance-evidence/benchmark-asv-summary.json
+        --core-only
+        --output targeted-performance-evidence/benchmark-performance-budget.json
+    - name: Upload targeted performance evidence
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: benchmark-asv-evidence
+        name: targeted-performance-evidence
         path: |
-          benchmark-asv-evidence/
+          targeted-performance-evidence/
+          benchmark/.asv/results/
+        if-no-files-found: ignore
+
+  scheduled_core_comparison:
+    name: Scheduled STF core performance
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 0
+    - name: Set up benchmark environment
+      uses: ./.github/actions/setup-ci
+      with:
+        python-version: "3.12"
+        dependency-group: ci-benchmark
+        runtime-profile: torch-cpu
+    - name: Collect scheduled benchmark environment evidence
+      run: >
+        python tools/collect_test_environment.py
+        --output scheduled-core-performance-evidence/environment-scheduled.json
+        --command "scheduled STF core ASV comparison"
+    - name: Collect scheduled benchmark coverage evidence
+      run: |
+        python -m tools.benchmark_coverage summary \
+          --output scheduled-core-performance-evidence/benchmark-coverage.json
+        python -m tools.benchmark_coverage details \
+          --output scheduled-core-performance-evidence/benchmark-coverage-detail.json
+    - name: Register ASV machine profile
+      working-directory: benchmark
+      run: asv --config asv.conf.json machine --yes
+    - name: Check benchmark suite importability
+      working-directory: benchmark
+      run: asv --config asv.conf.json check --verbose
+    - name: Compare previous release with main
+      working-directory: benchmark
+      run: |
+        set -o pipefail
+        BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' HEAD^)"
+        CANDIDATE_REF="HEAD"
+        BASELINE_SHA="$(git rev-parse "$BASELINE_REF")"
+        CANDIDATE_SHA="$(git rev-parse "$CANDIDATE_REF")"
+        BENCH_FILTER="$(python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" --profile stf-core)"
+        printf '%s\n' "$BASELINE_REF" > "$GITHUB_WORKSPACE/scheduled-core-performance-evidence/benchmark-baseline-ref.txt"
+        printf '%s\n' "$BASELINE_SHA" > "$GITHUB_WORKSPACE/scheduled-core-performance-evidence/benchmark-baseline-sha.txt"
+        printf '%s\n' "$CANDIDATE_REF" > "$GITHUB_WORKSPACE/scheduled-core-performance-evidence/benchmark-candidate-ref.txt"
+        printf '%s\n' "$CANDIDATE_SHA" > "$GITHUB_WORKSPACE/scheduled-core-performance-evidence/benchmark-candidate-sha.txt"
+        printf '%s\n' "$BENCH_FILTER" > "$GITHUB_WORKSPACE/scheduled-core-performance-evidence/benchmark-filter.txt"
+        ASV_EXIT_CODE=0
+        asv --config asv.conf.json continuous \
+          --factor 1.05 --split --show-stderr \
+          --attribute repeat=1 --attribute number=1 \
+          --bench "$BENCH_FILTER" "$BASELINE_REF" "$CANDIDATE_REF" \
+          2>&1 | tee "$GITHUB_WORKSPACE/scheduled-core-performance-evidence/asv-continuous.txt" || ASV_EXIT_CODE=$?
+        printf '%s\n' "$ASV_EXIT_CODE" > "$GITHUB_WORKSPACE/scheduled-core-performance-evidence/asv-continuous-exit-code.txt"
+    - name: Summarize scheduled comparison
+      if: always()
+      run: |
+        ASV_EXIT_CODE="$(cat scheduled-core-performance-evidence/asv-continuous-exit-code.txt 2>/dev/null || true)"
+        python tools/asv_summary.py \
+          --input scheduled-core-performance-evidence/asv-continuous.txt \
+          --output scheduled-core-performance-evidence/benchmark-asv-summary.json \
+          --asv-exit-code "${ASV_EXIT_CODE:-1}" --allow-missing
+    - name: Classify scheduled performance budget
+      if: always()
+      run: >
+        python -m tools.performance_budget summarize
+        --coverage-summary scheduled-core-performance-evidence/benchmark-coverage.json
+        --coverage-detail scheduled-core-performance-evidence/benchmark-coverage-detail.json
+        --asv-summary scheduled-core-performance-evidence/benchmark-asv-summary.json
+        --core-only
+        --output scheduled-core-performance-evidence/benchmark-performance-budget.json
+    - name: Upload scheduled performance evidence
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: scheduled-core-performance-evidence
+        path: |
+          scheduled-core-performance-evidence/
           benchmark/.asv/results/
         if-no-files-found: ignore

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -664,12 +664,56 @@ jobs:
             --output "${RUNNER_TEMP}/release-bundle/evidence/benchmark-coverage-release.json"
           python -m tools.benchmark_coverage details \
             --output "${RUNNER_TEMP}/release-bundle/evidence/benchmark-coverage-detail-release.json"
-          python -m tools.performance_budget summarize \
-            --coverage-summary "${RUNNER_TEMP}/release-bundle/evidence/benchmark-coverage-release.json" \
-            --coverage-detail "${RUNNER_TEMP}/release-bundle/evidence/benchmark-coverage-detail-release.json" \
-            --core-only \
-            --fail-on-release-blockers \
-            --output "${RUNNER_TEMP}/release-bundle/evidence/benchmark-performance-budget-release.json"
+      - name: Register release ASV machine profile
+        working-directory: benchmark
+        run: asv --config asv.conf.json machine --yes
+      - name: Check release ASV suite importability
+        working-directory: benchmark
+        run: asv --config asv.conf.json check --verbose
+      - name: Compare previous release with release candidate
+        working-directory: benchmark
+        env:
+          RELEASE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -o pipefail
+          CANDIDATE_REF="${RELEASE_HEAD_SHA:-HEAD}"
+          BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' "$CANDIDATE_REF^")"
+          BASELINE_SHA="$(git rev-parse "$BASELINE_REF")"
+          CANDIDATE_SHA="$(git rev-parse "$CANDIDATE_REF")"
+          BENCH_FILTER="$(python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" --profile stf-core)"
+          EVIDENCE_DIR="${RUNNER_TEMP}/release-bundle/evidence"
+          printf '%s\n' "$BASELINE_REF" > "$EVIDENCE_DIR/benchmark-baseline-ref.txt"
+          printf '%s\n' "$BASELINE_SHA" > "$EVIDENCE_DIR/benchmark-baseline-sha.txt"
+          printf '%s\n' "$CANDIDATE_REF" > "$EVIDENCE_DIR/benchmark-candidate-ref.txt"
+          printf '%s\n' "$CANDIDATE_SHA" > "$EVIDENCE_DIR/benchmark-candidate-sha.txt"
+          printf '%s\n' "$BENCH_FILTER" > "$EVIDENCE_DIR/benchmark-filter.txt"
+          ASV_EXIT_CODE=0
+          timeout 900 asv --config asv.conf.json continuous \
+            --factor 1.05 --split --show-stderr \
+            --attribute repeat=1 --attribute number=1 \
+            --bench "$BENCH_FILTER" "$BASELINE_REF" "$CANDIDATE_REF" \
+            2>&1 | tee "$EVIDENCE_DIR/asv-continuous.txt" || ASV_EXIT_CODE=$?
+          printf '%s\n' "$ASV_EXIT_CODE" > "$EVIDENCE_DIR/asv-continuous-exit-code.txt"
+      - name: Summarize release ASV comparison
+        if: always()
+        run: |
+          EVIDENCE_DIR="${RUNNER_TEMP}/release-bundle/evidence"
+          ASV_EXIT_CODE="$(cat "$EVIDENCE_DIR/asv-continuous-exit-code.txt" 2>/dev/null || true)"
+          python tools/asv_summary.py \
+            --input "$EVIDENCE_DIR/asv-continuous.txt" \
+            --output "$EVIDENCE_DIR/benchmark-asv-summary.json" \
+            --asv-exit-code "${ASV_EXIT_CODE:-1}" --allow-missing
+      - name: Classify strict release performance budget
+        if: always()
+        run: >
+          python -m tools.performance_budget summarize
+          --coverage-summary "${RUNNER_TEMP}/release-bundle/evidence/benchmark-coverage-release.json"
+          --coverage-detail "${RUNNER_TEMP}/release-bundle/evidence/benchmark-coverage-detail-release.json"
+          --asv-summary "${RUNNER_TEMP}/release-bundle/evidence/benchmark-asv-summary.json"
+          --core-only
+          --require-comparison
+          --fail-on-release-blockers
+          --output "${RUNNER_TEMP}/release-bundle/evidence/benchmark-performance-budget-release.json"
       - name: Export locked runtime dependencies
         run: >-
           uv export --frozen --no-dev --no-emit-project

--- a/.github/workflows/pytorch-performance.yml
+++ b/.github/workflows/pytorch-performance.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: "53 4 * * 2"
   workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: "Optional git ref/SHA for the before baseline. Leave empty to use the previous release tag."
+        required: false
+        type: string
+      candidate_ref:
+        description: "Optional git ref/SHA for the after candidate. Defaults to HEAD."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -13,7 +22,7 @@ jobs:
     name: PyTorch tensor benchmark evidence
     runs-on: ubuntu-latest
     continue-on-error: true
-    timeout-minutes: 45
+    timeout-minutes: 20
     steps:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -29,24 +38,47 @@ jobs:
       run: >
         python tools/collect_test_environment.py
         --output pytorch-benchmark-evidence/environment-pytorch-benchmark.json
-        --command "asv run dedicated PyTorch Tensor benchmark evidence"
+        --command "ASV PyTorch Tensor regression comparison"
     - name: Register PyTorch ASV machine profile
       working-directory: benchmark
       run: asv --config asv-pytorch.conf.json machine --yes
     - name: Check PyTorch benchmark suite importability
       working-directory: benchmark
       run: asv --config asv-pytorch.conf.json check --verbose
-    - name: Run PyTorch tensor benchmark evidence
+    - name: Compare PyTorch tensor benchmarks
       working-directory: benchmark
+      env:
+        INPUT_BASELINE_REF: ${{ inputs.baseline_ref }}
+        INPUT_CANDIDATE_REF: ${{ inputs.candidate_ref }}
       run: |
         set -o pipefail
-        asv --config asv-pytorch.conf.json run \
-          --quick \
-          --show-stderr \
-          --attribute repeat=1 \
-          --attribute number=1 \
-          'HEAD^!' \
-          2>&1 | tee "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/asv-pytorch-run.txt"
+        BASELINE_REF="$INPUT_BASELINE_REF"
+        if [ -z "$BASELINE_REF" ]; then
+          BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' HEAD^)"
+        fi
+        CANDIDATE_REF="${INPUT_CANDIDATE_REF:-HEAD}"
+        BASELINE_SHA="$(git rev-parse "$BASELINE_REF")"
+        CANDIDATE_SHA="$(git rev-parse "$CANDIDATE_REF")"
+        printf '%s\n' "$BASELINE_REF" > "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/benchmark-baseline-ref.txt"
+        printf '%s\n' "$BASELINE_SHA" > "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/benchmark-baseline-sha.txt"
+        printf '%s\n' "$CANDIDATE_REF" > "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/benchmark-candidate-ref.txt"
+        printf '%s\n' "$CANDIDATE_SHA" > "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/benchmark-candidate-sha.txt"
+        printf '%s\n' "dedicated-pytorch-tensor" > "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/benchmark-filter.txt"
+        ASV_EXIT_CODE=0
+        asv --config asv-pytorch.conf.json continuous \
+          --quick --show-stderr \
+          --attribute repeat=1 --attribute number=1 \
+          "$BASELINE_REF" "$CANDIDATE_REF" \
+          2>&1 | tee "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/asv-continuous.txt" || ASV_EXIT_CODE=$?
+        printf '%s\n' "$ASV_EXIT_CODE" > "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/asv-continuous-exit-code.txt"
+    - name: Summarize PyTorch tensor comparison
+      if: always()
+      run: |
+        ASV_EXIT_CODE="$(cat pytorch-benchmark-evidence/asv-continuous-exit-code.txt 2>/dev/null || true)"
+        python tools/asv_summary.py \
+          --input pytorch-benchmark-evidence/asv-continuous.txt \
+          --output pytorch-benchmark-evidence/benchmark-asv-summary.json \
+          --asv-exit-code "${ASV_EXIT_CODE:-1}" --allow-missing
     - name: Upload PyTorch benchmark artifacts
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/pytorch-performance.yml
+++ b/.github/workflows/pytorch-performance.yml
@@ -52,11 +52,11 @@ jobs:
         INPUT_CANDIDATE_REF: ${{ inputs.candidate_ref }}
       run: |
         set -o pipefail
+        CANDIDATE_REF="${INPUT_CANDIDATE_REF:-HEAD}"
         BASELINE_REF="$INPUT_BASELINE_REF"
         if [ -z "$BASELINE_REF" ]; then
-          BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' HEAD^)"
+          BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' "$CANDIDATE_REF^")"
         fi
-        CANDIDATE_REF="${INPUT_CANDIDATE_REF:-HEAD}"
         BASELINE_SHA="$(git rev-parse "$BASELINE_REF")"
         CANDIDATE_SHA="$(git rev-parse "$CANDIDATE_REF")"
         printf '%s\n' "$BASELINE_REF" > "$GITHUB_WORKSPACE/pytorch-benchmark-evidence/benchmark-baseline-ref.txt"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       benchmark_filter:
-        description: "Optional ASV --bench regex. Leave empty for the full release-candidate comparison."
+        description: "Optional ASV --bench regex. Leave empty for the bounded stf-core comparison."
         required: false
         type: string
 
@@ -168,8 +168,15 @@ jobs:
         if [ -z "$CANDIDATE_REF" ]; then
           CANDIDATE_REF="HEAD"
         fi
+        if [ -z "$BENCH_FILTER" ]; then
+          BENCH_FILTER="$(python "$GITHUB_WORKSPACE/tools/select_benchmark_filters.py" --profile stf-core)"
+        fi
+        BASELINE_SHA="$(git rev-parse "$BASELINE_REF")"
+        CANDIDATE_SHA="$(git rev-parse "$CANDIDATE_REF")"
         echo "$BASELINE_REF" > "$GITHUB_WORKSPACE/release-candidate-performance-evidence/benchmark-baseline-ref.txt"
+        echo "$BASELINE_SHA" > "$GITHUB_WORKSPACE/release-candidate-performance-evidence/benchmark-baseline-sha.txt"
         echo "$CANDIDATE_REF" > "$GITHUB_WORKSPACE/release-candidate-performance-evidence/benchmark-candidate-ref.txt"
+        echo "$CANDIDATE_SHA" > "$GITHUB_WORKSPACE/release-candidate-performance-evidence/benchmark-candidate-sha.txt"
         echo "$BENCH_FILTER" > "$GITHUB_WORKSPACE/release-candidate-performance-evidence/benchmark-filter.txt"
         ASV_COMMAND=(
           asv --config asv.conf.json continuous

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -49,12 +49,13 @@ The GitHub performance workflow can also be run manually with
 - `bench_filter`: optional ASV `--bench` regular expression for manual
   baseline/candidate comparisons.
 
-Every runtime pull request runs a bounded `pr-core` comparison over the core
-pipeline. A PR labeled `run-performance` selects the `changed` profile from
-changed files. The Tuesday schedule compares the previous release with `main`
-using `stf-core`, which combines catalog smoke, core pipeline routes, and
-selected memory sentinels. Manual comparisons with an empty `bench_filter` also
-select `stf-core`; a full-family run requires an explicit regex.
+Every runtime pull request runs a bounded `pr-core` comparison from the PR base
+to the checked-out merge commit over the core pipeline. A PR labeled
+`run-performance` selects the `changed` profile from changed files. The Tuesday
+schedule compares the previous release with `main` using `stf-core`, which
+combines catalog smoke, core pipeline routes, and selected memory sentinels.
+Manual comparisons with an empty `bench_filter` also select `stf-core`; a
+full-family run requires an explicit regex.
 
 Resolve the named profiles locally with:
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -3,11 +3,15 @@
 AlbumentationsX uses ASV for scheduled and release performance evidence. The
 benchmarks are separate from unit tests and should not be imported by tests.
 
-## Quick Run
+## Quick Comparison
 
 ```bash
 cd benchmark
-uv tool run --from asv asv --config asv.conf.json run --quick --show-stderr
+BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' HEAD^)"
+uv tool run --from asv asv --config asv.conf.json continuous \
+  --quick --show-stderr \
+  --attribute repeat=1 --attribute number=1 \
+  "$BASELINE_REF" HEAD
 ```
 
 For task-level before/after comparisons, use the same baseline/candidate shape
@@ -29,7 +33,11 @@ reviewable:
 
 ```bash
 cd benchmark
-uv tool run --from asv asv --config asv-pytorch.conf.json run --quick --show-stderr
+BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' HEAD^)"
+uv tool run --from asv asv --config asv-pytorch.conf.json continuous \
+  --quick --show-stderr \
+  --attribute repeat=1 --attribute number=1 \
+  "$BASELINE_REF" HEAD
 ```
 
 The GitHub performance workflow can also be run manually with
@@ -41,9 +49,20 @@ The GitHub performance workflow can also be run manually with
 - `bench_filter`: optional ASV `--bench` regular expression for manual
   baseline/candidate comparisons.
 
-Pull requests run a bounded comparison over catalog smoke, core pipeline,
-batch-route, and direct functional-kernel benchmarks. Scheduled runs and manual
-comparisons with an empty `bench_filter` run the full suite.
+Every runtime pull request runs a bounded `pr-core` comparison over the core
+pipeline. A PR labeled `run-performance` selects the `changed` profile from
+changed files. The Tuesday schedule compares the previous release with `main`
+using `stf-core`, which combines catalog smoke, core pipeline routes, and
+selected memory sentinels. Manual comparisons with an empty `bench_filter` also
+select `stf-core`; a full-family run requires an explicit regex.
+
+Resolve the named profiles locally with:
+
+```bash
+uv run python tools/select_benchmark_filters.py --profile pr-core
+uv run python tools/select_benchmark_filters.py --profile stf-core
+uv run python tools/select_benchmark_filters.py --profile changed --changed-files changed-files.txt
+```
 
 ## Matrix
 

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -160,14 +160,15 @@ They also retain lower-bound, property/regression, optional-extra, PyTorch,
 performance, and release artifact evidence where appropriate.
 
 The Performance workflow separates benchmark coverage from timed comparisons.
-Every runtime pull request runs the advisory `pr-core` base-to-head smoke. A
-`run-performance` label selects the changed-family comparison. The Tuesday
-schedule compares the previous release tag with the exact `main` commit using
-`stf-core`; it does not run the catalog-wide matrices as one timed job. Manual
-runs use `stf-core` when no filter is supplied, while a full-family comparison
-requires an explicit filter. The version-bump `Release preflight` runs the
-same `stf-core` comparison and fails if its release bundle lacks comparison
-evidence or contains a stable release-blocking regression.
+Every runtime pull request runs the advisory `pr-core` comparison from its base
+commit to the checked-out merge commit. A `run-performance` label selects the
+changed-family comparison. The Tuesday schedule compares the previous release
+tag with the exact `main` commit using `stf-core`; it does not run the
+catalog-wide matrices as one timed job. Manual runs use `stf-core` when no
+filter is supplied, while a full-family comparison requires an explicit filter.
+The version-bump `Release preflight` runs the same `stf-core` comparison and
+fails if its release bundle lacks comparison evidence or contains a stable
+release-blocking regression.
 
 CodeQL uses two path-scoped advanced workflows. `codeql-python.yml` runs for
 Python source, stubs, or CodeQL configuration changes. `codeql-actions.yml`

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -159,6 +159,16 @@ Nightly and release-candidate workflows run the complete 3 × 5 base suite.
 They also retain lower-bound, property/regression, optional-extra, PyTorch,
 performance, and release artifact evidence where appropriate.
 
+The Performance workflow separates benchmark coverage from timed comparisons.
+Every runtime pull request runs the advisory `pr-core` base-to-head smoke. A
+`run-performance` label selects the changed-family comparison. The Tuesday
+schedule compares the previous release tag with the exact `main` commit using
+`stf-core`; it does not run the catalog-wide matrices as one timed job. Manual
+runs use `stf-core` when no filter is supplied, while a full-family comparison
+requires an explicit filter. The version-bump `Release preflight` runs the
+same `stf-core` comparison and fails if its release bundle lacks comparison
+evidence or contains a stable release-blocking regression.
+
 CodeQL uses two path-scoped advanced workflows. `codeql-python.yml` runs for
 Python source, stubs, or CodeQL configuration changes. `codeql-actions.yml`
 runs for GitHub Actions and composite-action changes. Ordinary Markdown and

--- a/docs/maintaining/correctness-report-template.md
+++ b/docs/maintaining/correctness-report-template.md
@@ -62,6 +62,7 @@ Supported Python versions: 3.10, 3.11, 3.12, 3.13, 3.14
 | Core Compose overhead | `<status>` |
 | Memory checks | `<status>` |
 | ASV comparison summary | `<status/link>` |
+| ASV comparison refs | `<baseline-ref> -> <candidate-ref>` |
 | Benchmark coverage diff | `<ok/changed/unavailable/link>` |
 | Performance contract audit | `<batch/annotation/direct-kernel/parameter/memory counts>` |
 | Performance budget | `<ok/triage_required/release_blocked/link>` |

--- a/docs/maintaining/performance-coverage.md
+++ b/docs/maintaining/performance-coverage.md
@@ -288,8 +288,8 @@ Pull requests:
 
 - required: benchmark coverage validation through `tools.benchmark_coverage`
 - required: ASV suite importability where the performance workflow runs
-- advisory: every runtime PR runs a base-to-head `pr-core` comparison covering
-  `TimeCorePipeline` and its target-processor/tracing variants
+- advisory: every runtime PR runs a base-to-merge-commit `pr-core` comparison
+  covering `TimeCorePipeline` and its target-processor/tracing variants
 - advisory: a PR labeled `run-performance` runs the `changed` profile selected
   from its changed files; this is the deep family comparison route
 - benchmark infrastructure changes rely on ASV importability and benchmark

--- a/docs/maintaining/performance-coverage.md
+++ b/docs/maintaining/performance-coverage.md
@@ -276,9 +276,11 @@ the tooling emit an explicit unavailable diff artifact instead of silently
 skipping the comparison.
 
 Release-candidate verification has a dedicated Ubuntu performance comparison
-job. It runs ASV `continuous` against the configured baseline, writes raw ASV
-output, summarizes the comparison, and runs the performance budget in strict
-mode with `--require-comparison --fail-on-release-blockers`.
+job. A blank filter selects the bounded `stf-core` profile; an explicit filter
+is available for deep investigations. The job runs ASV `continuous` against
+the configured baseline, writes raw ASV output, summarizes the comparison, and
+runs the performance budget in strict mode with
+`--require-comparison --fail-on-release-blockers`.
 
 ## CI And Release Evidence
 
@@ -286,14 +288,14 @@ Pull requests:
 
 - required: benchmark coverage validation through `tools.benchmark_coverage`
 - required: ASV suite importability where the performance workflow runs
-- advisory: ASV before/after comparison on GitHub-hosted runners when runtime
-  or benchmark code changes; PR comparison starts with catalog smoke, core
-  pipeline, batch-route, and direct functional-kernel benchmarks, then adds
-  changed-family matrix benchmarks through `tools/select_benchmark_filters.py`
+- advisory: every runtime PR runs a base-to-head `pr-core` comparison covering
+  `TimeCorePipeline` and its target-processor/tracing variants
+- advisory: a PR labeled `run-performance` runs the `changed` profile selected
+  from its changed files; this is the deep family comparison route
 - benchmark infrastructure changes rely on ASV importability and benchmark
-  coverage validation in PR; full-suite comparison remains scheduled or manual
-- selected PR benchmark filter and changed-file evidence are uploaded with
-  benchmark artifacts when a comparison runs
+  coverage validation in PR; family matrices run only when selected explicitly
+- each timing route uploads exact baseline/candidate refs, the resolved filter,
+  raw ASV output, a summary, and a performance budget
 - performance-budget evidence classifies coverage status, benchmark stability,
   triage items, and release-blocking regressions
 - the default performance workflow evaluates the core budget with `--core-only`;
@@ -306,12 +308,14 @@ Pull requests:
 
 Nightly and scheduled runs:
 
-- full ASV evidence from the default-branch scheduled workflow
-- dedicated PyTorch Tensor ASV evidence from the PyTorch Tensor Performance
-  workflow
+- the default-branch schedule compares the previous reachable release tag with
+  the exact `main` commit using the bounded `stf-core` profile
+- the dedicated PyTorch Tensor schedule compares the previous release with the
+  exact candidate using its separate ASV config
 - environment JSON
 - benchmark coverage JSON
-- ASV result artifacts
+- exact baseline/candidate refs, resolved filter, raw ASV output, comparison
+  summary, performance budget, and ASV result artifacts
 
 Release candidates:
 
@@ -335,14 +339,19 @@ uv run asv --config asv.conf.json continuous \
   <candidate-ref>
 ```
 
-Manual workflow runs may pass `bench_filter` to scope a comparison or leave it
-empty to compare the full suite.
+Manual workflow runs may pass `bench_filter` to scope a comparison. An empty
+filter selects `stf-core`; a full-family run requires an explicit filter so the
+requested cost is visible before the run starts.
 
 Dedicated PyTorch Tensor benchmarks can be run locally with:
 
 ```bash
 cd benchmark
-uv run asv --config asv-pytorch.conf.json run --quick --show-stderr
+BASELINE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*' HEAD^)"
+uv run asv --config asv-pytorch.conf.json continuous \
+  --quick --show-stderr \
+  --attribute repeat=1 --attribute number=1 \
+  "$BASELINE_REF" HEAD
 ```
 
 The raw ASV comparison text is the source artifact. The compact JSON summary

--- a/docs/maintaining/release-process.md
+++ b/docs/maintaining/release-process.md
@@ -42,7 +42,10 @@ environment. It performs the release-specific work:
    `albumentations` outside the checkout.
 5. Checks `uv.lock` freshness.
 6. Verifies golden regression vectors and runs the regression/property suite.
-7. Collects benchmark coverage and classifies the core performance profile.
+7. Collects benchmark coverage and compares the previous reachable release
+   tag with the release candidate using the bounded `stf-core` profile. The
+   preflight stores exact refs, raw ASV output, a comparison summary, and a
+   strict performance budget; missing comparison evidence blocks the bundle.
 8. Audits locked runtime dependencies and GitHub Actions workflows.
 9. Generates the CycloneDX SBOM and Correctness & Compatibility Report.
 10. Creates checksums and an immutable release manifest.
@@ -182,8 +185,9 @@ Never publish different bytes under an existing version.
 ## Optional Release Candidate Verification
 
 `.github/workflows/release-candidate.yml` remains available for unusual,
-high-risk releases that need a full manual matrix or ASV comparison. It is not
-part of the normal release path.
+high-risk releases. Its blank benchmark filter selects `stf-core`; maintainers
+can provide an explicit regex when a full-family comparison is justified. It
+is not part of the normal release path.
 
 ## Security Releases
 

--- a/docs/maintaining/release-verification.md
+++ b/docs/maintaining/release-verification.md
@@ -61,7 +61,9 @@ The Correctness & Compatibility Report summarizes what CI tested for a release:
 - lower-bound dependency coverage
 - golden regression and property-test coverage
 - performance benchmark evidence
-- performance-budget status for coverage contracts and regression triage
+- exact ASV baseline-to-candidate refs and the resolved benchmark profile
+- performance-budget status for coverage contracts and regression triage;
+  normal release bundles require `comparison.provided: true`
 - runtime dependency audit, workflow audit, and OpenSSF Scorecard status
 - pip-audit, zizmor, Scorecard JSON, and Scorecard SARIF artifacts where the
   corresponding workflows ran

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ ci-benchmark = [
   "opencv-python-headless>=5.0.0.93",
 ]
 ci-release = [
+  { include-group = "ci-benchmark" },
   { include-group = "ci-test" },
   { include-group = "ci-package" },
   { include-group = "ci-security" },

--- a/tests/test_asv_summary.py
+++ b/tests/test_asv_summary.py
@@ -23,6 +23,7 @@ def test_summarize_asv_output_parses_changed_rows_with_parameter_pipes(tmp_path)
 
     summary = summarize_asv_output(asv_output, asv_exit_code=1, max_items=10)
 
+    assert summary["missing"] is False
     assert summary["asv_exit_code"] == 1
     assert summary["totals"] == {"changed": 2, "improvements": 1, "regressions": 1}
     assert summary["status"]["changed_significantly"] is True
@@ -38,3 +39,13 @@ def test_summarize_asv_output_handles_missing_input(tmp_path):
     assert summary["missing"] is True
     assert summary["totals"] == {"changed": 0, "improvements": 0, "regressions": 0}
     assert summary["regressions"] == []
+
+
+def test_summarize_asv_output_marks_unrecognized_failure_as_missing(tmp_path):
+    asv_output = tmp_path / "failed.txt"
+    asv_output.write_text("ASV failed before producing a comparison table.\n")
+
+    summary = summarize_asv_output(asv_output, asv_exit_code=1, max_items=10)
+
+    assert summary["missing"] is True
+    assert summary["asv_exit_code"] == 1

--- a/tests/test_ci_runtime_profiles.py
+++ b/tests/test_ci_runtime_profiles.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import yaml
 
-from tools.ci_matrix import CI_FOUNDATION_SHA, TORCH_RUNTIME_JOBS
+from tools.ci_matrix import CI_FOUNDATION_SHA, TORCH_RUNTIME_JOBS, _check_ci_dependency_groups
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SETUP_ACTION = REPO_ROOT / ".github" / "actions" / "setup-ci" / "action.yml"
@@ -62,3 +62,9 @@ def test_workflows_use_only_declared_groups_and_no_inline_torch_installs() -> No
                 }
 
         assert re.search(r"(?:uv |python -m )?pip install[^\n]*torch", text, flags=re.IGNORECASE) is None
+
+
+def test_dependency_group_check_reports_broken_include_reference() -> None:
+    issues = _check_ci_dependency_groups({"ci-release": [{"include-group": "ci-benhcmark"}]})
+
+    assert "refers to non-existent group 'ci-benhcmark'" in "\n".join(issues)

--- a/tests/test_correctness_report.py
+++ b/tests/test_correctness_report.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-from tools.generate_correctness_report import generate_report
+from tools.generate_correctness_report import _validate_required_evidence, generate_report
 
 
 def _write_json(path, data: dict) -> None:
@@ -83,7 +83,7 @@ def test_generate_report_accepts_required_release_evidence(tmp_path) -> None:
                 "smoke_only_transforms": 0,
             },
             "comparison": {
-                "provided": False,
+                "provided": True,
                 "release_blockers": [],
                 "triage_items": [],
             },
@@ -91,6 +91,18 @@ def test_generate_report_accepts_required_release_evidence(tmp_path) -> None:
             "status": "ok",
         },
     )
+    _write_json(
+        tmp_path / "benchmark-asv-summary-local.json",
+        {
+            "kind": "asv-comparison",
+            "missing": False,
+            "asv_exit_code": 0,
+            "status": {"performance_decreased": False},
+            "totals": {"changed": 0, "improvements": 0, "regressions": 0},
+        },
+    )
+    (tmp_path / "benchmark-baseline-ref.txt").write_text("2.4.2\n")
+    (tmp_path / "benchmark-candidate-ref.txt").write_text("release-head\n")
     _write_json(tmp_path / "security-local.json", {})
 
     report = generate_report(tmp_path)
@@ -104,6 +116,7 @@ def test_generate_report_accepts_required_release_evidence(tmp_path) -> None:
     assert "0 coverage contract failure(s)" in report
     assert "Security summary: provided" in report
     assert "CodeQL: managed through path-scoped advanced workflows" in report
+    assert "ASV comparison refs: `2.4.2` -> `release-head`" in report
 
 
 @pytest.mark.parametrize(
@@ -158,12 +171,53 @@ def test_generate_report_rejects_incomplete_or_failing_pytest_evidence(tmp_path,
         tmp_path / "benchmark-performance-budget-local.json",
         {
             "coverage": {"contract_failures": 0, "public_transforms": 1, "smoke_only_transforms": 0},
-            "comparison": {"provided": False, "release_blockers": [], "triage_items": []},
+            "comparison": {"provided": True, "release_blockers": [], "triage_items": []},
             "kind": "performance-budget",
             "status": "ok",
+        },
+    )
+    _write_json(
+        tmp_path / "benchmark-asv-summary-local.json",
+        {
+            "kind": "asv-comparison",
+            "missing": False,
+            "asv_exit_code": 0,
+            "status": {"performance_decreased": False},
+            "totals": {"changed": 0, "improvements": 0, "regressions": 0},
         },
     )
     _write_json(tmp_path / "security-local.json", {})
 
     with pytest.raises(ValueError, match=match):
         generate_report(tmp_path)
+
+
+def test_generate_report_rejects_missing_asv_comparison_in_strict_mode() -> None:
+    with pytest.raises(ValueError, match="ASV comparison summary JSON"):
+        _validate_required_evidence(
+            [{}],
+            [{"missing": False, "status": "ok", "totals": {}}],
+            [
+                {"asv_cases": 1, "coverage_depth": {}, "memory_benchmarks": 1},
+                {"kind": "benchmark-coverage-detail", "summary": {}, "layer_counts": {}},
+                {"kind": "performance-budget", "comparison": {"provided": True}},
+            ],
+            [{}],
+            allow_missing_evidence=False,
+        )
+
+
+def test_generate_report_rejects_budget_without_provided_comparison() -> None:
+    with pytest.raises(ValueError, match=r"comparison\.provided=true"):
+        _validate_required_evidence(
+            [{}],
+            [{"missing": False, "status": "ok", "totals": {}}],
+            [
+                {"asv_cases": 1, "coverage_depth": {}, "memory_benchmarks": 1},
+                {"kind": "benchmark-coverage-detail", "summary": {}, "layer_counts": {}},
+                {"kind": "asv-comparison", "missing": False},
+                {"kind": "performance-budget", "comparison": {"provided": False}},
+            ],
+            [{}],
+            allow_missing_evidence=False,
+        )

--- a/tests/test_correctness_report.py
+++ b/tests/test_correctness_report.py
@@ -207,7 +207,8 @@ def test_generate_report_rejects_missing_asv_comparison_in_strict_mode() -> None
         )
 
 
-def test_generate_report_rejects_budget_without_provided_comparison() -> None:
+@pytest.mark.parametrize("comparison", [{"provided": False}, None])
+def test_generate_report_rejects_budget_without_provided_comparison(comparison: dict | None) -> None:
     with pytest.raises(ValueError, match=r"comparison\.provided=true"):
         _validate_required_evidence(
             [{}],
@@ -216,7 +217,7 @@ def test_generate_report_rejects_budget_without_provided_comparison() -> None:
                 {"asv_cases": 1, "coverage_depth": {}, "memory_benchmarks": 1},
                 {"kind": "benchmark-coverage-detail", "summary": {}, "layer_counts": {}},
                 {"kind": "asv-comparison", "missing": False},
-                {"kind": "performance-budget", "comparison": {"provided": False}},
+                {"kind": "performance-budget", "comparison": comparison},
             ],
             [{}],
             allow_missing_evidence=False,

--- a/tests/test_performance_budget.py
+++ b/tests/test_performance_budget.py
@@ -146,6 +146,23 @@ def test_build_budget_treats_missing_asv_summary_as_missing_comparison() -> None
     assert budget["comparison"]["provided"] is False
 
 
+def test_build_budget_treats_empty_failed_asv_summary_as_missing_comparison() -> None:
+    budget = build_budget(
+        _coverage_summary(),
+        _coverage_detail(),
+        {
+            "missing": False,
+            "asv_exit_code": 1,
+            "status": {},
+            "totals": {"changed": 0, "improvements": 0, "regressions": 0},
+        },
+        require_comparison=True,
+    )
+
+    assert budget["status"] == "missing_comparison"
+    assert budget["comparison"]["provided"] is False
+
+
 def test_build_budget_rejects_missing_required_coverage_layers() -> None:
     coverage_detail = _coverage_detail()
     coverage_detail["layer_counts"] = {**coverage_detail["layer_counts"], "family_matrix": 0}

--- a/tests/test_performance_budget.py
+++ b/tests/test_performance_budget.py
@@ -134,6 +134,18 @@ def test_build_budget_requires_comparison_when_requested() -> None:
     assert "ASV comparison summary is required" in budget["issues"][0]
 
 
+def test_build_budget_treats_missing_asv_summary_as_missing_comparison() -> None:
+    budget = build_budget(
+        _coverage_summary(),
+        _coverage_detail(),
+        {"missing": True, "asv_exit_code": 1},
+        require_comparison=True,
+    )
+
+    assert budget["status"] == "missing_comparison"
+    assert budget["comparison"]["provided"] is False
+
+
 def test_build_budget_rejects_missing_required_coverage_layers() -> None:
     coverage_detail = _coverage_detail()
     coverage_detail["layer_counts"] = {**coverage_detail["layer_counts"], "family_matrix": 0}

--- a/tests/test_performance_workflow.py
+++ b/tests/test_performance_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -28,19 +29,36 @@ def test_performance_workflow_keeps_pr_evidence_job_fast() -> None:
     assert job["timeout-minutes"] == 10
     assert "asv --config asv.conf.json check --verbose" in run_text
     assert "asv --config asv.conf.json continuous" not in run_text
-    assert "asv --config asv.conf.json run" not in run_text
+    assert not re.search(r"asv --config asv\.conf\.json\s+run\b", run_text)
     assert "benchmark-performance-budget.json" in run_text
 
 
-def test_performance_workflow_keeps_full_asv_timing_opt_in() -> None:
+def test_performance_workflow_keeps_targeted_comparison_label_or_manual_gated() -> None:
     job = _performance_jobs()["asv_comparison"]
     run_text = _job_run_text(job)
 
     assert "run-performance" in job["if"]
     assert "asv --config asv.conf.json continuous" in run_text
-    assert "asv --config asv.conf.json run" in run_text
-    assert "benchmark-asv-evidence/changed-files.txt" in run_text
-    assert "tools/select_benchmark_filters.py" in run_text
+    assert "targeted-performance-evidence/changed-files.txt" in run_text
+    assert "--profile changed" in run_text
+    assert "--profile stf-core" in run_text
+    assert not re.search(r"asv --config asv\.conf\.json\s+run\b", run_text)
+
+
+def test_performance_workflow_adds_bounded_pr_and_scheduled_comparisons() -> None:
+    jobs = _performance_jobs()
+    pr_job = jobs["pr_core_comparison"]
+    scheduled_job = jobs["scheduled_core_comparison"]
+
+    assert pr_job["needs"] == "benchmark_evidence"
+    assert pr_job["timeout-minutes"] == 10
+    assert "--profile pr-core" in _job_run_text(pr_job)
+    assert "asv --config asv.conf.json continuous" in _job_run_text(pr_job)
+    assert scheduled_job["if"] == "github.event_name == 'schedule'"
+    assert scheduled_job["timeout-minutes"] == 20
+    assert "--profile stf-core" in _job_run_text(scheduled_job)
+    assert "git describe --tags --abbrev=0 --match '[0-9]*' HEAD^" in _job_run_text(scheduled_job)
+    assert not re.search(r"HEAD\^!", PERFORMANCE_WORKFLOW.read_text())
 
 
 def test_asv_install_commands_are_separate_cpu_torch_steps() -> None:
@@ -59,7 +77,7 @@ def test_asv_install_commands_are_separate_cpu_torch_steps() -> None:
 
 def test_every_asv_job_explicitly_uses_the_cpu_torch_runtime() -> None:
     workflow = yaml.safe_load(PERFORMANCE_WORKFLOW.read_text())
-    for job_name in ("benchmark_evidence", "asv_comparison"):
+    for job_name in ("benchmark_evidence", "pr_core_comparison", "asv_comparison", "scheduled_core_comparison"):
         setup_step = next(
             step for step in workflow["jobs"][job_name]["steps"] if step.get("uses") == "./.github/actions/setup-ci"
         )

--- a/tests/test_performance_workflow.py
+++ b/tests/test_performance_workflow.py
@@ -42,6 +42,8 @@ def test_performance_workflow_keeps_targeted_comparison_label_or_manual_gated() 
     assert "targeted-performance-evidence/changed-files.txt" in run_text
     assert "--profile changed" in run_text
     assert "--profile stf-core" in run_text
+    assert 'CANDIDATE_REF="${INPUT_CANDIDATE_REF:-HEAD}"' in run_text
+    assert "git describe --tags --abbrev=0 --match '[0-9]*' \"$CANDIDATE_REF^\"" in run_text
     assert not re.search(r"asv --config asv\.conf\.json\s+run\b", run_text)
 
 
@@ -54,11 +56,25 @@ def test_performance_workflow_adds_bounded_pr_and_scheduled_comparisons() -> Non
     assert pr_job["timeout-minutes"] == 10
     assert "--profile pr-core" in _job_run_text(pr_job)
     assert "asv --config asv.conf.json continuous" in _job_run_text(pr_job)
+    resolve_step = next(step for step in pr_job["steps"] if step.get("name") == "Resolve PR core comparison")
+    assert resolve_step["env"] == {
+        "PR_BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+        "PR_CANDIDATE_SHA": "${{ github.sha }}",
+    }
+    assert "$PR_CANDIDATE_SHA" in _job_run_text(pr_job)
+    assert "$PR_HEAD_SHA" not in _job_run_text(pr_job)
     assert scheduled_job["if"] == "github.event_name == 'schedule'"
     assert scheduled_job["timeout-minutes"] == 20
     assert "--profile stf-core" in _job_run_text(scheduled_job)
     assert "git describe --tags --abbrev=0 --match '[0-9]*' HEAD^" in _job_run_text(scheduled_job)
     assert not re.search(r"HEAD\^!", PERFORMANCE_WORKFLOW.read_text())
+
+
+def test_pytorch_performance_uses_candidate_revision_for_default_baseline() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "pytorch-performance.yml").read_text()
+
+    assert 'CANDIDATE_REF="${INPUT_CANDIDATE_REF:-HEAD}"' in workflow
+    assert "git describe --tags --abbrev=0 --match '[0-9]*' \"$CANDIDATE_REF^\"" in workflow
 
 
 def test_asv_install_commands_are_separate_cpu_torch_steps() -> None:

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -154,6 +154,13 @@ def test_version_bump_preflight_builds_publishable_bundle_in_core_profile() -> N
     assert "python -m tools.performance_budget summarize" in run_text
     assert "python tools/performance_budget.py" not in run_text
     assert "--core-only" in run_text
+    assert "asv --config asv.conf.json continuous" in run_text
+    assert "--profile stf-core" in run_text
+    assert "benchmark-asv-summary.json" in run_text
+    assert "benchmark-baseline-sha.txt" in run_text
+    assert "benchmark-candidate-sha.txt" in run_text
+    assert "--require-comparison" in run_text
+    assert "--fail-on-release-blockers" in run_text
     assert "--check performance_core" in run_text
     assert "release-preflight=${{ needs.release_preflight.result }}" in policy_run_text
 

--- a/tests/test_select_benchmark_filters.py
+++ b/tests/test_select_benchmark_filters.py
@@ -1,6 +1,42 @@
 from __future__ import annotations
 
-from tools.select_benchmark_filters import select_benchmark_patterns, select_benchmark_regex
+import pytest
+
+from tools.select_benchmark_filters import (
+    main,
+    select_benchmark_patterns,
+    select_benchmark_regex,
+    select_profile_patterns,
+    select_profile_regex,
+)
+
+
+def test_select_benchmark_filters_pr_core_is_bounded() -> None:
+    assert select_profile_patterns("pr-core") == ("TimeCorePipeline",)
+    assert select_profile_regex("pr-core") == "TimeCorePipeline"
+
+
+def test_select_benchmark_filters_stf_core_contains_runtime_and_memory_sentinels() -> None:
+    patterns = select_profile_patterns("stf-core")
+
+    assert patterns == (
+        "TimeCatalogTransformSmoke",
+        "TimeCorePipeline",
+        "peakmem_resize_large_rgb",
+        "peakmem_normalize_large_rgb",
+        "peakmem_batch_pipeline_medium_rgb",
+        "peakmem_mosaic_small_rgb",
+        "peakmem_copy_paste_small_rgb",
+        "peakmem_volume_pad_medium",
+    )
+
+
+def test_select_benchmark_filters_changed_profile_routes_changed_paths() -> None:
+    assert select_profile_patterns("changed", ["albumentations/core/composition.py"]) == (
+        "TimeBatch",
+        "TimeCatalogTransformSmoke",
+        "TimeCorePipeline",
+    )
 
 
 def test_select_benchmark_filters_keep_baseline_for_docs_only_changes() -> None:
@@ -67,3 +103,25 @@ def test_select_benchmark_filters_do_not_use_broad_functional_class_by_default()
 
     assert "TimeFunctional" not in patterns
     assert "TimeFunctionalGeometry" in patterns
+
+
+def test_select_benchmark_filters_reject_invalid_profile_inputs() -> None:
+    with pytest.raises(ValueError, match="does not accept changed paths"):
+        select_profile_patterns("pr-core", ["albumentations/core/composition.py"])
+    with pytest.raises(ValueError, match="requires changed paths"):
+        select_profile_patterns("changed")
+    with pytest.raises(ValueError, match="unknown benchmark profile"):
+        select_profile_patterns("everything")
+
+
+def test_select_benchmark_filters_cli_requires_profile_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.argv", ["select_benchmark_filters.py", "--profile", "changed"])
+    with pytest.raises(SystemExit, match="requires --changed-files"):
+        main()
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["select_benchmark_filters.py", "--profile", "pr-core", "--changed-files", "paths.txt"],
+    )
+    with pytest.raises(SystemExit, match="does not accept --changed-files"):
+        main()

--- a/tools/asv_summary.py
+++ b/tools/asv_summary.py
@@ -70,20 +70,21 @@ def summarize_asv_output(path: Path, *, asv_exit_code: int | None, max_items: in
 
     lines = path.read_text(errors="replace").splitlines()
     rows = [row for line in lines if (row := _parse_table_row(line)) is not None]
+    status = _status_flags(lines)
     regressions = [row for row in rows if row["change"] == "+"]
     improvements = [row for row in rows if row["change"] == "-"]
     return {
         "schema_version": 1,
         "kind": "asv-comparison",
         "source": str(path),
-        "missing": False,
+        "missing": not rows and not any(status.values()),
         "asv_exit_code": asv_exit_code,
         "totals": {
             "changed": len(rows),
             "improvements": len(improvements),
             "regressions": len(regressions),
         },
-        "status": _status_flags(lines),
+        "status": status,
         "improvements": _sorted_rows(improvements, reverse=False, max_items=max_items),
         "regressions": _sorted_rows(regressions, reverse=True, max_items=max_items),
     }

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -52,6 +52,8 @@ SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "upload_to_pypi.yml"
 SETUP_CI_ACTION = REPO_ROOT / ".github" / "actions" / "setup-ci" / "action.yml"
 CI_FOUNDATION_SHA = "6b9045dbea58026a1e8f96b0392c411934a27199"
+RETIRED_ASV_RUN_PATTERN = re.compile(r"asv --config asv\.conf\.json\s+run\b")
+RETIRED_REVISION_SELECTOR_PATTERN = re.compile(r"HEAD\^!")
 CONDA_RECIPE = REPO_ROOT / "conda.recipe" / "meta.yaml"
 DEVELOPMENT_REQUIREMENTS = REPO_ROOT / "requirements-dev.txt"
 CODEQL_ACTIONS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "codeql-actions.yml"
@@ -104,7 +106,7 @@ CI_DEPENDENCY_GROUPS = {
         "pytest",
         "ruff",
     },
-    "ci-release": {"cyclonedx-bom"},
+    "ci-release": {"asv", "cyclonedx-bom"},
     "ci-security": {"pip-audit", "zizmor"},
     "ci-test": {"defusedxml", "opencv-python-headless", "pytest", "pytest-cov", "pytest-xdist"},
     "ci-torch-cpu": {"torch"},
@@ -135,7 +137,9 @@ TORCH_RUNTIME_JOBS = {
     },
     PERFORMANCE_WORKFLOW: {
         "benchmark_evidence": "ci-benchmark",
+        "pr_core_comparison": "ci-benchmark",
         "asv_comparison": "ci-benchmark",
+        "scheduled_core_comparison": "ci-benchmark",
     },
     PYTORCH_PERFORMANCE_WORKFLOW: {"pytorch_tensor_asv": "ci-benchmark"},
 }
@@ -292,6 +296,25 @@ def _direct_dependency_names(entries: list[Any]) -> set[str]:
     return {re.split(r"[<>=!~\[]", entry, maxsplit=1)[0].casefold() for entry in entries if isinstance(entry, str)}
 
 
+def _dependency_group_packages(
+    group_name: str,
+    dependency_groups: dict[str, Any],
+    active_groups: frozenset[str] = frozenset(),
+) -> set[str]:
+    """Return direct package names, including recursively included groups."""
+    if group_name in active_groups:
+        return set()
+    entries = dependency_groups.get(group_name, [])
+    if not isinstance(entries, list):
+        return set()
+    packages = _direct_dependency_names(entries)
+    next_active_groups = active_groups | {group_name}
+    for entry in entries:
+        if isinstance(entry, dict) and isinstance(entry.get("include-group"), str):
+            packages.update(_dependency_group_packages(entry["include-group"], dependency_groups, next_active_groups))
+    return packages
+
+
 def _check_ci_dependency_groups(dependency_groups: dict[str, Any]) -> list[str]:
     issues: list[str] = []
     unexpected_groups = set(dependency_groups) - {*CI_DEPENDENCY_GROUPS, "dev"}
@@ -303,7 +326,7 @@ def _check_ci_dependency_groups(dependency_groups: dict[str, Any]) -> list[str]:
         if not isinstance(entries, list):
             issues.append(f"pyproject.toml is missing CI dependency group {group!r}")
             continue
-        packages = _direct_dependency_names(entries)
+        packages = _dependency_group_packages(group, dependency_groups)
         missing_packages = required_packages - packages
         if missing_packages:
             issues.append(f"pyproject.toml group {group!r} is missing {sorted(missing_packages)!r}")
@@ -589,11 +612,25 @@ def _check_pr_workflow() -> list[str]:
                 "tools.release_bundle finalize",
                 "dependency-group: ci-release",
                 "--core-only",
+                "asv --config asv.conf.json continuous",
+                "--profile stf-core",
+                "benchmark-asv-summary.json",
+                "--require-comparison",
+                "benchmark-baseline-sha.txt",
+                "benchmark-candidate-sha.txt",
                 "release-preflight=${{ needs.release_preflight.result }}",
             ),
             "selective PR gate",
         ),
     )
+
+    release_job = jobs.get("release_preflight")
+    if isinstance(release_job, dict):
+        release_text = _workflow_job_run_text(release_job)
+        if RETIRED_ASV_RUN_PATTERN.search(release_text) or RETIRED_REVISION_SELECTOR_PATTERN.search(release_text):
+            issues.append(f"{PR_WORKFLOW} release_preflight uses a retired single-revision ASV path")
+        if "--fail-on-release-blockers" not in release_text:
+            issues.append(f"{PR_WORKFLOW} release_preflight must fail on release performance blockers")
 
     return issues
 
@@ -760,6 +797,70 @@ def _check_release_candidate_workflow() -> list[str]:
     return issues
 
 
+def _check_benchmark_evidence_job(job: Any) -> list[str]:
+    if not isinstance(job, dict):
+        return [f"{PERFORMANCE_WORKFLOW} is missing benchmark_evidence job"]
+    issues: list[str] = []
+    if job.get("timeout-minutes") != 10:
+        issues.append(f"{PERFORMANCE_WORKFLOW} benchmark_evidence job must keep timeout-minutes at 10")
+    if job.get("if") != "github.event_name == 'pull_request'":
+        issues.append(f"{PERFORMANCE_WORKFLOW} benchmark_evidence must be PR-only")
+    run_text = _workflow_job_run_text(job)
+    issues.extend(
+        f"{PERFORMANCE_WORKFLOW} benchmark_evidence job must not run timing command: {command}"
+        for command, is_present in (
+            ("asv --config asv.conf.json continuous", "asv --config asv.conf.json continuous" in run_text),
+            ("single-revision ASV run", RETIRED_ASV_RUN_PATTERN.search(run_text) is not None),
+        )
+        if is_present
+    )
+    return issues
+
+
+def _check_pr_core_comparison_job(job: Any) -> list[str]:
+    if not isinstance(job, dict):
+        return [f"{PERFORMANCE_WORKFLOW} is missing pr_core_comparison job"]
+    issues: list[str] = []
+    if job.get("timeout-minutes") != 10:
+        issues.append(f"{PERFORMANCE_WORKFLOW} pr_core_comparison must keep timeout-minutes at 10")
+    if "benchmark_evidence" not in str(job.get("needs", "")):
+        issues.append(f"{PERFORMANCE_WORKFLOW} pr_core_comparison must consume benchmark_evidence")
+    if "--profile pr-core" not in _workflow_job_run_text(job):
+        issues.append(f"{PERFORMANCE_WORKFLOW} pr_core_comparison must select pr-core")
+    return issues
+
+
+def _check_targeted_comparison_job(job: Any) -> list[str]:
+    if not isinstance(job, dict):
+        return [f"{PERFORMANCE_WORKFLOW} is missing asv_comparison job"]
+    issues: list[str] = []
+    if "run-performance" not in str(job.get("if", "")):
+        issues.append(f"{PERFORMANCE_WORKFLOW} asv_comparison job must be PR label gated")
+    run_text = _workflow_job_run_text(job)
+    if "asv --config asv.conf.json continuous" not in run_text:
+        issues.append(f"{PERFORMANCE_WORKFLOW} asv_comparison job is missing timing command")
+    if RETIRED_ASV_RUN_PATTERN.search(run_text):
+        issues.append(f"{PERFORMANCE_WORKFLOW} asv_comparison job must not use the retired ASV run command")
+    return issues
+
+
+def _check_scheduled_comparison_job(job: Any) -> list[str]:
+    if not isinstance(job, dict):
+        return [f"{PERFORMANCE_WORKFLOW} is missing scheduled_core_comparison job"]
+    issues: list[str] = []
+    if job.get("timeout-minutes") != 20:
+        issues.append(f"{PERFORMANCE_WORKFLOW} scheduled_core_comparison must keep timeout-minutes at 20")
+    if job.get("if") != "github.event_name == 'schedule'":
+        issues.append(f"{PERFORMANCE_WORKFLOW} scheduled_core_comparison must be schedule-only")
+    run_text = _workflow_job_run_text(job)
+    issues.extend(
+        f"{PERFORMANCE_WORKFLOW} scheduled_core_comparison is missing {required}"
+        for required in ("--profile stf-core", "git describe --tags --abbrev=0 --match '[0-9]*' HEAD^")
+        if required not in run_text
+    )
+    return issues
+
+
 def _check_performance_workflow() -> list[str]:
     issues = _check_text_mentions(
         PERFORMANCE_WORKFLOW,
@@ -769,43 +870,33 @@ def _check_performance_workflow() -> list[str]:
             "tools.benchmark_coverage details",
             "asv --config asv.conf.json check --verbose",
             "asv --config asv.conf.json continuous",
-            "asv --config asv.conf.json run",
             "tools/asv_summary.py",
             "python -m tools.performance_budget summarize",
             "tools/select_benchmark_filters.py",
-            "benchmark-coverage-detail.json",
-            "benchmark-performance-budget.json",
+            "--profile pr-core",
+            "--profile stf-core",
+            "--profile changed",
+            "pr-core-performance-evidence/",
+            "targeted-performance-evidence/",
+            "scheduled-core-performance-evidence/",
             "benchmark-evidence/",
-            "benchmark-asv-evidence/",
             "benchmark-filter.txt",
             "changed-files.txt",
             "run-performance",
+            "git describe --tags --abbrev=0 --match '[0-9]*' HEAD^",
         ),
         "performance evidence gate",
     )
+    workflow_text = _read_text(PERFORMANCE_WORKFLOW)
+    if RETIRED_ASV_RUN_PATTERN.search(workflow_text):
+        issues.append(f"{PERFORMANCE_WORKFLOW} must not use the retired ASV run command")
+    if RETIRED_REVISION_SELECTOR_PATTERN.search(workflow_text):
+        issues.append(f"{PERFORMANCE_WORKFLOW} must not use the retired single-revision selector")
     jobs = _workflow_jobs(PERFORMANCE_WORKFLOW)
-    evidence_job = jobs.get("benchmark_evidence")
-    if not isinstance(evidence_job, dict):
-        issues.append(f"{PERFORMANCE_WORKFLOW} is missing benchmark_evidence job")
-    else:
-        if evidence_job.get("timeout-minutes") != 10:
-            issues.append(f"{PERFORMANCE_WORKFLOW} benchmark_evidence job must keep timeout-minutes at 10")
-        evidence_run_text = _workflow_job_run_text(evidence_job)
-        for command in ("asv --config asv.conf.json continuous", "asv --config asv.conf.json run"):
-            if command in evidence_run_text:
-                issues.append(f"{PERFORMANCE_WORKFLOW} benchmark_evidence job must not run timing command: {command}")
-
-    asv_job = jobs.get("asv_comparison")
-    if not isinstance(asv_job, dict):
-        issues.append(f"{PERFORMANCE_WORKFLOW} is missing asv_comparison job")
-        return issues
-
-    if "run-performance" not in str(asv_job.get("if", "")):
-        issues.append(f"{PERFORMANCE_WORKFLOW} asv_comparison job must be PR label gated")
-    asv_run_text = _workflow_job_run_text(asv_job)
-    for command in ("asv --config asv.conf.json continuous", "asv --config asv.conf.json run"):
-        if command not in asv_run_text:
-            issues.append(f"{PERFORMANCE_WORKFLOW} asv_comparison job is missing timing command: {command}")
+    issues.extend(_check_benchmark_evidence_job(jobs.get("benchmark_evidence")))
+    issues.extend(_check_pr_core_comparison_job(jobs.get("pr_core_comparison")))
+    issues.extend(_check_targeted_comparison_job(jobs.get("asv_comparison")))
+    issues.extend(_check_scheduled_comparison_job(jobs.get("scheduled_core_comparison")))
     return issues
 
 
@@ -819,7 +910,10 @@ def _check_pytorch_performance_workflow() -> list[str]:
             "dependency-group: ci-benchmark",
             "runtime-profile: torch-cpu",
             "asv --config asv-pytorch.conf.json check --verbose",
-            "asv --config asv-pytorch.conf.json run",
+            "asv --config asv-pytorch.conf.json continuous",
+            "benchmark-baseline-sha.txt",
+            "benchmark-candidate-sha.txt",
+            "benchmark-asv-summary.json",
             "pytorch-benchmark-evidence/",
         ),
         "PyTorch tensor performance evidence gate",

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -315,11 +315,26 @@ def _dependency_group_packages(
     return packages
 
 
+def _dependency_group_reference_issues(dependency_groups: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    for group, entries in dependency_groups.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            included_group = entry.get("include-group") if isinstance(entry, dict) else None
+            if isinstance(included_group, str) and included_group not in dependency_groups:
+                issues.append(
+                    f"pyproject.toml dependency group {group!r} refers to non-existent group {included_group!r}",
+                )
+    return issues
+
+
 def _check_ci_dependency_groups(dependency_groups: dict[str, Any]) -> list[str]:
     issues: list[str] = []
     unexpected_groups = set(dependency_groups) - {*CI_DEPENDENCY_GROUPS, "dev"}
     if unexpected_groups:
         issues.append(f"pyproject.toml defines unsupported dependency groups {sorted(unexpected_groups)!r}")
+    issues.extend(_dependency_group_reference_issues(dependency_groups))
 
     for group, required_packages in sorted(CI_DEPENDENCY_GROUPS.items()):
         entries = dependency_groups.get(group)
@@ -825,8 +840,19 @@ def _check_pr_core_comparison_job(job: Any) -> list[str]:
         issues.append(f"{PERFORMANCE_WORKFLOW} pr_core_comparison must keep timeout-minutes at 10")
     if "benchmark_evidence" not in str(job.get("needs", "")):
         issues.append(f"{PERFORMANCE_WORKFLOW} pr_core_comparison must consume benchmark_evidence")
-    if "--profile pr-core" not in _workflow_job_run_text(job):
+    run_text = _workflow_job_run_text(job)
+    if "--profile pr-core" not in run_text:
         issues.append(f"{PERFORMANCE_WORKFLOW} pr_core_comparison must select pr-core")
+    resolve_step = next(
+        (
+            step
+            for step in job.get("steps", [])
+            if isinstance(step, dict) and step.get("name") == "Resolve PR core comparison"
+        ),
+        None,
+    )
+    if not isinstance(resolve_step, dict) or resolve_step.get("env", {}).get("PR_CANDIDATE_SHA") != "${{ github.sha }}":
+        issues.append(f"{PERFORMANCE_WORKFLOW} pr_core_comparison must compare the checked-out merge commit")
     return issues
 
 
@@ -839,6 +865,8 @@ def _check_targeted_comparison_job(job: Any) -> list[str]:
     run_text = _workflow_job_run_text(job)
     if "asv --config asv.conf.json continuous" not in run_text:
         issues.append(f"{PERFORMANCE_WORKFLOW} asv_comparison job is missing timing command")
+    if "git describe --tags --abbrev=0 --match '[0-9]*' \"$CANDIDATE_REF^\"" not in run_text:
+        issues.append(f"{PERFORMANCE_WORKFLOW} asv_comparison must derive its default baseline from the candidate ref")
     if RETIRED_ASV_RUN_PATTERN.search(run_text):
         issues.append(f"{PERFORMANCE_WORKFLOW} asv_comparison job must not use the retired ASV run command")
     return issues
@@ -911,6 +939,7 @@ def _check_pytorch_performance_workflow() -> list[str]:
             "runtime-profile: torch-cpu",
             "asv --config asv-pytorch.conf.json check --verbose",
             "asv --config asv-pytorch.conf.json continuous",
+            "git describe --tags --abbrev=0 --match '[0-9]*' \"$CANDIDATE_REF^\"",
             "benchmark-baseline-sha.txt",
             "benchmark-candidate-sha.txt",
             "benchmark-asv-summary.json",

--- a/tools/generate_correctness_report.py
+++ b/tools/generate_correctness_report.py
@@ -214,6 +214,35 @@ def _has_performance_budget(summaries: list[dict[str, Any]]) -> bool:
     return any(summary.get("kind") == "performance-budget" for summary in summaries)
 
 
+def _has_asv_comparison(summaries: list[dict[str, Any]]) -> bool:
+    return any(summary.get("kind") == "asv-comparison" and not summary.get("missing") for summary in summaries)
+
+
+def _has_provided_performance_budget(summaries: list[dict[str, Any]]) -> bool:
+    return any(
+        summary.get("kind") == "performance-budget" and summary.get("comparison", {}).get("provided") is True
+        for summary in summaries
+    )
+
+
+def _format_comparison_refs(evidence_dir: Path | None) -> str:
+    if evidence_dir is None:
+        return "- ASV comparison refs: not provided in this evidence bundle"
+
+    def read_ref(name: str) -> str | None:
+        path = evidence_dir / name
+        if not path.exists():
+            return None
+        value = path.read_text().strip()
+        return value or None
+
+    baseline = read_ref("benchmark-baseline-ref.txt")
+    candidate = read_ref("benchmark-candidate-ref.txt")
+    if baseline is None or candidate is None:
+        return "- ASV comparison refs: not provided in this evidence bundle"
+    return f"- ASV comparison refs: `{baseline}` -> `{candidate}`"
+
+
 def _pytest_summary_issue(summary: dict[str, Any]) -> str | None:
     source = str(summary.get("source", "unknown source"))
     status = summary.get("status", "ok")
@@ -237,17 +266,12 @@ def _pytest_summary_issues(summaries: list[dict[str, Any]]) -> list[str]:
     return [issue for summary in summaries if (issue := _pytest_summary_issue(summary)) is not None]
 
 
-def _validate_required_evidence(
+def _missing_required_evidence(
     environments: list[dict[str, Any]],
     pytest_summaries: list[dict[str, Any]],
     benchmark_summaries: list[dict[str, Any]],
     security_summaries: list[dict[str, Any]],
-    *,
-    allow_missing_evidence: bool,
-) -> None:
-    if allow_missing_evidence:
-        return
-
+) -> list[str]:
     missing: list[str] = []
     if not environments:
         missing.append("environment*.json")
@@ -259,9 +283,27 @@ def _validate_required_evidence(
         missing.append("benchmark coverage detail JSON")
     if not _has_performance_budget(benchmark_summaries):
         missing.append("benchmark performance budget JSON")
+    if not _has_asv_comparison(benchmark_summaries):
+        missing.append("ASV comparison summary JSON")
+    if not _has_provided_performance_budget(benchmark_summaries):
+        missing.append("performance budget with comparison.provided=true")
     if not security_summaries:
         missing.append("security*.json")
+    return missing
 
+
+def _validate_required_evidence(
+    environments: list[dict[str, Any]],
+    pytest_summaries: list[dict[str, Any]],
+    benchmark_summaries: list[dict[str, Any]],
+    security_summaries: list[dict[str, Any]],
+    *,
+    allow_missing_evidence: bool,
+) -> None:
+    if allow_missing_evidence:
+        return
+
+    missing = _missing_required_evidence(environments, pytest_summaries, benchmark_summaries, security_summaries)
     if missing:
         msg = "Missing required release evidence artifact(s): " + ", ".join(missing)
         raise ValueError(msg)
@@ -362,6 +404,7 @@ Dependency sets tracked by the support policy: {dependency_sets}
 ## Performance
 
 {_format_benchmark_summary(benchmark_summaries)}
+{_format_comparison_refs(evidence_dir)}
 
 ## Security And Release Integrity
 

--- a/tools/generate_correctness_report.py
+++ b/tools/generate_correctness_report.py
@@ -220,7 +220,9 @@ def _has_asv_comparison(summaries: list[dict[str, Any]]) -> bool:
 
 def _has_provided_performance_budget(summaries: list[dict[str, Any]]) -> bool:
     return any(
-        summary.get("kind") == "performance-budget" and summary.get("comparison", {}).get("provided") is True
+        summary.get("kind") == "performance-budget"
+        and isinstance(summary.get("comparison"), dict)
+        and summary["comparison"].get("provided") is True
         for summary in summaries
     )
 

--- a/tools/performance_budget.py
+++ b/tools/performance_budget.py
@@ -249,8 +249,22 @@ def _regression_severity(policy: BenchmarkPolicy, ratio: float | None) -> str:
     return "changed_below_budget"
 
 
+def _has_completed_comparison(asv_summary: dict[str, Any]) -> bool:
+    if asv_summary.get("missing") is True:
+        return False
+    if any(asv_summary.get(key) for key in ("regressions", "improvements")):
+        return True
+
+    totals = asv_summary.get("totals")
+    if isinstance(totals, dict) and any(isinstance(value, int) and value > 0 for value in totals.values()):
+        return True
+
+    status = asv_summary.get("status")
+    return isinstance(status, dict) and any(value is True for value in status.values())
+
+
 def _classify_regressions(asv_summary: dict[str, Any] | None) -> dict[str, Any]:
-    if asv_summary is None or asv_summary.get("missing") is True:
+    if asv_summary is None or not _has_completed_comparison(asv_summary):
         return {
             "provided": False,
             "asv_exit_code": None if asv_summary is None else asv_summary.get("asv_exit_code"),

--- a/tools/performance_budget.py
+++ b/tools/performance_budget.py
@@ -250,10 +250,10 @@ def _regression_severity(policy: BenchmarkPolicy, ratio: float | None) -> str:
 
 
 def _classify_regressions(asv_summary: dict[str, Any] | None) -> dict[str, Any]:
-    if asv_summary is None:
+    if asv_summary is None or asv_summary.get("missing") is True:
         return {
             "provided": False,
-            "asv_exit_code": None,
+            "asv_exit_code": None if asv_summary is None else asv_summary.get("asv_exit_code"),
             "release_blockers": [],
             "triage_items": [],
             "changed_below_budget": [],

--- a/tools/select_benchmark_filters.py
+++ b/tools/select_benchmark_filters.py
@@ -1,17 +1,25 @@
-"""Select an ASV benchmark regex for changed repository paths."""
+"""Select a bounded ASV benchmark regex."""
 
 from __future__ import annotations
 
 import argparse
 from pathlib import Path
 
-BASELINE_PATTERNS = frozenset(
-    {
-        "TimeBatch",
+PROFILE_PATTERNS = {
+    "pr-core": ("TimeCorePipeline",),
+    "stf-core": (
         "TimeCatalogTransformSmoke",
         "TimeCorePipeline",
-    },
-)
+        "peakmem_resize_large_rgb",
+        "peakmem_normalize_large_rgb",
+        "peakmem_batch_pipeline_medium_rgb",
+        "peakmem_mosaic_small_rgb",
+        "peakmem_copy_paste_small_rgb",
+        "peakmem_volume_pad_medium",
+    ),
+}
+
+BASELINE_PATTERNS = frozenset({"TimeBatch", "TimeCatalogTransformSmoke", "TimeCorePipeline"})
 
 PATH_RULES: tuple[tuple[tuple[str, ...], frozenset[str]], ...] = (
     (
@@ -144,14 +152,31 @@ def select_benchmark_regex(changed_paths: list[str]) -> str:
     return "|".join(select_benchmark_patterns(changed_paths))
 
 
-def _read_changed_paths(path: Path | None, positional_paths: list[str]) -> list[str]:
-    if path is None:
-        return positional_paths
+def select_profile_patterns(profile: str, changed_paths: list[str] | None = None) -> tuple[str, ...]:
+    """Return deterministic ASV patterns for a named evidence profile."""
+    if profile in PROFILE_PATTERNS:
+        if changed_paths is not None:
+            raise ValueError(f"profile {profile!r} does not accept changed paths")
+        return PROFILE_PATTERNS[profile]
+    if profile == "changed":
+        if changed_paths is None:
+            raise ValueError("profile 'changed' requires changed paths")
+        return select_benchmark_patterns(changed_paths)
+    raise ValueError(f"unknown benchmark profile: {profile}")
+
+
+def select_profile_regex(profile: str, changed_paths: list[str] | None = None) -> str:
+    """Return one ASV regex for a named evidence profile."""
+    return "|".join(select_profile_patterns(profile, changed_paths))
+
+
+def _read_changed_paths(path: Path) -> list[str]:
     return [line for line in path.read_text().splitlines() if line.strip()]
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=("pr-core", "stf-core", "changed"), required=True)
     parser.add_argument("paths", nargs="*", help="changed repository paths")
     parser.add_argument(
         "--changed-files",
@@ -163,8 +188,14 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    changed_paths = _read_changed_paths(args.changed_files, args.paths)
-    print(select_benchmark_regex(changed_paths))
+    if args.paths:
+        raise SystemExit("positional paths are not supported; use --changed-files with --profile changed")
+    if args.profile == "changed" and args.changed_files is None:
+        raise SystemExit("--profile changed requires --changed-files")
+    if args.profile != "changed" and args.changed_files is not None:
+        raise SystemExit(f"--profile {args.profile} does not accept --changed-files")
+    changed_paths = _read_changed_paths(args.changed_files) if args.changed_files is not None else None
+    print(select_profile_regex(args.profile, changed_paths))
     return 0
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -110,6 +110,7 @@ ci-quality = [
 ]
 ci-release = [
     { name = "albu-spec" },
+    { name = "asv" },
     { name = "cyclonedx-bom" },
     { name = "deepdiff" },
     { name = "defusedxml" },
@@ -253,6 +254,7 @@ ci-quality = [
 ]
 ci-release = [
     { name = "albu-spec", specifier = ">=0.0.6" },
+    { name = "asv" },
     { name = "cyclonedx-bom", specifier = ">=7.3.1" },
     { name = "deepdiff", specifier = ">=9.1.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },


### PR DESCRIPTION
## Summary

The Performance workflow now keeps PR feedback bounded while preserving the STF Milestone 2 requirement for reproducible performance evidence. Timed comparisons use explicit baseline and candidate refs; coverage-only checks remain separate from timing.

## What changed

- Run an advisory `pr-core` baseline-to-head comparison on every runtime PR with a 10-minute budget.
- Keep `run-performance` for the changed-family profile and use `stf-core` for scheduled/manual comparisons.
- Compare the previous reachable release tag with the exact candidate in the schedule and release preflight.
- Make release preflight strict: missing comparison evidence or stable release-blocking regressions fail the release bundle.
- Preserve dedicated PyTorch Tensor comparison evidence.
- Upload exact refs/SHA, resolved filters, raw ASV output, summaries, and performance budgets.
- Update benchmark skill, README, CI policy, release docs, correctness report, and contract tests.

## STF Milestone 2

This does not remove the performance requirement. It replaces the slow single-revision/full-catalog path with explicit, bounded baseline-to-head evidence and a strict release gate.

## Validation

- `uv run pytest -q`: 14,081 passed, 32 skipped, 9 xfailed, 3 xpassed
- `pre-commit run --all-files`
- `uv run python -m tools.ci_matrix check`
- ASV importability checks for both configs
- benchmark coverage and performance-budget contract checks

## Summary by Sourcery

Scope performance comparisons to explicit benchmark evidence profiles while enforcing reproducible and strict release performance gates.

New Features:
- Introduce bounded `pr-core`, `stf-core`, and changed-family benchmark evidence profiles for runtime, scheduled, manual, and release comparisons.
- Add exact baseline/candidate reference tracking and performance evidence artifacts across benchmark workflows.

Bug Fixes:
- Prevent coverage-only checks from being treated as timed performance comparisons and recognize incomplete ASV output as missing comparison evidence.
- Make release preflight fail when required comparison evidence is absent or release-blocking performance regressions are detected.

Enhancements:
- Separate benchmark coverage validation from timed ASV comparisons while preserving dedicated PyTorch Tensor performance evidence.
- Extend CI policy validation, correctness reports, performance-budget classification, and dependency-group checks for the new release evidence requirements.

Build:
- Include benchmark dependencies in the release dependency group.

CI:
- Restructure performance workflows to use explicit bounded baseline-to-candidate ASV comparisons with dedicated PR, targeted, scheduled, and release paths.
- Add contract tests for benchmark profiles, workflow structure, ASV summary handling, performance budgets, release evidence, and dependency groups.

Documentation:
- Document benchmark evidence profiles, explicit comparison refs, bounded timing behavior, and strict release verification requirements.

Tests:
- Expand tests covering benchmark profile selection, workflow contracts, missing comparisons, strict release evidence, and performance-budget classification.