### PR TITLE
refactor: remove redundant test and tooling narration

### DIFF
--- a/albumentations/augmentations/pixel/_functional_weather.py
+++ b/albumentations/augmentations/pixel/_functional_weather.py
@@ -94,24 +94,18 @@ def add_snow_bleach(
     """
     max_value = MAX_VALUES_BY_DTYPE[np.dtype(img.dtype)]
 
-    # Precompute snow_point threshold
     snow_point = (snow_point * max_value / 2) + (max_value / 3)
 
-    # Convert image to HLS color space once and avoid repeated dtype casting
     image_hls = cv2.cvtColor(img, cv2.COLOR_RGB2HLS)
     lightness_channel = image_hls[:, :, 1].astype(np.float32)
 
-    # Utilize boolean indexing for efficient lightness adjustment
     mask = lightness_channel < snow_point
     lightness_channel[mask] *= brightness_coeff
 
-    # Clip the lightness values in place
     lightness_channel = clip(lightness_channel, img.dtype, inplace=True)
 
-    # Update the lightness channel in the original image
     image_hls[:, :, 1] = lightness_channel
 
-    # Convert back to RGB
     return cast("ImageType", cv2.cvtColor(image_hls, cv2.COLOR_HLS2RGB))
 
 

--- a/albumentations/core/analytics/telemetry.py
+++ b/albumentations/core/analytics/telemetry.py
@@ -15,23 +15,17 @@ from albumentations.core.analytics.user_id import get_user_id_manager
 
 
 class TelemetryClient:
-    """Sends Compose init events to Mixpanel with rate limiting (e.g. 30s) and pipeline-hash
-    deduplication. Disabled in CI and pytest.
+    """Send Compose initialization events with pipeline deduplication and process-wide rate limiting.
+    Disabled in CI and pytest.
 
-    Using Mixpanel backend for better library telemetry support:
-    - No parameter limits
-    - No web stream complications
-    - Full transform list tracking
-    - Better suited for custom events
+    Mixpanel accepts the complete transform list without web-stream limits.
     """
 
     _instance = None
     _initialized = False
 
     def __new__(cls) -> Self:
-        """Return the single TelemetryClient instance; create on first access.
-        Overrides __new__ to enforce one instance per process.
-        """
+        """Return the process-wide telemetry client."""
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
@@ -41,15 +35,15 @@ class TelemetryClient:
             self.backend = MixpanelBackend()
             # Disable telemetry in CI/test environments
             self.enabled = not (is_ci_environment() or is_pytest_running())
-            self.sent_pipelines: set[str] = set()  # Track sent pipeline hashes
+            self.sent_pipelines: set[str] = set()
             self.last_send_time: float = 0
-            self.rate_limit: float = 30.0  # 30 seconds between sends
+            self.rate_limit: float = 30.0
             self.user_id_manager = get_user_id_manager()
             self._initialized = True
 
     def track_compose_init(self, compose_data: dict[str, Any], telemetry: bool = True, use_thread: bool = True) -> None:
-        """Record a Compose init: check rate limit and dedup by pipeline hash, then send to
-        Mixpanel (default: in a daemon thread).
+        """Record a Compose initialization event after opt-out, deduplication, and rate-limit checks.
+        Send it in a daemon thread unless the caller asks for synchronous delivery.
 
         Args:
             compose_data (dict[str, Any]): Data collected from the Compose instance
@@ -60,60 +54,42 @@ class TelemetryClient:
         if not self.enabled or not telemetry:
             return
 
-        # Check global settings
         if not settings.telemetry_enabled:
             return
 
-        # Get persistent user ID
         user_id = self.user_id_manager.get_or_create_user_id()
-        if user_id is None:  # User opted out
+        if user_id is None:  # The user opted out.
             return
 
-        # Deduplication check
         pipeline_hash = compose_data.get("pipeline_hash")
         if pipeline_hash and pipeline_hash in self.sent_pipelines:
-            return  # Skip if already sent
+            return
 
-        # Rate limiting check
         current_time = time.time()
         if current_time - self.last_send_time < self.rate_limit:
-            return  # Skip if too soon
+            return
 
-        # Add user ID to event data
         compose_data["user_id"] = user_id
-
-        # Create event
         event = ComposeInitEvent(**compose_data)
 
-        # Send event to backend
         if use_thread:
-            # Send in background thread
             thread = Thread(target=self._send_event_thread, args=(event,), daemon=True)
             thread.start()
         else:
             # Send synchronously (mainly for testing)
             self._send_event(event)
 
-        # Update tracking
         if pipeline_hash:
             self.sent_pipelines.add(pipeline_hash)
         self.last_send_time = current_time
 
     def _send_event_thread(self, event: ComposeInitEvent) -> None:
-        """Run _send_event in a daemon thread; any exception suppressed so the main process is never affected.
-        Non-blocking; fire-and-forget.
-
-        Args:
-            event (ComposeInitEvent): The event to send
-
-        """
+        """Send an event without allowing telemetry failures to affect the caller."""
         with contextlib.suppress(Exception):
-            # Silently ignore all errors in thread
             self._send_event(event)
 
     def _send_event(self, event: ComposeInitEvent) -> bool:
-        """POST the event to Mixpanel track API. Returns True on success, False on network or
-        validation error. Synchronous, no retries.
+        """Send an event synchronously without retries.
 
         Args:
             event (ComposeInitEvent): The event to send
@@ -126,45 +102,29 @@ class TelemetryClient:
         try:
             self.backend.send_event(event)
         except (OSError, ValueError):
-            # Silently ignore telemetry errors
-            # OSError: network issues
-            # ValueError: data validation issues
             telemetry_sent = False
 
         return telemetry_sent
 
     def disable(self) -> None:
-        """Stop sending events; track_compose_init no-ops until enable(). Idempotent.
-        Call from CLI or config to turn off analytics.
-        """
+        """Stop sending events until enable() is called."""
         self.enabled = False
 
     def enable(self) -> None:
-        """Resume sending events; rate limit and global settings still apply. Idempotent.
-        Call after disable() to turn analytics back on.
-        """
+        """Resume sending events subject to the global setting and rate limit."""
         self.enabled = True
 
     def reset(self) -> None:
-        """Clear sent pipeline hashes and last-send time so the same pipeline can be sent again.
-        For tests; idempotent. In-memory only.
-        """
+        """Clear in-memory pipeline and rate-limit state."""
         self.sent_pipelines.clear()
         self.last_send_time = 0
 
 
-# Global telemetry client instance
 telemetry_client = None
 
 
 def get_telemetry_client() -> TelemetryClient:
-    """Return the global TelemetryClient; create on first call so Compose can send init events
-    without holding a reference. One instance per process.
-
-    Returns:
-        TelemetryClient: The global TelemetryClient instance.
-
-    """
+    """Return the process-wide telemetry client, creating it on first use."""
     global telemetry_client  # noqa: PLW0603
     if telemetry_client is None:
         telemetry_client = TelemetryClient()

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,9 +9,9 @@ Design documents are created for:
 - Complex features requiring detailed planning
 - Significant architectural changes
 - Features with multiple implementation phases
-- Systems that need comprehensive documentation for maintainers
+- System-wide behavior that needs maintainer documentation
 
-**Note**: Regular bug fixes and small improvements should be documented in commit messages and PR descriptions, not as separate design documents.
+Document regular bug fixes and small improvements in commit messages and PR descriptions.
 
 ## Current Architectural References
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -3671,48 +3671,39 @@ def test_grayscale_to_multichannel_float_values():
 
 
 @pytest.mark.parametrize(
-    ["method", "expected_property"],
+    "method",
     [
-        ("weighted_average", "uses_opencv_coefficients"),  # 0.299*R + 0.587*G + 0.114*B
-        ("from_lab", "uses_lightness_channel"),  # L from LAB
-        ("desaturation", "uses_min_max_average"),  # (min + max) / 2
-        ("average", "uses_simple_mean"),  # (R + G + B) / 3
-        ("max", "uses_maximum_value"),  # max(R, G, B)
-        ("pca", "uses_principal_component"),  # First principal component
+        "weighted_average",
+        "from_lab",
+        "desaturation",
+        "average",
+        "max",
+        "pca",
     ],
 )
-def test_to_gray_method_properties(method, expected_property):
-    """Test that each to_gray method has expected properties."""
-    # Create a specific test image to verify method behavior
-    # Red channel = 255, Green channel = 128, Blue channel = 0
+def test_to_gray_methods(method):
     test_img = np.zeros((10, 10, 3), dtype=np.uint8)
-    test_img[..., 0] = 255  # Red
-    test_img[..., 1] = 128  # Green
-    test_img[..., 2] = 0  # Blue
+    test_img[..., 0] = 255
+    test_img[..., 1] = 128
+    test_img[..., 2] = 0
 
     result = fpixel.to_gray(test_img, 1, method)
 
-    # Verify method-specific properties
     if method == "weighted_average":
-        # Should be close to OpenCV formula: 0.299*255 + 0.587*128 + 0.114*0 ≈ 151
         expected = int(0.299 * 255 + 0.587 * 128 + 0.114 * 0)
         assert np.abs(result[0, 0] - expected) <= 1, f"weighted_average result {result[0, 0]} != {expected}"
 
     elif method == "average":
-        # Should be (255 + 128 + 0) / 3 ≈ 127.67
         expected = int((255 + 128 + 0) / 3)
         assert np.abs(result[0, 0] - expected) <= 1, f"average result {result[0, 0]} != {expected}"
 
     elif method == "max":
-        # Should be max(255, 128, 0) = 255
         assert result[0, 0] == 255, f"max result {result[0, 0]} != 255"
 
     elif method == "desaturation":
-        # Should be (max + min) / 2 = (255 + 0) / 2 = 127.5
         expected = int((255 + 0) / 2)
         assert np.abs(result[0, 0] - expected) <= 1, f"desaturation result {result[0, 0]} != {expected}"
 
-    # All methods should produce values in valid range
     assert result.min() >= 0 and result.max() <= 255, f"Result out of range for method={method}"
 
 

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -173,18 +173,13 @@ def test_label_encoder_update_numeric_noop():
     assert encoder.is_numerical is True
 
 
-# Tests for LabelManager Implicit Update via process_field
 @pytest.mark.parametrize(
-    "data_name, label_field, initial_data, update_data, expected_final_labels, expected_dtype_after_decode",
+    "data_name, label_field, initial_data, update_data, expected_final_labels",
     [
-        # String labels
-        ("bboxes", "class_labels", ["cat", "dog"], ["bird", "cat"], ["cat", "dog", "bird", "cat"], object),
-        # Mixed labels
-        ("keypoints", "kp_labels", ["head", 1], [2, "tail", "head"], ["head", 1, 2, "tail", "head"], object),
-        # Initial empty, then update
-        ("bboxes", "instance_ids", [], ["obj1", "obj2"], ["obj1", "obj2"], object),
-        # Update with only existing
-        ("bboxes", "class_labels", ["cat", "dog"], ["dog", "cat"], ["cat", "dog", "dog", "cat"], object),
+        ("bboxes", "class_labels", ["cat", "dog"], ["bird", "cat"], ["cat", "dog", "bird", "cat"]),
+        ("keypoints", "kp_labels", ["head", 1], [2, "tail", "head"], ["head", 1, 2, "tail", "head"]),
+        ("bboxes", "instance_ids", [], ["obj1", "obj2"], ["obj1", "obj2"]),
+        ("bboxes", "class_labels", ["cat", "dog"], ["dog", "cat"], ["cat", "dog", "dog", "cat"]),
     ],
 )
 def test_label_manager_process_field_updates_encoder(
@@ -193,44 +188,34 @@ def test_label_manager_process_field_updates_encoder(
     initial_data,
     update_data,
     expected_final_labels,
-    expected_dtype_after_decode,
 ):
     manager = LabelManager()
 
-    # Process initial data
     encoded_initial = manager.process_field(data_name, label_field, initial_data)
     metadata_initial = manager.metadata[data_name][label_field]
     encoder_initial = metadata_initial.encoder
     num_classes_initial = encoder_initial.num_classes if encoder_initial else 0
 
-    # Process update data (should trigger implicit update)
     encoded_update = manager.process_field(data_name, label_field, update_data)
     metadata_updated = manager.metadata[data_name][label_field]
     encoder_updated = metadata_updated.encoder
     num_classes_updated = encoder_updated.num_classes if encoder_updated else 0
 
-    # Check if encoder was updated (if new labels were present)
     if set(update_data) - set(initial_data):
         assert num_classes_updated > num_classes_initial
-        assert encoder_updated is encoder_initial  # Should be the same instance
+        assert encoder_updated is encoder_initial
     else:
         assert num_classes_updated == num_classes_initial
 
-    # Check restoration of both batches using the final updated encoder
     restored_initial = manager.restore_field(data_name, label_field, encoded_initial)
     restored_update = manager.restore_field(data_name, label_field, encoded_update)
 
-    # Combine original + update data for checking restored combined labels
-    np.concatenate([np.array(initial_data).flatten(), np.array(update_data).flatten()])
     combined_encoded = np.concatenate([encoded_initial, encoded_update])
 
-    # Decode the combined encoded data
     decoded_combined = manager.restore_field(data_name, label_field, combined_encoded)
 
-    # Check final decoded labels (order might differ from input due to sorting in encoder)
     np.testing.assert_array_equal(sorted(decoded_combined, key=str), sorted(expected_final_labels, key=str))
 
-    # Check type preservation
     assert isinstance(restored_initial, list if isinstance(initial_data, np.ndarray) else type(initial_data))
     assert isinstance(restored_update, list if isinstance(update_data, np.ndarray) else type(update_data))
 

--- a/tests/test_flip_masks_comprehensive.py
+++ b/tests/test_flip_masks_comprehensive.py
@@ -1,12 +1,3 @@
-"""Comprehensive tests for flip transforms with masks.
-
-These tests verify:
-1. Correct axis flipping for different mask shapes
-2. Array contiguity (no negative strides)
-3. Compatibility with PyTorch tensor conversion
-4. Actual transformation correctness (not just shapes)
-"""
-
 import numpy as np
 import pytest
 
@@ -14,197 +5,108 @@ import albumentations as A
 
 
 class TestFlipMasksCorrectness:
-    """Test that flips actually flip the correct pixels on the correct axes."""
-
     @pytest.mark.parametrize(
         "transform_class,axis",
         [
-            (A.HorizontalFlip, 1),  # Flips along width (axis 1 for 2D, axis 2 for 3D+)
-            (A.VerticalFlip, 0),  # Flips along height (axis 0 for 2D, axis 1 for 3D+)
+            (A.HorizontalFlip, 1),
+            (A.VerticalFlip, 0),
         ],
     )
     def test_flip_single_mask_correctness(self, transform_class, axis):
-        """Test that single mask (H, W, C) is flipped on the correct axis."""
-        # Create a mask with distinct pattern
         mask = np.array(
             [
                 [[1, 10], [2, 20], [3, 30]],
                 [[4, 40], [5, 50], [6, 60]],
             ],
             dtype=np.uint8,
-        )  # Shape: (2, 3, 2) = (H, W, C)
+        )
 
         transform = transform_class(p=1.0)
         aug = A.Compose([transform])
         result = aug(image=np.zeros((2, 3, 3), dtype=np.uint8), mask=mask)
 
-        # Verify the flip happened on the correct axis
-        if axis == 0:  # Vertical flip (flip H)
+        if axis == 0:
             expected = np.flip(mask, axis=0)
-            # Should be: [[4,40], [5,50], [6,60]], [[1,10], [2,20], [3,30]]
-        else:  # Horizontal flip (flip W)
+        else:
             expected = np.flip(mask, axis=1)
-            # Should be: [[3,30], [2,20], [1,10]], [[6,60], [5,50], [4,40]]
 
         np.testing.assert_array_equal(result["mask"], expected)
 
     @pytest.mark.parametrize(
         "transform_class,axis",
         [
-            (A.HorizontalFlip, 2),  # Flips along width (axis 2 for (N,H,W,C))
-            (A.VerticalFlip, 1),  # Flips along height (axis 1 for (N,H,W,C))
+            (A.HorizontalFlip, 2),
+            (A.VerticalFlip, 1),
         ],
     )
     def test_flip_masks_batch_correctness(self, transform_class, axis):
-        """Test that masks batch (N, H, W, C) is flipped on the correct axis."""
-        # Create two masks with distinct patterns
         masks = np.array(
             [
-                [  # First mask
+                [
                     [[1, 10], [2, 20], [3, 30]],
                     [[4, 40], [5, 50], [6, 60]],
                 ],
-                [  # Second mask
+                [
                     [[7, 70], [8, 80], [9, 90]],
                     [[10, 100], [11, 110], [12, 120]],
                 ],
             ],
             dtype=np.uint8,
-        )  # Shape: (2, 2, 3, 2) = (N, H, W, C)
+        )
 
         transform = transform_class(p=1.0)
         aug = A.Compose([transform])
         result = aug(image=np.zeros((2, 3, 3), dtype=np.uint8), masks=masks)
 
-        # Verify the flip happened on the correct axis
         expected = np.flip(masks, axis=axis)
         np.testing.assert_array_equal(result["masks"], expected)
 
     def test_transpose_mask_correctness(self):
-        """Test that Transpose actually transposes H and W."""
-        # Create a mask with distinct pattern
         mask = np.array(
             [
                 [[1, 10], [2, 20], [3, 30]],
                 [[4, 40], [5, 50], [6, 60]],
             ],
             dtype=np.uint8,
-        )  # Shape: (2, 3, 2) = (H=2, W=3, C=2)
+        )
 
         transform = A.Transpose(p=1.0)
         aug = A.Compose([transform])
         result = aug(image=np.zeros((2, 3, 3), dtype=np.uint8), mask=mask)
 
-        # After transpose: (H, W, C) -> (W, H, C) = (3, 2, 2)
-        assert result["mask"].shape == (3, 2, 2)
-
-        # Verify actual transposition: axes (0,1,2) -> (1,0,2)
         expected = np.transpose(mask, (1, 0, 2))
         np.testing.assert_array_equal(result["mask"], expected)
 
     def test_transpose_masks_batch_correctness(self):
-        """Test that Transpose transposes H and W for batch."""
         masks = np.array(
             [
-                [  # First mask (H=2, W=3)
+                [
                     [[1, 10], [2, 20], [3, 30]],
                     [[4, 40], [5, 50], [6, 60]],
                 ],
-                [  # Second mask
+                [
                     [[7, 70], [8, 80], [9, 90]],
                     [[10, 100], [11, 110], [12, 120]],
                 ],
             ],
             dtype=np.uint8,
-        )  # Shape: (N=2, H=2, W=3, C=2)
+        )
 
         transform = A.Transpose(p=1.0)
         aug = A.Compose([transform])
         result = aug(image=np.zeros((2, 3, 3), dtype=np.uint8), masks=masks)
 
-        # After transpose: (N, H, W, C) -> (N, W, H, C) = (2, 3, 2, 2)
-        assert result["masks"].shape == (2, 3, 2, 2)
-
-        # Verify actual transposition: axes (0,1,2,3) -> (0,2,1,3)
         expected = np.transpose(masks, (0, 2, 1, 3))
         np.testing.assert_array_equal(result["masks"], expected)
 
 
-class TestFlipMasksContiguity:
-    """Test that flipped masks are contiguous (no negative strides)."""
-
-    @pytest.mark.parametrize(
-        "transform_class",
-        [
-            A.HorizontalFlip,
-            A.VerticalFlip,
-            A.Transpose,
-            A.D4,
-        ],
-    )
-    def test_single_mask_non_contiguous_input(self, transform_class):
-        """Test that single mask non-contiguous input is handled gracefully."""
-        mask = np.random.randint(0, 2, (80, 120, 3), dtype=np.uint8)
-
-        transform = transform_class(p=1.0)
-        aug = A.Compose([transform])
-        result = aug(image=np.zeros((80, 120, 3), dtype=np.uint8), mask=mask)
-        assert "mask" in result
-        assert isinstance(result["mask"], np.ndarray)
-
-    @pytest.mark.parametrize(
-        "transform_class",
-        [
-            A.HorizontalFlip,
-            A.VerticalFlip,
-            A.Transpose,
-            A.D4,
-        ],
-    )
-    def test_masks_batch_non_contiguous_input(self, transform_class):
-        """Test that masks batch non-contiguous input is handled gracefully."""
-        masks = np.random.randint(0, 2, (5, 80, 120, 3), dtype=np.uint8)
-
-        transform = transform_class(p=1.0)
-        aug = A.Compose([transform])
-        result = aug(image=np.zeros((80, 120, 3), dtype=np.uint8), masks=masks)
-        assert "masks" in result
-        assert isinstance(result["masks"], np.ndarray)
-
-    @pytest.mark.parametrize(
-        "transform_class",
-        [
-            A.HorizontalFlip,
-            A.VerticalFlip,
-            A.Transpose,
-            A.D4,
-        ],
-    )
-    def test_mask3d_non_contiguous_input(self, transform_class):
-        """Test that 3D mask non-contiguous input is handled gracefully."""
-        mask3d = np.random.randint(0, 2, (20, 80, 120, 3), dtype=np.uint8)
-
-        transform = transform_class(p=1.0)
-        aug = A.Compose([transform])
-        result = aug(
-            image=np.zeros((80, 120, 3), dtype=np.uint8),
-            volume=np.zeros((20, 80, 120, 3), dtype=np.uint8),
-            mask3d=mask3d,
-        )
-        assert "mask3d" in result
-        assert isinstance(result["mask3d"], np.ndarray)
-
-
 @pytest.mark.pytorch
 class TestFlipMasksPyTorchCompatibility:
-    """Test that flipped masks can be converted to PyTorch tensors."""
-
     def test_horizontal_flip_with_to_tensor_v2(self):
-        """Test the exact scenario that was failing: HFlip + ToFloat + ToTensorV2."""
         import torch
 
         image = np.random.randint(0, 256, (101, 99, 3), dtype=np.uint8)
-        masks = np.stack([image[:, :, 0]] * 2)  # Shape: (2, 101, 99)
+        masks = np.stack([image[:, :, 0]] * 2)
 
         transform = A.Compose(
             [
@@ -216,46 +118,14 @@ class TestFlipMasksPyTorchCompatibility:
             strict=True,
         )
 
-        # This was failing before the fix
         result = transform(image=image, masks=masks)
 
-        # Verify tensor conversion worked
         assert isinstance(result["image"], torch.Tensor)
         assert isinstance(result["masks"], torch.Tensor)
-        assert result["masks"].shape[0] == 2  # 2 masks
+        assert result["masks"].shape[0] == 2
 
 
 class TestD4MasksSpecific:
-    """Test D4 transform with all group elements."""
-
-    @pytest.mark.parametrize("group_element", ["e", "r90", "r180", "r270", "v", "h", "t", "hvt"])
-    def test_d4_mask_non_contiguous_input_all_elements(self, group_element):
-        """Test that all D4 group elements handle non-contiguous masks gracefully when used through Compose."""
-        mask = np.random.randint(0, 2, (100, 100, 3), dtype=np.uint8)
-
-        # Seed to get specific group element (this is implementation detail, but tests D4's behavior)
-        # For testing purposes, we just verify that going through Compose produces contiguous output
-        transform = A.D4(p=1.0)
-        aug = A.Compose([transform])
-
-        # Apply through Compose
-        result = aug(image=np.zeros((100, 100, 3), dtype=np.uint8), mask=mask)
-        assert "mask" in result
-        assert isinstance(result["mask"], np.ndarray)
-
-    @pytest.mark.parametrize("group_element", ["e", "r90", "r180", "r270", "v", "h", "t", "hvt"])
-    def test_d4_masks_batch_non_contiguous_input_all_elements(self, group_element):
-        """Test that all D4 group elements handle non-contiguous masks batch gracefully when used through Compose."""
-        masks = np.random.randint(0, 2, (3, 100, 100, 3), dtype=np.uint8)
-
-        transform = A.D4(p=1.0)
-        aug = A.Compose([transform])
-
-        # Apply through Compose
-        result = aug(image=np.zeros((100, 100, 3), dtype=np.uint8), masks=masks)
-        assert "masks" in result
-        assert isinstance(result["masks"], np.ndarray)
-
     @pytest.mark.parametrize(
         "group_element,should_transpose",
         [
@@ -270,20 +140,18 @@ class TestD4MasksSpecific:
         ],
     )
     def test_d4_mask_dimension_changes(self, group_element, should_transpose):
-        """Test that D4 changes dimensions correctly for non-square masks."""
-        # Non-square mask
         mask = np.random.randint(0, 2, (80, 120, 3), dtype=np.uint8)
 
-        transform = A.D4(p=1.0)
-        result = transform.apply_to_mask(mask, group_element=group_element)
+        result = A.Compose([A.D4(group_element=group_element, p=1.0)])(
+            image=np.zeros((80, 120, 3), dtype=np.uint8),
+            mask=mask,
+        )["mask"]
 
         if should_transpose:
-            # Should swap H and W
             assert result.shape == (120, 80, 3), (
                 f"D4 with '{group_element}' should swap dimensions but got {result.shape}"
             )
         else:
-            # Should preserve H and W
             assert result.shape == (80, 120, 3), (
                 f"D4 with '{group_element}' should preserve dimensions but got {result.shape}"
             )

--- a/tests/test_keypoint.py
+++ b/tests/test_keypoint.py
@@ -482,18 +482,14 @@ def test_compose_with_keypoint_noop(keypoints, keypoint_format: str, labels: int
     np.testing.assert_allclose(transformed["keypoints"], keypoints)
 
 
-@pytest.mark.parametrize(
-    ["keypoints", "keypoint_format"],
-    [([[20, 30, 40, 50]], "xyas"), (np.array([[20, 30, 40, 50]]), "xyas")],
-)
-def test_compose_with_keypoint_noop_error_label_fields(keypoints, keypoint_format: str) -> None:
+def test_compose_with_keypoint_noop_error_label_fields() -> None:
     # Now with Pydantic validation, the error is caught during Compose creation (fail fast)
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError, match=r"'str' instances are not allowed as a Sequence value"):
         A.Compose(
             [A.NoOp(p=1.0)],
-            keypoint_params={"coord_format": keypoint_format, "label_fields": "class_id"},
+            keypoint_params={"coord_format": "xyas", "label_fields": "class_id"},
             strict=True,
         )
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -106,25 +106,20 @@ class TestTelemetryClient:
             client.enable()
             client.reset()  # Clear state
 
-            # First event should go through
-            event1 = {
-                "pipeline_hash": "hash1",
-                "transforms": ["RandomCrop"],
-            }
-            client.track_compose_init(event1, telemetry=True)
-            first_time = client.last_send_time
-            assert first_time > 0
+            with patch("albumentations.core.analytics.telemetry.time.time", side_effect=[100.0, 100.0, 101.0]):
+                client.track_compose_init(
+                    {"pipeline_hash": "hash1", "transforms": ["RandomCrop"]},
+                    telemetry=True,
+                )
+                assert client.last_send_time == 100.0
 
-            event2 = {
-                "pipeline_hash": "hash2",
-                "transforms": ["HorizontalFlip"],
-            }
-            client.track_compose_init(event2, telemetry=True)
-            assert client.last_send_time == first_time
+                event = {"pipeline_hash": "hash2", "transforms": ["HorizontalFlip"]}
+                client.track_compose_init(event, telemetry=True)
+                assert client.last_send_time == 100.0
 
-            client.last_send_time = 0
-            client.track_compose_init(event2, telemetry=True)
-            assert client.last_send_time > first_time
+                client.last_send_time = 0
+                client.track_compose_init(event, telemetry=True)
+                assert client.last_send_time == 101.0
         finally:
             settings.update(telemetry=original_telemetry)
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,6 +1,5 @@
 """Tests for telemetry functionality in AlbumentationsX."""
 
-import time
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -116,17 +115,14 @@ class TestTelemetryClient:
             first_time = client.last_send_time
             assert first_time > 0
 
-            # Second event within rate limit should be skipped
-            time.sleep(0.1)  # Small delay
             event2 = {
                 "pipeline_hash": "hash2",
                 "transforms": ["HorizontalFlip"],
             }
             client.track_compose_init(event2, telemetry=True)
-            assert client.last_send_time == first_time  # Time shouldn't update
+            assert client.last_send_time == first_time
 
-            # Wait for rate limit to expire
-            client.last_send_time = 0  # Force expire
+            client.last_send_time = 0
             client.track_compose_init(event2, telemetry=True)
             assert client.last_send_time > first_time
         finally:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1943,11 +1943,12 @@ def test_crop_and_pad_px_pixel_values(px, expected_shape):
     image = np.ones((10, 10, 3), dtype=np.uint8) * 255
 
     transformed_image = transform(image=image)["image"]
+    assert transformed_image.shape == expected_shape
 
     if isinstance(px, int):
-        px = [px] * 4  # Convert to list of 4 elements
+        px = [px] * 4
     if isinstance(px, tuple) and len(px) == 2:
-        px = [px[0], px[1], px[0], px[1]]  # Convert to 4 elements for padding
+        px = [px[0], px[1], px[0], px[1]]
 
     if px is not None:
         if all(p >= 0 for p in px):  # Padding

--- a/tests/transforms3d/test_functions.py
+++ b/tests/transforms3d/test_functions.py
@@ -5,28 +5,26 @@ from albumentations.augmentations.transforms3d import functional as f3d
 
 
 @pytest.mark.parametrize(
-    "input_shape,n_channels",
+    "input_shape",
     [
-        ((3, 3, 3), None),  # 3D case
-        ((3, 3, 3, 2), 2),  # 4D case
+        (3, 3, 3),
+        (3, 3, 3, 2),
     ],
 )
-def test_uniqueness(input_shape: tuple, n_channels: int | None):
-    # Create test cube with unique values
+def test_uniqueness(input_shape: tuple):
     n_elements = np.prod(input_shape)
     test_cube = np.arange(n_elements).reshape(input_shape)
 
-    # Generate all 48 transformations
     transformations = [f3d.transform_cube(test_cube, i) for i in range(48)]
 
-    # Check uniqueness
-    unique_transforms = {str(t) for t in transformations}
+    unique_transforms = {str(transformation) for transformation in transformations}
     assert len(unique_transforms) == 48, "Not all transformations are unique!"
 
-    # Check shape preservation
     expected_shape = input_shape
-    for t in transformations:
-        assert t.shape == expected_shape, f"Wrong shape: got {t.shape}, expected {expected_shape}"
+    for transformation in transformations:
+        assert transformation.shape == expected_shape, (
+            f"Wrong shape: got {transformation.shape}, expected {expected_shape}"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -464,48 +464,41 @@ def test_crop_3d_shapes(transform, input_shape, expected_shape):
     ],
 )
 @pytest.mark.parametrize(
-    ["input_shape", "target_shape", "description"],
+    ["input_shape", "target_shape"],
     [
-        # Padding needed in all dimensions
-        (
+        pytest.param(
             (10, 100, 100),
             (16, 128, 128),
-            "pad_all_dims",
+            id="pad_all_dims",
         ),
-        # Padding needed only in depth
-        (
+        pytest.param(
             (5, 100, 100),
             (10, 50, 50),
-            "pad_depth_only",
+            id="pad_depth_only",
         ),
-        # Padding needed only in height
-        (
+        pytest.param(
             (10, 40, 100),
             (8, 64, 50),
-            "pad_height_only",
+            id="pad_height_only",
         ),
-        # Padding needed only in width
-        (
+        pytest.param(
             (10, 100, 40),
             (8, 50, 64),
-            "pad_width_only",
+            id="pad_width_only",
         ),
-        # Padding needed in height and width
-        (
+        pytest.param(
             (10, 40, 40),
             (8, 64, 64),
-            "pad_height_width",
+            id="pad_height_width",
         ),
-        # No padding needed (smaller crop)
-        (
+        pytest.param(
             (10, 100, 100),
             (8, 64, 64),
-            "no_padding_needed",
+            id="no_padding_needed",
         ),
     ],
-    ids=lambda x: x[2] if isinstance(x, tuple) else x,
 )
-def test_crop_3d_padding(transform_cls, input_shape, target_shape, description):
+def test_crop_3d_padding(transform_cls, input_shape, target_shape):
     volume = np.random.randint(0, 256, input_shape, dtype=np.uint8)
 
     transform = A.Compose([transform_cls(p=1, size=target_shape, pad_if_needed=True, fill=0, fill_mask=0)], seed=0)

--- a/tools/check_conda_dependencies.py
+++ b/tools/check_conda_dependencies.py
@@ -26,7 +26,6 @@ def parse_requirement(req: str) -> tuple[str, str]:
 
 def normalize_package_name(name: str) -> str:
     """Normalize package name for comparison (conda vs pip naming)."""
-    # Common package name mappings between pip and conda
     mappings = {
         "opencv-python-headless": "opencv-python-headless",
         "torch": "pytorch",
@@ -46,11 +45,9 @@ def versions_match(version1: str, version2: str) -> bool:
         bool: True if versions match (considering .0 suffixes are equivalent).
 
     """
-    # Direct match
     if version1 == version2:
         return True
 
-    # Extract operator and version
     match1 = re.match(r"([>=<~!]+)(.+)", version1)
     match2 = re.match(r"([>=<~!]+)(.+)", version2)
 
@@ -60,14 +57,11 @@ def versions_match(version1: str, version2: str) -> bool:
     op1, ver1 = match1.groups()
     op2, ver2 = match2.groups()
 
-    # Operators must match
     if op1 != op2:
         return False
 
-    # Normalize versions by removing trailing .0 segments
     def normalize_version(ver: str) -> str:
         parts = ver.split(".")
-        # Remove trailing zeros
         while len(parts) > 1 and parts[-1] == "0":
             parts.pop()
         return ".".join(parts)

--- a/tools/check_naming_conflicts.py
+++ b/tools/check_naming_conflicts.py
@@ -1,11 +1,4 @@
-"""Check for naming conflicts between modules and exported names.
-
-This script detects conflicts between module names and defined function/class names
-that could cause problems with frameworks like Hydra that rely on direct module paths.
-
-Example usage:
-    python -m tools.check_naming_conflicts
-"""
+"""Detect module/export name conflicts that break direct module-path lookups."""
 
 import ast
 import os
@@ -14,21 +7,12 @@ from pathlib import Path
 
 
 def get_module_names(base_dir: str) -> set[str]:
-    """Find all submodule names (directories with __init__.py).
-
-    Args:
-        base_dir (str): Base directory to search within
-
-    Returns:
-        Set[str]: Set of module names (not paths, just the directory names)
-
-    """
+    """Return package subdirectory names."""
     module_names = set()
     for dirpath, _, filenames in os.walk(base_dir):
         if "__init__.py" in filenames:
-            # We want the last component of the path as the module name
             module_name = Path(dirpath).name
-            if dirpath != base_dir:  # Skip root dir
+            if dirpath != base_dir:
                 module_names.add(module_name)
     return module_names
 
@@ -36,11 +20,9 @@ def get_module_names(base_dir: str) -> set[str]:
 def _extract_names_from_node(node) -> set[str]:
     """Extract names from AST nodes."""
     names = set()
-    # Classes and functions
     if isinstance(node, (ast.ClassDef, ast.FunctionDef)):
         if not node.name.startswith("_"):
             names.add(node.name)
-    # Variables
     elif isinstance(node, ast.Assign):
         for target in node.targets:
             if isinstance(target, ast.Name) and not target.id.startswith("_"):
@@ -49,15 +31,7 @@ def _extract_names_from_node(node) -> set[str]:
 
 
 def get_defined_names(base_dir: str) -> set[str]:
-    """Find all top-level names defined in Python files that would be exported with *.
-
-    Args:
-        base_dir (str): Base directory to search within
-
-    Returns:
-        Set[str]: Set of defined names that could be exported via wildcard imports
-
-    """
+    """Return public top-level names defined in Python files."""
     defined_names = set()
 
     for root, _, files in os.walk(base_dir):
@@ -73,7 +47,6 @@ def get_defined_names(base_dir: str) -> set[str]:
 
                 tree = ast.parse(file_content, filepath)
 
-                # Look for top-level definitions that don't start with underscore
                 for node in ast.iter_child_nodes(tree):
                     defined_names.update(_extract_names_from_node(node))
             except (SyntaxError, UnicodeDecodeError, IsADirectoryError) as e:
@@ -83,15 +56,7 @@ def get_defined_names(base_dir: str) -> set[str]:
 
 
 def find_conflicts(base_dir: str = "albumentations") -> tuple[set[str], set[str], set[str]]:
-    """Find conflicts between module names and defined names.
-
-    Args:
-        base_dir (str): Base directory to check
-
-    Returns:
-        Tuple[Set[str], Set[str], Set[str]]: Tuple containing (module_names, defined_names, conflicts)
-
-    """
+    """Return module names, defined names, and their overlap."""
     module_names = get_module_names(base_dir)
     defined_names = get_defined_names(base_dir)
 
@@ -104,7 +69,6 @@ def main():
     """Main entry point for the script."""
     base_dir = "albumentations"
 
-    # Check if base directory exists
     if not Path(base_dir).is_dir():
         print(f"Error: Directory '{base_dir}' not found.", file=sys.stderr)
         sys.exit(1)

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -50,10 +50,7 @@ def is_deprecated(cls) -> bool:
     if not cls.__doc__:
         return False
 
-    # Split docstring into sections and look only at the first section (before Args:)
     main_desc = cls.__doc__.split("Args:")[0]
-
-    # Check if there's a deprecation notice in the main description
     return any("deprecated" in line.lower() for line in main_desc.split("\n") if line.strip())
 
 
@@ -83,7 +80,6 @@ def get_dual_transforms_info():
             and not issubclass(cls, albumentations.Transform3D)  # Exclude 3D transforms
             and name not in IGNORED_CLASSES
         ) and not is_deprecated(cls):
-            # Get supported bbox types
             supported_bbox_types = getattr(cls, "_supported_bbox_types", frozenset({"hbb"}))
 
             dual_transforms_info[name] = {
@@ -103,7 +99,6 @@ def get_3d_transforms_info():
             and issubclass(cls, (albumentations.Transform3D, albumentations.VolumeOnlyTransform))
             and name not in IGNORED_CLASSES
         ) and not is_deprecated(cls):
-            # Get targets from class or parent class if not defined
             targets = cls._targets if hasattr(cls, "_targets") else albumentations.Transform3D._targets
 
             transforms_3d_info[name] = {
@@ -120,7 +115,6 @@ def make_transforms_targets_table(transforms_info, header, targets_to_check=None
         targets_iter = targets_to_check or Targets
         for target in targets_iter:
             if split_bboxes and target == Targets.BBOXES:
-                # Split BBoxes into HBB and OBB columns
                 supported_bbox_types = info.get("supported_bbox_types", frozenset({"hbb"}))
                 hbb_mark = "✓" if target in info["targets"] and "hbb" in supported_bbox_types else ""
                 obb_mark = "✓" if target in info["targets"] and "obb" in supported_bbox_types else ""
@@ -176,7 +170,6 @@ def check_docs(
     with Path(filepath).open(encoding="utf8") as f:
         text = f.read()
 
-    # Find sections using regex
     sections = {
         "Pixel-level": {
             "pattern": r"### Pixel-level transforms\n\n(.*?)(?=###|\Z)",
@@ -197,9 +190,7 @@ def check_docs(
 
     outdated_docs = set()
 
-    # Check each section
     for section_name, section_info in sections.items():
-        # Find section content
         match = re.search(section_info["pattern"], text, re.DOTALL)
         if not match:
             outdated_docs.add(section_name)
@@ -208,14 +199,12 @@ def check_docs(
             )
             continue
 
-        # Check if all generated lines are in the section
         section_content = strip_utm_query_params(match[1].strip())
         for line in section_info["generated"].split("\n"):
             if line.strip() and line not in section_content:
                 outdated_docs.add(section_name)
                 section_info["lines_not_in_text"].append(line)
 
-    # If any sections are outdated, raise error with detailed information
     if outdated_docs:
         msg = (
             "Docs for the following transform types are outdated: {outdated_docs_headers}.\n"
@@ -227,7 +216,6 @@ def check_docs(
             filename=Path(filepath).name,
         )
 
-        # Add missing lines for each outdated section
         for section_name, section_info in sections.items():
             if section_name in outdated_docs:
                 msg += (
@@ -250,7 +238,6 @@ def main() -> None:
 
     image_only_transforms_links = make_transforms_targets_links(image_only_transforms)
 
-    # Build header for dual transforms with split BBoxes columns
     # Exclude USER_DATA - it is passthrough by default, not a spatial target
     dual_header = []
     for target in ALL_TARGETS:


### PR DESCRIPTION
## Summary

- Remove narration that repeats the code, while retaining comments that explain contracts, user controls, and test-only behavior.
- Replace redundant or vacuous test setup with direct assertions, including the declared CropAndPad output shapes.
- Preserve the zero-copy NumPy output contract; tensor conversion continues to repair negative strides only where required.

## Validation

- `UV_CACHE_DIR=/private/tmp/ax-unslop-uv-cache uv run python -m tools.quality_gate fast` — all substantive checks passed, including 1,850 contract tests (6 skipped). Its all-files end-of-file hook could not open existing read-only `.codex` files; their terminating newlines were separately verified.
- `UV_CACHE_DIR=/private/tmp/ax-unslop-uv-cache uv run pre-commit run --files <changed files>` — passed.
- Focused pytest suite — 89 passed.

## Summary by Sourcery

Reduce redundant narration and vacuous test scaffolding while preserving meaningful contracts and behavior coverage.

Enhancements:
- Remove redundant comments, docstrings, test descriptions, and unused test scaffolding while retaining behavior-focused assertions and meaningful contracts.
- Simplify telemetry, utility, and test code descriptions without changing runtime behavior.
- Strengthen CropAndPad tests by asserting the declared output shapes directly and keep focused transform behavior coverage.

Documentation:
- Clarify the design-document guidance for documenting system-wide behavior and routine changes.

Tests:
- Streamline redundant test parametrization and setup while preserving substantive behavior, shape, telemetry, and compatibility checks.