### PR TITLE
feat: add ElasticTransform3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,20 +378,21 @@ Where:
 - Volume: 3D array of shape (D, H, W) or (D, H, W, C) where D is depth, H is height, W is width, and C is number of channels (optional)
 - Mask3D: Binary or multi-class 3D mask of shape (D, H, W) where each slice represents segmentation for the corresponding volume slice
 
-| Transform                                                                           | Volume | Mask3D | Keypoints |
-| ----------------------------------------------------------------------------------- | :----: | :----: | :-------: |
-| [Affine3D](https://albumentations.ai/explore/transform/Affine3D/)                   | ✓      | ✓      | ✓         |
-| [Anisotropy3D](https://albumentations.ai/explore/transform/Anisotropy3D/)           | ✓      |        |           |
-| [CenterCrop3D](https://albumentations.ai/explore/transform/CenterCrop3D/)           | ✓      | ✓      | ✓         |
-| [CoarseDropout3D](https://albumentations.ai/explore/transform/CoarseDropout3D/)     | ✓      | ✓      | ✓         |
-| [CubicSymmetry](https://albumentations.ai/explore/transform/CubicSymmetry/)         | ✓      | ✓      | ✓         |
-| [Flip3D](https://albumentations.ai/explore/transform/Flip3D/)                       | ✓      | ✓      | ✓         |
-| [GridShuffle3D](https://albumentations.ai/explore/transform/GridShuffle3D/)         | ✓      | ✓      | ✓         |
-| [Pad3D](https://albumentations.ai/explore/transform/Pad3D/)                         | ✓      | ✓      | ✓         |
-| [PadIfNeeded3D](https://albumentations.ai/explore/transform/PadIfNeeded3D/)         | ✓      | ✓      | ✓         |
-| [RandomCrop3D](https://albumentations.ai/explore/transform/RandomCrop3D/)           | ✓      | ✓      | ✓         |
-| [RandomRotate90_3D](https://albumentations.ai/explore/transform/RandomRotate90_3D/) | ✓      | ✓      | ✓         |
-| [Resize3D](https://albumentations.ai/explore/transform/Resize3D/)                   | ✓      | ✓      | ✓         |
+| Transform                                                                             | Volume | Mask3D | Keypoints |
+| ------------------------------------------------------------------------------------- | :----: | :----: | :-------: |
+| [Affine3D](https://albumentations.ai/explore/transform/Affine3D/)                     | ✓      | ✓      | ✓         |
+| [Anisotropy3D](https://albumentations.ai/explore/transform/Anisotropy3D/)             | ✓      |        |           |
+| [CenterCrop3D](https://albumentations.ai/explore/transform/CenterCrop3D/)             | ✓      | ✓      | ✓         |
+| [CoarseDropout3D](https://albumentations.ai/explore/transform/CoarseDropout3D/)       | ✓      | ✓      | ✓         |
+| [CubicSymmetry](https://albumentations.ai/explore/transform/CubicSymmetry/)           | ✓      | ✓      | ✓         |
+| [ElasticTransform3D](https://albumentations.ai/explore/transform/ElasticTransform3D/) | ✓      | ✓      | ✓         |
+| [Flip3D](https://albumentations.ai/explore/transform/Flip3D/)                         | ✓      | ✓      | ✓         |
+| [GridShuffle3D](https://albumentations.ai/explore/transform/GridShuffle3D/)           | ✓      | ✓      | ✓         |
+| [Pad3D](https://albumentations.ai/explore/transform/Pad3D/)                           | ✓      | ✓      | ✓         |
+| [PadIfNeeded3D](https://albumentations.ai/explore/transform/PadIfNeeded3D/)           | ✓      | ✓      | ✓         |
+| [RandomCrop3D](https://albumentations.ai/explore/transform/RandomCrop3D/)             | ✓      | ✓      | ✓         |
+| [RandomRotate90_3D](https://albumentations.ai/explore/transform/RandomRotate90_3D/)   | ✓      | ✓      | ✓         |
+| [Resize3D](https://albumentations.ai/explore/transform/Resize3D/)                     | ✓      | ✓      | ✓         |
 
 ## A few more examples of **augmentations**
 

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -19,6 +19,7 @@ from albumentations.core.bbox_utils import (
     normalize_bboxes,
 )
 from albumentations.core.type_definitions import ImageType
+from albumentations.core.utils import get_volume_shape
 
 __all__ = [
     "crop",
@@ -370,7 +371,8 @@ def volume_crop_yx(
         ValueError: If crop coordinates are invalid.
 
     """
-    _, height, width = volume.shape[:3]
+    volume_shape = get_volume_shape(volume)
+    _, height, width = volume_shape
     if x_max <= x_min or y_max <= y_min:
         raise ValueError(
             "Crop coordinates must satisfy min < max. Got: "
@@ -381,7 +383,7 @@ def volume_crop_yx(
         raise ValueError(
             "Crop coordinates must be within image dimensions (H, W). Got: "
             f"(x_min={x_min}, y_min={y_min}, x_max={x_max}, y_max={y_max}) "
-            f"for volume shape {volume.shape[:3]}",
+            f"for volume shape {volume_shape}",
         )
 
     # Crop along H (axis 1) and W (axis 2)

--- a/albumentations/augmentations/geometric/_functional_distortion.py
+++ b/albumentations/augmentations/geometric/_functional_distortion.py
@@ -116,6 +116,21 @@ def upscale_distortion_maps(
     return dx, dy
 
 
+def sample_elastic_control_coefficients(
+    control_grid_shape: tuple[int, int],
+    coefficient_radius: float | np.float32,
+    random_generator: np.random.Generator,
+) -> np.ndarray:
+    """Sample float32 2D cubic control coefficients uniformly within a displacement-radius disk."""
+    random_values = random_generator.random((*control_grid_shape, 2), dtype=np.float32)
+    vector_radius = np.float32(coefficient_radius) * np.sqrt(random_values[..., 0])
+    angle = np.float32(2 * np.pi) * random_values[..., 1]
+    control_coefficients = np.empty((*control_grid_shape, 2), dtype=np.float32)
+    control_coefficients[..., 0] = vector_radius * np.cos(angle)
+    control_coefficients[..., 1] = vector_radius * np.sin(angle)
+    return control_coefficients
+
+
 def expand_control_grid(
     control_coefficients: np.ndarray,
     output_shape: tuple[int, int],
@@ -698,6 +713,7 @@ __all__ = [
     "get_camera_matrix_distortion_maps",
     "get_fisheye_distortion_maps",
     "remap_elastic_keypoints",
+    "sample_elastic_control_coefficients",
     "tps_transform",
     "upscale_distortion_maps",
 ]

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -295,6 +295,11 @@ class ElasticTransform(BaseRemapTransform):
         `ReplayCompose` stores the compact sampled coefficient lattice and replays it for the same
         spatial shape. Applied configuration fixes the realized magnitude but samples a new lattice.
 
+    See Also:
+        - ElasticTransform3D: Applies coupled XY, XZ, and YZ cubic fields to volumetric data and XYZ keypoints.
+        - GridDistortion: Uses a rectilinear grid when piecewise-linear deformation fits the data.
+        - OpticalDistortion: Simulates lens-like radial distortion in camera images.
+
     Examples:
         >>> import numpy as np
         >>> import albumentations as A

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -420,21 +420,6 @@ class ElasticTransform(BaseRemapTransform):
             }
         )
 
-    def _apply_label_mappings_without_geometry(
-        self,
-        params: dict[str, Any],
-        data: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Preserve every target while applying configured keypoint and semantic-mask
-        label mappings for an exact identity deformation.
-        """
-        result = dict(data)
-        if "keypoints" in result and result["keypoints"] is not None:
-            result["keypoints"] = self._apply_label_mapping_to_keypoints(result["keypoints"], **params)
-        if self._semantic_mask_label_mappings:
-            result = self._apply_label_mapping_to_semantic_masks(result, **params)
-        return result
-
     def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Build one dense map for the invocation and reject replay on another spatial shape before dispatching all
         synchronized targets with exact map sharing.
@@ -449,7 +434,7 @@ class ElasticTransform(BaseRemapTransform):
                     f"ElasticTransform replay requires the same spatial shape {recorded_shape}, got {current_shape}",
                 )
         if not params["control_coefficients"]:
-            return self._apply_label_mappings_without_geometry(params, kwargs)
+            return self._apply_label_mappings_without_dispatch(params, kwargs)
 
         runtime_params = dict(params)
         control_coefficients = np.asarray(params["control_coefficients"], dtype=np.float32)

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -406,13 +406,12 @@ class ElasticTransform(BaseRemapTransform):
                 }
             )
 
-        random_values = sampling.random_generator.random((*self.control_grid_shape, 2), dtype=np.float32)
         radius = np.float32(magnitude * min(height - 1, width - 1))
-        vector_radius = radius * np.sqrt(random_values[..., 0])
-        angle = np.float32(2 * np.pi) * random_values[..., 1]
-        control_coefficients = np.empty((*self.control_grid_shape, 2), dtype=np.float32)
-        control_coefficients[..., 0] = vector_radius * np.cos(angle)
-        control_coefficients[..., 1] = vector_radius * np.sin(angle)
+        control_coefficients = fgeometric.sample_elastic_control_coefficients(
+            self.control_grid_shape,
+            radius,
+            sampling.random_generator,
+        )
         return SampledParams(
             params={
                 "displacement_magnitude": magnitude,

--- a/albumentations/augmentations/geometric/distortion.py
+++ b/albumentations/augmentations/geometric/distortion.py
@@ -419,6 +419,21 @@ class ElasticTransform(BaseRemapTransform):
             }
         )
 
+    def _apply_label_mappings_without_geometry(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Preserve every target while applying configured keypoint and semantic-mask
+        label mappings for an exact identity deformation.
+        """
+        result = dict(data)
+        if "keypoints" in result and result["keypoints"] is not None:
+            result["keypoints"] = self._apply_label_mapping_to_keypoints(result["keypoints"], **params)
+        if self._semantic_mask_label_mappings:
+            result = self._apply_label_mapping_to_semantic_masks(result, **params)
+        return result
+
     def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Build one dense map for the invocation and reject replay on another spatial shape before dispatching all
         synchronized targets with exact map sharing.
@@ -433,7 +448,7 @@ class ElasticTransform(BaseRemapTransform):
                     f"ElasticTransform replay requires the same spatial shape {recorded_shape}, got {current_shape}",
                 )
         if not params["control_coefficients"]:
-            return self._apply_label_mappings_without_dispatch(params, kwargs)
+            return self._apply_label_mappings_without_geometry(params, kwargs)
 
         runtime_params = dict(params)
         control_coefficients = np.asarray(params["control_coefficients"], dtype=np.float32)

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -7,6 +7,8 @@ from typing import Any, Literal, cast
 
 import numkong as nk
 
+from albumentations.core.utils import get_volume_shape
+
 from ._functional_shared import (
     MAX_VALUES_BY_DTYPE,
     MULTICHANNEL_LUT_LARGE_IMAGE_PIXELS,
@@ -923,7 +925,7 @@ def iso_noise_volume(
         cv2.cvtColor(image, cv2.COLOR_RGB2HLS, dst=hls_volume[depth_index])
 
     luminance_std = float(np.std(hls_volume[..., 1]))
-    volume_shape = volume.shape[:3]
+    volume_shape = get_volume_shape(volume)
     luminance_noise = random_generator.poisson(luminance_std * intensity, size=volume_shape).astype(np.float32)
     color_noise = random_generator.normal(0, color_shift * intensity, size=volume_shape).astype(np.float32)
 

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -1469,18 +1469,12 @@ class FilmGrain(_FullVolumeNoiseTransform):
         groups: list[TargetParams] = []
         for views in targets.group_image_like_by(
             lambda view: (
-                tuple((view.descriptor.shape or ())[:3])
-                if view.canonical_type == "volume"
-                else tuple(view.descriptor.spatial_shape or ()),
+                tuple(view.descriptor.spatial_shape or ()),
                 _sampling_family(view),
             ),
         ):
             view = views[0]
-            spatial_shape = (
-                tuple(view.descriptor.shape[:3])
-                if view.canonical_type == "volume" and view.descriptor.shape is not None
-                else tuple(view.descriptor.spatial_shape or ())
-            )
+            spatial_shape = tuple(view.descriptor.spatial_shape or ())
             groups.append(
                 TargetParams(
                     targets=tuple(item.name for item in views),

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -239,41 +239,37 @@ def create_elastic_grid_3d(
     sampling_grid[..., 1] = _normalized_axis(height)[np.newaxis, :, np.newaxis]
     sampling_grid[..., 2] = _normalized_axis(depth)[:, np.newaxis, np.newaxis]
 
-    active_plane_count = len(control_coefficients)
-    if active_plane_count == 0:
+    if not control_coefficients:
         return sampling_grid
 
-    plane_count = np.float32(active_plane_count)
+    plane_count = np.float32(3)
     depth_scale = np.float32(2.0 / (depth * plane_count))
     height_scale = np.float32(2.0 / (height * plane_count))
     width_scale = np.float32(2.0 / (width * plane_count))
-    if "xy" in control_coefficients:
-        _add_elastic_plane(
-            sampling_grid,
-            control_coefficients["xy"],
-            sampling_grid.shape[1:3],
-            0,
-            (0, 1),
-            (width_scale, height_scale),
-        )
-    if "xz" in control_coefficients:
-        _add_elastic_plane(
-            sampling_grid,
-            control_coefficients["xz"],
-            (sampling_grid.shape[0], sampling_grid.shape[2]),
-            1,
-            (0, 2),
-            (width_scale, depth_scale),
-        )
-    if "yz" in control_coefficients:
-        _add_elastic_plane(
-            sampling_grid,
-            control_coefficients["yz"],
-            sampling_grid.shape[:2],
-            2,
-            (1, 2),
-            (height_scale, depth_scale),
-        )
+    _add_elastic_plane(
+        sampling_grid,
+        control_coefficients["xy"],
+        sampling_grid.shape[1:3],
+        0,
+        (0, 1),
+        (width_scale, height_scale),
+    )
+    _add_elastic_plane(
+        sampling_grid,
+        control_coefficients["xz"],
+        (sampling_grid.shape[0], sampling_grid.shape[2]),
+        1,
+        (0, 2),
+        (width_scale, depth_scale),
+    )
+    _add_elastic_plane(
+        sampling_grid,
+        control_coefficients["yz"],
+        sampling_grid.shape[:2],
+        2,
+        (1, 2),
+        (height_scale, depth_scale),
+    )
     return sampling_grid
 
 
@@ -405,34 +401,30 @@ def _elastic_plane_displacement(
     volume_shape: tuple[int, int, int],
 ) -> np.ndarray:
     displacement = np.zeros((len(points), 3), dtype=np.float64)
-    active_plane_count = len(control_coefficients)
-    if active_plane_count == 0:
+    if not control_coefficients:
         return displacement
 
-    if "xy" in control_coefficients:
-        xy_displacement = fgeometric.evaluate_control_grid(
-            points[:, :2],
-            control_coefficients["xy"],
-            volume_shape[1:],
-        )
-        displacement[:, :2] += xy_displacement
-    if "xz" in control_coefficients:
-        xz_displacement = fgeometric.evaluate_control_grid(
-            points[:, (0, 2)],
-            control_coefficients["xz"],
-            (volume_shape[0], volume_shape[2]),
-        )
-        displacement[:, 0] += xz_displacement[:, 0]
-        displacement[:, 2] += xz_displacement[:, 1]
-    if "yz" in control_coefficients:
-        yz_displacement = fgeometric.evaluate_control_grid(
-            points[:, 1:3],
-            control_coefficients["yz"],
-            volume_shape[:2],
-        )
-        displacement[:, 1] += yz_displacement[:, 0]
-        displacement[:, 2] += yz_displacement[:, 1]
-    return displacement / active_plane_count
+    xy_displacement = fgeometric.evaluate_control_grid(
+        points[:, :2],
+        control_coefficients["xy"],
+        volume_shape[1:],
+    )
+    displacement[:, :2] += xy_displacement
+    xz_displacement = fgeometric.evaluate_control_grid(
+        points[:, (0, 2)],
+        control_coefficients["xz"],
+        (volume_shape[0], volume_shape[2]),
+    )
+    displacement[:, 0] += xz_displacement[:, 0]
+    displacement[:, 2] += xz_displacement[:, 1]
+    yz_displacement = fgeometric.evaluate_control_grid(
+        points[:, 1:3],
+        control_coefficients["yz"],
+        volume_shape[:2],
+    )
+    displacement[:, 1] += yz_displacement[:, 0]
+    displacement[:, 2] += yz_displacement[:, 1]
+    return displacement / np.float32(3)
 
 
 @handle_empty_array("keypoints")

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -14,8 +14,9 @@ from typing import Any, Literal, cast
 import cv2
 import numpy as np
 import torch
-from albucore import resize3d, warp_affine3d
+from albucore import clip, remap3d, resize3d, warp_affine3d
 
+from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.type_definitions import NUM_VOLUME_DIMENSIONS, ImageType, VolumeType
 
@@ -84,11 +85,11 @@ def create_affine_transformation_matrix_3d(
     )
 
 
-def _prepare_numpy_affine_3d_volume(
+def _prepare_numpy_resampled_volume(
     volume: VolumeType,
     is_mask: bool,
 ) -> tuple[VolumeType, np.dtype[Any], bool, bool]:
-    """Prepare a NumPy volume for Albucore's affine router, adding a mask channel and promoting integer masks so
+    """Prepare a NumPy volume for an Albucore resampling router, adding a mask channel and promoting integer masks so
     source dtype is restored after resampling.
     """
     is_channel_less = volume.ndim == NUM_VOLUME_DIMENSIONS - 1
@@ -100,11 +101,11 @@ def _prepare_numpy_affine_3d_volume(
     return working_volume, original_dtype, is_channel_less, needs_mask_promotion
 
 
-def _prepare_tensor_affine_3d_volume(
+def _prepare_tensor_resampled_volume(
     volume: torch.Tensor,
     is_mask: bool,
 ) -> tuple[torch.Tensor, torch.dtype, bool, bool]:
-    """Prepare a CPU Tensor volume for Albucore's affine router, adding a mask channel and promoting integer masks
+    """Prepare a CPU Tensor volume for an Albucore resampling router, adding a mask channel and promoting integer masks
     so source dtype is restored after resampling.
     """
     is_channel_less = volume.ndim == NUM_VOLUME_DIMENSIONS - 1
@@ -138,7 +139,7 @@ def affine_3d(
             original_numpy_dtype,
             is_channel_less_numpy,
             needs_mask_promotion,
-        ) = _prepare_numpy_affine_3d_volume(
+        ) = _prepare_numpy_resampled_volume(
             volume,
             is_mask,
         )
@@ -150,7 +151,7 @@ def affine_3d(
             original_tensor_dtype,
             is_channel_less_tensor,
             needs_mask_promotion,
-        ) = _prepare_tensor_affine_3d_volume(
+        ) = _prepare_tensor_resampled_volume(
             volume,
             is_mask,
         )
@@ -184,6 +185,284 @@ def affine_3d(
         return result[..., 0]
     if is_channel_less_tensor:
         return result[0]
+    return result
+
+
+def _normalized_axis(length: int) -> np.ndarray:
+    axis = np.arange(length, dtype=np.float32)
+    axis *= np.float32(2.0 / length)
+    axis += np.float32(1.0 / length - 1.0)
+    return axis
+
+
+def _add_elastic_plane(
+    sampling_grid: np.ndarray,
+    control_coefficients: np.ndarray,
+    dense_shape: tuple[int, int],
+    broadcast_axis: int,
+    coordinate_axes: tuple[int, int],
+    component_scales: tuple[np.float32, np.float32],
+) -> None:
+    dense_plane = fgeometric.expand_control_grid(control_coefficients, dense_shape)
+    for component_index in range(2):
+        dense_plane[component_index] *= component_scales[component_index]
+        sampling_grid[..., coordinate_axes[component_index]] += np.expand_dims(
+            dense_plane[component_index],
+            axis=broadcast_axis,
+        )
+
+
+def create_elastic_grid_3d(
+    control_coefficients: Mapping[str, np.ndarray],
+    volume_shape: tuple[int, int, int],
+) -> np.ndarray:
+    """Build one normalized 3D pull grid from compact C2 control planes for volumetric deformation without dense
+    displacement or meshgrid allocations.
+
+    Args:
+        control_coefficients (Mapping[str, np.ndarray]): Active XY, XZ, and YZ cubic coefficient planes.
+        volume_shape (tuple[int, int, int]): Output `(depth, height, width)` shape.
+
+    Returns:
+        np.ndarray: Float32 normalized `(depth, height, width, 3)` pull coordinates in `(x, y, z)` order.
+
+    """
+    depth, height, width = volume_shape
+    sampling_grid = np.empty((depth, height, width, 3), dtype=np.float32)
+    sampling_grid[..., 0] = _normalized_axis(width)
+    sampling_grid[..., 1] = _normalized_axis(height)[np.newaxis, :, np.newaxis]
+    sampling_grid[..., 2] = _normalized_axis(depth)[:, np.newaxis, np.newaxis]
+
+    active_plane_count = len(control_coefficients)
+    if active_plane_count == 0:
+        return sampling_grid
+
+    plane_count = np.float32(active_plane_count)
+    depth_scale = np.float32(2.0 / (depth * plane_count))
+    height_scale = np.float32(2.0 / (height * plane_count))
+    width_scale = np.float32(2.0 / (width * plane_count))
+    if "xy" in control_coefficients:
+        _add_elastic_plane(
+            sampling_grid,
+            control_coefficients["xy"],
+            sampling_grid.shape[1:3],
+            0,
+            (0, 1),
+            (width_scale, height_scale),
+        )
+    if "xz" in control_coefficients:
+        _add_elastic_plane(
+            sampling_grid,
+            control_coefficients["xz"],
+            (sampling_grid.shape[0], sampling_grid.shape[2]),
+            1,
+            (0, 2),
+            (width_scale, depth_scale),
+        )
+    if "yz" in control_coefficients:
+        _add_elastic_plane(
+            sampling_grid,
+            control_coefficients["yz"],
+            sampling_grid.shape[:2],
+            2,
+            (1, 2),
+            (height_scale, depth_scale),
+        )
+    return sampling_grid
+
+
+def _clip_interpolated_float_volume(
+    result: VolumeType | torch.Tensor,
+    original_numpy_dtype: np.dtype[Any] | None,
+    original_tensor_dtype: torch.dtype | None,
+    interpolation: int,
+    is_mask: bool,
+) -> VolumeType | torch.Tensor:
+    if is_mask or interpolation == cv2.INTER_NEAREST:
+        return result
+    if isinstance(result, np.ndarray) and original_numpy_dtype == np.dtype(np.float32):
+        return clip(result, np.dtype(np.float32), inplace=True)
+    if isinstance(result, torch.Tensor) and original_tensor_dtype == torch.float32:
+        return result.clamp_(0.0, 1.0)
+    return result
+
+
+def remap_3d(
+    volume: VolumeType | torch.Tensor,
+    sampling_grid: np.ndarray,
+    interpolation: int,
+    border_mode: int,
+    fill: float | tuple[float, ...] | None,
+    *,
+    is_mask: bool = False,
+) -> VolumeType | torch.Tensor:
+    """Apply one prebuilt normalized 3D pull grid through Albucore while retaining channel-less mask semantics and
+    supported NumPy or CPU Tensor containers.
+
+    Args:
+        volume (VolumeType | torch.Tensor): Public NumPy volume or CPU Tensor volume or mask.
+        sampling_grid (np.ndarray): Normalized float32 `(D, H, W, 3)` pull grid.
+        interpolation (int): Nearest or trilinear interpolation flag.
+        border_mode (int): Constant or replicate border flag.
+        fill (float | tuple[float, ...] | None): Constant scalar or per-channel border value.
+        is_mask (bool): Whether to restore an integer channel-less mask after sampling.
+
+    Returns:
+        VolumeType | torch.Tensor: Sampled volume or mask with the caller's public representation.
+
+    """
+    if isinstance(volume, np.ndarray):
+        working_volume, original_numpy_dtype, is_channel_less_numpy, needs_mask_promotion = (
+            _prepare_numpy_resampled_volume(volume, is_mask)
+        )
+        original_tensor_dtype = None
+        is_channel_less_tensor = False
+    elif isinstance(volume, torch.Tensor):
+        working_volume, original_tensor_dtype, is_channel_less_tensor, needs_mask_promotion = (
+            _prepare_tensor_resampled_volume(volume, is_mask)
+        )
+        original_numpy_dtype = None
+        is_channel_less_numpy = False
+    else:
+        msg = f"remap_3d expects a NumPy array or CPU torch.Tensor, got {type(volume).__name__}"
+        raise TypeError(msg)
+
+    result = remap3d(
+        working_volume,
+        sampling_grid,
+        interpolation=interpolation,
+        border_mode=border_mode,
+        border_value=fill,
+    )
+    result = _clip_interpolated_float_volume(
+        result,
+        original_numpy_dtype,
+        original_tensor_dtype,
+        interpolation,
+        is_mask,
+    )
+    if needs_mask_promotion:
+        if isinstance(result, np.ndarray):
+            if original_numpy_dtype is None:
+                raise RuntimeError("NumPy remap result requires a NumPy source dtype")
+            result = np.rint(result).astype(original_numpy_dtype, copy=False)
+        else:
+            if original_tensor_dtype is None:
+                raise RuntimeError("Tensor remap result requires a Tensor source dtype")
+            result = torch.round(result).to(original_tensor_dtype)
+
+    if is_channel_less_numpy:
+        return result[..., 0]
+    if is_channel_less_tensor:
+        return result[0]
+    return result
+
+
+def _elastic_plane_displacement(
+    points: np.ndarray,
+    control_coefficients: Mapping[str, np.ndarray],
+    volume_shape: tuple[int, int, int],
+) -> np.ndarray:
+    displacement = np.zeros((len(points), 3), dtype=np.float64)
+    active_plane_count = len(control_coefficients)
+    if active_plane_count == 0:
+        return displacement
+
+    if "xy" in control_coefficients:
+        xy_displacement = fgeometric.evaluate_control_grid(
+            points[:, :2],
+            control_coefficients["xy"],
+            volume_shape[1:],
+        )
+        displacement[:, :2] += xy_displacement
+    if "xz" in control_coefficients:
+        xz_displacement = fgeometric.evaluate_control_grid(
+            points[:, (0, 2)],
+            control_coefficients["xz"],
+            (volume_shape[0], volume_shape[2]),
+        )
+        displacement[:, 0] += xz_displacement[:, 0]
+        displacement[:, 2] += xz_displacement[:, 1]
+    if "yz" in control_coefficients:
+        yz_displacement = fgeometric.evaluate_control_grid(
+            points[:, 1:3],
+            control_coefficients["yz"],
+            volume_shape[:2],
+        )
+        displacement[:, 1] += yz_displacement[:, 0]
+        displacement[:, 2] += yz_displacement[:, 1]
+    return displacement / active_plane_count
+
+
+@handle_empty_array("keypoints")
+def remap_elastic_keypoints_3d(
+    keypoints: np.ndarray,
+    control_coefficients: Mapping[str, np.ndarray],
+    volume_shape: tuple[int, int, int],
+    tolerance: float = 1e-3,
+) -> np.ndarray:
+    """Invert a bounded 3D elastic pull field for XYZ keypoints with a fixed-point solver and strict forward
+    residual, keeping every trailing attribute intact.
+
+    Args:
+        keypoints (np.ndarray): XYZ keypoints with optional trailing attributes.
+        control_coefficients (Mapping[str, np.ndarray]): Active compact cubic control planes.
+        volume_shape (tuple[int, int, int]): `(depth, height, width)` source shape.
+        tolerance (float): Maximum accepted forward residual in voxel units.
+
+    Returns:
+        np.ndarray: Keypoints in output coordinates; unconverged or out-of-domain rows have `-1` spatial coordinates.
+
+    """
+    source_points = np.asarray(keypoints[:, :3], dtype=np.float64)
+    transformed_points = source_points.copy()
+    active_points = np.isfinite(source_points).all(axis=1)
+    for _ in range(96):
+        with np.errstate(invalid="ignore", over="ignore"):
+            updated_points = source_points - _elastic_plane_displacement(
+                transformed_points,
+                control_coefficients,
+                volume_shape,
+            )
+        active_points &= np.isfinite(updated_points).all(axis=1)
+        if (
+            active_points.any()
+            and np.max(
+                np.abs(updated_points[active_points] - transformed_points[active_points]),
+                initial=0.0,
+            )
+            <= tolerance * 0.1
+        ):
+            transformed_points = updated_points
+            break
+        transformed_points = updated_points
+        transformed_points[~active_points] = np.nan
+        if not active_points.any():
+            break
+
+    residual = np.full(len(source_points), np.inf, dtype=np.float64)
+    if active_points.any():
+        valid_points = transformed_points[active_points]
+        residual[active_points] = np.max(
+            np.abs(
+                valid_points
+                + _elastic_plane_displacement(valid_points, control_coefficients, volume_shape)
+                - source_points[active_points],
+            ),
+            axis=1,
+        )
+    depth, height, width = volume_shape
+    valid = np.isfinite(residual) & (residual <= tolerance)
+    valid &= (
+        (transformed_points[:, 0] >= -tolerance)
+        & (transformed_points[:, 0] <= width + tolerance)
+        & (transformed_points[:, 1] >= -tolerance)
+        & (transformed_points[:, 1] <= height + tolerance)
+        & (transformed_points[:, 2] >= -tolerance)
+        & (transformed_points[:, 2] <= depth + tolerance)
+    )
+    result = keypoints.copy()
+    result[:, :3] = np.where(valid[:, np.newaxis], transformed_points, -1.0).astype(result.dtype, copy=False)
     return result
 
 

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -20,6 +20,7 @@ from albucore import clip, remap3d, resize3d, warp_affine3d
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.utils import handle_empty_array
 from albumentations.core.type_definitions import NUM_VOLUME_DIMENSIONS, ImageType, VolumeType
+from albumentations.core.utils import get_volume_shape
 
 AxisValues3D = Mapping[Literal["x", "y", "z"], float] | Mapping[str, float]
 
@@ -309,10 +310,7 @@ def elastic_transform_3d(
     is_mask: bool = False,
 ) -> VolumeType | torch.Tensor:
     """Build and apply a compact elastic pull field to one volume or mask."""
-    if isinstance(volume, torch.Tensor):
-        source_shape = tuple(volume.shape[1:] if volume.ndim == NUM_VOLUME_DIMENSIONS else volume.shape)
-    else:
-        source_shape = volume.shape[:3]
+    source_shape = get_volume_shape(volume)
     recorded_shape = tuple(sampler["volume_shape"])
     if source_shape != recorded_shape:
         raise ValueError(
@@ -570,10 +568,7 @@ def anisotropy_3d(
     NumPy applies antialiasing while shrinking; PyTorch does not yet provide 5D trilinear antialiasing, so Tensor input
     uses the non-antialiased native route until upstream support is available.
     """
-    source_shape = cast(
-        "tuple[int, int, int]",
-        tuple(volume.shape[1:]) if isinstance(volume, torch.Tensor) else volume.shape[:3],
-    )
+    source_shape = get_volume_shape(volume)
     if source_shape == downsample_shape:
         return volume
 

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -309,9 +309,10 @@ def elastic_transform_3d(
     is_mask: bool = False,
 ) -> VolumeType | torch.Tensor:
     """Build and apply a compact elastic pull field to one volume or mask."""
-    source_shape = (
-        tuple(volume.shape if is_mask else volume.shape[1:]) if isinstance(volume, torch.Tensor) else volume.shape[:3]
-    )
+    if isinstance(volume, torch.Tensor):
+        source_shape = tuple(volume.shape[1:] if volume.ndim == NUM_VOLUME_DIMENSIONS else volume.shape)
+    else:
+        source_shape = volume.shape[:3]
     recorded_shape = tuple(sampler["volume_shape"])
     if source_shape != recorded_shape:
         raise ValueError(

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -9,12 +9,13 @@ specifically designed for 3D data.
 import math
 import random
 from collections.abc import Mapping
+from copy import deepcopy
 from typing import Any, Literal, cast
 
 import cv2
 import numpy as np
 import torch
-from albucore import clip, remap3d, resize3d, warp_affine3d
+from albucore import remap3d, resize3d, warp_affine3d
 
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.utils import handle_empty_array
@@ -212,21 +213,26 @@ def _add_elastic_plane(
         )
 
 
+def _as_elastic_control_coefficients(control_coefficients: Mapping[str, Any]) -> dict[str, np.ndarray]:
+    return {plane: np.asarray(coefficients, dtype=np.float32) for plane, coefficients in control_coefficients.items()}
+
+
 def create_elastic_grid_3d(
-    control_coefficients: Mapping[str, np.ndarray],
+    control_coefficients: Mapping[str, Any],
     volume_shape: tuple[int, int, int],
 ) -> np.ndarray:
     """Build one normalized 3D pull grid from compact C2 control planes for volumetric deformation without dense
     displacement or meshgrid allocations.
 
     Args:
-        control_coefficients (Mapping[str, np.ndarray]): Active XY, XZ, and YZ cubic coefficient planes.
+        control_coefficients (Mapping[str, Any]): Active XY, XZ, and YZ cubic coefficient planes.
         volume_shape (tuple[int, int, int]): Output `(depth, height, width)` shape.
 
     Returns:
         np.ndarray: Float32 normalized `(depth, height, width, 3)` pull coordinates in `(x, y, z)` order.
 
     """
+    control_coefficients = _as_elastic_control_coefficients(control_coefficients)
     depth, height, width = volume_shape
     sampling_grid = np.empty((depth, height, width, 3), dtype=np.float32)
     sampling_grid[..., 0] = _normalized_axis(width)
@@ -271,20 +277,62 @@ def create_elastic_grid_3d(
     return sampling_grid
 
 
-def _clip_interpolated_float_volume(
-    result: VolumeType | torch.Tensor,
-    original_numpy_dtype: np.dtype[Any] | None,
-    original_tensor_dtype: torch.dtype | None,
+class ElasticTransform3DSampler(dict[str, Any]):
+    """Carry serializable elastic coefficients and one invocation-local sampling grid."""
+
+    __slots__ = ("_remaining_grid_uses", "sampling_grid")
+
+    def __init__(
+        self,
+        control_coefficients: Mapping[str, Any],
+        volume_shape: tuple[int, int, int],
+        raster_target_count: int,
+    ) -> None:
+        super().__init__(control_coefficients=control_coefficients, volume_shape=volume_shape)
+        self.sampling_grid = (
+            None if not control_coefficients else create_elastic_grid_3d(control_coefficients, volume_shape)
+        )
+        self._remaining_grid_uses = raster_target_count
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> dict[str, Any]:
+        return deepcopy(dict(self), memo)
+
+    def release_sampling_grid(self) -> None:
+        self._remaining_grid_uses -= 1
+        if self._remaining_grid_uses == 0:
+            self.sampling_grid = None
+
+
+def elastic_transform_3d(
+    volume: VolumeType | torch.Tensor,
+    sampler: Mapping[str, Any],
     interpolation: int,
-    is_mask: bool,
+    border_mode: int,
+    fill: float | tuple[float, ...] | None,
+    *,
+    is_mask: bool = False,
 ) -> VolumeType | torch.Tensor:
-    if is_mask or interpolation == cv2.INTER_NEAREST:
-        return result
-    if isinstance(result, np.ndarray) and original_numpy_dtype == np.dtype(np.float32):
-        return clip(result, np.dtype(np.float32), inplace=True)
-    if isinstance(result, torch.Tensor) and original_tensor_dtype == torch.float32:
-        return result.clamp_(0.0, 1.0)
-    return result
+    """Build and apply a compact elastic pull field to one volume or mask."""
+    source_shape = (
+        tuple(volume.shape if is_mask else volume.shape[1:]) if isinstance(volume, torch.Tensor) else volume.shape[:3]
+    )
+    recorded_shape = tuple(sampler["volume_shape"])
+    if source_shape != recorded_shape:
+        raise ValueError(
+            f"ElasticTransform3D replay requires the same spatial shape {recorded_shape}, got {source_shape}",
+        )
+    control_coefficients = sampler["control_coefficients"]
+    if not control_coefficients:
+        return volume
+    sampling_grid = getattr(sampler, "sampling_grid", None)
+    uses_cached_grid = sampling_grid is not None
+    if not uses_cached_grid:
+        sampling_grid = create_elastic_grid_3d(control_coefficients, recorded_shape)
+    try:
+        return remap_3d(volume, sampling_grid, interpolation, border_mode, fill, is_mask=is_mask)
+    finally:
+        if uses_cached_grid and isinstance(sampler, ElasticTransform3DSampler):
+            sampler.release_sampling_grid()
 
 
 def remap_3d(
@@ -333,13 +381,6 @@ def remap_3d(
         interpolation=interpolation,
         border_mode=border_mode,
         border_value=fill,
-    )
-    result = _clip_interpolated_float_volume(
-        result,
-        original_numpy_dtype,
-        original_tensor_dtype,
-        interpolation,
-        is_mask,
     )
     if needs_mask_promotion:
         if isinstance(result, np.ndarray):
@@ -397,7 +438,7 @@ def _elastic_plane_displacement(
 @handle_empty_array("keypoints")
 def remap_elastic_keypoints_3d(
     keypoints: np.ndarray,
-    control_coefficients: Mapping[str, np.ndarray],
+    control_coefficients: Mapping[str, Any],
     volume_shape: tuple[int, int, int],
     tolerance: float = 1e-3,
 ) -> np.ndarray:
@@ -406,7 +447,7 @@ def remap_elastic_keypoints_3d(
 
     Args:
         keypoints (np.ndarray): XYZ keypoints with optional trailing attributes.
-        control_coefficients (Mapping[str, np.ndarray]): Active compact cubic control planes.
+        control_coefficients (Mapping[str, Any]): Active compact cubic control planes.
         volume_shape (tuple[int, int, int]): `(depth, height, width)` source shape.
         tolerance (float): Maximum accepted forward residual in voxel units.
 
@@ -414,6 +455,7 @@ def remap_elastic_keypoints_3d(
         np.ndarray: Keypoints in output coordinates; unconverged or out-of-domain rows have `-1` spatial coordinates.
 
     """
+    control_coefficients = _as_elastic_control_coefficients(control_coefficients)
     source_points = np.asarray(keypoints[:, :3], dtype=np.float64)
     transformed_points = source_points.copy()
     active_points = np.isfinite(source_points).all(axis=1)

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -15,7 +15,7 @@ from typing import Any, Literal, cast
 import cv2
 import numpy as np
 import torch
-from albucore import remap3d, resize3d, warp_affine3d
+from albucore import clip, remap3d, resize3d, warp_affine3d
 
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.utils import handle_empty_array
@@ -331,6 +331,22 @@ def elastic_transform_3d(
             sampler.release_sampling_grid()
 
 
+def _clip_interpolated_float_volume(
+    result: VolumeType | torch.Tensor,
+    original_numpy_dtype: np.dtype[Any] | None,
+    original_tensor_dtype: torch.dtype | None,
+    interpolation: int,
+    is_mask: bool,
+) -> VolumeType | torch.Tensor:
+    if is_mask or interpolation == cv2.INTER_NEAREST:
+        return result
+    if isinstance(result, np.ndarray) and original_numpy_dtype == np.dtype(np.float32):
+        return clip(result, np.dtype(np.float32), inplace=True)
+    if isinstance(result, torch.Tensor) and original_tensor_dtype == torch.float32:
+        return result.clamp_(0.0, 1.0)
+    return result
+
+
 def remap_3d(
     volume: VolumeType | torch.Tensor,
     sampling_grid: np.ndarray,
@@ -377,6 +393,13 @@ def remap_3d(
         interpolation=interpolation,
         border_mode=border_mode,
         border_value=fill,
+    )
+    result = _clip_interpolated_float_volume(
+        result,
+        original_numpy_dtype,
+        original_tensor_dtype,
+        interpolation,
+        is_mask,
     )
     if needs_mask_promotion:
         if isinstance(result, np.ndarray):

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -426,26 +426,16 @@ def _elastic_plane_displacement(
     if not control_coefficients:
         return displacement
 
-    xy_displacement = fgeometric.evaluate_control_grid(
-        points[:, :2],
-        control_coefficients["xy"],
-        volume_shape[1:],
-    )
-    displacement[:, :2] += xy_displacement
-    xz_displacement = fgeometric.evaluate_control_grid(
-        points[:, (0, 2)],
-        control_coefficients["xz"],
-        (volume_shape[0], volume_shape[2]),
-    )
-    displacement[:, 0] += xz_displacement[:, 0]
-    displacement[:, 2] += xz_displacement[:, 1]
-    yz_displacement = fgeometric.evaluate_control_grid(
-        points[:, 1:3],
-        control_coefficients["yz"],
-        volume_shape[:2],
-    )
-    displacement[:, 1] += yz_displacement[:, 0]
-    displacement[:, 2] += yz_displacement[:, 1]
+    for plane, point_axes, control_shape, displacement_axes in (
+        ("xy", slice(0, 2), volume_shape[1:], slice(0, 2)),
+        ("xz", (0, 2), (volume_shape[0], volume_shape[2]), (0, 2)),
+        ("yz", slice(1, 3), volume_shape[:2], slice(1, 3)),
+    ):
+        displacement[:, displacement_axes] += fgeometric.evaluate_control_grid(
+            points[:, point_axes],
+            control_coefficients[plane],
+            control_shape,
+        )
     return displacement / np.float32(3)
 
 

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -293,8 +293,7 @@ class ElasticTransform3D(Transform3D):
           deformation's Lipschitz constant below one.
         - Replay stores compact coefficients and requires the same `(depth, height, width)` shape. Applied
           configuration fixes only the realized magnitude and samples fresh coefficient planes.
-        - CPU Tensor volumes with one channel run natively; multi-channel volumes use Compose's NumPy bridge and
-          return a Tensor with the original layout.
+        - CPU Tensor volumes run natively for every channel count and retain their `(C, D, H, W)` layout.
         - This transform changes voxel-index coordinates. Physical spacing, orientation metadata, and 3D bounding
           boxes are outside its contract.
 
@@ -1848,7 +1847,7 @@ class CoarseDropout3D(Transform3D):
             tuple[np.ndarray, np.ndarray, np.ndarray]: Arrays of hole dimensions (depths, heights, widths)
 
         """
-        depth, height, width = volume_shape[:3]
+        depth, height, width = volume_shape
 
         hole_depths = np.maximum(1, np.ceil(depth * sampling.random_generator.uniform(*depth_range, size=size))).astype(
             int,
@@ -1897,7 +1896,7 @@ class CoarseDropout3D(Transform3D):
             sampling=sampling,
         )
 
-        depth, height, width = volume_shape[:3]
+        depth, height, width = volume_shape
 
         z_min = sampling.random_generator.integers(0, depth - hole_depths + 1, size=num_holes)
         y_min = sampling.random_generator.integers(0, height - hole_heights + 1, size=num_holes)

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -39,6 +39,7 @@ __all__ = [
     "CenterCrop3D",
     "CoarseDropout3D",
     "CubicSymmetry",
+    "ElasticTransform3D",
     "Flip3D",
     "GridShuffle3D",
     "Pad3D",
@@ -68,6 +69,20 @@ AXIS_NAMES_3D: tuple[AxisName3D, ...] = ("x", "y", "z")
 
 def _sampling_volume_shape(targets: TargetSet) -> tuple[int, int, int]:
     return targets.require_aligned_spatial_shape(NUM_DIMENSIONS)
+
+
+def _sample_elastic_control_coefficients(
+    control_grid_shape: tuple[int, int],
+    coefficient_radius: float,
+    random_generator: np.random.Generator,
+) -> np.ndarray:
+    random_values = random_generator.random((*control_grid_shape, 2), dtype=np.float32)
+    vector_radius = np.float32(coefficient_radius) * np.sqrt(random_values[..., 0])
+    angle = np.float32(2 * np.pi) * random_values[..., 1]
+    control_coefficients = np.empty((*control_grid_shape, 2), dtype=np.float32)
+    control_coefficients[..., 0] = vector_radius * np.cos(angle)
+    control_coefficients[..., 1] = vector_radius * np.sin(angle)
+    return control_coefficients
 
 
 class Affine3D(Transform3D):
@@ -255,6 +270,255 @@ class Affine3D(Transform3D):
 
     def apply_to_keypoints(self, keypoints: np.ndarray, matrix: np.ndarray, **params: Any) -> np.ndarray:
         return f3d.keypoints_affine_3d(keypoints, matrix)
+
+
+class ElasticTransform3D(Transform3D):
+    """Apply a smooth bounded 3D elastic deformation from compact cubic control planes, useful for volumetric
+    segmentation and anatomy-shape robustness.
+
+    The transform samples XY, XZ, and YZ cubic B-spline coefficient planes, averages their embedded displacement
+    fields, and resamples each raster target once through Albucore `remap3d`. The same compact field drives volume,
+    `mask3d`, and XYZ keypoint geometry. `displacement_range` scales coefficients by the shortest active voxel-center
+    span, so the policy transfers across volume sizes without a dense noise or smoothing pass.
+
+    Args:
+        displacement_range (tuple[float, float]): Inclusive relative coefficient-radius range. Default: `(0.02, 0.05)`.
+        control_grid_shape (tuple[int, int]): Cubic coefficient rows and columns for each plane. Default:
+            `(7, 7)`.
+        interpolation (Literal[0, 1]): Volume interpolation: `cv2.INTER_NEAREST` or `cv2.INTER_LINEAR`. Default:
+            `cv2.INTER_LINEAR`.
+        mask_interpolation (Literal[0, 1]): `mask3d` interpolation: `cv2.INTER_NEAREST` or `cv2.INTER_LINEAR`.
+            Default: `cv2.INTER_NEAREST`.
+        border_mode (Literal[0, 1]): Border policy: `cv2.BORDER_CONSTANT` or `cv2.BORDER_REPLICATE`. Default:
+            `cv2.BORDER_CONSTANT`.
+        fill (tuple[float, ...] | float): Constant fill for volume channels. Default: `0`.
+        fill_mask (tuple[float, ...] | float): Constant fill for `mask3d`. Default: `0`.
+        p (float): Probability of applying the transform. Default: `0.5`.
+
+    Targets:
+        volume, mask3d, keypoints
+
+    Image types:
+        uint8, float32
+
+    Notes:
+        - The constructor enforces `2 * high * sqrt((rows - 3)^2 + (columns - 3)^2) < 0.75`, which bounds the
+          deformation's Lipschitz constant below one.
+        - Replay stores compact coefficients and requires the same `(depth, height, width)` shape. Applied
+          configuration fixes only the realized magnitude and samples fresh coefficient planes.
+        - CPU Tensor volumes with one channel run natively; multi-channel volumes use Compose's NumPy bridge and
+          return a Tensor with the original layout.
+        - This transform changes voxel-index coordinates. Physical spacing, orientation metadata, and 3D bounding
+          boxes are outside its contract.
+
+    See Also:
+        - ElasticTransform: Applies the same bounded cubic field policy to 2D images and annotations.
+        - Affine3D: Applies global rotation, scale, and translation when local elastic deformation is unnecessary.
+
+    Examples:
+        >>> import albumentations as A
+        >>> import cv2
+        >>> import numpy as np
+        >>> volume = np.random.default_rng(137).random((16, 64, 96, 1), dtype=np.float32)
+        >>> mask3d = np.zeros((16, 64, 96), dtype=np.uint8)
+        >>> keypoints = np.array([[48.0, 32.0, 8.0]], dtype=np.float32)
+        >>> keypoint_labels = [3]
+        >>> transform = A.Compose([
+        ...     A.ElasticTransform3D(
+        ...         displacement_range=(0.02, 0.05),
+        ...         control_grid_shape=(7, 7),
+        ...         interpolation=cv2.INTER_LINEAR,
+        ...         mask_interpolation=cv2.INTER_NEAREST,
+        ...         p=1.0,
+        ...     ),
+        ... ], keypoint_params=A.KeypointParams(coord_format="xyz", label_fields=["keypoint_labels"]))
+        >>> result = transform(
+        ...     volume=volume,
+        ...     mask3d=mask3d,
+        ...     keypoints=keypoints,
+        ...     keypoint_labels=keypoint_labels,
+        ... )
+        >>> result["volume"].shape, result["mask3d"].shape, result["keypoint_labels"]
+        ((16, 64, 96, 1), (16, 64, 96), [3])
+
+    """
+
+    _runtime_generated_params = frozenset({"sampling_grid"})
+    _targets = (Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS)
+    _supports_cpu_tensor = True
+    _cpu_tensor_targets = frozenset({"volume", "mask3d"})
+    _cpu_tensor_channels = frozenset({1})
+
+    class InitSchema(BaseTransformInitSchema):
+        displacement_range: Annotated[
+            tuple[float, float],
+            AfterValidator(check_range_bounds(0)),
+            AfterValidator(nondecreasing),
+        ]
+        control_grid_shape: tuple[int, int]
+        interpolation: Literal[0, 1]
+        mask_interpolation: Literal[0, 1]
+        border_mode: Literal[0, 1]
+        fill: tuple[float, ...] | float
+        fill_mask: tuple[float, ...] | float
+
+        @field_validator("control_grid_shape")
+        @classmethod
+        def _validate_control_grid_shape(cls, value: tuple[int, int]) -> tuple[int, int]:
+            if len(value) != 2 or min(value) < 4:
+                raise ValueError("control_grid_shape must contain two dimensions, each at least 4")
+            return value
+
+        @model_validator(mode="after")
+        def _validate_topology_bound(self) -> Self:
+            rows, columns = self.control_grid_shape
+            high = self.displacement_range[1]
+            bound = 2 * high * float(np.sqrt((rows - 3) ** 2 + (columns - 3) ** 2))
+            if bound >= 0.75:
+                raise ValueError(
+                    "displacement_range and control_grid_shape violate the strict topology bound: "
+                    "2 * high * sqrt((rows - 3)^2 + (columns - 3)^2) must be less than 0.75",
+                )
+            return self
+
+    def __init__(
+        self,
+        displacement_range: tuple[float, float] = (0.02, 0.05),
+        control_grid_shape: tuple[int, int] = (7, 7),
+        interpolation: Literal[0, 1] = CV2_INTER_LINEAR,
+        mask_interpolation: Literal[0, 1] = CV2_INTER_NEAREST,
+        border_mode: Literal[0, 1] = CV2_BORDER_CONSTANT,
+        fill: tuple[float, ...] | float = 0,
+        fill_mask: tuple[float, ...] | float = 0,
+        p: float = 0.5,
+    ):
+        super().__init__(p=p)
+        self.displacement_range = displacement_range
+        self.control_grid_shape = control_grid_shape
+        self.interpolation = interpolation
+        self.mask_interpolation = mask_interpolation
+        self.border_mode = border_mode
+        self.fill = fill
+        self.fill_mask = fill_mask
+
+    def sample_parameters(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
+        sampling: SamplingContext,
+    ) -> SampledParams:
+        del params, data
+        volume_shape = _sampling_volume_shape(targets)
+        low, high = self.displacement_range
+        magnitude = low if low == high else sampling.py_random.uniform(low, high)
+        sampling.applied_overrides["displacement_range"] = (magnitude, magnitude)
+        if magnitude == 0:
+            return SampledParams(
+                params={
+                    "control_coefficients": {},
+                    "volume_shape": volume_shape,
+                }
+            )
+
+        shortest_active_span = min(axis_length - 1 for axis_length in volume_shape if axis_length > 1)
+        coefficient_radius = magnitude * shortest_active_span
+        control_coefficients = {
+            plane: _sample_elastic_control_coefficients(
+                self.control_grid_shape,
+                coefficient_radius,
+                sampling.random_generator,
+            ).tolist()
+            for plane in ("xy", "xz", "yz")
+        }
+        return SampledParams(
+            params={
+                "control_coefficients": control_coefficients,
+                "volume_shape": volume_shape,
+            }
+        )
+
+    def _apply_label_mappings_without_geometry(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        result = dict(data)
+        if "keypoints" in result and result["keypoints"] is not None:
+            result["keypoints"] = self._apply_label_mapping_to_keypoints(result["keypoints"], **params)
+        if self._semantic_mask_label_mappings:
+            result = self._apply_label_mapping_to_semantic_masks(result, **params)
+        return result
+
+    def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Build the ephemeral sampling grid once, enforce replay shape, and dispatch every target with the sampled
+        compact coefficient planes.
+        """
+        params = dict(sampled_params.params)
+        recorded_shape = tuple(params["volume_shape"])
+        if self.replay_mode:
+            current_shape = _sampling_volume_shape(self._build_target_set(kwargs))
+            if current_shape != recorded_shape:
+                raise ValueError(
+                    f"ElasticTransform3D replay requires the same spatial shape {recorded_shape}, got {current_shape}",
+                )
+        if not params["control_coefficients"]:
+            return self._apply_label_mappings_without_geometry(params, kwargs)
+
+        runtime_params = dict(params)
+        runtime_params["volume_shape"] = recorded_shape
+        runtime_params["control_coefficients"] = {
+            plane: np.asarray(coefficients, dtype=np.float32)
+            for plane, coefficients in params["control_coefficients"].items()
+        }
+        runtime_params["sampling_grid"] = f3d.create_elastic_grid_3d(
+            runtime_params["control_coefficients"],
+            recorded_shape,
+        )
+        runtime_sampled_params = SampledParams(
+            params=runtime_params,
+            target_params=sampled_params.target_params,
+            target_schema=sampled_params.target_schema,
+        )
+        return super().apply_with_params(runtime_sampled_params, *args, **kwargs)
+
+    def apply_to_volume(
+        self,
+        volume: VolumeType,
+        sampling_grid: np.ndarray,
+        **params: Any,
+    ) -> VolumeType:
+        return cast(
+            "VolumeType",
+            f3d.remap_3d(volume, sampling_grid, self.interpolation, self.border_mode, self.fill),
+        )
+
+    def apply_to_mask3d(
+        self,
+        mask3d: VolumeType,
+        sampling_grid: np.ndarray,
+        **params: Any,
+    ) -> VolumeType:
+        return cast(
+            "VolumeType",
+            f3d.remap_3d(
+                mask3d,
+                sampling_grid,
+                self.mask_interpolation,
+                self.border_mode,
+                self.fill_mask,
+                is_mask=True,
+            ),
+        )
+
+    def apply_to_keypoints(
+        self,
+        keypoints: np.ndarray,
+        control_coefficients: dict[str, np.ndarray],
+        volume_shape: tuple[int, int, int],
+        **params: Any,
+    ) -> np.ndarray:
+        return f3d.remap_elastic_keypoints_3d(keypoints, control_coefficients, volume_shape)
 
 
 class Anisotropy3D(VolumeOnlyTransform):

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -71,20 +71,6 @@ def _sampling_volume_shape(targets: TargetSet) -> tuple[int, int, int]:
     return targets.require_aligned_spatial_shape(NUM_DIMENSIONS)
 
 
-def _sample_elastic_control_coefficients(
-    control_grid_shape: tuple[int, int],
-    coefficient_radius: float,
-    random_generator: np.random.Generator,
-) -> np.ndarray:
-    random_values = random_generator.random((*control_grid_shape, 2), dtype=np.float32)
-    vector_radius = np.float32(coefficient_radius) * np.sqrt(random_values[..., 0])
-    angle = np.float32(2 * np.pi) * random_values[..., 1]
-    control_coefficients = np.empty((*control_grid_shape, 2), dtype=np.float32)
-    control_coefficients[..., 0] = vector_radius * np.cos(angle)
-    control_coefficients[..., 1] = vector_radius * np.sin(angle)
-    return control_coefficients
-
-
 class Affine3D(Transform3D):
     """Apply a sampled 3D affine mapping to volume and mask3d by rotating, scaling, and shifting
     voxel coordinates for robust medical-imaging augmentation.
@@ -423,7 +409,7 @@ class ElasticTransform3D(Transform3D):
         shortest_active_span = min(axis_length - 1 for axis_length in volume_shape if axis_length > 1)
         coefficient_radius = magnitude * shortest_active_span
         control_coefficients = {
-            plane: _sample_elastic_control_coefficients(
+            plane: fgeometric.sample_elastic_control_coefficients(
                 self.control_grid_shape,
                 coefficient_radius,
                 sampling.random_generator,

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -343,7 +343,6 @@ class ElasticTransform3D(Transform3D):
 
     """
 
-    _runtime_generated_params = frozenset({"sampling_grid"})
     _targets = (Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS)
     _supports_cpu_tensor = True
     _cpu_tensor_targets = frozenset({"volume", "mask3d"})
@@ -410,14 +409,14 @@ class ElasticTransform3D(Transform3D):
     ) -> SampledParams:
         del params, data
         volume_shape = _sampling_volume_shape(targets)
+        raster_target_count = len(targets.by_canonical_type("volume")) + len(targets.by_canonical_type("mask3d"))
         low, high = self.displacement_range
         magnitude = low if low == high else sampling.py_random.uniform(low, high)
         sampling.applied_overrides["displacement_range"] = (magnitude, magnitude)
         if magnitude == 0:
             return SampledParams(
                 params={
-                    "control_coefficients": {},
-                    "volume_shape": volume_shape,
+                    "sampler": f3d.ElasticTransform3DSampler({}, volume_shape, raster_target_count),
                 }
             )
 
@@ -433,77 +432,42 @@ class ElasticTransform3D(Transform3D):
         }
         return SampledParams(
             params={
-                "control_coefficients": control_coefficients,
-                "volume_shape": volume_shape,
+                "sampler": f3d.ElasticTransform3DSampler(
+                    control_coefficients,
+                    volume_shape,
+                    raster_target_count,
+                ),
             }
         )
-
-    def _apply_label_mappings_without_geometry(
-        self,
-        params: dict[str, Any],
-        data: dict[str, Any],
-    ) -> dict[str, Any]:
-        result = dict(data)
-        if "keypoints" in result and result["keypoints"] is not None:
-            result["keypoints"] = self._apply_label_mapping_to_keypoints(result["keypoints"], **params)
-        if self._semantic_mask_label_mappings:
-            result = self._apply_label_mapping_to_semantic_masks(result, **params)
-        return result
-
-    def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Build the ephemeral sampling grid once, enforce replay shape, and dispatch every target with the sampled
-        compact coefficient planes.
-        """
-        params = dict(sampled_params.params)
-        recorded_shape = tuple(params["volume_shape"])
-        if self.replay_mode:
-            current_shape = _sampling_volume_shape(self._build_target_set(kwargs))
-            if current_shape != recorded_shape:
-                raise ValueError(
-                    f"ElasticTransform3D replay requires the same spatial shape {recorded_shape}, got {current_shape}",
-                )
-        if not params["control_coefficients"]:
-            return self._apply_label_mappings_without_geometry(params, kwargs)
-
-        runtime_params = dict(params)
-        runtime_params["volume_shape"] = recorded_shape
-        runtime_params["control_coefficients"] = {
-            plane: np.asarray(coefficients, dtype=np.float32)
-            for plane, coefficients in params["control_coefficients"].items()
-        }
-        runtime_params["sampling_grid"] = f3d.create_elastic_grid_3d(
-            runtime_params["control_coefficients"],
-            recorded_shape,
-        )
-        runtime_sampled_params = SampledParams(
-            params=runtime_params,
-            target_params=sampled_params.target_params,
-            target_schema=sampled_params.target_schema,
-        )
-        return super().apply_with_params(runtime_sampled_params, *args, **kwargs)
 
     def apply_to_volume(
         self,
         volume: VolumeType,
-        sampling_grid: np.ndarray,
+        sampler: dict[str, Any],
         **params: Any,
     ) -> VolumeType:
         return cast(
             "VolumeType",
-            f3d.remap_3d(volume, sampling_grid, self.interpolation, self.border_mode, self.fill),
+            f3d.elastic_transform_3d(
+                volume,
+                sampler,
+                self.interpolation,
+                self.border_mode,
+                self.fill,
+            ),
         )
 
     def apply_to_mask3d(
         self,
         mask3d: VolumeType,
-        sampling_grid: np.ndarray,
+        sampler: dict[str, Any],
         **params: Any,
     ) -> VolumeType:
         return cast(
             "VolumeType",
-            f3d.remap_3d(
+            f3d.elastic_transform_3d(
                 mask3d,
-                sampling_grid,
+                sampler,
                 self.mask_interpolation,
                 self.border_mode,
                 self.fill_mask,
@@ -514,11 +478,17 @@ class ElasticTransform3D(Transform3D):
     def apply_to_keypoints(
         self,
         keypoints: np.ndarray,
-        control_coefficients: dict[str, np.ndarray],
-        volume_shape: tuple[int, int, int],
+        sampler: dict[str, Any],
         **params: Any,
     ) -> np.ndarray:
-        return f3d.remap_elastic_keypoints_3d(keypoints, control_coefficients, volume_shape)
+        control_coefficients = sampler["control_coefficients"]
+        if not control_coefficients:
+            return keypoints
+        return f3d.remap_elastic_keypoints_3d(
+            keypoints,
+            control_coefficients,
+            tuple(sampler["volume_shape"]),
+        )
 
 
 class Anisotropy3D(VolumeOnlyTransform):

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -7,6 +7,7 @@ such as spatial dimensions, apply dropout effects, and perform symmetry operatio
 interface and implements specific 3D augmentation logic.
 """
 
+from collections.abc import Mapping
 from typing import Annotated, Any, ClassVar, Final, Literal, cast
 
 import numpy as np
@@ -330,9 +331,6 @@ class ElasticTransform3D(Transform3D):
     """
 
     _targets = (Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS)
-    _supports_cpu_tensor = True
-    _cpu_tensor_targets = frozenset({"volume", "mask3d"})
-    _cpu_tensor_channels = frozenset({1})
 
     class InitSchema(BaseTransformInitSchema):
         displacement_range: Annotated[
@@ -428,8 +426,8 @@ class ElasticTransform3D(Transform3D):
 
     def apply_to_volume(
         self,
-        volume: VolumeType,
-        sampler: dict[str, Any],
+        volume: VolumeType | torch.Tensor,
+        sampler: Mapping[str, Any],
         **params: Any,
     ) -> VolumeType:
         return cast(
@@ -445,8 +443,8 @@ class ElasticTransform3D(Transform3D):
 
     def apply_to_mask3d(
         self,
-        mask3d: VolumeType,
-        sampler: dict[str, Any],
+        mask3d: VolumeType | torch.Tensor,
+        sampler: Mapping[str, Any],
         **params: Any,
     ) -> VolumeType:
         return cast(
@@ -464,7 +462,7 @@ class ElasticTransform3D(Transform3D):
     def apply_to_keypoints(
         self,
         keypoints: np.ndarray,
-        sampler: dict[str, Any],
+        sampler: Mapping[str, Any],
         **params: Any,
     ) -> np.ndarray:
         control_coefficients = sampler["control_coefficients"]

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -60,7 +60,7 @@ from .tensor import (
 from .tracing import TraceOptions, TraceResult, _ExecutionTrace
 from .transforms_interface import BasicTransform, DualTransform
 from .type_definitions import StackedMasks4D, Targets
-from .utils import DataProcessor, format_args, get_shape
+from .utils import DataProcessor, format_args, get_shape, get_volume_shape
 
 __all__ = [
     "BaseCompose",
@@ -2528,7 +2528,7 @@ class Compose(BaseCompose, HubMixin):
             if data_value.ndim not in {3, 4}:  # (D,H,W) or (D,H,W,C)
                 raise TypeError(f"{data_name} must be 3D or 4D array")
             shapes.append(data_value.shape[1:3])  # H,W
-            volume_shapes.append(data_value.shape[:3])  # D,H,W
+            volume_shapes.append(get_volume_shape(data_value))
 
     @staticmethod
     def _process_tensor_data_shape(
@@ -2543,7 +2543,7 @@ class Compose(BaseCompose, HubMixin):
         if data_name in {"image", "images", "mask", "masks", "volume", "mask3d"}:
             shapes.append(tuple(data_value.shape[-2:]))
         if data_name in {"volume", "mask3d"}:
-            volume_shapes.append(tuple(data_value.shape[-3:]))
+            volume_shapes.append(get_volume_shape(data_value))
 
     def _validate_data(self, data: dict[str, Any]) -> None:
         """Validate input data keys and arguments. When strict, checks every key is in

--- a/albumentations/core/transform_params.py
+++ b/albumentations/core/transform_params.py
@@ -13,6 +13,7 @@ import torch
 from albucore import MAX_VALUES_BY_DTYPE
 
 from .type_definitions import Targets
+from .utils import get_volume_shape
 
 _TARGET_ORDER = {
     "image": 0,
@@ -433,7 +434,12 @@ def _target_sort_key(descriptor: TargetDescriptor) -> tuple[int, int, str]:
 def _describe_target(name: str, canonical_type: str, value: Any) -> TargetDescriptor:
     shape = tuple(int(dim) for dim in value.shape) if hasattr(value, "shape") else None
     dtype = getattr(value, "dtype", None)
-    return _describe_target_cached(name, canonical_type, shape, dtype, isinstance(value, torch.Tensor))
+    volume_shape = (
+        get_volume_shape(value)
+        if canonical_type in {"volume", "mask3d"} and isinstance(value, np.ndarray | torch.Tensor)
+        else None
+    )
+    return _describe_target_cached(name, canonical_type, shape, dtype, isinstance(value, torch.Tensor), volume_shape)
 
 
 def _value_scale(dtype: Any) -> float | None:
@@ -452,6 +458,7 @@ def _describe_target_cached(
     shape: tuple[int, ...] | None,
     dtype: Any,
     tensor: bool,
+    volume_shape: tuple[int, int, int] | None,
 ) -> TargetDescriptor:
     layout = canonical_type
     topology = canonical_type
@@ -468,7 +475,7 @@ def _describe_target_cached(
             channels = shape[1] if tensor else (shape[-1] if len(shape) > 3 else 1)
             layout, topology = ("images_nchw", "batch_2d") if tensor else ("images_nhwc", "batch_2d")
         elif canonical_type == "volume":
-            spatial_shape = shape[1:] if tensor else shape[:3]
+            spatial_shape = volume_shape
             channels = shape[0] if tensor else (shape[-1] if len(shape) > 3 else 1)
             layout, topology = ("volume_cdhw", "volume_3d") if tensor else ("volume_dhwc", "volume_3d")
         elif canonical_type == "mask":
@@ -480,7 +487,7 @@ def _describe_target_cached(
             channels = shape[1] if tensor else (shape[-1] if len(shape) > 3 else 1)
             layout, topology = ("masks_nchw", "batch_mask_2d") if tensor else ("masks_nhwc", "batch_mask_2d")
         elif canonical_type == "mask3d":
-            spatial_shape = shape[1:] if tensor else shape[:3]
+            spatial_shape = volume_shape
             channels = shape[0] if tensor else (shape[-1] if len(shape) > 3 else 1)
             layout, topology = ("mask3d_cdhw", "mask_3d") if tensor else ("mask3d_dhwc", "mask_3d")
 

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -1775,6 +1775,18 @@ class DualTransform(BasicTransform):
 
         return keypoints
 
+    def _apply_label_mappings_without_dispatch(
+        self,
+        params: Mapping[str, Any],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
+        result = dict(data)
+        if "keypoints" in result and result["keypoints"] is not None:
+            result["keypoints"] = self._apply_label_mapping_to_keypoints(result["keypoints"], **params)
+        if self._semantic_mask_label_mappings:
+            result = self._apply_label_mapping_to_semantic_masks(result, **params)
+        return result
+
     def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply a dual transform with its parameters, including configured keypoint and transform-aware
         semantic-mask label mappings.

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -65,7 +65,7 @@ from .type_definitions import (
     Targets,
     VolumeType,
 )
-from .utils import format_args
+from .utils import format_args, get_volume_shape
 
 __all__ = [
     "BasicTransform",
@@ -1161,14 +1161,20 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
 
     @staticmethod
     def _shared_shape_from_data_key(key: str, value: Any) -> tuple[int, ...]:
+        if key in {"volume", "mask3d"}:
+            _, height, width = get_volume_shape(value)
+            channel_count = value.shape[0] if isinstance(value, torch.Tensor) else value.shape[-1]
+            return (
+                (height, width, channel_count)
+                if isinstance(value, torch.Tensor) or value.ndim == 4
+                else (height, width)
+            )
         if not isinstance(value, torch.Tensor):
             return value.shape if key in {"image", "mask"} else value.shape[1:]
         if key in {"image", "mask"}:
             return value.shape[1], value.shape[2], value.shape[0]
         if key in {"images", "masks"}:
             return value.shape[2], value.shape[3], value.shape[1]
-        if key in {"volume", "mask3d"}:
-            return value.shape[2], value.shape[3], value.shape[0]
         return value.shape[1:]
 
     def _extract_shared_shape_from_data(self, data: dict[str, Any]) -> tuple[int, ...] | None:

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -1775,18 +1775,6 @@ class DualTransform(BasicTransform):
 
         return keypoints
 
-    def _apply_label_mappings_without_dispatch(
-        self,
-        params: Mapping[str, Any],
-        data: dict[str, Any],
-    ) -> dict[str, Any]:
-        result = dict(data)
-        if "keypoints" in result and result["keypoints"] is not None:
-            result["keypoints"] = self._apply_label_mapping_to_keypoints(result["keypoints"], **params)
-        if self._semantic_mask_label_mappings:
-            result = self._apply_label_mapping_to_semantic_masks(result, **params)
-        return result
-
     def apply_with_params(self, sampled_params: SampledParams, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Apply a dual transform with its parameters, including configured keypoint and transform-aware
         semantic-mask label mappings.

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -9,7 +9,7 @@ the transformation pipeline.
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar, cast
 
 import numpy as np
 import torch
@@ -17,6 +17,7 @@ import torch
 from albumentations.core.label_manager import LabelManager
 
 from .serialization import Serializable
+from .type_definitions import NUM_VOLUME_DIMENSIONS
 
 
 def get_shape(data: dict[str, Any]) -> tuple[int, int]:
@@ -73,13 +74,16 @@ def get_image_data(data: dict[str, Any]) -> dict[str, Any]:
                 height, width = shape[2], shape[3]
                 num_channels = int(shape[1])
             else:
-                height, width = shape[2], shape[3]
+                _, height, width = get_volume_shape(array)
                 num_channels = int(shape[0])
         elif target == "image":
             height, width = shape[0], shape[1]
             num_channels = shape[-1]
-        else:
+        elif target == "images":
             height, width = shape[1], shape[2]
+            num_channels = shape[-1]
+        else:
+            _, height, width = get_volume_shape(array)
             num_channels = shape[-1]
         return {
             "dtype": array.dtype,
@@ -90,33 +94,18 @@ def get_image_data(data: dict[str, Any]) -> dict[str, Any]:
     raise ValueError("No valid image/volume data found in data dict")
 
 
-def _volume_shape_from_array(vol: Any) -> tuple[int, int, int]:
-    """Return (D, H, W) from a single volume array, handling both torch CDHW/DHW layouts
-    and numpy DHWC/DHW layouts. Private helper for `get_volume_shape`.
+def get_volume_shape(volume: np.ndarray | torch.Tensor) -> tuple[int, int, int]:
+    """Return `(D, H, W)` from a volume in its canonical container layout.
+
+    NumPy volumes are `(D, H, W, C)` and Tensor volumes are `(C, D, H, W)` inside Compose. Channel-less `(D, H, W)`
+    arrays are retained for direct functional calls.
     """
-    if isinstance(vol, torch.Tensor):
-        return vol.shape[1], vol.shape[2], vol.shape[3]
-    return vol.shape[0], vol.shape[1], vol.shape[2]
-
-
-def get_volume_shape(data: dict[str, Any]) -> tuple[int, int, int] | None:
-    """Extract depth, height, and width dimensions from canonical volume data when present for spatial annotation
-    processing steps.
-
-    Handles PyTorch tensor layouts (CDHW) and numpy layouts (DHWC).
-
-    Args:
-        data (dict[str, Any]): Dictionary containing volume data
-
-    Returns:
-        tuple[int, int, int] | None: (depth, height, width) dimensions if volume data exists, None otherwise
-
-    """
-    volume = data.get("volume")
-    if volume is not None:
-        return _volume_shape_from_array(volume)
-
-    return None
+    if volume.ndim == NUM_VOLUME_DIMENSIONS - 1:
+        return cast("tuple[int, int, int]", tuple(volume.shape))
+    return cast(
+        "tuple[int, int, int]",
+        tuple(volume.shape[1:] if isinstance(volume, torch.Tensor) else volume.shape[:-1]),
+    )
 
 
 def _get_shape_from_image(img: np.ndarray | torch.Tensor) -> tuple[int, int]:
@@ -141,10 +130,8 @@ def _get_shape_from_volume(vol: np.ndarray | torch.Tensor) -> tuple[int, int]:
     """Extract (height, width) from a single volume (D,H,W or D,H,W,C). Private helper for
     get_shape when data has 'volume' key.
     """
-    if isinstance(vol, torch.Tensor):
-        return vol.shape[2], vol.shape[3]
-    # Regular numpy array in DHWC format
-    return vol.shape[1], vol.shape[2]
+    _, height, width = get_volume_shape(vol)
+    return height, width
 
 
 def format_args(args_dict: dict[str, Any]) -> str:
@@ -277,9 +264,9 @@ class DataProcessor(ABC, Generic[ParamsT]):
 
         # For xyz keypoints, get full 3D shape if available
         if hasattr(self.params, "coord_format") and self.params.coord_format == "xyz":
-            volume_shape = get_volume_shape(data)
-            if volume_shape is not None:
-                shape = volume_shape
+            volume = data.get("volume")
+            if volume is not None:
+                shape = get_volume_shape(volume)
 
         data = self._process_data_fields(data, shape, filter_already_applied=filter_already_applied)
         return self.remove_label_fields_from_data(data)

--- a/benchmark/benchmarks/catalog.py
+++ b/benchmark/benchmarks/catalog.py
@@ -57,6 +57,10 @@ PARAM_OVERRIDES: Mapping[str, Mapping[str, Any]] = {
         "scale_range": {"x": (1.05, 1.05), "y": (0.95, 0.95), "z": (1.0, 1.0)},
         "translate_percent_range": {"x": (0.02, 0.02), "y": (-0.02, -0.02), "z": (0.0, 0.0)},
     },
+    "ElasticTransform3D": {
+        "control_grid_shape": (7, 7),
+        "displacement_range": (0.05, 0.05),
+    },
     "CenterCrop": {"height": 96, "width": 96},
     "CenterCrop3D": {"size": (4, 48, 48)},
     "ConstrainedCoarseDropout": {"mask_indices": [1]},

--- a/benchmark/benchmarks/test_family_matrix.py
+++ b/benchmark/benchmarks/test_family_matrix.py
@@ -300,6 +300,11 @@ VOLUME_TRANSFORMS: Mapping[str, Factory] = {
     "pad3d": lambda: albumentations.Pad3D(padding=(1, 2, 2), p=1.0),
     "pad_if_needed3d": lambda: albumentations.PadIfNeeded3D(min_zyx=(18, 144, 144), p=1.0),
     "coarse_dropout3d": lambda: albumentations.CoarseDropout3D(p=1.0),
+    "elastic3d": lambda: albumentations.ElasticTransform3D(
+        displacement_range=(0.05, 0.05),
+        control_grid_shape=(7, 7),
+        p=1.0,
+    ),
     "grid_shuffle3d": lambda: albumentations.GridShuffle3D(grid_zyx=(2, 2, 2), p=1.0),
     "cubic_symmetry": lambda: albumentations.CubicSymmetry(p=1.0),
     "flip3d": lambda: albumentations.Flip3D(flip_axes=(0, 1, 2), p=1.0),

--- a/benchmark/benchmarks/test_functional_kernels.py
+++ b/benchmark/benchmarks/test_functional_kernels.py
@@ -57,6 +57,7 @@ FUNCTIONAL_GEOMETRY_ANNOTATION_COUNTS: Mapping[str, tuple[int, ...]] = {
 FUNCTIONAL_3D_KERNELS = (
     "affine_3d",
     "anisotropy_3d",
+    "elastic_3d",
     "resize3d",
     "crop3d",
     "pad_3d_with_params",
@@ -468,6 +469,17 @@ def _call_anisotropy_3d(benchmark: Any) -> np.ndarray:
     return f3d.anisotropy_3d(benchmark.volume, benchmark.anisotropy_downsample_shape, antialias=True)
 
 
+def _call_elastic_3d(benchmark: Any) -> np.ndarray:
+    sampling_grid = f3d.create_elastic_grid_3d(benchmark.elastic_control_coefficients, benchmark.volume.shape[:3])
+    return f3d.remap_3d(
+        benchmark.volume,
+        sampling_grid,
+        cv2.INTER_LINEAR,
+        cv2.BORDER_CONSTANT,
+        0,
+    )
+
+
 def _call_resize3d(benchmark: Any) -> np.ndarray:
     return resize3d(benchmark.volume, benchmark.resize_shape, cv2.INTER_LINEAR)
 
@@ -495,6 +507,7 @@ def _call_rician_noise(benchmark: Any) -> np.ndarray:
 FUNCTIONAL_3D_CALLS: Mapping[str, ImageKernelCall] = {
     "affine_3d": _call_affine_3d,
     "anisotropy_3d": _call_anisotropy_3d,
+    "elastic_3d": _call_elastic_3d,
     "resize3d": _call_resize3d,
     "crop3d": _call_crop3d,
     "pad_3d_with_params": _call_pad_3d_with_params,
@@ -646,12 +659,15 @@ class TimeFunctional3DKernels:
             {"x": 3.0, "y": -2.0, "z": 5.0},
             self.volume.shape[:3],
         )
+        rng = np.random.default_rng(137 + depth + height + width)
+        self.elastic_control_coefficients = {
+            plane: rng.uniform(-0.25, 0.25, (7, 7, 2)).astype(np.float32) for plane in ("xy", "xz", "yz")
+        }
         self.crop_coords = (1, depth - 1, height // 4, height * 3 // 4, width // 4, width * 3 // 4)
         self.holes = np.array(
             [[1, height // 4, width // 4, min(depth - 1, 4), height // 2, width // 2]],
             dtype=np.int32,
         )
-        rng = np.random.default_rng(137 + depth + height + width)
         self.tiles = f3d.split_uniform_grid_3d((depth, height, width), (2, 2, 2), rng)
         shape_groups = f3d.create_shape_groups_3d(self.tiles)
         self.mapping = f3d.shuffle_tiles_within_shape_groups_3d(shape_groups, rng)

--- a/benchmark/pytorch_benchmarks/test_tensor.py
+++ b/benchmark/pytorch_benchmarks/test_tensor.py
@@ -287,11 +287,7 @@ class TimeTensorNativeAffine3D:
 
 
 class TimeTensorElasticTransform3D:
-    """Benchmark Tensor `ElasticTransform3D(volume=...)` with the native C=1 route and C=3/C=5 NumPy bridges.
-
-    The direct Tensor route uses C,D,H,W single-volume data. Its NumPy comparison paths use
-    the matching D,H,W,C volume and the normal `ToTensor3D` handoff.
-    """
+    """Benchmark native Tensor `ElasticTransform3D(volume=...)` across the supported volume matrix."""
 
     params = (TENSOR_NATIVE_VOLUME_CASES,)
     param_names = ("case_id",)

--- a/benchmark/pytorch_benchmarks/test_tensor.py
+++ b/benchmark/pytorch_benchmarks/test_tensor.py
@@ -284,3 +284,53 @@ class TimeTensorNativeAffine3D:
 
     def peakmem_tensor_direct(self, case_id: str) -> None:
         self.tensor_direct(volume=self.tensor)
+
+
+class TimeTensorElasticTransform3D:
+    """Benchmark Tensor `ElasticTransform3D(volume=...)` with the native C=1 route and C=3/C=5 NumPy bridges.
+
+    The direct Tensor route uses C,D,H,W single-volume data. Its NumPy comparison paths use
+    the matching D,H,W,C volume and the normal `ToTensor3D` handoff.
+    """
+
+    params = (TENSOR_NATIVE_VOLUME_CASES,)
+    param_names = ("case_id",)
+
+    def setup(self, case_id: str) -> None:
+        size_name, channels, dtype_name = _parse_image_case(case_id)
+        self.volume = make_volume(size_name, channels, dtype_from_name(dtype_name))
+        self.mask3d = make_mask3d(size_name)
+        self.tensor = torch.from_numpy(np.ascontiguousarray(self.volume.transpose(3, 0, 1, 2)))
+        self.tensor_mask3d = torch.from_numpy(self.mask3d)
+        transform_kwargs = {
+            "displacement_range": (0.05, 0.05),
+            "control_grid_shape": (7, 7),
+            "p": 1.0,
+        }
+        elastic = albumentations.ElasticTransform3D(**transform_kwargs)
+        self.numpy_direct = albumentations.Compose([elastic], seed=137, strict=True)
+        self.numpy_model_ready = albumentations.Compose(
+            [elastic, albumentations.ToTensor3D(p=1.0)],
+            seed=137,
+            strict=True,
+        )
+        self.tensor_direct = albumentations.Compose(
+            [albumentations.ElasticTransform3D(**transform_kwargs)],
+            seed=137,
+            strict=True,
+        )
+
+    def time_numpy_direct(self, case_id: str) -> None:
+        self.numpy_direct(volume=self.volume)
+
+    def time_numpy_model_ready(self, case_id: str) -> None:
+        self.numpy_model_ready(volume=self.volume, mask3d=self.mask3d)
+
+    def time_tensor_direct(self, case_id: str) -> None:
+        self.tensor_direct(volume=self.tensor)
+
+    def time_tensor_and_mask3d(self, case_id: str) -> None:
+        self.tensor_direct(volume=self.tensor, mask3d=self.tensor_mask3d)
+
+    def peakmem_tensor_direct(self, case_id: str) -> None:
+        self.tensor_direct(volume=self.tensor)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -38,6 +38,11 @@ parameter.
 Implemented contract for the greenfield 2D elastic transform: bounded cubic B-spline coefficient grids, synchronized
 targets, certificate-bounded keypoint inversion, and separate constructor, applied-config, and `ReplayCompose` persistence rules.
 
+### [ElasticTransform3D](elastic-transform3d.md)
+
+Implemented true 3D elastic deformation from compact orthogonal cubic control planes, one `remap3d` call per raster target,
+a native CPU Tensor route for one channel, and a measured NumPy bridge for multi-channel volumes.
+
 ### [Generated Transform Target Contracts](transform-target-contracts.md)
 
 Coverage contract for the shared transform-case registry and reusable target profiles.

--- a/docs/design/elastic-transform.md
+++ b/docs/design/elastic-transform.md
@@ -7,9 +7,9 @@ all synchronized targets. The field is sampled from a compact cubic B-spline
 coefficient lattice. Map construction therefore depends on the lattice and the
 output shape, not on a full-resolution random-noise sample.
 
-True 3D elastic deformation is a separate follow-up. The current transform
-applies its 2D XY map to every depth slice. A future 3D transform will wait for
-a tested dense 3D remap primitive in Albucore.
+For deformation that also moves voxels along depth, use
+[ElasticTransform3D](elastic-transform3d.md). `ElasticTransform` deliberately
+keeps its slice-consistent XY contract for volumes.
 
 ## Public contract
 

--- a/docs/design/elastic-transform3d.md
+++ b/docs/design/elastic-transform3d.md
@@ -1,0 +1,99 @@
+# ElasticTransform3D: bounded smooth volume deformation
+
+**Status:** implemented
+
+## Overview
+
+`ElasticTransform3D` applies one smooth XYZ pull field to a volume, `mask3d`, and XYZ keypoints. It samples compact cubic B-spline coefficient planes, expands them into one normalized `(D, H, W, 3)` sampling grid, and calls Albucore `remap3d` once for each raster target.
+
+Use it when a label remains valid under small, smooth changes to volumetric anatomy or acquisition geometry. It changes voxel-index coordinates only. Voxel spacing, orientation metadata, and 3D bounding boxes are outside this transform's contract.
+
+## Problem Statement
+
+Applying the 2D `ElasticTransform` map to every depth slice leaves depth unchanged. A true 3D deformation needs each displacement component to depend on depth, height, and width.
+
+Generating dense 3D random noise and smoothing it pays for full-resolution random generation, a 3D filter, intermediate fields, and resampling. `ElasticTransform3D` instead builds its field from three compact orthogonal control planes. The representation cannot model arbitrary local three-way variation. That limit keeps the field smooth, bounded, and inexpensive to construct.
+
+## Design Principles
+
+### One compact field defines all geometry
+
+Each invocation samples one magnitude and three coefficient planes: XY, XZ, and YZ. The transform averages their contributions, so identical sampled geometry drives every volume, mask, and keypoint target.
+
+### The deformation remains bounded and invertible
+
+`displacement_range=(low, high)` is relative to the shortest positive voxel-center span. For sampled magnitude `m`, every control vector has radius at most `m * shortest_span`. The constructor accepts only configurations satisfying:
+
+```text
+2 * high * sqrt((rows - 3)^2 + (columns - 3)^2) < 0.75
+```
+
+The bound is strict. It keeps the continuous pull map in the supported no-fold regime and permits a fixed-point inverse for keypoints.
+
+### The hot path avoids redundant dense work
+
+The implementation samples `2 * rows * columns` values per control plane, expands only 2D planes, and adds each result directly into the final sampling grid. It does not create dense 3D random noise, run 3D smoothing, allocate a separate dense displacement volume, create a meshgrid, or resample once per plane.
+
+### Tensor input follows the measured faster route
+
+NumPy volumes use `(D, H, W, C)`. CPU Tensor `volume` and `mask3d` inputs with one channel use `(C, D, H, W)` and `(D, H, W)` directly. Multi-channel Tensor volumes use Compose's single NumPy bridge and return in `(C, D, H, W)` layout because that route is faster or equally fast on the measured matrix.
+
+The current routing decision was measured on 2026-08-28 on an Apple M4 Max with Torch restricted to one CPU thread. Three ABBA pairs covered the standard `(8, 64, 64)` and `(16, 128, 128)` volumes; C=1, C=3, and C=5; and `uint8` and `float32`. C=1 stayed within 4% of the bridge. C=3 included a 14% native slowdown, and C=5 was 20–41% slower natively, so only C=1 stays direct. The Tensor ASV lane tracks the standard volume cases. A routing decision for a larger volume requires a separate ABBA run.
+
+## Implementation
+
+### Public API
+
+```python
+A.ElasticTransform3D(
+    displacement_range=(0.02, 0.05),
+    control_grid_shape=(7, 7),
+    interpolation=cv2.INTER_LINEAR,
+    mask_interpolation=cv2.INTER_NEAREST,
+    border_mode=cv2.BORDER_CONSTANT,
+    fill=0,
+    fill_mask=0,
+    p=0.5,
+)
+```
+
+`control_grid_shape=(rows, columns)` contains cubic B-spline coefficients. Both dimensions must be at least four. `interpolation` selects volume resampling, while the cubic field basis remains fixed.
+
+### Field construction and coordinate convention
+
+For output coordinate `q = (x, y, z)`, the source coordinate is `S(q) = q + d(q)`. Positive displacement samples from a larger source coordinate. Let `V_xy`, `V_xz`, and `V_yz` be the three plane fields embedded in XYZ vector space. The final displacement is:
+
+```text
+d(z, y, x) = mean(V_xy(y, x), V_xz(z, x), V_yz(z, y))
+```
+
+where the mean includes all three planes.
+
+The functional layer converts this pull map to Albucore's normalized `(x, y, z)` grid once. `remap3d` receives the grid and the public interpolation, border, and fill settings.
+
+### Targets and persistence
+
+- `volume` uses `interpolation`, `border_mode`, and `fill`.
+- `mask3d` uses `mask_interpolation`, `border_mode`, and `fill_mask`; channel-less integer masks retain their dtype.
+- Keypoints use a bounded fixed-point inverse of `S`. Accepted rows have forward residual at most `1e-3` voxel units, and trailing keypoint columns remain unchanged.
+- `ReplayCompose` stores compact coefficient planes and the input spatial shape. It reproduces the geometry for the same shape and raises `ValueError` for another shape.
+- Applied configuration records the realized magnitude as `displacement_range=(m, m)` and samples fresh coefficient planes when reconstructed.
+
+## Testing Strategy
+
+Focused tests cover constructor validation, the strict topology boundary, every supported raster dtype path, fill behavior, target alignment, keypoint inversion, exact identity, seeded execution, strict-JSON replay, applied-configuration reconstruction, additional targets, and native Tensor output parity.
+
+The permanent ASV coverage has two layers:
+
+- `TimeVolumetricFullMatrix` runs the public Compose route over the standard volume size and dtype matrix.
+- `TimeFunctional3DKernels` measures complete grid construction plus `remap3d`, so a field-only speedup cannot hide a slower resampling route.
+
+External MONAI and TorchIO transforms use dense Gaussian and full 3D B-spline fields, respectively. Their public parameters do not express this transform's bounded orthogonal-plane field exactly. Compare them only under a documented matched-workload protocol; do not call a diagnostic timing result semantic equivalence.
+
+## References
+
+- [Issue #327: ElasticTransform3D design](https://github.com/albumentations-team/AlbumentationsX/issues/327)
+- [Bounded 2D ElasticTransform](elastic-transform.md)
+- [Applied configuration and replay contracts](applied-config-replay-contracts.md)
+- [Torch CPU backend and Tensor-native Compose](torch-cpu-backend-migration.md)
+- [Albucore](https://github.com/albumentations-team/albucore)

--- a/docs/design/elastic-transform3d.md
+++ b/docs/design/elastic-transform3d.md
@@ -69,7 +69,7 @@ d(z, y, x) = mean(V_xy(y, x), V_xz(z, x), V_yz(z, y))
 
 where the mean includes all three planes.
 
-The functional layer converts this pull map to Albucore's normalized `(x, y, z)` grid once. `remap3d` receives the grid and the public interpolation, border, and fill settings.
+The sampler converts the compact planes to Albucore's normalized `(x, y, z)` grid once and passes it to every raster target. `ReplayCompose` persists only the compact sampler data and rebuilds the grid after a JSON round trip.
 
 ### Targets and persistence
 

--- a/docs/design/elastic-transform3d.md
+++ b/docs/design/elastic-transform3d.md
@@ -34,11 +34,11 @@ The bound is strict. It keeps the continuous pull map in the supported no-fold r
 
 The implementation samples `2 * rows * columns` values per control plane, expands only 2D planes, and adds each result directly into the final sampling grid. It does not create dense 3D random noise, run 3D smoothing, allocate a separate dense displacement volume, create a meshgrid, or resample once per plane.
 
-### Tensor input follows the measured faster route
+### Tensor execution follows the selected handler
 
-NumPy volumes use `(D, H, W, C)`. CPU Tensor `volume` and `mask3d` inputs with one channel use `(C, D, H, W)` and `(D, H, W)` directly. Multi-channel Tensor volumes use Compose's single NumPy bridge and return in `(C, D, H, W)` layout because that route is faster or equally fast on the measured matrix.
+NumPy volumes use `(D, H, W, C)`. CPU Tensor volumes use `(C, D, H, W)`; `mask3d` accepts `(D, H, W)` or `(C, D, H, W)`. `ElasticTransform3D` declares Tensor input on its volume and mask handlers, so Albucore `remap3d` executes those targets directly for every accepted channel count. The target container and layout are unchanged at the public boundary.
 
-The current routing decision was measured on 2026-08-28 on an Apple M4 Max with Torch restricted to one CPU thread. Three ABBA pairs covered the standard `(8, 64, 64)` and `(16, 128, 128)` volumes; C=1, C=3, and C=5; and `uint8` and `float32`. C=1 stayed within 4% of the bridge. C=3 included a 14% native slowdown, and C=5 was 20–41% slower natively, so only C=1 stays direct. The Tensor ASV lane tracks the standard volume cases. A routing decision for a larger volume requires a separate ABBA run.
+The routing rule belongs to the base transform layer: it inspects the handler receiving each Tensor target. A handler without a Tensor annotation uses its existing NumPy lifecycle through a leaf-local bridge. `Compose` validates Tensor inputs and normalizes optional channels; it does not select Elastic3D's backend route.
 
 ## Implementation
 
@@ -81,7 +81,7 @@ The sampler converts the compact planes to Albucore's normalized `(x, y, z)` gri
 
 ## Testing Strategy
 
-Focused tests cover constructor validation, the strict topology boundary, every supported raster dtype path, fill behavior, target alignment, keypoint inversion, exact identity, seeded execution, strict-JSON replay, applied-configuration reconstruction, additional targets, and native Tensor output parity.
+Focused tests cover constructor validation, the strict topology boundary, every supported raster dtype path, fill behavior, target alignment, keypoint inversion, exact identity, seeded execution, strict-JSON replay, applied-configuration reconstruction, additional targets, and native Tensor output parity for one, three, and five channels.
 
 The permanent ASV coverage has two layers:
 
@@ -95,5 +95,5 @@ External MONAI and TorchIO transforms use dense Gaussian and full 3D B-spline fi
 - [Issue #327: ElasticTransform3D design](https://github.com/albumentations-team/AlbumentationsX/issues/327)
 - [Bounded 2D ElasticTransform](elastic-transform.md)
 - [Applied configuration and replay contracts](applied-config-replay-contracts.md)
-- [Torch CPU backend and Tensor-native Compose](torch-cpu-backend-migration.md)
+- [NumPy and CPU Tensor Transform Routing](numpy-tensor-routing.md)
 - [Albucore](https://github.com/albumentations-team/albucore)

--- a/tests/contracts/test_image_range_contract.py
+++ b/tests/contracts/test_image_range_contract.py
@@ -90,7 +90,8 @@ def test_range_preserving_transforms_keep_normalized_image_targets_in_range(
             continue
         image = result[target]
         max_value = np.iinfo(image.dtype).max if image.dtype == np.uint8 else 1.0
+        range_tolerance = np.finfo(np.float32).eps if image.dtype == np.float32 else 0
         assert image.dtype in (np.uint8, np.float32), f"{case.case_id}: {target} returned {image.dtype}"
         assert np.isfinite(image).all(), f"{case.case_id}: {target} contains non-finite values"
-        assert image.min() >= 0, f"{case.case_id}: {target} has values below zero"
-        assert image.max() <= max_value, f"{case.case_id}: {target} exceeds {max_value}"
+        assert image.min() >= -range_tolerance, f"{case.case_id}: {target} has values below zero"
+        assert image.max() <= max_value + range_tolerance, f"{case.case_id}: {target} exceeds {max_value}"

--- a/tests/contracts/test_image_range_contract.py
+++ b/tests/contracts/test_image_range_contract.py
@@ -90,8 +90,7 @@ def test_range_preserving_transforms_keep_normalized_image_targets_in_range(
             continue
         image = result[target]
         max_value = np.iinfo(image.dtype).max if image.dtype == np.uint8 else 1.0
-        range_tolerance = np.finfo(np.float32).eps if image.dtype == np.float32 else 0
         assert image.dtype in (np.uint8, np.float32), f"{case.case_id}: {target} returned {image.dtype}"
         assert np.isfinite(image).all(), f"{case.case_id}: {target} contains non-finite values"
-        assert image.min() >= -range_tolerance, f"{case.case_id}: {target} has values below zero"
-        assert image.max() <= max_value + range_tolerance, f"{case.case_id}: {target} exceeds {max_value}"
+        assert image.min() >= 0, f"{case.case_id}: {target} has values below zero"
+        assert image.max() <= max_value, f"{case.case_id}: {target} exceeds {max_value}"

--- a/tests/files/public_transform_positional_parameters.json
+++ b/tests/files/public_transform_positional_parameters.json
@@ -3,6 +3,7 @@
   "AdvancedBlur": ["blur_range", "sigma_x_range", "sigma_y_range", "rotate_range", "beta_range", "noise_range", "p"],
   "Affine": ["scale", "translate_percent", "translate_px", "rotate", "shear", "interpolation", "mask_interpolation", "fit_output", "keep_ratio", "rotate_method", "balanced_scale", "border_mode", "fill", "fill_mask", "p"],
   "Affine3D": ["rotate_range", "scale_range", "translate_percent_range", "interpolation", "mask_interpolation", "border_mode", "fill", "fill_mask", "p"],
+  "ElasticTransform3D": ["displacement_range", "control_grid_shape", "interpolation", "mask_interpolation", "border_mode", "fill", "fill_mask", "p"],
   "Anisotropy3D": ["axes", "num_axes_range", "downscale_factor_range", "antialias", "p"],
   "AnnotationArtifacts": ["element_types", "element_probabilities", "count_range", "text_length_range", "font_scale_range", "thickness_range", "size_ratio_range", "line_length_ratio_range", "tip_length_range", "corner_prob", "black_white_prob", "p"],
   "AtLeastOneBBoxRandomCrop": ["height", "width", "erosion_factor", "p"],

--- a/tests/helpers/target_profiles.py
+++ b/tests/helpers/target_profiles.py
@@ -14,6 +14,7 @@ import numpy as np
 import torch
 
 import albumentations as A
+from albumentations.core.utils import get_volume_shape
 from tests.helpers.contract_data import (
     ContractDataFactory,
     make_target_empty_hbb_data,
@@ -133,7 +134,7 @@ def _assert_volume_mask3d(
         depth_axis = -3 if isinstance(volume, torch.Tensor) else 0
         assert volume.shape[depth_axis] == source["volume"].shape[depth_axis]
         assert mask3d.shape[-3] == source["mask3d"].shape[-3]
-    spatial_shape = volume.shape[-3:] if isinstance(volume, torch.Tensor) else volume.shape[:3]
+    spatial_shape = get_volume_shape(volume)
     assert spatial_shape == mask3d.shape[-3:]
     assert volume.dtype == source["volume"].dtype
     assert mask3d.dtype == source["mask3d"].dtype

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -613,6 +613,18 @@ _BASE_CASE_SPECS: list[list[Any]] = [
     ],
     [A.Resize3D, {"size": (2, 30, 30), "interpolation": cv2.INTER_NEAREST, "mask_interpolation": cv2.INTER_LINEAR}],
     [
+        A.ElasticTransform3D,
+        {
+            "displacement_range": (0.15, 0.15),
+            "control_grid_shape": (4, 5),
+            "interpolation": cv2.INTER_LINEAR,
+            "mask_interpolation": cv2.INTER_LINEAR,
+            "border_mode": cv2.BORDER_REPLICATE,
+            "fill": 17,
+            "fill_mask": 31,
+        },
+    ],
+    [
         A.Affine3D,
         {
             "rotate_range": {"x": (-10.0, 10.0), "y": (-5.0, 5.0), "z": (-15.0, 15.0)},
@@ -888,6 +900,11 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
             "fill": 7,
             "fill_mask": 3,
         },
+    ),
+    (
+        "nearest-interpolation",
+        A.ElasticTransform3D,
+        {"interpolation": cv2.INTER_NEAREST},
     ),
     ("wide-alpha", A.Enhance, {"alpha_range": (0.2, 0.8)}),
     ("explicit-mask", A.Equalize, {"mask": np.ones((128, 128, 1), dtype=np.uint8), "mask_params": ("mask",)}),

--- a/tests/test_tensor_compose.py
+++ b/tests/test_tensor_compose.py
@@ -675,15 +675,17 @@ def test_invalid_targets_as_params_tensor_fails_before_transform_probability() -
         transform(image=np.zeros((5, 7, 3), dtype=np.uint8), refs=refs)
 
 
-def test_tensor_shape_helpers_use_nchw_and_cdhw_contracts() -> None:
+def test_shape_helpers_use_canonical_numpy_and_tensor_volume_contracts() -> None:
     image = torch.zeros((3, 11, 13), dtype=torch.uint8)
     images = torch.zeros((5, 3, 11, 13), dtype=torch.uint8)
     volume = torch.zeros((3, 7, 11, 13), dtype=torch.uint8)
+    numpy_volume = np.zeros((7, 11, 13, 3), dtype=np.uint8)
 
     assert get_shape({"image": image}) == (11, 13)
     assert get_shape({"images": images}) == (11, 13)
     assert get_shape({"volume": volume}) == (11, 13)
-    assert get_volume_shape({"volume": volume}) == (7, 11, 13)
+    assert get_volume_shape(volume) == (7, 11, 13)
+    assert get_volume_shape(numpy_volume) == (7, 11, 13)
     assert get_image_data({"images": images}) == {
         "dtype": torch.uint8,
         "height": 11,

--- a/tests/transforms3d/test_elastic_transform3d.py
+++ b/tests/transforms3d/test_elastic_transform3d.py
@@ -16,29 +16,26 @@ def _forward_elastic_point(
     volume_shape: tuple[int, int, int],
 ) -> np.ndarray:
     displacement = np.zeros(3, dtype=np.float64)
-    if "xy" in control_coefficients:
-        displacement[:2] += fgeometric.evaluate_control_grid(
-            point[np.newaxis, :2],
-            control_coefficients["xy"],
-            volume_shape[1:],
-        )[0]
-    if "xz" in control_coefficients:
-        xz_displacement = fgeometric.evaluate_control_grid(
-            point[np.newaxis, (0, 2)],
-            control_coefficients["xz"],
-            (volume_shape[0], volume_shape[2]),
-        )[0]
-        displacement[0] += xz_displacement[0]
-        displacement[2] += xz_displacement[1]
-    if "yz" in control_coefficients:
-        yz_displacement = fgeometric.evaluate_control_grid(
-            point[np.newaxis, 1:3],
-            control_coefficients["yz"],
-            volume_shape[:2],
-        )[0]
-        displacement[1] += yz_displacement[0]
-        displacement[2] += yz_displacement[1]
-    return point + displacement / len(control_coefficients)
+    displacement[:2] += fgeometric.evaluate_control_grid(
+        point[np.newaxis, :2],
+        control_coefficients["xy"],
+        volume_shape[1:],
+    )[0]
+    xz_displacement = fgeometric.evaluate_control_grid(
+        point[np.newaxis, (0, 2)],
+        control_coefficients["xz"],
+        (volume_shape[0], volume_shape[2]),
+    )[0]
+    displacement[0] += xz_displacement[0]
+    displacement[2] += xz_displacement[1]
+    yz_displacement = fgeometric.evaluate_control_grid(
+        point[np.newaxis, 1:3],
+        control_coefficients["yz"],
+        volume_shape[:2],
+    )[0]
+    displacement[1] += yz_displacement[0]
+    displacement[2] += yz_displacement[1]
+    return point + displacement / 3
 
 
 def test_elastic_transform3d_shares_one_field_between_volume_mask_and_keypoints() -> None:
@@ -101,6 +98,8 @@ def test_elastic_transform3d_topology_bound_is_strict() -> None:
 def test_elastic_transform3d_yz_grid_matches_its_voxel_displacement() -> None:
     volume_shape = (5, 7, 11)
     control_coefficients = {
+        "xy": np.zeros((4, 5, 2), dtype=np.float32),
+        "xz": np.zeros((4, 5, 2), dtype=np.float32),
         "yz": np.random.default_rng(137).uniform(-0.2, 0.2, (4, 5, 2)).astype(np.float32),
     }
     output_points = np.array(((3.0, 2.0, 1.0), (7.0, 5.0, 3.0)), dtype=np.float64)
@@ -142,7 +141,10 @@ def test_elastic_transform3d_keypoint_inverse_recovers_xyz_reference() -> None:
 def test_elastic_transform3d_remap_respects_constant_volume_and_mask_fills() -> None:
     volume = np.ones((3, 5, 7, 1), dtype=np.float32)
     mask3d = np.ones((3, 5, 7), dtype=np.uint16)
-    sampling_grid = f3d.create_elastic_grid_3d({}, volume.shape[:3])
+    sampling_grid = f3d.create_elastic_grid_3d(
+        {plane: np.zeros((4, 4, 2), dtype=np.float32) for plane in ("xy", "xz", "yz")},
+        volume.shape[:3],
+    )
     sampling_grid[..., 0] = 2.0
 
     remapped_volume = f3d.remap_3d(

--- a/tests/transforms3d/test_elastic_transform3d.py
+++ b/tests/transforms3d/test_elastic_transform3d.py
@@ -1,0 +1,310 @@
+import json
+
+import cv2
+import numpy as np
+import pytest
+import torch
+
+import albumentations as A
+from albumentations.augmentations.geometric import functional as fgeometric
+from albumentations.augmentations.transforms3d import functional as f3d
+
+
+def _forward_elastic_point(
+    point: np.ndarray,
+    control_coefficients: dict[str, np.ndarray],
+    volume_shape: tuple[int, int, int],
+) -> np.ndarray:
+    displacement = np.zeros(3, dtype=np.float64)
+    if "xy" in control_coefficients:
+        displacement[:2] += fgeometric.evaluate_control_grid(
+            point[np.newaxis, :2],
+            control_coefficients["xy"],
+            volume_shape[1:],
+        )[0]
+    if "xz" in control_coefficients:
+        xz_displacement = fgeometric.evaluate_control_grid(
+            point[np.newaxis, (0, 2)],
+            control_coefficients["xz"],
+            (volume_shape[0], volume_shape[2]),
+        )[0]
+        displacement[0] += xz_displacement[0]
+        displacement[2] += xz_displacement[1]
+    if "yz" in control_coefficients:
+        yz_displacement = fgeometric.evaluate_control_grid(
+            point[np.newaxis, 1:3],
+            control_coefficients["yz"],
+            volume_shape[:2],
+        )[0]
+        displacement[1] += yz_displacement[0]
+        displacement[2] += yz_displacement[1]
+    return point + displacement / len(control_coefficients)
+
+
+def test_elastic_transform3d_shares_one_field_between_volume_mask_and_keypoints() -> None:
+    mask3d = np.zeros((9, 9, 9), dtype=np.uint8)
+    mask3d[4, 4, 4] = 137
+    volume = mask3d[..., np.newaxis]
+    keypoints = np.array([[4.0, 4.0, 4.0, 17.0]], dtype=np.float32)
+    transform = A.Compose(
+        [
+            A.ElasticTransform3D(
+                displacement_range=(0.05, 0.05),
+                control_grid_shape=(7, 7),
+                interpolation=cv2.INTER_NEAREST,
+                mask_interpolation=cv2.INTER_NEAREST,
+                p=1.0,
+            ),
+        ],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        seed=137,
+        strict=True,
+    )
+
+    result = transform(volume=volume, mask3d=mask3d, keypoints=keypoints)
+
+    np.testing.assert_array_equal(result["volume"][..., 0], result["mask3d"])
+    mask_keypoint = np.argwhere(result["mask3d"] == 137)[0][::-1]
+    np.testing.assert_allclose(result["keypoints"][0, :3], mask_keypoint, atol=1.0)
+    np.testing.assert_array_equal(result["keypoints"][:, 3:], keypoints[:, 3:])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"displacement_range": (-0.01, 0.05)},
+        {"displacement_range": (0.05, 0.01)},
+        {"control_grid_shape": (3, 7)},
+        {"displacement_range": (0.2, 0.2)},
+    ],
+)
+def test_elastic_transform3d_rejects_invalid_constructor_contract(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        A.ElasticTransform3D(**kwargs)
+
+
+def test_elastic_transform3d_topology_bound_is_strict() -> None:
+    control_grid_shape = (4, 5)
+    limit = 0.75 / (2 * np.sqrt((control_grid_shape[0] - 3) ** 2 + (control_grid_shape[1] - 3) ** 2))
+
+    A.ElasticTransform3D(
+        displacement_range=(0.0, float(np.nextafter(limit, 0.0))),
+        control_grid_shape=control_grid_shape,
+    )
+    with pytest.raises(ValueError, match="strict topology bound"):
+        A.ElasticTransform3D(
+            displacement_range=(0.0, float(np.nextafter(limit, np.inf))),
+            control_grid_shape=control_grid_shape,
+        )
+
+
+def test_elastic_transform3d_yz_grid_matches_its_voxel_displacement() -> None:
+    volume_shape = (5, 7, 11)
+    control_coefficients = {
+        "yz": np.random.default_rng(137).uniform(-0.2, 0.2, (4, 5, 2)).astype(np.float32),
+    }
+    output_points = np.array(((3.0, 2.0, 1.0), (7.0, 5.0, 3.0)), dtype=np.float64)
+
+    sampling_grid = f3d.create_elastic_grid_3d(control_coefficients, volume_shape)
+    grid_points = sampling_grid[
+        output_points[:, 2].astype(int),
+        output_points[:, 1].astype(int),
+        output_points[:, 0].astype(int),
+    ]
+    source_points = (grid_points + 1.0) * np.asarray((volume_shape[2], volume_shape[1], volume_shape[0])) / 2.0 - 0.5
+    expected_points = np.stack(
+        [_forward_elastic_point(point, control_coefficients, volume_shape) for point in output_points],
+    )
+
+    np.testing.assert_allclose(source_points, expected_points, atol=1e-6)
+
+
+def test_elastic_transform3d_keypoint_inverse_recovers_xyz_reference() -> None:
+    volume_shape = (17, 19, 23)
+    random_generator = np.random.default_rng(137)
+    control_coefficients = {
+        plane: random_generator.uniform(-0.2, 0.2, (4, 5, 2)).astype(np.float32) for plane in ("xy", "xz", "yz")
+    }
+    output_points = random_generator.uniform([1.0, 1.0, 1.0], [21.0, 17.0, 15.0], (32, 3))
+    source_points = np.stack(
+        [_forward_elastic_point(point, control_coefficients, volume_shape) for point in output_points],
+    )
+    keypoints = np.column_stack(
+        [source_points, np.full(len(source_points), 17.0, dtype=np.float32)],
+    ).astype(np.float32)
+
+    transformed = f3d.remap_elastic_keypoints_3d(keypoints, control_coefficients, volume_shape)
+
+    np.testing.assert_allclose(transformed[:, :3], output_points, atol=1e-3)
+    np.testing.assert_array_equal(transformed[:, 3:], keypoints[:, 3:])
+
+
+def test_elastic_transform3d_remap_respects_constant_volume_and_mask_fills() -> None:
+    volume = np.ones((3, 5, 7, 1), dtype=np.uint8)
+    mask3d = np.ones((3, 5, 7), dtype=np.uint16)
+    sampling_grid = f3d.create_elastic_grid_3d({}, volume.shape[:3])
+    sampling_grid[..., 0] = 2.0
+
+    remapped_volume = f3d.remap_3d(
+        volume,
+        sampling_grid,
+        cv2.INTER_LINEAR,
+        cv2.BORDER_CONSTANT,
+        fill=17,
+    )
+    remapped_mask = f3d.remap_3d(
+        mask3d,
+        sampling_grid,
+        cv2.INTER_NEAREST,
+        cv2.BORDER_CONSTANT,
+        fill=31,
+        is_mask=True,
+    )
+
+    np.testing.assert_array_equal(remapped_volume, np.full_like(volume, 17))
+    np.testing.assert_array_equal(remapped_mask, np.full_like(mask3d, 31))
+
+
+def test_elastic_transform3d_identity_skips_resampling_for_zero_magnitude() -> None:
+    zero_magnitude_volume = np.random.default_rng(137).random((7, 11, 13, 1), dtype=np.float32)
+    zero_magnitude = A.Compose([A.ElasticTransform3D(displacement_range=(0.0, 0.0), p=1.0)], strict=True)
+
+    zero_result = zero_magnitude(volume=zero_magnitude_volume)["volume"]
+
+    assert zero_result is zero_magnitude_volume
+
+
+def test_elastic_transform3d_seeded_compose_reproduces_the_compact_field() -> None:
+    volume = np.random.default_rng(137).random((7, 11, 13, 1), dtype=np.float32)
+    kwargs = {"displacement_range": (0.02, 0.05), "control_grid_shape": (7, 7), "p": 1.0}
+    first = A.Compose([A.ElasticTransform3D(**kwargs)], seed=137, strict=True)
+    second = A.Compose([A.ElasticTransform3D(**kwargs)], seed=137, strict=True)
+
+    np.testing.assert_array_equal(first(volume=volume)["volume"], second(volume=volume)["volume"])
+
+
+def test_elastic_transform3d_shares_geometry_with_additional_volume_and_mask_targets() -> None:
+    volume = np.random.default_rng(137).integers(0, 256, (7, 11, 13, 1), dtype=np.uint8)
+    mask3d = np.arange(7 * 11 * 13, dtype=np.uint8).reshape(7, 11, 13)
+    transform = A.Compose(
+        [A.ElasticTransform3D(displacement_range=(0.05, 0.05), p=1.0)],
+        additional_targets={"second_volume": "volume", "second_mask3d": "mask3d"},
+        seed=137,
+        strict=True,
+    )
+
+    result = transform(
+        volume=volume,
+        mask3d=mask3d,
+        second_volume=volume,
+        second_mask3d=mask3d,
+    )
+
+    np.testing.assert_array_equal(result["volume"], result["second_volume"])
+    np.testing.assert_array_equal(result["mask3d"], result["second_mask3d"])
+
+
+def test_elastic_transform3d_rejects_keypoint_only_input_without_a_spatial_domain() -> None:
+    transform = A.Compose(
+        [A.ElasticTransform3D(p=1.0)],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        strict=True,
+    )
+
+    with pytest.raises(ValueError, match="No image or volume"):
+        transform(keypoints=np.array([[4.0, 5.0, 6.0]], dtype=np.float32))
+
+
+def test_elastic_transform3d_replay_roundtrip_and_shape_guard() -> None:
+    volume = np.random.default_rng(137).random((7, 11, 13, 2), dtype=np.float32)
+    mask3d = np.arange(7 * 11 * 13, dtype=np.uint16).reshape(7, 11, 13)
+    keypoints = np.array([[6.0, 5.0, 3.0, 17.0]], dtype=np.float32)
+    transform = A.ReplayCompose(
+        [A.ElasticTransform3D(displacement_range=(0.02, 0.05), p=1.0)],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        seed=137,
+    )
+
+    result = transform(volume=volume, mask3d=mask3d, keypoints=keypoints)
+    replayed = A.ReplayCompose.replay(
+        json.loads(json.dumps(result["replay"], allow_nan=False)),
+        volume=volume,
+        mask3d=mask3d,
+        keypoints=keypoints,
+    )
+
+    for target in ("volume", "mask3d", "keypoints"):
+        np.testing.assert_array_equal(result[target], replayed[target])
+    with pytest.raises(ValueError, match="same spatial shape"):
+        A.ReplayCompose.replay(result["replay"], volume=volume[:-1])
+
+
+def test_elastic_transform3d_applied_config_fixes_magnitude_without_storing_coefficients() -> None:
+    volume = np.random.default_rng(137).random((7, 11, 13, 1), dtype=np.float32)
+    pipeline = A.Compose(
+        [A.ElasticTransform3D(displacement_range=(0.02, 0.05), p=1.0)],
+        save_applied_params=True,
+        seed=137,
+    )
+
+    result = pipeline(volume=volume)
+    _, applied_config = json.loads(json.dumps(result["applied_transforms"], allow_nan=False))[0]
+
+    assert applied_config["displacement_range"][0] == applied_config["displacement_range"][1]
+    assert "control_coefficients" not in applied_config
+    reconstructed = A.Compose.from_applied_transforms(result["applied_transforms"], seed=137)
+    assert reconstructed(volume=volume)["volume"].shape == volume.shape
+
+
+def test_elastic_transform3d_tensor_volume_and_mask_use_native_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    volume = np.random.default_rng(137).integers(0, 256, (7, 11, 13, 1), dtype=np.uint8)
+    mask3d = np.arange(7 * 11 * 13, dtype=np.uint16).reshape(7, 11, 13)
+    tensor_volume = torch.from_numpy(volume).permute(3, 0, 1, 2)
+    tensor_mask3d = torch.from_numpy(mask3d)
+    transform_kwargs = {"displacement_range": (0.05, 0.05), "control_grid_shape": (7, 7), "p": 1.0}
+    numpy_transform = A.Compose([A.ElasticTransform3D(**transform_kwargs)], seed=137, strict=True)
+    tensor_transform = A.Compose([A.ElasticTransform3D(**transform_kwargs)], seed=137, strict=True)
+
+    monkeypatch.setattr(
+        A.Compose,
+        "_bridge_tensor_data_to_numpy",
+        lambda *_args, **_kwargs: pytest.fail("ElasticTransform3D unexpectedly selected Compose's NumPy bridge"),
+    )
+    assert tensor_transform.transforms[0].supports_cpu_tensor is True
+    numpy_result = numpy_transform(volume=volume, mask3d=mask3d)
+    tensor_result = tensor_transform(volume=tensor_volume, mask3d=tensor_mask3d)
+
+    assert tensor_result["volume"].dtype == tensor_volume.dtype
+    assert tensor_result["mask3d"].dtype == tensor_mask3d.dtype
+    torch.testing.assert_close(
+        tensor_result["volume"],
+        torch.from_numpy(numpy_result["volume"]).permute(3, 0, 1, 2),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(tensor_result["mask3d"], torch.from_numpy(numpy_result["mask3d"]), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("channels", (3, 5))
+def test_elastic_transform3d_multichannel_tensor_volume_uses_the_numpy_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+    channels: int,
+) -> None:
+    volume = np.random.default_rng(137).integers(0, 256, (7, 11, 13, channels), dtype=np.uint8)
+    tensor_volume = torch.from_numpy(volume).permute(3, 0, 1, 2)
+    transform = A.Compose([A.ElasticTransform3D(p=1.0)], seed=137, strict=True)
+    bridge_calls = 0
+    original_bridge = A.Compose._bridge_tensor_data_to_numpy
+
+    def count_bridge(self: A.Compose, *args: object, **kwargs: object) -> None:
+        nonlocal bridge_calls
+        bridge_calls += 1
+        original_bridge(self, *args, **kwargs)
+
+    monkeypatch.setattr(A.Compose, "_bridge_tensor_data_to_numpy", count_bridge)
+
+    result = transform(volume=tensor_volume)["volume"]
+
+    assert bridge_calls == 1
+    assert result.shape == tensor_volume.shape
+    assert result.dtype == tensor_volume.dtype

--- a/tests/transforms3d/test_elastic_transform3d.py
+++ b/tests/transforms3d/test_elastic_transform3d.py
@@ -140,7 +140,7 @@ def test_elastic_transform3d_keypoint_inverse_recovers_xyz_reference() -> None:
 
 
 def test_elastic_transform3d_remap_respects_constant_volume_and_mask_fills() -> None:
-    volume = np.ones((3, 5, 7, 1), dtype=np.uint8)
+    volume = np.ones((3, 5, 7, 1), dtype=np.float32)
     mask3d = np.ones((3, 5, 7), dtype=np.uint16)
     sampling_grid = f3d.create_elastic_grid_3d({}, volume.shape[:3])
     sampling_grid[..., 0] = 2.0

--- a/tests/transforms3d/test_elastic_transform3d.py
+++ b/tests/transforms3d/test_elastic_transform3d.py
@@ -139,7 +139,7 @@ def test_elastic_transform3d_keypoint_inverse_recovers_xyz_reference() -> None:
 
 
 def test_elastic_transform3d_remap_respects_constant_volume_and_mask_fills() -> None:
-    volume = np.ones((3, 5, 7, 1), dtype=np.float32)
+    volume = np.ones((3, 5, 7, 1), dtype=np.uint8)
     mask3d = np.ones((3, 5, 7), dtype=np.uint16)
     sampling_grid = f3d.create_elastic_grid_3d(
         {plane: np.zeros((4, 4, 2), dtype=np.float32) for plane in ("xy", "xz", "yz")},

--- a/tests/transforms3d/test_elastic_transform3d.py
+++ b/tests/transforms3d/test_elastic_transform3d.py
@@ -9,6 +9,7 @@ import albumentations as A
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.transforms3d import functional as f3d
 from albumentations.core import transforms_interface
+from albumentations.core.utils import get_volume_shape
 
 
 def _forward_elastic_point(
@@ -144,7 +145,7 @@ def test_elastic_transform3d_remap_respects_constant_volume_and_mask_fills() -> 
     mask3d = np.ones((3, 5, 7), dtype=np.uint16)
     sampling_grid = f3d.create_elastic_grid_3d(
         {plane: np.zeros((4, 4, 2), dtype=np.float32) for plane in ("xy", "xz", "yz")},
-        volume.shape[:3],
+        get_volume_shape(volume),
     )
     sampling_grid[..., 0] = 2.0
 

--- a/tests/transforms3d/test_elastic_transform3d.py
+++ b/tests/transforms3d/test_elastic_transform3d.py
@@ -8,6 +8,7 @@ import torch
 import albumentations as A
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.transforms3d import functional as f3d
+from albumentations.core import transforms_interface
 
 
 def _forward_elastic_point(
@@ -258,9 +259,19 @@ def test_elastic_transform3d_applied_config_fixes_magnitude_without_storing_coef
     assert reconstructed(volume=volume)["volume"].shape == volume.shape
 
 
-def test_elastic_transform3d_tensor_volume_and_mask_use_native_route(monkeypatch: pytest.MonkeyPatch) -> None:
-    volume = np.random.default_rng(137).integers(0, 256, (7, 11, 13, 1), dtype=np.uint8)
-    mask3d = np.arange(7 * 11 * 13, dtype=np.uint16).reshape(7, 11, 13)
+@pytest.mark.parametrize("channels", (1, 3, 5))
+@pytest.mark.parametrize("dtype", (np.uint8, np.float32))
+def test_elastic_transform3d_tensor_raster_targets_use_native_route(
+    monkeypatch: pytest.MonkeyPatch,
+    channels: int,
+    dtype: type[np.uint8] | type[np.float32],
+) -> None:
+    random_generator = np.random.default_rng(137)
+    if dtype == np.uint8:
+        volume = random_generator.integers(0, 256, (7, 11, 13, channels), dtype=dtype)
+    else:
+        volume = random_generator.random((7, 11, 13, channels), dtype=dtype)
+    mask3d = np.arange(7 * 11 * 13, dtype=np.int16).reshape(7, 11, 13)
     tensor_volume = torch.from_numpy(volume).permute(3, 0, 1, 2)
     tensor_mask3d = torch.from_numpy(mask3d)
     transform_kwargs = {"displacement_range": (0.05, 0.05), "control_grid_shape": (7, 7), "p": 1.0}
@@ -268,11 +279,10 @@ def test_elastic_transform3d_tensor_volume_and_mask_use_native_route(monkeypatch
     tensor_transform = A.Compose([A.ElasticTransform3D(**transform_kwargs)], seed=137, strict=True)
 
     monkeypatch.setattr(
-        A.Compose,
-        "_bridge_tensor_data_to_numpy",
-        lambda *_args, **_kwargs: pytest.fail("ElasticTransform3D unexpectedly selected Compose's NumPy bridge"),
+        transforms_interface,
+        "tensor_to_numpy_spatial",
+        lambda *_args, **_kwargs: pytest.fail("ElasticTransform3D unexpectedly entered the NumPy fallback"),
     )
-    assert tensor_transform.transforms[0].supports_cpu_tensor is True
     numpy_result = numpy_transform(volume=volume, mask3d=mask3d)
     tensor_result = tensor_transform(volume=tensor_volume, mask3d=tensor_mask3d)
 
@@ -281,32 +291,7 @@ def test_elastic_transform3d_tensor_volume_and_mask_use_native_route(monkeypatch
     torch.testing.assert_close(
         tensor_result["volume"],
         torch.from_numpy(numpy_result["volume"]).permute(3, 0, 1, 2),
-        rtol=0,
-        atol=0,
+        rtol=1e-6,
+        atol=1e-6,
     )
     torch.testing.assert_close(tensor_result["mask3d"], torch.from_numpy(numpy_result["mask3d"]), rtol=0, atol=0)
-
-
-@pytest.mark.parametrize("channels", (3, 5))
-def test_elastic_transform3d_multichannel_tensor_volume_uses_the_numpy_bridge(
-    monkeypatch: pytest.MonkeyPatch,
-    channels: int,
-) -> None:
-    volume = np.random.default_rng(137).integers(0, 256, (7, 11, 13, channels), dtype=np.uint8)
-    tensor_volume = torch.from_numpy(volume).permute(3, 0, 1, 2)
-    transform = A.Compose([A.ElasticTransform3D(p=1.0)], seed=137, strict=True)
-    bridge_calls = 0
-    original_bridge = A.Compose._bridge_tensor_data_to_numpy
-
-    def count_bridge(self: A.Compose, *args: object, **kwargs: object) -> None:
-        nonlocal bridge_calls
-        bridge_calls += 1
-        original_bridge(self, *args, **kwargs)
-
-    monkeypatch.setattr(A.Compose, "_bridge_tensor_data_to_numpy", count_bridge)
-
-    result = transform(volume=tensor_volume)["volume"]
-
-    assert bridge_calls == 1
-    assert result.shape == tensor_volume.shape
-    assert result.dtype == tensor_volume.dtype

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1049,6 +1049,7 @@ def test_center_crop3d_keypoints(
         except_augmentations={
             A.CoarseDropout3D,
             A.Anisotropy3D,
+            A.ElasticTransform3D,
         },
     ),
 )

--- a/tools/benchmark_coverage.py
+++ b/tools/benchmark_coverage.py
@@ -233,6 +233,7 @@ SPECIAL_TARGET_ALIAS_TO_TRANSFORM = {
 VOLUME_ALIAS_TO_TRANSFORM = {
     "affine3d": "Affine3D",
     "anisotropy3d": "Anisotropy3D",
+    "elastic3d": "ElasticTransform3D",
     "center_crop3d": "CenterCrop3D",
     "coarse_dropout3d": "CoarseDropout3D",
     "cubic_symmetry": "CubicSymmetry",
@@ -281,6 +282,7 @@ DIRECT_KERNEL_TRANSFORMS = frozenset(
         "Affine",
         "Affine3D",
         "Anisotropy3D",
+        "ElasticTransform3D",
         "AutoContrast",
         "Blur",
         "CenterCrop3D",
@@ -356,7 +358,7 @@ MEMORY_COVERED_TRANSFORMS = frozenset(
 )
 
 PYTORCH_TERMINAL_TENSOR_TRANSFORMS = frozenset({"ToTensor3D", "ToTensorV2"})
-PYTORCH_NATIVE_VOLUME_TRANSFORMS = frozenset({"Affine3D", "Anisotropy3D", "Resize3D"})
+PYTORCH_NATIVE_VOLUME_TRANSFORMS = frozenset({"Affine3D", "Anisotropy3D", "ElasticTransform3D", "Resize3D"})
 PYTORCH_NATIVE_TENSOR_TRANSFORMS = PYTORCH_NATIVE_VOLUME_TRANSFORMS | frozenset({"Transpose"})
 PYTORCH_TENSOR_TRANSFORMS = PYTORCH_TERMINAL_TENSOR_TRANSFORMS | PYTORCH_NATIVE_TENSOR_TRANSFORMS
 PYTORCH_IMAGE_CASES = pytorch_tensor_benchmarks.IMAGE_CASES
@@ -368,6 +370,7 @@ DIRECT_KERNEL_CASE_PREFIXES_BY_TRANSFORM = {
     "Affine": ("bboxes_affine", "keypoints_affine"),
     "Affine3D": ("affine_3d",),
     "Anisotropy3D": ("anisotropy_3d",),
+    "ElasticTransform3D": ("elastic_3d",),
     "AutoContrast": ("auto_contrast",),
     "Blur": ("box_blur",),
     "CenterCrop3D": ("crop3d",),
@@ -451,6 +454,7 @@ ASV_BENCHMARKS = {
     "pytorch_tensor_3d": "pytorch_benchmarks.test_tensor.TimeToTensor3D",
     "pytorch_tensor_native": "pytorch_benchmarks.test_tensor.TimeTensorNativeTranspose",
     "pytorch_tensor_native_affine3d": "pytorch_benchmarks.test_tensor.TimeTensorNativeAffine3D",
+    "pytorch_tensor_native_elastic3d": "pytorch_benchmarks.test_tensor.TimeTensorElasticTransform3D",
     "pytorch_tensor_native_3d": "pytorch_benchmarks.test_tensor.TimeTensorNativeAnisotropy3D",
     "pytorch_tensor_native_resize3d": "pytorch_benchmarks.test_tensor.TimeTensorNativeResize3D",
     "reference_data": "benchmarks.test_family_matrix.TimeReferenceDataFullMatrix.time_transform",
@@ -1238,6 +1242,7 @@ def _benchmark_case_index() -> dict[str, list[dict[str, str]]]:
     for transform_name, benchmark_name in {
         "Affine3D": "pytorch_tensor_native_affine3d",
         "Anisotropy3D": "pytorch_tensor_native_3d",
+        "ElasticTransform3D": "pytorch_tensor_native_elastic3d",
         "Resize3D": "pytorch_tensor_native_resize3d",
     }.items():
         for case_id in PYTORCH_NATIVE_VOLUME_CASES:


### PR DESCRIPTION
Closes #327.

## Summary

Adds `ElasticTransform3D` for bounded smooth volumetric deformation. Three compact cubic coefficient planes (XY, XZ, and YZ) build one normalized Albucore `remap3d` pull grid shared by `volume` and `mask3d`; XYZ keypoints use the same geometry. Replay persists compact coefficients and rejects a different spatial shape.

The shared 2D/3D control-coefficient sampler now lives in the geometric functional layer. Elastic3D builds no dense random noise, smoothing volume, or intermediate dense displacement field.

Float32 linear resampling clips to the public `[0, 1]` output contract. Nearest interpolation and masks avoid that pass.

## Tensor execution

`main` selects a leaf's Tensor path from the annotation on the handler it invokes. `ElasticTransform3D.apply_to_volume` and `apply_to_mask3d` accept `torch.Tensor`, so all accepted CPU Tensor channel counts use Albucore `remap3d` directly. `volume` uses `C,D,H,W`; `mask3d` accepts `D,H,W` and `C,D,H,W`.

`Compose` validates Tensor inputs and normalizes optional channels. It contains no Elastic3D target, dtype, or channel routing rule. A handler without a Tensor annotation uses the base leaf-local NumPy bridge.

The rewrite also fixes Elastic3D's shape check after root normalization adds the optional channel to a Tensor `mask3d`.

## Benchmark evidence

The table compares the rebased pre-rewrite leaf fallback with the current native handler route for the public `Compose(volume=tensor)` call. Each value is the median of three paired ABBA runs on macOS 26.4.1 arm64, Torch 2.13.0, OpenCV 5.0.0, and Albucore 0.2.16. Torch and OpenCV each used one thread. Each run warmed up five calls, then used five median samples of 20 calls (100 timed calls per cell).

| Volume | C | dtype | Fallback (ms) | Native (ms) | Change |
| --- | ---: | --- | ---: | ---: | ---: |
| 8x64x64 | 1 | uint8 | 0.852 | 0.959 | +12.6% |
| 8x64x64 | 1 | float32 | 0.799 | 0.924 | +15.7% |
| 8x64x64 | 3 | uint8 | 1.329 | 1.414 | +6.4% |
| 8x64x64 | 3 | float32 | 1.432 | 1.361 | -5.0% |
| 8x64x64 | 5 | uint8 | 2.706 | 2.628 | -2.9% |
| 8x64x64 | 5 | float32 | 2.542 | 2.589 | +1.8% |
| 16x128x128 | 1 | uint8 | 4.540 | 4.600 | +1.3% |
| 16x128x128 | 1 | float32 | 4.236 | 4.488 | +6.0% |
| 16x128x128 | 3 | uint8 | 10.297 | 10.061 | -2.3% |
| 16x128x128 | 3 | float32 | 8.851 | 9.630 | +8.8% |
| 16x128x128 | 5 | uint8 | 17.027 | 20.839 | +22.3% |
| 16x128x128 | 5 | float32 | 17.179 | 21.151 | +23.1% |

The matrix has wins and regressions. Handler annotations are the route declaration under the new architecture, so this PR adds no C/dtype dispatcher in `Compose`. NumPy input remains on the existing NumPy implementation.

## Validation

- `python -m tools.quality_gate fast`: passed, including 2,708 contract tests and full pre-commit
- `pytest -n auto -q`: passed
- Focused Tensor, 3D, sampling, semantic-mask, and target-contract suites: 2,532 passed
- `tests/transforms3d/test_elastic_transform3d.py`: 21 passed
- Commit hooks, mypy, and Pyrefly: passed

## Summary by Sourcery

Introduce bounded 3D elastic deformation with synchronized raster and keypoint geometry, native CPU Tensor support, and robust replay and shape contracts.

New Features:
- Add the `ElasticTransform3D` augmentation for smooth bounded volumetric deformation across volumes, masks, and XYZ keypoints.
- Support native CPU Tensor execution for 3D elastic volume and mask targets alongside existing NumPy inputs.
- Add replay, applied-configuration, shape-validation, and synchronized-target support for the new transform.

Bug Fixes:
- Correct volume spatial-shape handling across NumPy and Tensor layouts, including channel-less masks and normalized Tensor inputs.
- Preserve the public `[0, 1]` range for float32 volumes after linear resampling.

Enhancements:
- Centralize elastic control-coefficient sampling for shared 2D and 3D use.
- Build volumetric deformation from compact control planes and shared remap grids without dense 3D noise or displacement intermediates.
- Extend Tensor routing and target metadata to select native leaf handlers based on annotations.

Documentation:
- Document `ElasticTransform3D` support and its bounded volumetric deformation design.

Tests:
- Add comprehensive 3D elastic transform coverage for deformation geometry, keypoints, masks, replay, validation, fills, dtypes, and native Tensor parity.
- Add benchmark coverage for functional and native Tensor ElasticTransform3D execution.