### PR TITLE
refactor(tooling): unify AX repository checks

### DIFF
--- a/.codex/rules/albumentations-rules.md
+++ b/.codex/rules/albumentations-rules.md
@@ -23,8 +23,8 @@ always_apply: true
   different units or behavior.
 - Keep public docstrings focused on user-facing behavior. Omit post-initialization, serialization, replay, and other
   implementation details unless they are part of the supported public contract.
-- Run `pre-commit run check-ax-coding-guidance --all-files` for deterministic AX source contracts. Its diagnostic and
-  `docs/contributing/coding_guidelines.md` are the mechanical source of truth.
+- Run `pre-commit run check-ax-rules --all-files` for AX repository checks. Its `coding-guidance` diagnostics and
+  `docs/contributing/coding_guidelines.md` are the mechanical source of truth for deterministic source contracts.
 - Use `pytest.mark.parametrize` for parameterized tests
 - Default test values should be 137, not 42
 - NEVER create temporary tests - add permanent tests to test suite

--- a/.codex/skills/review-transform/SKILL.md
+++ b/.codex/skills/review-transform/SKILL.md
@@ -26,8 +26,8 @@ Run these checks in order. Report issues with severity: 🔴 Critical, 🟡 Impo
 
 ## 3. Mechanical AX contracts (🔴 Critical)
 
-Run `pre-commit run check-ax-coding-guidance --all-files` first. Report a failing `AXG` diagnostic exactly; otherwise
-record that the hook passed. Keep the deterministic contract and its exceptions in
+Run `pre-commit run check-ax-rules --all-files` first. Report a failing `AXG` diagnostic exactly; otherwise record
+that the hook passed. Keep the deterministic contract and its exceptions in
 `docs/contributing/coding_guidelines.md`.
 
 Use human review for what the hook cannot decide: whether constructor fields express a coherent public API, whether

--- a/.codex/skills/validate-and-fix/SKILL.md
+++ b/.codex/skills/validate-and-fix/SKILL.md
@@ -25,8 +25,8 @@ change beyond the version uses the corresponding dependency, artifact, and insta
 4. **If a selected command fails**: fix the issue, then repeat that command. Do not expand the validation scope unless the
    failure proves that the initial scope was incomplete.
 
-For transform or guidance changes, the focused mechanical check is
-`pre-commit run check-ax-coding-guidance --all-files`. Keep deterministic contract details in
+For transform or guidance changes, the focused mechanical check is `pre-commit run check-ax-rules --all-files`.
+Keep deterministic contract details in
 `docs/contributing/coding_guidelines.md`; keep design and benchmark review in the applicable skill.
 
 Before handoff, check `git status --short`. `pre-commit run --all-files` omits untracked files, so run `pre-commit`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
         name: Check AlbumentationsX rules
         entry: uv run python -m tools.ax_rules
         language: system
-        files: ^((?!tools/).*\.py$|README\.md$|pyproject\.toml$|tools/(ax_coding_guidance/|ax_rules/|check_docstring_format\.py$|check_naming_conflicts\.py$|make_transforms_docs\.py$)|\.pre-commit-config\.yaml$)
       - id: verify-regression-vectors
         name: Verify regression vector contracts
         entry: uv run python -m tools.verify_regression_vectors --all

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,11 @@ repos:
         language: system
         pass_filenames: false
         files: ^(pyproject\.toml|\.github/workflows/|docs/maintaining/|tools/ci_matrix\.py)
-      - id: check-public-transform-docstrings
-        name: Check public transform docstring metadata
-        entry: uv run pytest -q tests/test_docstrings.py -k short_description_length
+      - id: check-ax-rules
+        name: Check AlbumentationsX rules
+        entry: uv run python -m tools.ax_rules
         language: system
-        pass_filenames: false
-        files: ^(albumentations/|tests/test_docstrings\.py$|\.pre-commit-config\.yaml$|pyproject\.toml$)
+        files: ^((?!tools/).*\.py$|README\.md$|pyproject\.toml$|tools/(ax_coding_guidance/|ax_rules/|check_docstring_format\.py$|check_naming_conflicts\.py$|make_transforms_docs\.py$)|\.pre-commit-config\.yaml$)
       - id: verify-regression-vectors
         name: Verify regression vector contracts
         entry: uv run python -m tools.verify_regression_vectors --all
@@ -82,23 +81,6 @@ repos:
       - id: requirements-txt-fixer
   - repo: local
     hooks:
-    - id: check-docstrings
-      name: Check Docstrings for '---' and '``' (double backticks)
-      entry: python tools/check_docstring_format.py
-      language: python
-      types: [python]
-      exclude: ^tools/
-    - id: check-naming-conflicts
-      name: Check for naming conflicts between modules and functions/classes
-      entry: python -m tools.check_naming_conflicts
-      language: python
-      pass_filenames: false
-    - id: check-ax-coding-guidance
-      name: Check AlbumentationsX coding guidance
-      entry: python -m tools.ax_coding_guidance
-      language: python
-      pass_filenames: false
-      files: ^(albumentations/|tools/ax_coding_guidance/|tests/test_ax_coding_guidance\.py$|\.pre-commit-config\.yaml$)
     - id: check-local-markdown-links
       name: Check local Markdown links
       entry: python tools/check_local_markdown_links.py
@@ -116,12 +98,6 @@ repos:
         entry: python ./tools/check_conda_dependencies.py
         language: system
         files: ^(pyproject\.toml|conda\.recipe/meta\.yaml|tools/check_conda_dependencies\.py)$
-      - id: check-readme-transforms-docs
-        name: Check README transform tables match albumentations
-        entry: uv run python -m tools.make_transforms_docs check README.md
-        language: system
-        pass_filenames: false
-        files: ^(README\.md|albumentations/).*$
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.4
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Codex Instructions for AlbumentationsX
 
-`check-ax-coding-guidance` owns deterministic AX source contracts; its canonical explanation is in
-`docs/contributing/coding_guidelines.md`. Do not duplicate those mechanics in this file.
+`check-ax-rules` owns configurable AX repository checks. Its `coding-guidance` rule owns deterministic AX source
+contracts; the canonical explanation is in `docs/contributing/coding_guidelines.md`. Do not duplicate those mechanics
+in this file.
 
 Read `docs/contributing/codex_guidelines.md` to choose the owning skill or design document. Load only the workflow that
 matches the task; runtime-code work always uses `performance-optimization`.

--- a/docs/contributing/codex_guidelines.md
+++ b/docs/contributing/codex_guidelines.md
@@ -1,7 +1,7 @@
 # Codex Working Guide for AlbumentationsX
 
-This is a routing guide, not a second coding rulebook. Deterministic AX source contracts are owned by
-`check-ax-coding-guidance`; read its diagnostic and the canonical explanation in
+This is a routing guide, not a second coding rulebook. Deterministic AX source contracts are owned by the
+`coding-guidance` rule in `check-ax-rules`; read its diagnostic and the canonical explanation in
 `docs/contributing/coding_guidelines.md` rather than duplicating a checklist in a prompt.
 
 ## Choose the owning workflow
@@ -30,8 +30,8 @@ Read a design document only when the change enters its boundary:
 ## Work in this order
 
 1. Establish the public contract, affected routes, and the smallest validation that could disprove the change.
-2. Run `pre-commit run check-ax-coding-guidance --all-files` after a transform or guidance change. Treat a failing
-   `AXG` diagnostic as the mechanical finding; record a pass as evidence rather than inventing one.
+2. Run `pre-commit run check-ax-rules --all-files` after a transform or guidance change. Treat a failing `AXG`
+   diagnostic as the mechanical finding; record a pass as evidence rather than inventing one.
 3. Review what the hook cannot prove: public API coherence, mathematical and target semantics, replay strength,
    ownership and aliasing, the appropriate functional/Albucore boundary, and benchmark evidence.
 4. Record the commands actually run and their results. Do not describe unrun checks as evidence.

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -51,8 +51,9 @@ We use pre-commit hooks to maintain consistent code quality. These hooks automat
 - Pyrefly runs through the official pre-commit hook in system mode, using the same `uv` environment as CI.
 
 AX repository checks run through one configurable hook: `pre-commit run check-ax-rules --all-files`. Its enabled
-rules are listed in `[tool.ax-rules.rules]` in `pyproject.toml`; set an entry to `false` to disable it. The
-`coding-guidance` rule emits `AXG001`–`AXG025` diagnostics for transform API, sampling, schema, naming,
+rules are listed in `[tool.ax-rules.rules]` in `pyproject.toml`; set an entry to `false` to disable it. On commit,
+each enabled rule runs only for the files in its own scope; `uv run python -m tools.ax_rules` without filenames runs
+every enabled rule. The `coding-guidance` rule emits `AXG001`–`AXG025` diagnostics for transform API, sampling, schema, naming,
 performance-shape, documentation, bbox propagation, and target-specific sampling contracts. The public
 `BboxParams.__init__(bbox_type="hbb")` compatibility default is intentional; all internal transform, processor, and
 functional calls must pass `bbox_type` explicitly. Keep design judgment and benchmark interpretation in the relevant

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -50,13 +50,14 @@ We use pre-commit hooks to maintain consistent code quality. These hooks automat
 
 - Pyrefly runs through the official pre-commit hook in system mode, using the same `uv` environment as CI.
 
-The repository-specific deterministic rules run through one package-wide hook:
-`pre-commit run check-ax-coding-guidance --all-files`. It emits `AXG001`–`AXG024` diagnostics for transform API,
-sampling, schema, naming, performance-shape, documentation, bbox propagation, and target-specific sampling contracts. The public
+AX repository checks run through one configurable hook: `pre-commit run check-ax-rules --all-files`. Its enabled
+rules are listed in `[tool.ax-rules.rules]` in `pyproject.toml`; set an entry to `false` to disable it. The
+`coding-guidance` rule emits `AXG001`–`AXG025` diagnostics for transform API, sampling, schema, naming,
+performance-shape, documentation, bbox propagation, and target-specific sampling contracts. The public
 `BboxParams.__init__(bbox_type="hbb")` compatibility default is intentional; all internal transform, processor, and
 functional calls must pass `bbox_type` explicitly. Keep design judgment and benchmark interpretation in the relevant
-review skill rather than duplicating these mechanical checks. `AGENTS.md`, `.codex/rules/`, and `.codex/skills/` point to
-this document and the hook instead of restating the AXG catalog.
+review skill rather than duplicating these mechanical checks. `AGENTS.md`, `.codex/rules/`, and `.codex/skills/` point
+to this document and the hook instead of restating the AXG catalog.
 
 - Before handing off Python changes, run the fast local quality gate:
 
@@ -420,7 +421,7 @@ those decisions from the first-target `params["shape"]` field.
 
 Every transform `apply*` method must name each sampled parameter it reads, including execution parameters such as
 `shape` and `bbox_type`. Keep `**params` only to forward parameters to another handler; do not read it with
-`params[...]` or `params.get(...)`. The `check-ax-coding-guidance` pre-commit hook enforces this rule.
+`params[...]` or `params.get(...)`. The `coding-guidance` rule in `check-ax-rules` enforces this rule.
 
 #### Keep `apply*` Methods Thin
 
@@ -435,7 +436,7 @@ lines, and standalone comments do not count; a line that contains code and an in
 infrastructure classes whose names begin with `Base` (for example, `BaseCrop` and `BaseMaxSizeTransform`) are excluded.
 Name a non-public base class `BaseX`, not `X`. This rule
 does not apply to `Compose` orchestration such as `apply_in_invocation`; it is enforced by the unified
-`check-ax-coding-guidance` pre-commit hook (`AXG003`).
+`coding-guidance` rule in `check-ax-rules` (`AXG003`).
 
 ### Parameter Generation
 
@@ -547,7 +548,7 @@ class MyTransform(ImageOnlyTransform):
         contrast_range: tuple[float, float] = (0.8, 1.2)  # ❌ No defaults in InitSchema
 ```
 
-The rule is enforced by the unified `check-ax-coding-guidance` pre-commit hook (`AXG001`). It checks nested and
+The rule is enforced by the `coding-guidance` rule in `check-ax-rules` (`AXG001`). It checks nested and
 module-level `*InitSchema` classes, follows imported schema inheritance, and does not exempt discriminator fields.
 If a transform only repeats inherited constructor inputs and explicitly forwards them, it does not need an empty schema.
 When it adds an input or changes an annotation, its non-empty schema must declare that input (`AXG020`).

--- a/docs/design/target-specific-parameter-sampling-inventory.md
+++ b/docs/design/target-specific-parameter-sampling-inventory.md
@@ -126,4 +126,4 @@ representation test before changing the implementation.
 3. Vary the representation property that drives materialization: shape, channels, dtype scale, layout, topology, or
    content. A test that only checks output shape does not prove the plan is target-correct.
 4. Assert the structured replay payload and verify replay does not sample again.
-5. Run `check-ax-coding-guidance`, the focused transform tests, and the full quality gate.
+5. Run `check-ax-rules`, the focused transform tests, and the full quality gate.

--- a/docs/design/target-specific-parameter-sampling.md
+++ b/docs/design/target-specific-parameter-sampling.md
@@ -739,7 +739,7 @@ dispatch, and application all contribute to user-visible cost.
 
 ## Source Enforcement
 
-The implemented `check-ax-coding-guidance` rules protect the architectural boundary.
+The implemented `coding-guidance` rule in `check-ax-rules` protects the architectural boundary.
 The rule should detect:
 
 - a `sample_parameters` override returning a plain dictionary;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -528,3 +528,10 @@ check_references = true
 check_type_consistency = true
 exclude_files = [ "__init__.py" ]
 verbose = false
+
+[tool.ax-rules.rules]
+coding-guidance = true
+docstring-format = true
+naming-conflicts = true
+public-transform-docstrings = true
+readme-transform-docs = true

--- a/tests/test_ax_rules.py
+++ b/tests/test_ax_rules.py
@@ -1,0 +1,96 @@
+"""Tests for the configurable AlbumentationsX rule dispatcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.ax_rules import runner
+
+
+def write_rule_config(root: Path, rules: str) -> None:
+    (root / "pyproject.toml").write_text(f"[tool.ax-rules.rules]\n{rules}", encoding="utf-8")
+
+
+def passing_rule(_: Path, __: tuple[Path, ...]) -> int:
+    return 0
+
+
+def test_enabled_rule_ids_respect_pyproject(tmp_path: Path) -> None:
+    write_rule_config(tmp_path, "first = false\nsecond = true\n")
+    rules = {
+        "first": passing_rule,
+        "second": passing_rule,
+    }
+    assert runner.enabled_rule_ids(tmp_path, rules) == ("second",)
+
+
+def test_enabled_rule_ids_reject_unknown_or_non_boolean_settings(tmp_path: Path) -> None:
+    rules = {"known": passing_rule}
+    write_rule_config(tmp_path, "unknown = true\n")
+    with pytest.raises(runner.ConfigurationError, match="unknown AX rule IDs: unknown"):
+        runner.enabled_rule_ids(tmp_path, rules)
+    write_rule_config(tmp_path, 'known = "yes"\n')
+    with pytest.raises(runner.ConfigurationError, match="AX rule settings must be booleans: known"):
+        runner.enabled_rule_ids(tmp_path, rules)
+
+
+def test_enabled_rule_ids_require_every_rule_to_be_configured(tmp_path: Path) -> None:
+    write_rule_config(tmp_path, "first = true\n")
+    rules = {
+        "first": passing_rule,
+        "second": passing_rule,
+    }
+    with pytest.raises(runner.ConfigurationError, match="missing AX rule settings: second"):
+        runner.enabled_rule_ids(tmp_path, rules)
+
+
+def test_repository_config_declares_every_ax_rule() -> None:
+    root = Path(__file__).parents[1]
+    assert runner.enabled_rule_ids(root) == tuple(runner.RULES)
+
+
+def test_run_invokes_only_enabled_rules_with_pre_commit_python_files(tmp_path: Path) -> None:
+    calls: list[tuple[str, tuple[Path, ...]]] = []
+
+    def check(name: str):
+        def run(_: Path, paths: tuple[Path, ...]) -> int:
+            calls.append((name, paths))
+            return 0
+
+        return run
+
+    write_rule_config(tmp_path, "first = true\nsecond = false\n")
+    source = tmp_path / "albumentations" / "example.py"
+    source.parent.mkdir()
+    source.write_text("", encoding="utf-8")
+    rules = {
+        "first": check("first"),
+        "second": check("second"),
+    }
+    assert runner.run(tmp_path, ("albumentations/example.py", "tools/helper.py"), rules) == 0
+    assert calls == [("first", (source,))]
+
+
+def test_docstring_paths_exclude_asv_environments_from_a_full_run(tmp_path: Path) -> None:
+    source = tmp_path / "albumentations" / "example.py"
+    asv_environment = tmp_path / "benchmark" / ".asv" / "env" / "dependency.py"
+    source.parent.mkdir()
+    asv_environment.parent.mkdir(parents=True)
+    source.write_text("", encoding="utf-8")
+    asv_environment.write_text("", encoding="utf-8")
+    assert runner.docstring_paths(tmp_path, ()) == (source,)
+
+
+def test_pre_commit_uses_the_single_ax_rule_hook() -> None:
+    config = (Path(__file__).parents[1] / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    assert config.count("id: check-ax-rules") == 1
+    for retired_hook in (
+        "check-ax-coding-guidance",
+        "check-docstrings",
+        "check-naming-conflicts",
+        "check-public-transform-docstrings",
+        "check-readme-transforms-docs",
+    ):
+        assert f"id: {retired_hook}" not in config

--- a/tests/test_ax_rules.py
+++ b/tests/test_ax_rules.py
@@ -17,17 +17,29 @@ def passing_rule(_: Path, __: tuple[Path, ...]) -> int:
     return 0
 
 
+def matches_any_file(_: Path, __: tuple[Path, ...]) -> bool:
+    return True
+
+
+def matches_no_file(_: Path, __: tuple[Path, ...]) -> bool:
+    return False
+
+
+def rule(check=passing_rule) -> runner.Rule:
+    return runner.Rule(check, matches_any_file)
+
+
 def test_enabled_rule_ids_respect_pyproject(tmp_path: Path) -> None:
     write_rule_config(tmp_path, "first = false\nsecond = true\n")
     rules = {
-        "first": passing_rule,
-        "second": passing_rule,
+        "first": rule(),
+        "second": rule(),
     }
     assert runner.enabled_rule_ids(tmp_path, rules) == ("second",)
 
 
 def test_enabled_rule_ids_reject_unknown_or_non_boolean_settings(tmp_path: Path) -> None:
-    rules = {"known": passing_rule}
+    rules = {"known": rule()}
     write_rule_config(tmp_path, "unknown = true\n")
     with pytest.raises(runner.ConfigurationError, match="unknown AX rule IDs: unknown"):
         runner.enabled_rule_ids(tmp_path, rules)
@@ -39,8 +51,8 @@ def test_enabled_rule_ids_reject_unknown_or_non_boolean_settings(tmp_path: Path)
 def test_enabled_rule_ids_require_every_rule_to_be_configured(tmp_path: Path) -> None:
     write_rule_config(tmp_path, "first = true\n")
     rules = {
-        "first": passing_rule,
-        "second": passing_rule,
+        "first": rule(),
+        "second": rule(),
     }
     with pytest.raises(runner.ConfigurationError, match="missing AX rule settings: second"):
         runner.enabled_rule_ids(tmp_path, rules)
@@ -51,7 +63,7 @@ def test_repository_config_declares_every_ax_rule() -> None:
     assert runner.enabled_rule_ids(root) == tuple(runner.RULES)
 
 
-def test_run_invokes_only_enabled_rules_with_pre_commit_python_files(tmp_path: Path) -> None:
+def test_run_passes_all_changed_paths_to_enabled_rules(tmp_path: Path) -> None:
     calls: list[tuple[str, tuple[Path, ...]]] = []
 
     def check(name: str):
@@ -66,11 +78,52 @@ def test_run_invokes_only_enabled_rules_with_pre_commit_python_files(tmp_path: P
     source.parent.mkdir()
     source.write_text("", encoding="utf-8")
     rules = {
-        "first": check("first"),
-        "second": check("second"),
+        "first": rule(check("first")),
+        "second": rule(check("second")),
     }
     assert runner.run(tmp_path, ("albumentations/example.py", "tools/helper.py"), rules) == 0
-    assert calls == [("first", (source,))]
+    assert calls == [("first", (source, tmp_path / "tools/helper.py"))]
+
+
+@pytest.mark.parametrize(
+    ("filenames", "expected"),
+    [
+        (("README.md",), ("readme-transform-docs",)),
+        (("docs/guide.md",), ()),
+        (("pyproject.toml",), ("public-transform-docstrings",)),
+        (("tests/test_rules.py",), ("docstring-format",)),
+        (("tools/ax_coding_guidance/example.py",), ("coding-guidance",)),
+        ((".pre-commit-config.yaml",), ("coding-guidance", "public-transform-docstrings")),
+        (("albumentations/example.py",), tuple(runner.RULES)),
+    ],
+)
+def test_selected_rule_ids_use_each_rule_file_scope(
+    tmp_path: Path,
+    filenames: tuple[str, ...],
+    expected: tuple[str, ...],
+) -> None:
+    write_rule_config(tmp_path, "\n".join(f"{name} = true" for name in runner.RULES))
+    paths = tuple(tmp_path / filename for filename in filenames)
+    assert runner.selected_rule_ids(tmp_path, paths) == expected
+
+
+def test_run_without_filenames_runs_every_enabled_rule(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def check(name: str):
+        def run(_: Path, __: tuple[Path, ...]) -> int:
+            calls.append(name)
+            return 0
+
+        return run
+
+    write_rule_config(tmp_path, "first = true\nsecond = true\n")
+    rules = {
+        "first": runner.Rule(check("first"), matches_no_file),
+        "second": runner.Rule(check("second"), matches_no_file),
+    }
+    assert runner.run(tmp_path, (), rules) == 0
+    assert calls == ["first", "second"]
 
 
 def test_docstring_paths_exclude_asv_environments_from_a_full_run(tmp_path: Path) -> None:
@@ -83,9 +136,20 @@ def test_docstring_paths_exclude_asv_environments_from_a_full_run(tmp_path: Path
     assert runner.docstring_paths(tmp_path, ()) == (source,)
 
 
+def test_docstring_paths_do_not_fall_back_for_non_python_files(tmp_path: Path) -> None:
+    readme = tmp_path / "README.md"
+    source = tmp_path / "albumentations" / "example.py"
+    source.parent.mkdir()
+    readme.write_text("", encoding="utf-8")
+    source.write_text("", encoding="utf-8")
+    assert runner.docstring_paths(tmp_path, (readme,)) == ()
+
+
 def test_pre_commit_uses_the_single_ax_rule_hook() -> None:
     config = (Path(__file__).parents[1] / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     assert config.count("id: check-ax-rules") == 1
+    hook = config.split("- id: check-ax-rules", maxsplit=1)[1].split("- id:", maxsplit=1)[0]
+    assert "files:" not in hook
     for retired_hook in (
         "check-ax-coding-guidance",
         "check-docstrings",

--- a/tools/ax_rules/__init__.py
+++ b/tools/ax_rules/__init__.py
@@ -1,0 +1,5 @@
+"""Configurable repository checks for AlbumentationsX."""
+
+from .runner import main
+
+__all__ = ["main"]

--- a/tools/ax_rules/__init__.py
+++ b/tools/ax_rules/__init__.py
@@ -1,5 +1,0 @@
-"""Configurable repository checks for AlbumentationsX."""
-
-from .runner import main
-
-__all__ = ["main"]

--- a/tools/ax_rules/__main__.py
+++ b/tools/ax_rules/__main__.py
@@ -1,0 +1,3 @@
+from .runner import main
+
+raise SystemExit(main())

--- a/tools/ax_rules/runner.py
+++ b/tools/ax_rules/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeAlias
 
@@ -18,6 +19,7 @@ except ModuleNotFoundError:  # Python 3.10
 
 
 RuleCheck: TypeAlias = Callable[[Path, tuple[Path, ...]], int]
+RuleSelector: TypeAlias = Callable[[Path, tuple[Path, ...]], bool]
 
 
 class ConfigurationError(ValueError):
@@ -43,7 +45,7 @@ def _run_docstring_format(root: Path, filenames: tuple[Path, ...]) -> int:
     return int(bool(errors))
 
 
-def _run_naming_conflicts(root: Path, _: tuple[Path, ...]) -> int:
+def _run_naming_conflicts(root: Path, _filenames: tuple[Path, ...]) -> int:
     _, _, conflicts = check_naming_conflicts.find_conflicts(str(root / "albumentations"))
     if not conflicts:
         return 0
@@ -68,12 +70,58 @@ def _run_readme_transform_docs(root: Path, _: tuple[Path, ...]) -> int:
     return 0
 
 
-RULES: dict[str, RuleCheck] = {
-    "coding-guidance": _run_coding_guidance,
-    "docstring-format": _run_docstring_format,
-    "naming-conflicts": _run_naming_conflicts,
-    "public-transform-docstrings": _run_public_transform_docstrings,
-    "readme-transform-docs": _run_readme_transform_docs,
+def _relative_paths(root: Path, filenames: tuple[Path, ...]) -> tuple[str, ...]:
+    return tuple(path.relative_to(root).as_posix() for path in filenames)
+
+
+def _matches_coding_guidance(root: Path, filenames: tuple[Path, ...]) -> bool:
+    return any(
+        path in {".pre-commit-config.yaml", "tests/test_ax_coding_guidance.py"}
+        or path.startswith(("albumentations/", "tools/ax_coding_guidance/"))
+        for path in _relative_paths(root, filenames)
+    )
+
+
+def _python_source_paths(root: Path, filenames: tuple[Path, ...]) -> tuple[Path, ...]:
+    return tuple(
+        path for path in filenames if path.suffix == ".py" and not path.relative_to(root).is_relative_to("tools")
+    )
+
+
+def _matches_docstring_format(root: Path, filenames: tuple[Path, ...]) -> bool:
+    return bool(_python_source_paths(root, filenames))
+
+
+def _matches_naming_conflicts(root: Path, filenames: tuple[Path, ...]) -> bool:
+    return any(path.startswith("albumentations/") and path.endswith(".py") for path in _relative_paths(root, filenames))
+
+
+def _matches_public_transform_docstrings(root: Path, filenames: tuple[Path, ...]) -> bool:
+    return any(
+        path in {".pre-commit-config.yaml", "pyproject.toml", "tests/test_docstrings.py"}
+        or path.startswith("albumentations/")
+        for path in _relative_paths(root, filenames)
+    )
+
+
+def _matches_readme_transform_docs(root: Path, filenames: tuple[Path, ...]) -> bool:
+    return any(path == "README.md" or path.startswith("albumentations/") for path in _relative_paths(root, filenames))
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A repository check and the changed files that require it."""
+
+    check: RuleCheck
+    applies_to: RuleSelector
+
+
+RULES: dict[str, Rule] = {
+    "coding-guidance": Rule(_run_coding_guidance, _matches_coding_guidance),
+    "docstring-format": Rule(_run_docstring_format, _matches_docstring_format),
+    "naming-conflicts": Rule(_run_naming_conflicts, _matches_naming_conflicts),
+    "public-transform-docstrings": Rule(_run_public_transform_docstrings, _matches_public_transform_docstrings),
+    "readme-transform-docs": Rule(_run_readme_transform_docs, _matches_readme_transform_docs),
 }
 
 
@@ -97,7 +145,7 @@ def _read_rule_settings(root: Path) -> Mapping[str, Any]:
     return rules
 
 
-def enabled_rule_ids(root: Path, rules: Mapping[str, RuleCheck] = RULES) -> tuple[str, ...]:
+def enabled_rule_ids(root: Path, rules: Mapping[str, Rule] = RULES) -> tuple[str, ...]:
     """Return the explicitly configured AX rule IDs."""
     settings = _read_rule_settings(root)
     unknown = sorted(set(settings) - set(rules))
@@ -112,25 +160,26 @@ def enabled_rule_ids(root: Path, rules: Mapping[str, RuleCheck] = RULES) -> tupl
     return tuple(name for name in rules if settings[name])
 
 
-def _source_paths(root: Path, filenames: Iterable[str]) -> tuple[Path, ...]:
+def _changed_paths(root: Path, filenames: Iterable[str]) -> tuple[Path, ...]:
     paths: list[Path] = []
+    root = root.resolve()
     for filename in filenames:
         path = Path(filename)
         if not path.is_absolute():
             path = root / path
+        path = path.resolve()
         try:
-            relative = path.resolve().relative_to(root.resolve())
+            path.relative_to(root)
         except ValueError:
             continue
-        if path.suffix == ".py" and relative.parts and relative.parts[0] != "tools":
-            paths.append(path)
+        paths.append(path)
     return tuple(paths)
 
 
 def docstring_paths(root: Path, filenames: tuple[Path, ...]) -> tuple[Path, ...]:
     """Return changed Python files or the repository's owned docstring sources."""
     if filenames:
-        return filenames
+        return _python_source_paths(root, filenames)
     return tuple(
         path
         for source_dir in ("albumentations", "benchmark", "tests")
@@ -140,15 +189,30 @@ def docstring_paths(root: Path, filenames: tuple[Path, ...]) -> tuple[Path, ...]
     )
 
 
-def run(root: Path, filenames: Iterable[str] = (), rules: Mapping[str, RuleCheck] = RULES) -> int:
+def selected_rule_ids(
+    root: Path,
+    filenames: tuple[Path, ...],
+    rules: Mapping[str, Rule] = RULES,
+    *,
+    run_all: bool = False,
+) -> tuple[str, ...]:
+    """Return enabled rules that apply to the current invocation."""
+    enabled = enabled_rule_ids(root, rules)
+    if run_all:
+        return enabled
+    return tuple(name for name in enabled if rules[name].applies_to(root, filenames))
+
+
+def run(root: Path, filenames: Iterable[str] = (), rules: Mapping[str, Rule] = RULES) -> int:
     """Run every enabled rule and return a pre-commit compatible status."""
-    source_paths = _source_paths(root, filenames)
+    supplied_filenames = tuple(filenames)
+    changed_paths = _changed_paths(root, supplied_filenames)
     try:
-        selected = enabled_rule_ids(root, rules)
+        selected = selected_rule_ids(root, changed_paths, rules, run_all=not supplied_filenames)
     except ConfigurationError as exc:
         print(f"AXR configuration error: {exc}", file=sys.stderr)
         return 2
-    failures = [name for name in selected if rules[name](root, source_paths)]
+    failures = [name for name in selected if rules[name].check(root, changed_paths)]
     return int(bool(failures))
 
 

--- a/tools/ax_rules/runner.py
+++ b/tools/ax_rules/runner.py
@@ -1,0 +1,160 @@
+"""Run enabled AlbumentationsX repository rules from ``pyproject.toml``."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable, Iterable, Mapping
+from pathlib import Path
+from typing import Any, TypeAlias
+
+from tools import check_docstring_format, check_naming_conflicts
+from tools.ax_coding_guidance.runner import InfrastructureError, run_repo
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+
+RuleCheck: TypeAlias = Callable[[Path, tuple[Path, ...]], int]
+
+
+class ConfigurationError(ValueError):
+    """Raised when the AX rule selection is invalid."""
+
+
+def _run_coding_guidance(root: Path, _: tuple[Path, ...]) -> int:
+    try:
+        diagnostics = run_repo(root)
+    except InfrastructureError as exc:
+        print(f"AXG infrastructure error: {exc}", file=sys.stderr)
+        return 2
+    for diagnostic in diagnostics:
+        print(diagnostic.format())
+    return int(bool(diagnostics))
+
+
+def _run_docstring_format(root: Path, filenames: tuple[Path, ...]) -> int:
+    paths = docstring_paths(root, filenames)
+    errors = check_docstring_format.collect_errors(paths, root=root)
+    for error in errors:
+        print(error)
+    return int(bool(errors))
+
+
+def _run_naming_conflicts(root: Path, _: tuple[Path, ...]) -> int:
+    _, _, conflicts = check_naming_conflicts.find_conflicts(str(root / "albumentations"))
+    if not conflicts:
+        return 0
+    check_naming_conflicts.print_conflicts(conflicts)
+    return 1
+
+
+def _run_public_transform_docstrings(root: Path, _: tuple[Path, ...]) -> int:
+    import pytest
+
+    return pytest.main(["-q", "tests/test_docstrings.py", "-k", "short_description_length"])
+
+
+def _run_readme_transform_docs(root: Path, _: tuple[Path, ...]) -> int:
+    from tools import make_transforms_docs
+
+    try:
+        make_transforms_docs.check_transform_docs(root / "README.md")
+    except ValueError as exc:
+        print(exc)
+        return 1
+    return 0
+
+
+RULES: dict[str, RuleCheck] = {
+    "coding-guidance": _run_coding_guidance,
+    "docstring-format": _run_docstring_format,
+    "naming-conflicts": _run_naming_conflicts,
+    "public-transform-docstrings": _run_public_transform_docstrings,
+    "readme-transform-docs": _run_readme_transform_docs,
+}
+
+
+def _read_rule_settings(root: Path) -> Mapping[str, Any]:
+    config_path = root / "pyproject.toml"
+    try:
+        data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ConfigurationError(f"cannot read {config_path}: {exc}") from exc
+    tool = data.get("tool", {})
+    if not isinstance(tool, dict):
+        raise ConfigurationError("[tool] must be a table")
+    ax_rules = tool.get("ax-rules", {})
+    if not isinstance(ax_rules, dict):
+        raise ConfigurationError("[tool.ax-rules] must be a table")
+    rules = ax_rules.get("rules")
+    if rules is None:
+        return {}
+    if not isinstance(rules, dict):
+        raise ConfigurationError("[tool.ax-rules.rules] must be a table of booleans")
+    return rules
+
+
+def enabled_rule_ids(root: Path, rules: Mapping[str, RuleCheck] = RULES) -> tuple[str, ...]:
+    """Return the explicitly configured AX rule IDs."""
+    settings = _read_rule_settings(root)
+    unknown = sorted(set(settings) - set(rules))
+    if unknown:
+        raise ConfigurationError(f"unknown AX rule IDs: {', '.join(unknown)}")
+    missing = sorted(set(rules) - set(settings))
+    if missing:
+        raise ConfigurationError(f"missing AX rule settings: {', '.join(missing)}")
+    invalid = sorted(name for name, enabled in settings.items() if not isinstance(enabled, bool))
+    if invalid:
+        raise ConfigurationError(f"AX rule settings must be booleans: {', '.join(invalid)}")
+    return tuple(name for name in rules if settings[name])
+
+
+def _source_paths(root: Path, filenames: Iterable[str]) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    for filename in filenames:
+        path = Path(filename)
+        if not path.is_absolute():
+            path = root / path
+        try:
+            relative = path.resolve().relative_to(root.resolve())
+        except ValueError:
+            continue
+        if path.suffix == ".py" and relative.parts and relative.parts[0] != "tools":
+            paths.append(path)
+    return tuple(paths)
+
+
+def docstring_paths(root: Path, filenames: tuple[Path, ...]) -> tuple[Path, ...]:
+    """Return changed Python files or the repository's owned docstring sources."""
+    if filenames:
+        return filenames
+    return tuple(
+        path
+        for source_dir in ("albumentations", "benchmark", "tests")
+        if (root / source_dir).is_dir()
+        for path in (root / source_dir).rglob("*.py")
+        if ".asv" not in path.relative_to(root).parts
+    )
+
+
+def run(root: Path, filenames: Iterable[str] = (), rules: Mapping[str, RuleCheck] = RULES) -> int:
+    """Run every enabled rule and return a pre-commit compatible status."""
+    source_paths = _source_paths(root, filenames)
+    try:
+        selected = enabled_rule_ids(root, rules)
+    except ConfigurationError as exc:
+        print(f"AXR configuration error: {exc}", file=sys.stderr)
+        return 2
+    failures = [name for name in selected if rules[name](root, source_paths)]
+    return int(bool(failures))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check configured AlbumentationsX repository rules")
+    parser.add_argument("filenames", nargs="*", help="files supplied by pre-commit")
+    args = parser.parse_args(argv)
+    root = Path(__file__).resolve().parents[2]
+    return run(root, args.filenames)

--- a/tools/check_docstring_format.py
+++ b/tools/check_docstring_format.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 DOCSTRING_PATTERN = re.compile(r'["\']{3}[\s\S]+?["\']{3}')
@@ -8,35 +9,48 @@ DASH_PATTERN = re.compile(r"---{2,}")
 DOUBLE_BACKTICK_PATTERN = re.compile(r"(?<!`)``(?!`)")
 
 
-def check_docstrings_for_dashes(file_path: str) -> bool:
+def check_docstrings_for_dashes(file_path: str | Path) -> bool:
     with Path(file_path).open(encoding="utf-8") as file:
         content = file.read()
     return all(not DASH_PATTERN.search(match.group()) for match in DOCSTRING_PATTERN.finditer(content))
 
 
-def check_docstrings_for_double_backticks(file_path: str) -> bool:
+def check_docstrings_for_double_backticks(file_path: str | Path) -> bool:
     with Path(file_path).open(encoding="utf-8") as file:
         content = file.read()
     return all(not DOUBLE_BACKTICK_PATTERN.search(match.group()) for match in DOCSTRING_PATTERN.finditer(content))
 
 
-def main():
-    exit_code = 0
-    for file_path in sys.argv[1:]:
+def collect_errors(file_paths: Iterable[str | Path], *, root: Path | None = None) -> list[str]:
+    """Return format errors for Python docstrings outside local tooling."""
+    errors: list[str] = []
+    for file_path in file_paths:
+        path = Path(file_path)
+        try:
+            relative = path.resolve().relative_to(root.resolve()).as_posix() if root else str(path)
+        except ValueError:
+            continue
+        if root and (not relative.endswith(".py") or relative.startswith("tools/")):
+            continue
         if not check_docstrings_for_dashes(file_path):
-            print(
-                f"Error in {file_path}: According to Google Style docstrings, '---' should not be used "
+            errors.append(
+                f"Error in {relative}: According to Google Style docstrings, '---' should not be used "
                 "to underline sections. Please refer to "
-                "https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings",
+                "https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings"
             )
-            exit_code = 1
         if not check_docstrings_for_double_backticks(file_path):
-            print(
-                f"Error in {file_path}: Double backticks (``) in docstrings get incorrectly re-rendered "
-                "on the website. Use single backticks (`) or other formatting instead.",
+            errors.append(
+                f"Error in {relative}: Double backticks (``) in docstrings get incorrectly re-rendered "
+                "on the website. Use single backticks (`) or other formatting instead."
             )
-            exit_code = 1
-    sys.exit(exit_code)
+    return errors
+
+
+def main() -> None:
+    errors = collect_errors(sys.argv[1:])
+    for error in errors:
+        print(error)
+    sys.exit(bool(errors))
 
 
 if __name__ == "__main__":

--- a/tools/check_naming_conflicts.py
+++ b/tools/check_naming_conflicts.py
@@ -65,6 +65,15 @@ def find_conflicts(base_dir: str = "albumentations") -> tuple[set[str], set[str]
     return module_names, defined_names, conflicts
 
 
+def print_conflicts(conflicts: set[str]) -> None:
+    """Print the established remediation for module/export conflicts."""
+    print("⚠️ Naming conflicts detected between modules and defined names:", file=sys.stderr)
+    for conflict in sorted(conflicts):
+        print(f"  - '{conflict}' is both a module name and a function/class", file=sys.stderr)
+    print("\nThese conflicts can cause problems with tools like Hydra that use direct module paths.")
+    print("Consider renaming either the module or the function/class.")
+
+
 def main():
     """Main entry point for the script."""
     base_dir = "albumentations"
@@ -76,11 +85,7 @@ def main():
     _, _, conflicts = find_conflicts(base_dir)
 
     if conflicts:
-        print("⚠️ Naming conflicts detected between modules and defined names:", file=sys.stderr)
-        for conflict in sorted(conflicts):
-            print(f"  - '{conflict}' is both a module name and a function/class", file=sys.stderr)
-        print("\nThese conflicts can cause problems with tools like Hydra that use direct module paths.")
-        print("Consider renaming either the module or the function/class.")
+        print_conflicts(conflicts)
         sys.exit(1)
 
     print("✅ No naming conflicts detected between modules and defined names.")

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -226,19 +226,14 @@ def check_docs(
         raise ValueError(msg.strip())
 
 
-def main() -> None:
-    args = parse_args()
-    command = args.command
-    if command not in {"make", "check"}:
-        raise ValueError(f"You should provide a valid command: {{make|check}}. Got {command} instead.")
-
+def generated_transform_docs() -> tuple[str, str, str]:
+    """Return the generated README content for each transform category."""
     image_only_transforms = get_image_only_transforms_info()
     dual_transforms = get_dual_transforms_info()
     transforms_3d = get_3d_transforms_info()
 
-    image_only_transforms_links = make_transforms_targets_links(image_only_transforms)
+    image_only_transform_links = make_transforms_targets_links(image_only_transforms)
 
-    # Exclude USER_DATA - it is passthrough by default, not a spatial target
     dual_header = []
     for target in ALL_TARGETS:
         if target == Targets.BBOXES:
@@ -246,38 +241,47 @@ def main() -> None:
         else:
             dual_header.append(target.value)
 
-    dual_transforms_table = make_transforms_targets_table(
+    dual_transform_table = make_transforms_targets_table(
         dual_transforms,
         header=["Transform", *dual_header],
         targets_to_check=ALL_TARGETS,
         split_bboxes=True,
     )
-
     transforms_3d_table = make_transforms_targets_table(
         transforms_3d,
         header=["Transform"] + [target.value for target in [Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS]],
         targets_to_check=[Targets.VOLUME, Targets.MASK3D, Targets.KEYPOINTS],
     )
+    return image_only_transform_links, dual_transform_table, transforms_3d_table
+
+
+def check_transform_docs(filepath: str | Path) -> None:
+    """Raise when transform documentation in ``filepath`` is out of date."""
+    check_docs(str(filepath), *generated_transform_docs())
+
+
+def main() -> None:
+    args = parse_args()
+    command = args.command
+    if command not in {"make", "check"}:
+        raise ValueError(f"You should provide a valid command: {{make|check}}. Got {command} instead.")
+
+    image_only_transform_links, dual_transform_table, transforms_3d_table = generated_transform_docs()
 
     if command == "make":
         print("===== COPY THIS TABLE TO README.MD BELOW ### Pixel-level transforms =====")
-        print(image_only_transforms_links)
+        print(image_only_transform_links)
         print("===== END OF COPY =====")
         print()
         print("===== COPY THIS TABLE TO README.MD BELOW ### Spatial-level transforms =====")
-        print(dual_transforms_table)
+        print(dual_transform_table)
         print("===== END OF COPY =====")
         print()
         print("===== COPY THIS TABLE TO README.MD BELOW ### 3D transforms =====")
         print(transforms_3d_table)
         print("===== END OF COPY =====")
     else:
-        check_docs(
-            args.filepath,
-            image_only_transforms_links,
-            dual_transforms_table,
-            transforms_3d_table,
-        )
+        check_docs(args.filepath, image_only_transform_links, dual_transform_table, transforms_3d_table)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Consolidate five AX repository checks behind check-ax-rules.
- Select each rule explicitly through the tool.ax-rules.rules table in pyproject.toml.
- Reuse existing validators and update the contributor guidance.

## Validation
- uv run pytest -q tests/test_ax_rules.py tests/test_ax_coding_guidance.py tests/test_pre_commit_hooks.py tests/test_docstrings.py
- pre-commit run --all-files --show-diff-on-failure

## Summary by Sourcery

Unify AlbumentationsX repository validation under a configurable `check-ax-rules` command and update its guidance and coverage.

New Features:
- Add a configurable `check-ax-rules` dispatcher that runs the five enabled AlbumentationsX repository checks from `pyproject.toml`.
- Select checks based on changed-file scope during commits while supporting full enabled-rule runs without filenames.

Bug Fixes:
- Ensure docstring validation excludes tooling and ASV environment files and handles repository-relative diagnostics consistently.

Enhancements:
- Refactor existing validators and documentation generation checks for reuse through the unified rule runner.
- Validate rule configuration for unknown, missing, and non-boolean settings.

CI:
- Replace the five separate AX-related pre-commit hooks with a single `check-ax-rules` hook.

Documentation:
- Update contributor, Codex, and review guidance to reference the unified AX rules hook and configurable rule selection.

Tests:
- Add comprehensive tests for rule configuration, file scoping, full runs, hook consolidation, and docstring path handling.