### PR TITLE
perf(random-sun-flare): reuse flare layers across batches

### DIFF
--- a/albumentations/augmentations/pixel/_functional_weather.py
+++ b/albumentations/augmentations/pixel/_functional_weather.py
@@ -624,7 +624,7 @@ def add_sun_flare_physics_based(
 def add_sun_flare_batch(
     images: ImageType,
     method: str,
-    flare_center: tuple[float, float],
+    flare_center: tuple[int, int],
     src_radius: int,
     src_color: tuple[int, ...],
     circles: list[Any],
@@ -662,6 +662,12 @@ def _add_weighted_uint8_batch(
     return result
 
 
+def _normalize_cv2_rgb_color(color: tuple[int, ...]) -> tuple[int, int, int]:
+    """Match OpenCV's zero-padding and truncation for an RGB drawing color."""
+    padded = (*color, 0, 0, 0)
+    return padded[0], padded[1], padded[2]
+
+
 @uint8_io
 @preserve_channel_dim
 def _add_sun_flare_overlay_batch(
@@ -676,6 +682,7 @@ def _add_sun_flare_overlay_batch(
     overlay = images.copy()
     output = overlay.copy()
     overlay_pixels = overlay.reshape(images.shape[0], -1, images.shape[-1])
+    normalized_src_color = _normalize_cv2_rgb_color(src_color)
 
     weighted_brightness = 0.0
     total_radius_length = 0.0
@@ -690,7 +697,7 @@ def _add_sun_flare_overlay_batch(
             cv2.circle(circle_mask, (x - x_min, y - y_min), rad3, 1, -1)
             mask_y, mask_x = np.nonzero(circle_mask)
             indices = (mask_y + y_min) * width + mask_x + x_min
-            overlay_pixels[:, indices] = circle_color
+            overlay_pixels[:, indices] = _normalize_cv2_rgb_color(circle_color)
         output = _add_weighted_uint8_batch(overlay, alpha, output, 1 - alpha)
 
     point = [int(x) for x in flare_center]
@@ -715,24 +722,23 @@ def _add_sun_flare_overlay_batch(
 
         for i in range(num_times):
             indices = sorted_indices[offsets[i] : offsets[i + 1]]
-            overlay_pixels[:, indices] = src_color
+            overlay_pixels[:, indices] = normalized_src_color
             alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
             output = _add_weighted_uint8_batch(overlay, alp, output, 1 - alp)
 
     return output
 
 
-@uint8_io
-@clipped
 def _add_sun_flare_physics_based_batch(
     images: ImageType,
     flare_center: tuple[int, int],
     src_radius: int,
-    src_color: tuple[int, int, int],
+    src_color: tuple[int, ...],
     circles: list[Any],
 ) -> ImageType:
     """Apply the physics-based sun flare kernel across an image batch."""
-    output = images.copy()
+    convert_to_uint8 = images.dtype != np.uint8
+    output = np.empty(images.shape, dtype=np.float32 if convert_to_uint8 else np.uint8)
     height, width = images.shape[1:3]
 
     flare_layer = np.zeros((height, width, images.shape[-1]), dtype=np.float32)
@@ -776,7 +782,16 @@ def _add_sun_flare_physics_based_batch(
     )
     flare_layer = cv2.merge(channels)
 
-    return cast("ImageType", 255 - ((255 - output) * (255 - flare_layer) / 255))
+    np.subtract(np.float32(255), flare_layer, out=flare_layer)
+    for index, image in enumerate(images):
+        image_uint8 = (
+            from_float(cast("ImageFloat32", image), target_dtype=np.dtype(np.uint8)) if convert_to_uint8 else image
+        )
+        blended = cast("ImageFloat32", 255 - ((255 - image_uint8) * flare_layer / 255))
+        blended_uint8 = clip(blended, np.dtype(np.uint8))
+        output[index] = to_float(blended_uint8) if convert_to_uint8 else blended_uint8
+
+    return cast("ImageType", output)
 
 
 @uint8_io

--- a/albumentations/augmentations/pixel/_functional_weather.py
+++ b/albumentations/augmentations/pixel/_functional_weather.py
@@ -619,6 +619,150 @@ def add_sun_flare_physics_based(
     return cast("ImageType", 255 - ((255 - output) * (255 - flare_layer) / 255))
 
 
+def add_sun_flare_batch(
+    images: ImageType,
+    method: str,
+    flare_center: tuple[float, float],
+    src_radius: int,
+    src_color: tuple[int, ...],
+    circles: list[Any],
+) -> ImageType:
+    """Apply one sampled sun flare to an RGB image batch."""
+    if len(images) == 0:
+        return images
+
+    if images.ndim != 4:
+        raise ValueError("This transformation expects 3-channel images")
+
+    non_rgb_error(images)
+
+    if method == "overlay":
+        return _add_sun_flare_overlay_batch(images, flare_center, src_radius, src_color, circles)
+    if method == "physics_based":
+        return _add_sun_flare_physics_based_batch(images, flare_center, src_radius, src_color, circles)
+
+    raise ValueError(f"Invalid method: {method}")
+
+
+@uint8_io
+@preserve_channel_dim
+def _add_sun_flare_overlay_batch(
+    images: ImageType,
+    flare_center: tuple[float, float],
+    src_radius: int,
+    src_color: tuple[int, ...],
+    circles: list[Any],
+) -> ImageType:
+    """Apply the overlay sun flare kernel across an image batch."""
+    height, width = images.shape[1:3]
+    overlay = images.reshape(-1, width, images.shape[-1]).copy()
+    output = overlay.copy()
+    overlay_batch = overlay.reshape(images.shape)
+    overlay_pixels = overlay_batch.reshape(images.shape[0], -1, images.shape[-1])
+
+    weighted_brightness = 0.0
+    total_radius_length = 0.0
+
+    for alpha, (x, y), rad3, circle_color in circles:
+        weighted_brightness += alpha * rad3
+        total_radius_length += rad3
+        x_min, x_max = max(x - rad3, 0), min(x + rad3 + 1, width)
+        y_min, y_max = max(y - rad3, 0), min(y + rad3 + 1, height)
+        if x_min < x_max and y_min < y_max:
+            circle_mask = np.zeros((y_max - y_min, x_max - x_min), dtype=np.uint8)
+            cv2.circle(circle_mask, (x - x_min, y - y_min), rad3, 1, -1)
+            mask_y, mask_x = np.nonzero(circle_mask)
+            indices = (mask_y + y_min) * width + mask_x + x_min
+            overlay_pixels[:, indices] = circle_color
+        output = add_weighted(overlay, alpha, output, 1 - alpha)
+
+    point = [int(x) for x in flare_center]
+    overlay = output.copy()
+    overlay_batch = overlay.reshape(images.shape)
+    overlay_pixels = overlay_batch.reshape(images.shape[0], -1, images.shape[-1])
+    num_times = src_radius // 10
+
+    max_alpha = weighted_brightness / total_radius_length * 5
+    alpha = np.linspace(0.0, min(max_alpha, 1.0), num=num_times)
+    rad = np.linspace(1, src_radius, num=num_times)
+
+    if num_times:
+        radiuses = [int(value) for value in rad]
+        radius_index = np.full((height, width), -1, dtype=np.int16)
+        for i in range(num_times - 1, -1, -1):
+            cv2.circle(radius_index, point, radiuses[i], i, -1)
+
+        flat_radius_index = radius_index.ravel()
+        sorted_indices = np.argsort(flat_radius_index)
+        counts = np.bincount(flat_radius_index + 1, minlength=num_times + 1)
+        offsets = np.cumsum(counts)
+
+        for i in range(num_times):
+            indices = sorted_indices[offsets[i] : offsets[i + 1]]
+            overlay_pixels[:, indices] = src_color
+            alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
+            output = add_weighted(overlay, alp, output, 1 - alp)
+
+    return output.reshape(images.shape)
+
+
+@uint8_io
+@clipped
+def _add_sun_flare_physics_based_batch(
+    images: ImageType,
+    flare_center: tuple[int, int],
+    src_radius: int,
+    src_color: tuple[int, int, int],
+    circles: list[Any],
+) -> ImageType:
+    """Apply the physics-based sun flare kernel across an image batch."""
+    output = images.copy()
+    height, width = images.shape[1:3]
+
+    flare_layer = np.zeros((height, width, images.shape[-1]), dtype=np.float32)
+
+    cv2.circle(flare_layer, flare_center, src_radius, src_color, -1)
+
+    for angle in [0, 45, 90, 135]:
+        end_point = (
+            int(flare_center[0] + np.cos(np.radians(angle)) * max(width, height)),
+            int(flare_center[1] + np.sin(np.radians(angle)) * max(width, height)),
+        )
+        cv2.line(flare_layer, flare_center, end_point, src_color, 2)
+
+    for _, center, size, color in circles:
+        cv2.circle(flare_layer, center, int(size**0.33), color, -1)
+
+    flare_layer = cv2.GaussianBlur(flare_layer, (0, 0), sigmaX=15, sigmaY=15)
+
+    y = np.arange(height, dtype=np.float32)[:, np.newaxis] - flare_center[1]
+    x = np.arange(width, dtype=np.float32)[np.newaxis, :] - flare_center[0]
+    mask = x * x + y * y
+    mask = albucore_sqrt(mask, inplace=True)
+    mask *= np.float32(1 / (max(width, height) * 0.7))
+    np.clip(mask, 0, 1, out=mask)
+    np.subtract(1, mask, out=mask)
+
+    flare_layer *= mask[..., np.newaxis]
+
+    channels = list(cv2.split(flare_layer))
+    channels[0] = cv2.GaussianBlur(
+        channels[0],
+        (0, 0),
+        sigmaX=3,
+        sigmaY=3,
+    )
+    channels[2] = cv2.GaussianBlur(
+        channels[2],
+        (0, 0),
+        sigmaX=5,
+        sigmaY=5,
+    )
+    flare_layer = cv2.merge(channels)
+
+    return cast("ImageType", 255 - ((255 - output) * (255 - flare_layer) / 255))
+
+
 @uint8_io
 @preserve_channel_dim
 def add_shadow(
@@ -1053,6 +1197,7 @@ __all__ = [
     "add_shadow_batch",
     "add_snow_bleach",
     "add_snow_texture",
+    "add_sun_flare_batch",
     "add_sun_flare_overlay",
     "add_sun_flare_physics_based",
     "apply_atmospheric_fog",

--- a/albumentations/augmentations/pixel/_functional_weather.py
+++ b/albumentations/augmentations/pixel/_functional_weather.py
@@ -37,6 +37,8 @@ from ._functional_sharpness import (
 _maybe_process_in_chunks = cast("Any", maybe_process_in_chunks)
 # Keep sustained-batch chunks on Albucore's large-array route while bounding temporary conversion memory.
 _FROM_FLOAT_BATCH_MIN_CHUNK_ELEMENTS = 512 * 1024
+# Keep each image boundary aligned across common SIMD block sizes before blending the flattened batch.
+_SUN_FLARE_SIMD_ALIGNMENT_ELEMENTS = 4096
 
 
 def add_snow_bleach(
@@ -644,6 +646,23 @@ def add_sun_flare_batch(
     raise ValueError(f"Invalid method: {method}")
 
 
+def _add_weighted_uint8_batch(
+    image1: ImageType,
+    weight1: float,
+    image2: ImageType,
+    weight2: float,
+    image_elements: int,
+) -> ImageType:
+    """Blend a uint8 batch without changing rounding at image boundaries."""
+    if image_elements % _SUN_FLARE_SIMD_ALIGNMENT_ELEMENTS == 0:
+        return add_weighted(image1, weight1, image2, weight2)
+
+    result = np.multiply(image1, np.float32(weight1), dtype=np.float32)
+    np.add(result, np.multiply(image2, np.float32(weight2), dtype=np.float32), out=result)
+    np.rint(result, out=result)
+    return result.astype(np.uint8)
+
+
 @uint8_io
 @preserve_channel_dim
 def _add_sun_flare_overlay_batch(
@@ -655,6 +674,7 @@ def _add_sun_flare_overlay_batch(
 ) -> ImageType:
     """Apply the overlay sun flare kernel across an image batch."""
     height, width = images.shape[1:3]
+    image_elements = images[0].size
     overlay = images.reshape(-1, width, images.shape[-1]).copy()
     output = overlay.copy()
     overlay_batch = overlay.reshape(images.shape)
@@ -674,7 +694,7 @@ def _add_sun_flare_overlay_batch(
             mask_y, mask_x = np.nonzero(circle_mask)
             indices = (mask_y + y_min) * width + mask_x + x_min
             overlay_pixels[:, indices] = circle_color
-        output = add_weighted(overlay, alpha, output, 1 - alpha)
+        output = _add_weighted_uint8_batch(overlay, alpha, output, 1 - alpha, image_elements)
 
     point = [int(x) for x in flare_center]
     overlay = output.copy()
@@ -701,7 +721,7 @@ def _add_sun_flare_overlay_batch(
             indices = sorted_indices[offsets[i] : offsets[i + 1]]
             overlay_pixels[:, indices] = src_color
             alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
-            output = add_weighted(overlay, alp, output, 1 - alp)
+            output = _add_weighted_uint8_batch(overlay, alp, output, 1 - alp, image_elements)
 
     return output.reshape(images.shape)
 

--- a/albumentations/augmentations/pixel/_functional_weather.py
+++ b/albumentations/augmentations/pixel/_functional_weather.py
@@ -651,16 +651,15 @@ def _add_weighted_uint8_batch(
     weight1: float,
     image2: ImageType,
     weight2: float,
-    image_elements: int,
 ) -> ImageType:
-    """Blend a uint8 batch without changing rounding at image boundaries."""
-    if image_elements % _SUN_FLARE_SIMD_ALIGNMENT_ELEMENTS == 0:
+    """Blend a uint8 batch without changing backend routing at image boundaries."""
+    if image1[0].size % _SUN_FLARE_SIMD_ALIGNMENT_ELEMENTS == 0:
         return add_weighted(image1, weight1, image2, weight2)
 
-    result = np.multiply(image1, np.float32(weight1), dtype=np.float32)
-    np.add(result, np.multiply(image2, np.float32(weight2), dtype=np.float32), out=result)
-    np.rint(result, out=result)
-    return result.astype(np.uint8)
+    result = np.empty_like(image1)
+    for index in range(len(image1)):
+        result[index] = add_weighted(image1[index], weight1, image2[index], weight2)
+    return result
 
 
 @uint8_io
@@ -674,11 +673,9 @@ def _add_sun_flare_overlay_batch(
 ) -> ImageType:
     """Apply the overlay sun flare kernel across an image batch."""
     height, width = images.shape[1:3]
-    image_elements = images[0].size
-    overlay = images.reshape(-1, width, images.shape[-1]).copy()
+    overlay = images.copy()
     output = overlay.copy()
-    overlay_batch = overlay.reshape(images.shape)
-    overlay_pixels = overlay_batch.reshape(images.shape[0], -1, images.shape[-1])
+    overlay_pixels = overlay.reshape(images.shape[0], -1, images.shape[-1])
 
     weighted_brightness = 0.0
     total_radius_length = 0.0
@@ -694,12 +691,11 @@ def _add_sun_flare_overlay_batch(
             mask_y, mask_x = np.nonzero(circle_mask)
             indices = (mask_y + y_min) * width + mask_x + x_min
             overlay_pixels[:, indices] = circle_color
-        output = _add_weighted_uint8_batch(overlay, alpha, output, 1 - alpha, image_elements)
+        output = _add_weighted_uint8_batch(overlay, alpha, output, 1 - alpha)
 
     point = [int(x) for x in flare_center]
     overlay = output.copy()
-    overlay_batch = overlay.reshape(images.shape)
-    overlay_pixels = overlay_batch.reshape(images.shape[0], -1, images.shape[-1])
+    overlay_pixels = overlay.reshape(images.shape[0], -1, images.shape[-1])
     num_times = src_radius // 10
 
     max_alpha = weighted_brightness / total_radius_length * 5
@@ -721,9 +717,9 @@ def _add_sun_flare_overlay_batch(
             indices = sorted_indices[offsets[i] : offsets[i + 1]]
             overlay_pixels[:, indices] = src_color
             alp = alpha[num_times - i - 1] * alpha[num_times - i - 1] * alpha[num_times - i - 1]
-            output = _add_weighted_uint8_batch(overlay, alp, output, 1 - alp, image_elements)
+            output = _add_weighted_uint8_batch(overlay, alp, output, 1 - alp)
 
-    return output.reshape(images.shape)
+    return output
 
 
 @uint8_io

--- a/albumentations/augmentations/pixel/weather.py
+++ b/albumentations/augmentations/pixel/weather.py
@@ -909,6 +909,16 @@ class RandomSunFlare(ImageOnlyTransform):
 
         raise ValueError(f"Invalid method: {self.method}")
 
+    def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
+        return fpixel.add_sun_flare_batch(
+            images,
+            self.method,
+            params["flare_center"],
+            self.src_radius,
+            self.src_color,
+            params["circles"],
+        )
+
     def sample_parameters(
         self,
         params: dict[str, Any],

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -512,9 +512,10 @@ def test_equalize_uniform_image():
 
 @pytest.mark.parametrize("method", ["overlay", "physics_based"])
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
-def test_sun_flare_batch_matches_per_image(method, dtype):
+@pytest.mark.parametrize(("height", "width"), [(101, 99), (256, 256)])
+def test_sun_flare_batch_matches_per_image(method, dtype, height, width):
     rng = np.random.default_rng(137)
-    images = rng.integers(0, 256, (4, 32, 28, 3), dtype=np.uint8)
+    images = rng.integers(0, 256, (4, height, width, 3), dtype=np.uint8)
     if dtype == np.float32:
         images = (images.astype(np.float32) / 255).astype(np.float32)
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -11,6 +11,7 @@ from albucore import (
 )
 from sklearn.decomposition import NMF
 
+import albumentations as A
 import albumentations.augmentations.blur.functional as fblur
 import albumentations.augmentations.geometric.functional as fgeometric
 import albumentations.augmentations.pixel._functional_torchvision as ftorchvision
@@ -507,6 +508,54 @@ def test_equalize_uniform_image():
     mask = np.ones((100, 100, 1), dtype=bool)
     result_masked = fpixel.equalize(uniform_img, mask=mask, mode="cv")
     np.testing.assert_array_equal(result_masked, uniform_img)
+
+
+@pytest.mark.parametrize("method", ["overlay", "physics_based"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_sun_flare_batch_matches_per_image(method, dtype):
+    rng = np.random.default_rng(137)
+    images = rng.integers(0, 256, (4, 32, 28, 3), dtype=np.uint8)
+    if dtype == np.float32:
+        images = (images.astype(np.float32) / 255).astype(np.float32)
+
+    params = {
+        "flare_center": (13, 9),
+        "src_radius": 40,
+        "src_color": (240, 210, 180),
+        "circles": [
+            (0.12, (4, 8), 8, (230, 200, 190)),
+            (0.18, (24, 20), 27, (220, 240, 200)),
+        ],
+    }
+    scalar = fpixel.add_sun_flare_overlay if method == "overlay" else fpixel.add_sun_flare_physics_based
+    expected = np.stack([scalar(image, **params) for image in images])
+    actual = fpixel.add_sun_flare_batch(images, method, **params)
+
+    transform = A.RandomSunFlare(method=method, src_radius=40, src_color=(240, 210, 180), p=1)
+    delegated = transform.apply_to_images(images, **params)
+
+    if dtype == np.float32:
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-7, equal_nan=False)
+        np.testing.assert_allclose(delegated, actual, rtol=1e-6, atol=1e-7, equal_nan=False)
+    else:
+        np.testing.assert_array_equal(actual, expected)
+        np.testing.assert_array_equal(delegated, actual)
+
+
+@pytest.mark.parametrize("method", ["overlay", "physics_based"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_sun_flare_batch_preserves_empty_identity(method, dtype):
+    images = np.empty((0, 24, 20, 3), dtype=dtype)
+    params = {
+        "flare_center": (10, 10),
+        "src_radius": 40,
+        "src_color": (255, 255, 255),
+        "circles": [],
+    }
+
+    result = fpixel.add_sun_flare_batch(images, method, **params)
+
+    assert result is images
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -15,6 +15,7 @@ import albumentations as A
 import albumentations.augmentations.blur.functional as fblur
 import albumentations.augmentations.geometric.functional as fgeometric
 import albumentations.augmentations.pixel._functional_torchvision as ftorchvision
+import albumentations.augmentations.pixel._functional_weather as fweather
 import albumentations.augmentations.pixel.functional as fpixel
 from albumentations.core.type_definitions import d4_group_elements
 from tests.conftest import (
@@ -541,6 +542,56 @@ def test_sun_flare_batch_matches_per_image(method, dtype, height, width):
     else:
         np.testing.assert_array_equal(actual, expected)
         np.testing.assert_array_equal(delegated, actual)
+
+
+@pytest.mark.parametrize("src_color", [(255,), (255, 200), (255, 200, 100, 50)])
+def test_sun_flare_overlay_batch_matches_cv2_color_semantics(src_color):
+    rng = np.random.default_rng(137)
+    images = rng.integers(0, 256, (2, 32, 28, 3), dtype=np.uint8)
+    params = {
+        "flare_center": (13, 9),
+        "src_radius": 40,
+        "src_color": src_color,
+        "circles": [(0.12, (4, 8), 8, src_color)],
+    }
+    expected = np.stack([fpixel.add_sun_flare_overlay(image, **params) for image in images])
+    transform = A.RandomSunFlare(src_radius=40, src_color=src_color, method="overlay", p=1)
+
+    actual = transform.apply_to_images(images, **params)
+
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_sun_flare_physics_batch_bounds_conversion_and_blending_per_image(monkeypatch):
+    images = np.zeros((3, 24, 20, 3), dtype=np.float32)
+    converted_shapes = []
+    blended_shapes = []
+    original_from_float = fweather.from_float
+    original_clip = fweather.clip
+
+    def tracked_from_float(image, *args, **kwargs):
+        converted_shapes.append(image.shape)
+        return original_from_float(image, *args, **kwargs)
+
+    def tracked_clip(image, *args, **kwargs):
+        blended_shapes.append(image.shape)
+        return original_clip(image, *args, **kwargs)
+
+    monkeypatch.setattr(fweather, "from_float", tracked_from_float)
+    monkeypatch.setattr(fweather, "clip", tracked_clip)
+
+    result = fweather.add_sun_flare_batch(
+        images,
+        "physics_based",
+        flare_center=(10, 10),
+        src_radius=40,
+        src_color=(255, 255, 255),
+        circles=[],
+    )
+
+    assert result.shape == images.shape
+    assert converted_shapes == [(24, 20, 3)] * len(images)
+    assert blended_shapes == [(24, 20, 3)] * len(images)
 
 
 @pytest.mark.parametrize("method", ["overlay", "physics_based"])

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2565,6 +2565,57 @@ def test_random_sun_flare_invalid_input(params):
         A.RandomSunFlare(**params)
 
 
+@pytest.mark.parametrize("method", ["overlay", "physics_based"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("target_name", ["images", "volume"])
+def test_random_sun_flare_batch_replay(method, dtype, target_name):
+    rng = np.random.default_rng(137)
+    images = rng.integers(0, 256, (3, 32, 28, 3), dtype=np.uint8)
+    if dtype == np.float32:
+        images = (images.astype(np.float32) / 255).astype(np.float32)
+    original = images.copy()
+
+    transform = A.ReplayCompose(
+        [
+            A.RandomSunFlare(
+                method=method,
+                src_radius=40,
+                src_color=(240, 210, 180),
+                p=1.0,
+            ),
+        ],
+        seed=137,
+    )
+
+    data = {target_name: images}
+    result = transform(**data)
+    replayed = A.ReplayCompose.replay(result["replay"], **data)
+
+    assert result[target_name].shape == images.shape
+    assert result[target_name].dtype == images.dtype
+    np.testing.assert_array_equal(result[target_name], replayed[target_name])
+    np.testing.assert_array_equal(images, original)
+
+
+@pytest.mark.parametrize("method", ["overlay", "physics_based"])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_random_sun_flare_empty_batch(method, dtype):
+    images = np.empty((0, 24, 20, 3), dtype=dtype)
+
+    result = A.Compose([A.RandomSunFlare(method=method, p=1.0)], seed=137, strict=True)(images=images)
+
+    assert result["images"].shape == images.shape
+    assert result["images"].dtype == images.dtype
+
+
+@pytest.mark.parametrize("method", ["overlay", "physics_based"])
+def test_random_sun_flare_batch_rejects_non_rgb_images(method):
+    images = np.zeros((2, 24, 20, 1), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="3-channel"):
+        A.Compose([A.RandomSunFlare(method=method, p=1.0)], strict=True)(images=images)
+
+
 @pytest.mark.parametrize(
     ["augmentation_cls", "params"],
     get_primary_2d_transform_params(


### PR DESCRIPTION
## Summary

- Reuse one rasterized flare setup for each same-shape `RandomSunFlare` image batch.
- Keep rasterization, dtype routing, empty-batch handling, method selection, clipping, and blending in `_functional_weather.py`.
- Preserve exact uint8 parity, tight float32 parity, and existing single-image behavior.

Fixes #45.

## Validation

- `uv run --group ci-test --group ci-torch-cpu pytest -q tests/functional/test_functional.py -k sun_flare`: 16 passed, 512 deselected.
- `uv run --group ci-test --group ci-torch-cpu pytest -q tests/test_transforms.py -k random_sun_flare`: 25 passed, 2414 deselected.
- `uv run --group ci-test --group ci-torch-cpu pytest -q tests/contracts`: 1850 passed, 6 skipped.
- `uv run --group ci-test --group ci-torch-cpu pytest -q tests/property/test_applied_config_replay.py --hypothesis-profile=ci-fast`: 2 passed.
- `uv run --group ci-test --group ci-torch-cpu pytest -q tests/test_serialization.py`: 1378 passed.
- `uv run --group ci-quality --group ci-torch-cpu pre-commit run check-ax-coding-guidance --all-files`: passed.
- `uv run --group ci-quality --group ci-torch-cpu python -m tools.quality_gate fast`: passed with one CPU thread.
- `git diff --check`: passed.
- Performance matrix: 96 cells, direct and Compose routes, overlay and physics_based methods, sizes 256/512/1024, uint8 and float32, batch sizes 2/4/8/16. Each 256 cell used 3 repetitions, each 512 cell used 2, and each 1024 cell used 1. Both runs used one CPU thread and the same harness. Baseline SHA: `42c5da22f9feba6ec7ae7e6bf79b318f2174a105`.
- Final-head physics follow-up: 24 direct cells across sizes 256/512/1024, uint8 and float32, and batch sizes 2/4/8/16 matched the inherited per-image result exactly. The minimum speedup was 1.47x and the geometric-mean speedup was 2.87x, with no regression.
- Peak working set at batch 8 with `1024x1024x3` inputs: uint8 measured 347.4 MiB for the inherited path and 353.7 MiB for the candidate (+1.8%); float32 measured 520.0 MiB and 518.8 MiB (-0.2%). Each route ran in a fresh process with one CPU thread.

<details>
<summary>Full performance matrix</summary>

| Route | Method | Size | Dtype | Batch | Baseline (s) | Candidate (s) | Change |
| --- | --- | ---: | --- | ---: | ---: | ---: | ---: |
| direct | overlay | 256 | uint8 | 2 | 0.098670 | 0.086820 | -12.0% |
| direct | overlay | 256 | uint8 | 4 | 0.203403 | 0.173213 | -14.8% |
| direct | overlay | 256 | uint8 | 8 | 0.376625 | 0.354816 | -5.8% |
| direct | overlay | 256 | uint8 | 16 | 0.732801 | 0.717966 | -2.0% |
| direct | overlay | 256 | float32 | 2 | 0.096702 | 0.092519 | -4.3% |
| direct | overlay | 256 | float32 | 4 | 0.193952 | 0.178390 | -8.0% |
| direct | overlay | 256 | float32 | 8 | 0.385038 | 0.368718 | -4.2% |
| direct | overlay | 256 | float32 | 16 | 0.769439 | 0.729949 | -5.1% |
| direct | overlay | 512 | uint8 | 2 | 0.307660 | 0.319037 | +3.7% |
| direct | overlay | 512 | uint8 | 4 | 0.625318 | 0.627810 | +0.4% |
| direct | overlay | 512 | uint8 | 8 | 1.240635 | 1.248598 | +0.6% |
| direct | overlay | 512 | uint8 | 16 | 2.520632 | 2.497150 | -0.9% |
| direct | overlay | 512 | float32 | 2 | 0.331560 | 0.324430 | -2.2% |
| direct | overlay | 512 | float32 | 4 | 0.646997 | 0.641428 | -0.9% |
| direct | overlay | 512 | float32 | 8 | 1.291447 | 1.262533 | -2.2% |
| direct | overlay | 512 | float32 | 16 | 2.588632 | 2.551027 | -1.5% |
| direct | overlay | 1024 | uint8 | 2 | 1.231718 | 1.259892 | +2.3% |
| direct | overlay | 1024 | uint8 | 4 | 2.494105 | 2.393628 | -4.0% |
| direct | overlay | 1024 | uint8 | 8 | 5.006156 | 4.609054 | -7.9% |
| direct | overlay | 1024 | uint8 | 16 | 9.939220 | 9.591795 | -3.5% |
| direct | overlay | 1024 | float32 | 2 | 1.307359 | 1.270512 | -2.8% |
| direct | overlay | 1024 | float32 | 4 | 2.614123 | 2.492422 | -4.7% |
| direct | overlay | 1024 | float32 | 8 | 5.088395 | 4.924615 | -3.2% |
| direct | overlay | 1024 | float32 | 16 | 10.538631 | 9.800779 | -7.0% |
| direct | physics_based | 256 | uint8 | 2 | 0.007409 | 0.005389 | -27.3% |
| direct | physics_based | 256 | uint8 | 4 | 0.015242 | 0.007642 | -49.9% |
| direct | physics_based | 256 | uint8 | 8 | 0.031640 | 0.013182 | -58.3% |
| direct | physics_based | 256 | uint8 | 16 | 0.063327 | 0.023117 | -63.5% |
| direct | physics_based | 256 | float32 | 2 | 0.011381 | 0.009660 | -15.1% |
| direct | physics_based | 256 | float32 | 4 | 0.022772 | 0.009743 | -57.2% |
| direct | physics_based | 256 | float32 | 8 | 0.046494 | 0.021642 | -53.5% |
| direct | physics_based | 256 | float32 | 16 | 0.092400 | 0.040038 | -56.7% |
| direct | physics_based | 512 | uint8 | 2 | 0.050222 | 0.029269 | -41.7% |
| direct | physics_based | 512 | uint8 | 4 | 0.099359 | 0.040203 | -59.5% |
| direct | physics_based | 512 | uint8 | 8 | 0.208705 | 0.061608 | -70.5% |
| direct | physics_based | 512 | uint8 | 16 | 0.407590 | 0.100417 | -75.4% |
| direct | physics_based | 512 | float32 | 2 | 0.060652 | 0.035443 | -41.6% |
| direct | physics_based | 512 | float32 | 4 | 0.117634 | 0.052645 | -55.2% |
| direct | physics_based | 512 | float32 | 8 | 0.234196 | 0.077731 | -66.8% |
| direct | physics_based | 512 | float32 | 16 | 0.470608 | 0.148026 | -68.5% |
| direct | physics_based | 1024 | uint8 | 2 | 0.217391 | 0.120394 | -44.6% |
| direct | physics_based | 1024 | uint8 | 4 | 0.439946 | 0.161926 | -63.2% |
| direct | physics_based | 1024 | uint8 | 8 | 0.861541 | 0.244001 | -71.7% |
| direct | physics_based | 1024 | uint8 | 16 | 1.727299 | 0.429972 | -75.1% |
| direct | physics_based | 1024 | float32 | 2 | 0.255010 | 0.145670 | -42.9% |
| direct | physics_based | 1024 | float32 | 4 | 0.520325 | 0.209709 | -59.7% |
| direct | physics_based | 1024 | float32 | 8 | 1.004369 | 0.355802 | -64.6% |
| direct | physics_based | 1024 | float32 | 16 | 2.179061 | 0.667399 | -69.4% |
| compose | overlay | 256 | uint8 | 2 | 0.084949 | 0.083096 | -2.2% |
| compose | overlay | 256 | uint8 | 4 | 0.170474 | 0.161697 | -5.1% |
| compose | overlay | 256 | uint8 | 8 | 0.340700 | 0.331642 | -2.7% |
| compose | overlay | 256 | uint8 | 16 | 0.690169 | 0.665453 | -3.6% |
| compose | overlay | 256 | float32 | 2 | 0.090009 | 0.085501 | -5.0% |
| compose | overlay | 256 | float32 | 4 | 0.175841 | 0.164595 | -6.4% |
| compose | overlay | 256 | float32 | 8 | 0.360229 | 0.337076 | -6.4% |
| compose | overlay | 256 | float32 | 16 | 0.721410 | 0.673214 | -6.7% |
| compose | overlay | 512 | uint8 | 2 | 0.292469 | 0.280376 | -4.1% |
| compose | overlay | 512 | uint8 | 4 | 0.561786 | 0.557498 | -0.8% |
| compose | overlay | 512 | uint8 | 8 | 1.106225 | 1.108445 | +0.2% |
| compose | overlay | 512 | uint8 | 16 | 2.221852 | 2.212025 | -0.4% |
| compose | overlay | 512 | float32 | 2 | 0.290194 | 0.288598 | -0.5% |
| compose | overlay | 512 | float32 | 4 | 0.576152 | 0.573295 | -0.5% |
| compose | overlay | 512 | float32 | 8 | 1.208537 | 1.129594 | -6.5% |
| compose | overlay | 512 | float32 | 16 | 2.278648 | 2.264961 | -0.6% |
| compose | overlay | 1024 | uint8 | 2 | 1.245673 | 1.264580 | +1.5% |
| compose | overlay | 1024 | uint8 | 4 | 2.500991 | 2.444865 | -2.2% |
| compose | overlay | 1024 | uint8 | 8 | 4.900407 | 4.835695 | -1.3% |
| compose | overlay | 1024 | uint8 | 16 | 9.853808 | 9.645789 | -2.1% |
| compose | overlay | 1024 | float32 | 2 | 1.256328 | 1.280399 | +1.9% |
| compose | overlay | 1024 | float32 | 4 | 2.562176 | 2.497526 | -2.5% |
| compose | overlay | 1024 | float32 | 8 | 5.144588 | 4.925243 | -4.3% |
| compose | overlay | 1024 | float32 | 16 | 10.198777 | 9.845714 | -3.5% |
| compose | physics_based | 256 | uint8 | 2 | 0.007721 | 0.005554 | -28.1% |
| compose | physics_based | 256 | uint8 | 4 | 0.015675 | 0.007974 | -49.1% |
| compose | physics_based | 256 | uint8 | 8 | 0.031481 | 0.013043 | -58.6% |
| compose | physics_based | 256 | uint8 | 16 | 0.062536 | 0.022888 | -63.4% |
| compose | physics_based | 256 | float32 | 2 | 0.011557 | 0.009629 | -16.7% |
| compose | physics_based | 256 | float32 | 4 | 0.023373 | 0.009776 | -58.2% |
| compose | physics_based | 256 | float32 | 8 | 0.046384 | 0.020207 | -56.4% |
| compose | physics_based | 256 | float32 | 16 | 0.093608 | 0.038257 | -59.1% |
| compose | physics_based | 512 | uint8 | 2 | 0.050598 | 0.028659 | -43.4% |
| compose | physics_based | 512 | uint8 | 4 | 0.099229 | 0.041113 | -58.6% |
| compose | physics_based | 512 | uint8 | 8 | 0.200278 | 0.063249 | -68.4% |
| compose | physics_based | 512 | uint8 | 16 | 0.405355 | 0.106151 | -73.8% |
| compose | physics_based | 512 | float32 | 2 | 0.058824 | 0.037706 | -35.9% |
| compose | physics_based | 512 | float32 | 4 | 0.117986 | 0.056549 | -52.1% |
| compose | physics_based | 512 | float32 | 8 | 0.255148 | 0.077093 | -69.8% |
| compose | physics_based | 512 | float32 | 16 | 0.470837 | 0.148997 | -68.4% |
| compose | physics_based | 1024 | uint8 | 2 | 0.223396 | 0.123121 | -44.9% |
| compose | physics_based | 1024 | uint8 | 4 | 0.440909 | 0.162486 | -63.1% |
| compose | physics_based | 1024 | uint8 | 8 | 0.873724 | 0.242513 | -72.2% |
| compose | physics_based | 1024 | uint8 | 16 | 1.717494 | 0.406496 | -76.3% |
| compose | physics_based | 1024 | float32 | 2 | 0.261543 | 0.145003 | -44.6% |
| compose | physics_based | 1024 | float32 | 4 | 0.514672 | 0.230903 | -55.1% |
| compose | physics_based | 1024 | float32 | 8 | 1.002595 | 0.370578 | -63.0% |
| compose | physics_based | 1024 | float32 | 16 | 2.107966 | 0.650867 | -69.1% |

</details>

## Compatibility

The existing single-image kernels remain unchanged. Batch output preserves exact uint8 values against stacked scalar calls and float32 within `rtol=1e-6, atol=1e-7`. Empty RGB batches return the original object, non-RGB validation remains enforced, and replayed image and volume calls use the recorded parameters. One-, two-, and four-component source colors retain OpenCV's RGB zero-padding and truncation semantics. The measured matrix had a maximum regression of 3.7% in the direct overlay 512 uint8 batch 2 cell. The batch overlay keeps the fused NumKong blend when each image ends on a conservative common SIMD boundary. Other shapes invoke the same blend kernel once per image, preserving backend routing and rounding at every image boundary. The macOS ready-only matrix exposed boundary-dependent NumKong rounding on commit `84f01b0` with a `101x99x3` image, where one of 29,997 values differed by one. The platform-independent arithmetic fallback on `9c2b415` also failed parity because it did not match the scalar backend. The final parity matrix covers both `101x99` and aligned `256x256` images. Physics rasterization remains shared, while dtype conversion, screen blending, and clipping are bounded to one image at a time. The required 256, 512, and 1024 RGB benchmark shapes retain the measured fused overlay path, and the final physics follow-up remains faster in all 24 direct cells. The full test suite remains a CI responsibility.

## AI assistance disclosure

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.

## Summary by Sourcery

Optimize RandomSunFlare batch processing by reusing shared flare setup while preserving existing output behavior.

New Features:
- Add batch processing support for RandomSunFlare across image and volume inputs.

Bug Fixes:
- Preserve single-image parity, dtype behavior, color semantics, replay behavior, validation, and empty-batch identity for batched sun flares.

Enhancements:
- Improve batched sun flare performance by reusing rasterized flare layers and sharing physics-based rasterization across images.

Tests:
- Add coverage for batched sun flare parity, color handling, bounded conversion and blending, replay, empty batches, and non-RGB validation.