### PR TITLE
fix(pixel): restore AutoContrast batch semantics

### DIFF
--- a/albumentations/augmentations/pixel/color_basic.py
+++ b/albumentations/augmentations/pixel/color_basic.py
@@ -23,7 +23,6 @@ from ._color_shared import (
     Self,
     VolumeType,
     albucore,
-    batch_transform,
     check_range_bounds,
     field_validator,
     fpixel,
@@ -1291,10 +1290,6 @@ class AutoContrast(ImageOnlyTransform):
 
     def apply(self, img: ImageType, **params: Any) -> ImageType:
         return fpixel.auto_contrast(img, self.cutoff, self.ignore, self.method)
-
-    @batch_transform("channel")
-    def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
-        return self.apply(images, **params)
 
 
 __all__ = [

--- a/tests/test_benchmark_coverage.py
+++ b/tests/test_benchmark_coverage.py
@@ -444,13 +444,10 @@ def test_benchmark_coverage_details_track_batch_and_annotation_audit_paths() -> 
     crop_and_pad = _coverage_for("CropAndPad")
 
     assert auto_contrast["performance_contract"]["batch"] == {
-        "implementation_methods": ["apply_to_images"],
-        "reason": (
-            "custom batch methods are inventoried for review; current release-critical evidence comes from "
-            "catalog smoke, family matrices, direct kernels, and core batch dispatch until this route is promoted"
-        ),
+        "implementation_methods": [],
+        "reason": "transform does not declare a custom batch route that needs dedicated batch scaling evidence",
         "required_layers": [],
-        "status": "tracked_without_dedicated_matrix",
+        "status": "not_required",
     }
     assert crop_and_pad["performance_contract"]["annotation"]["status"] == "tracked_without_dedicated_scaling"
     assert crop_and_pad["performance_contract"]["annotation"]["implementation_methods"] == [

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -876,6 +876,98 @@ def test_random_brightness_contrast_torchvision_mode_uses_per_image_batch_means(
     np.testing.assert_array_equal(result, expected)
 
 
+@pytest.mark.parametrize("target", ["images", "volume"])
+@pytest.mark.parametrize(
+    ("method", "cutoff", "ignore"),
+    [
+        ("cdf", 0, None),
+        ("pil", 0, None),
+        ("cdf", 5, 0),
+        ("pil", 5, 0),
+    ],
+)
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("num_channels", [1, 3, 5])
+def test_auto_contrast_batch_matches_per_image(
+    target: str,
+    method: str,
+    cutoff: float,
+    ignore: int | None,
+    dtype: type[np.generic],
+    num_channels: int,
+) -> None:
+    histograms = np.array(
+        [
+            [0] * 4 + [10] + [40] * 14 + [90] * 16 + [150] * 16 + [220] * 12 + [250],
+            [0] * 8 + [30] + [60] * 10 + [100] * 14 + [140] * 16 + [190] * 14 + [245],
+        ],
+        dtype=np.uint8,
+    ).reshape(2, 8, 8, 1)
+    data = np.repeat(histograms, num_channels, axis=-1)
+    if dtype == np.float32:
+        data = data.astype(np.float32) / 255.0
+    transform = A.Compose(
+        [A.AutoContrast(cutoff=cutoff, ignore=ignore, method=method, p=1.0)],
+        seed=137,
+        strict=True,
+    )
+
+    actual = transform(**{target: data})[target]
+    expected = np.stack([transform(image=image)["image"] for image in data])
+
+    np.testing.assert_array_equal(actual, expected)
+
+    if ignore is not None:
+        without_ignore = A.Compose(
+            [A.AutoContrast(cutoff=cutoff, ignore=None, method=method, p=1.0)],
+            seed=137,
+            strict=True,
+        )(**{target: data})[target]
+        assert not np.array_equal(actual, without_ignore)
+
+        if num_channels > 1:
+            without_cutoff = A.Compose(
+                [A.AutoContrast(cutoff=0, ignore=ignore, method=method, p=1.0)],
+                seed=137,
+                strict=True,
+            )(**{target: data})[target]
+            assert not np.array_equal(actual, without_cutoff)
+
+
+@pytest.mark.parametrize("target", ["images", "volume"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_auto_contrast_preserves_empty_batch(target: str, dtype: type[np.generic]) -> None:
+    data = np.empty((0, 4, 6, 3), dtype=dtype)
+    transform = A.Compose([A.AutoContrast(p=1.0)], seed=137, strict=True)
+
+    result = transform(**{target: data})[target]
+
+    assert result.shape == data.shape
+    assert result.dtype == data.dtype
+
+
+@pytest.mark.parametrize("target", ["images", "volume"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_auto_contrast_batch_handles_non_contiguous_read_only_input(
+    target: str,
+    dtype: type[np.generic],
+) -> None:
+    rng = np.random.default_rng(137)
+    source = rng.integers(0, 256, (2, 4, 12, 3), dtype=np.uint8)
+    if dtype == np.float32:
+        source = source.astype(np.float32) / 255.0
+    data = source[:, :, ::2, :]
+    data.setflags(write=False)
+    data_before = data.copy()
+    transform = A.Compose([A.AutoContrast(p=1.0)], seed=137, strict=True)
+
+    actual = transform(**{target: data})[target]
+    expected = np.stack([transform(image=image)["image"] for image in data])
+
+    np.testing.assert_array_equal(data, data_before)
+    np.testing.assert_array_equal(actual, expected)
+
+
 def test_random_brightness_contrast_torchvision_mode_safe_output_uses_combined_coefficients():
     image = np.array([[[50], [100], [150]]], dtype=np.uint8)
     transform = A.RandomBrightnessContrast(


### PR DESCRIPTION
solve #469 

## Summary by Sourcery

Restore per-image AutoContrast semantics for batched inputs and remove the custom batch route that caused incorrect processing.

Bug Fixes:
- Restore AutoContrast batch and volume processing so results match applying the transform independently to each image.

Enhancements:
- Ensure AutoContrast handles empty, non-contiguous, and read-only batch inputs while preserving shape and dtype.

Tests:
- Add coverage for AutoContrast batch semantics across methods, cutoffs, ignored values, dtypes, channel counts, and supported batch targets.

## Summary by Sourcery

Restore correct per-image AutoContrast semantics for batched inputs and strengthen coverage of supported batch cases.

Bug Fixes:
- Restore per-image AutoContrast behavior for batched images and volumes.

Enhancements:
- Remove the custom AutoContrast batch route so standard batch processing preserves expected semantics and input compatibility.

Tests:
- Add coverage for AutoContrast batch and volume behavior across methods, cutoffs, ignored values, dtypes, channel counts, empty inputs, and non-contiguous read-only arrays.