### PR TITLE
test: cover ImageOnly transforms in Tensor contract matrix

### DIFF
--- a/docs/design/transform-target-contracts.md
+++ b/docs/design/transform-target-contracts.md
@@ -1,7 +1,7 @@
 # Generated Transform Target Contracts
 
 **Status:** Implemented
-**Scope:** public `DualTransform` execution across images, annotations, volume data, and batches
+**Scope:** public `DualTransform` execution plus Tensor routing for `ImageOnlyTransform` targets
 **Primary readers:** maintainers adding transform modes, targets, metadata requirements, or target-specific behavior
 
 ## What adding a registry case now covers
@@ -12,20 +12,25 @@ volume/`mask3d` coverage without another transform list.
 One primary mode per class also runs against the more expensive dtype, channel, batch, empty-target, memory-layout, and
 read-only profiles.
 
+Every primary `ImageOnlyTransform` mode automatically runs through the Tensor bridge for `image`, batched `images`, and
+`volume`. These profiles check `CHW`, `NCHW`, and `CDHW` Tensor layouts without adding annotation targets that an
+image-only transform does not declare.
+
 The generated matrix answers three questions:
 
 | Matrix | Cases | Profiles | Property under test |
 |---|---|---|---|
-| Core | Every registered mode | Applicable core profiles | A public mode executes every declared target and preserves target structure |
-| Extended | One explicit primary mode per class | Applicable extended profiles | Mode-independent dtype, channel, batch, empty-target, and memory contracts hold |
-| Tensor | Every core pair plus selected extended pairs | Equivalent plain CPU Tensor targets | Container, layout, dtype, values, replay parity, and input ownership match the NumPy case |
+| Core | Every registered `DualTransform` mode | Applicable core profiles | A public mode executes every declared target and preserves target structure |
+| Extended | One explicit primary `DualTransform` mode per class | Applicable extended profiles | Mode-independent dtype, channel, batch, empty-target, and memory contracts hold |
+| Tensor | Every core pair plus selected extended pairs; one primary ImageOnly mode per class | Equivalent plain CPU Tensor targets | Container, layout, dtype, values, replay parity, and input ownership match the NumPy case |
 
 Running every mode through the core profiles closes the gap that allowed a new mutually exclusive constructor mode to
 miss bbox, keypoint, or volume tests. Restricting extended profiles to primary modes controls runtime because these
 workloads test array representation rather than constructor branching.
 
-The Tensor matrix reuses the same cases, profile factories, applicability decisions, and `targets_as_params` metadata.
-It adds no second transform inventory.
+The Tensor matrix reuses the same case inventory, applicability decisions, and `targets_as_params` metadata. It uses
+dedicated image-only target profiles because those transforms do not declare annotation targets; it adds no second
+transform inventory.
 
 ## One configuration inventory, reusable target workloads
 
@@ -91,7 +96,7 @@ by a read-only array.
 
 `tests/helpers/target_contracts.py` creates a pair only when all of these conditions hold:
 
-1. the case class is a `DualTransform`;
+1. the case class is a `DualTransform`, or an `ImageOnlyTransform` for the dedicated Tensor profiles;
 2. the profile contains every target required by the case;
 3. a required target is non-empty when the mode needs data from it;
 4. the transform's declared `_targets` contain every profile target, including batch forms derived from their singular
@@ -102,9 +107,9 @@ by a read-only array.
 The resolver selects pairs from capabilities. A missing declared capability prevents collection. A collected pair that
 cannot execute fails with its case ID and profile ID.
 
-Meta-tests enforce that pair IDs are unique, every registered `DualTransform` case has core coverage, and every profile
-collects at least once. Performance pressure is handled by the core/extended tier boundary; applicable core pairs are
-never sampled or skipped.
+Meta-tests enforce that pair IDs are unique, every registered `DualTransform` case has core coverage, every primary
+`ImageOnlyTransform` case has all three Tensor target routes, and every general target profile collects at least once.
+Performance pressure is handled by the core/extended tier boundary; applicable core pairs are never sampled or skipped.
 
 ## Every pair crosses the same public boundaries
 
@@ -172,6 +177,8 @@ pre-commit run --all-files --show-diff-on-failure
 The architecture remains complete while:
 
 - adding one registered mode automatically creates all applicable core pairs;
+- adding one registered `ImageOnlyTransform` mode automatically creates Tensor pairs for image, image batches, and
+  volumes;
 - target profiles contain no transform class lists or constructor kwargs;
 - core selection uses declared capabilities and has no class-name skip branches;
 - all-mode and primary-mode views are explicit at each consumer;

--- a/tests/contracts/test_target_cluster_contract.py
+++ b/tests/contracts/test_target_cluster_contract.py
@@ -5,8 +5,10 @@ import albumentations as A
 from tests.helpers.target_contracts import (
     CORE_TARGET_CONTRACT_PAIRS,
     EXTENDED_TARGET_CONTRACT_PAIRS,
+    TENSOR_IMAGE_ONLY_TARGET_CONTRACT_PAIRS,
     TENSOR_TARGET_CONTRACT_PAIRS,
     TargetContractPair,
+    make_target_contract_data,
     run_target_cluster_contract,
     run_tensor_target_cluster_contract,
 )
@@ -54,6 +56,19 @@ def test_every_primary_image_only_transform_case_has_tensor_target_coverage() ->
     missing = expected_pairs - covered_pairs
 
     assert not missing, f"ImageOnlyTransform Tensor target coverage is missing: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("pair", TENSOR_IMAGE_ONLY_TARGET_CONTRACT_PAIRS, ids=lambda pair: pair.pair_id)
+def test_image_only_tensor_profiles_preserve_primary_image_data(pair: TargetContractPair) -> None:
+    primary_image = pair.case.primary_data_factory(np.random.default_rng(137))["image"]
+    source = make_target_contract_data(pair.case, pair.profile, np.random.default_rng(137))
+    target_name = next(iter(pair.profile.required_targets))
+    target = source[target_name]
+    image = target if target_name == "image" else target[0]
+    expected_image = primary_image if primary_image.ndim == 3 else primary_image[..., None]
+
+    assert image.dtype == expected_image.dtype
+    np.testing.assert_array_equal(image, expected_image)
 
 
 def test_every_target_profile_is_collected() -> None:

--- a/tests/contracts/test_target_cluster_contract.py
+++ b/tests/contracts/test_target_cluster_contract.py
@@ -11,7 +11,7 @@ from tests.helpers.target_contracts import (
     run_tensor_target_cluster_contract,
 )
 from tests.helpers.target_profiles import TARGET_PROFILES_BY_ID
-from tests.helpers.transform_cases import ALL_DUAL_TRANSFORM_CONTRACT_CASES
+from tests.helpers.transform_cases import ALL_DUAL_TRANSFORM_CONTRACT_CASES, PRIMARY_IMAGE_ONLY_TRANSFORM_CONTRACT_CASES
 
 
 @pytest.mark.parametrize("pair", CORE_TARGET_CONTRACT_PAIRS, ids=lambda pair: pair.pair_id)
@@ -43,6 +43,17 @@ def test_every_dual_transform_case_has_core_target_coverage() -> None:
     missing = {case.case_id for case in ALL_DUAL_TRANSFORM_CONTRACT_CASES} - covered_case_ids
 
     assert not missing, f"DualTransform cases without core target coverage: {sorted(missing)}"
+
+
+def test_every_primary_image_only_transform_case_has_tensor_target_coverage() -> None:
+    image_only_case_ids = {case.case_id for case in PRIMARY_IMAGE_ONLY_TRANSFORM_CONTRACT_CASES}
+    expected_pairs = {
+        (case_id, profile_id) for case_id in image_only_case_ids for profile_id in ("image", "images-batch", "volume")
+    }
+    covered_pairs = {(pair.case.case_id, pair.profile.profile_id) for pair in TENSOR_TARGET_CONTRACT_PAIRS}
+    missing = expected_pairs - covered_pairs
+
+    assert not missing, f"ImageOnlyTransform Tensor target coverage is missing: {sorted(missing)}"
 
 
 def test_every_target_profile_is_collected() -> None:

--- a/tests/helpers/contract_data.py
+++ b/tests/helpers/contract_data.py
@@ -38,8 +38,8 @@ def make_mask_data(rng: np.random.Generator) -> dict[str, Any]:
     return data
 
 
-def make_target_image_mask_data(rng: np.random.Generator) -> dict[str, Any]:
-    """Return an asymmetric coordinate-coded image and multiclass mask."""
+def make_target_image_data(rng: np.random.Generator) -> dict[str, Any]:
+    """Return an asymmetric coordinate-coded image."""
     height, width, _ = TARGET_IMAGE_SHAPE
     offset = int(rng.integers(0, 256))
     rows = np.arange(height, dtype=np.uint16)[:, None]
@@ -52,11 +52,23 @@ def make_target_image_mask_data(rng: np.random.Generator) -> dict[str, Any]:
         ],
         axis=-1,
     ).astype(np.uint8)
+    return {"image": image}
+
+
+def _make_target_mask() -> np.ndarray:
+    height, width, _ = TARGET_IMAGE_SHAPE
     mask = np.zeros((height, width), dtype=np.uint8)
     mask[9:41, 17:73] = 1
     mask[52:87, 61:117] = 2
     mask[24:75, 92:104] = 3
-    return {"image": image, "mask": mask}
+    return mask
+
+
+def make_target_image_mask_data(rng: np.random.Generator) -> dict[str, Any]:
+    """Return an asymmetric coordinate-coded image and multiclass mask."""
+    data = make_target_image_data(rng)
+    data["mask"] = _make_target_mask()
+    return data
 
 
 def make_target_hbb_data(rng: np.random.Generator) -> dict[str, Any]:
@@ -105,15 +117,25 @@ def make_target_keypoint_data(rng: np.random.Generator) -> dict[str, Any]:
 
 def make_target_volume_data(rng: np.random.Generator) -> dict[str, Any]:
     """Return a coordinate-coded volume and a slice-specific multiclass mask3d."""
-    depth, height, width, channels = TARGET_VOLUME_SHAPE
-    volume = np.empty(TARGET_VOLUME_SHAPE, dtype=np.uint8)
+    data = make_target_volume_only_data(rng)
+    depth, height, width, _ = TARGET_VOLUME_SHAPE
     mask3d = np.empty((depth, height, width), dtype=np.uint8)
+    mask = _make_target_mask()
     for depth_index in range(depth):
-        slice_data = make_target_image_mask_data(rng)
-        volume[depth_index] = (slice_data["image"].astype(np.uint16) + 17 * depth_index).astype(np.uint8)
-        mask3d[depth_index] = (slice_data["mask"] + depth_index).astype(np.uint8)
+        mask3d[depth_index] = (mask + depth_index).astype(np.uint8)
+    data["mask3d"] = mask3d
+    return data
+
+
+def make_target_volume_only_data(rng: np.random.Generator) -> dict[str, Any]:
+    """Return a coordinate-coded volume without an annotation target."""
+    depth, _, _, channels = TARGET_VOLUME_SHAPE
+    volume = np.empty(TARGET_VOLUME_SHAPE, dtype=np.uint8)
+    for depth_index in range(depth):
+        image = make_target_image_data(rng)["image"]
+        volume[depth_index] = (image.astype(np.uint16) + 17 * depth_index).astype(np.uint8)
     assert volume.shape[-1] == channels
-    return {"volume": volume, "mask3d": mask3d}
+    return {"volume": volume}
 
 
 def make_target_float_image_mask_data(rng: np.random.Generator) -> dict[str, Any]:

--- a/tests/helpers/target_contracts.py
+++ b/tests/helpers/target_contracts.py
@@ -21,9 +21,15 @@ from albumentations.core.tensor import (
 )
 from tests.helpers.applied_config import ReplayProfile
 from tests.helpers.contract_assertions import assert_contract_values_equal
-from tests.helpers.target_profiles import TARGET_CONTRACT_PROFILES, ProfileCost, TargetProfile
+from tests.helpers.target_profiles import (
+    IMAGE_ONLY_TENSOR_TARGET_PROFILES,
+    TARGET_CONTRACT_PROFILES,
+    ProfileCost,
+    TargetProfile,
+)
 from tests.helpers.transform_cases import (
     PRIMARY_DUAL_TRANSFORM_CONTRACT_CASES,
+    PRIMARY_IMAGE_ONLY_TRANSFORM_CONTRACT_CASES,
     TRANSFORM_CONTRACT_CASES,
     TransformContractCase,
 )
@@ -41,8 +47,12 @@ class TargetContractPair:
         return f"{self.case.case_id}--{self.profile.profile_id}"
 
 
-def _supports_profile(case: TransformContractCase, profile: TargetProfile) -> bool:
-    if not issubclass(case.transform_cls, A.DualTransform):
+def _supports_profile(
+    case: TransformContractCase,
+    profile: TargetProfile,
+    transform_base: type[A.BasicTransform] = A.DualTransform,
+) -> bool:
+    if not issubclass(case.transform_cls, transform_base):
         return False
     if not case.required_targets <= profile.required_targets:
         return False
@@ -80,6 +90,13 @@ EXTENDED_TARGET_CONTRACT_PAIRS = tuple(
     if profile.cost is ProfileCost.EXTENDED and _supports_profile(case, profile)
 )
 
+TENSOR_IMAGE_ONLY_TARGET_CONTRACT_PAIRS = tuple(
+    TargetContractPair(case=case, profile=profile)
+    for case in PRIMARY_IMAGE_ONLY_TRANSFORM_CONTRACT_CASES
+    for profile in IMAGE_ONLY_TENSOR_TARGET_PROFILES
+    if _supports_profile(case, profile, A.ImageOnlyTransform)
+)
+
 _TENSOR_EXTENDED_PROFILE_IDS = frozenset(
     {
         "float-image-mask",
@@ -93,6 +110,7 @@ _TENSOR_EXTENDED_PROFILE_IDS = frozenset(
 TENSOR_TARGET_CONTRACT_PAIRS = (
     *CORE_TARGET_CONTRACT_PAIRS,
     *(pair for pair in EXTENDED_TARGET_CONTRACT_PAIRS if pair.profile.profile_id in _TENSOR_EXTENDED_PROFILE_IDS),
+    *TENSOR_IMAGE_ONLY_TARGET_CONTRACT_PAIRS,
 )
 
 

--- a/tests/helpers/target_contracts.py
+++ b/tests/helpers/target_contracts.py
@@ -7,6 +7,7 @@ import json
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -162,9 +163,24 @@ def _assert_tensor_result_containers(
             assert isinstance(result[data_name], torch.Tensor)
 
 
+def make_target_contract_data(
+    case: TransformContractCase,
+    profile: TargetProfile,
+    rng: np.random.Generator,
+) -> dict[str, Any]:
+    """Build profile targets and transform-specific context for one contract execution."""
+    if profile.primary_data_adapter is not None:
+        data_factory = partial(profile.primary_data_adapter, case.primary_data_factory)
+    elif profile.data_factory is not None:
+        data_factory = profile.data_factory
+    else:
+        raise ValueError(f"{profile.profile_id}: missing data factory")
+    return case.make_data(rng, data_factory)
+
+
 def run_tensor_target_cluster_contract(case: TransformContractCase, profile: TargetProfile, seed: int) -> None:
     """Replay one generated NumPy case with equivalent public Tensor targets."""
-    source = case.make_data(np.random.default_rng(seed), profile.data_factory)
+    source = make_target_contract_data(case, profile, np.random.default_rng(seed))
     numpy_data = copy.deepcopy(source)
     transform = case.transform_cls(**copy.deepcopy(dict(case.init_kwargs)), p=1)
     tensor_data = _convert_contract_data(source, transform, _numpy_target_to_tensor)
@@ -194,8 +210,8 @@ def run_tensor_target_cluster_contract(case: TransformContractCase, profile: Tar
 
 def run_target_cluster_contract(case: TransformContractCase, profile: TargetProfile, seed: int) -> None:
     """Execute one registered mode against one reusable target workload."""
-    source_data = case.make_data(np.random.default_rng(seed), profile.data_factory)
-    replay_data = case.make_data(np.random.default_rng(seed), profile.data_factory)
+    source_data = make_target_contract_data(case, profile, np.random.default_rng(seed))
+    replay_data = make_target_contract_data(case, profile, np.random.default_rng(seed))
     source_snapshot = copy.deepcopy(source_data)
     replay_snapshot = copy.deepcopy(replay_data)
     compose_kwargs = copy.deepcopy(dict(profile.compose_kwargs))
@@ -222,7 +238,7 @@ def run_target_cluster_contract(case: TransformContractCase, profile: TargetProf
         for key in source_snapshot:
             assert_contract_values_equal(replay_result[key], result[key], key)
 
-    replay_compose_data = case.make_data(np.random.default_rng(seed), profile.data_factory)
+    replay_compose_data = make_target_contract_data(case, profile, np.random.default_rng(seed))
     replay_compose_snapshot = copy.deepcopy(replay_compose_data)
     replay_transform = case.transform_cls(**copy.deepcopy(dict(case.init_kwargs)), p=1)
     replay_pipeline = A.ReplayCompose([replay_transform], **copy.deepcopy(dict(profile.compose_kwargs)))
@@ -231,7 +247,7 @@ def run_target_cluster_contract(case: TransformContractCase, profile: TargetProf
     assert_contract_values_equal(replay_compose_data, replay_compose_snapshot, "replay_compose_input")
     replayed_result = A.ReplayCompose.replay(
         replay_compose_result["replay"],
-        **case.make_data(np.random.default_rng(seed), profile.data_factory),
+        **make_target_contract_data(case, profile, np.random.default_rng(seed)),
     )
     for key in replay_compose_snapshot:
         assert_contract_values_equal(replayed_result[key], replay_compose_result[key], key)

--- a/tests/helpers/target_profiles.py
+++ b/tests/helpers/target_profiles.py
@@ -16,6 +16,7 @@ import torch
 import albumentations as A
 from albumentations.core.utils import get_volume_shape
 from tests.helpers.contract_data import (
+    TARGET_VOLUME_SHAPE,
     ContractDataFactory,
     make_target_empty_hbb_data,
     make_target_empty_keypoint_data,
@@ -23,7 +24,6 @@ from tests.helpers.contract_data import (
     make_target_grayscale_image_mask_data,
     make_target_hbb_data,
     make_target_image_batch_data,
-    make_target_image_data,
     make_target_image_mask_data,
     make_target_keypoint_data,
     make_target_mask_batch_data,
@@ -32,13 +32,13 @@ from tests.helpers.contract_data import (
     make_target_obb_data,
     make_target_readonly_image_mask_data,
     make_target_volume_data,
-    make_target_volume_only_data,
 )
 
 if TYPE_CHECKING:
     from tests.helpers.transform_cases import TransformContractCase
 
 TargetAssertion = Callable[["TransformContractCase", dict[str, Any], dict[str, Any]], None]
+PrimaryDataAdapter = Callable[[ContractDataFactory, np.random.Generator], dict[str, Any]]
 
 
 def _as_numpy(value: Any) -> np.ndarray:
@@ -171,6 +171,24 @@ def _assert_volume_shape(case: TransformContractCase, source: dict[str, Any], re
     assert get_volume_shape(volume) == get_volume_shape(source["volume"])
 
 
+def _primary_image(data_factory: ContractDataFactory, rng: np.random.Generator) -> np.ndarray:
+    image = data_factory(rng)["image"]
+    return image if image.ndim == 3 else image[..., None]
+
+
+def _image_from_primary_data(data_factory: ContractDataFactory, rng: np.random.Generator) -> dict[str, Any]:
+    return {"image": _primary_image(data_factory, rng)}
+
+
+def _images_from_primary_data(data_factory: ContractDataFactory, rng: np.random.Generator) -> dict[str, Any]:
+    return {"images": np.stack([_primary_image(data_factory, rng) for _ in range(2)])}
+
+
+def _volume_from_primary_data(data_factory: ContractDataFactory, rng: np.random.Generator) -> dict[str, Any]:
+    depth = TARGET_VOLUME_SHAPE[0]
+    return {"volume": np.stack([_primary_image(data_factory, rng) for _ in range(depth)])}
+
+
 def _assert_masks(case: TransformContractCase, source: dict[str, Any], result: dict[str, Any]) -> None:
     masks = result["masks"]
     assert masks.ndim == 3
@@ -184,17 +202,20 @@ class TargetProfile:
 
     profile_id: str
     required_targets: frozenset[str]
-    data_factory: ContractDataFactory
+    data_factory: ContractDataFactory | None
     assert_result: TargetAssertion
     compose_kwargs: Mapping[str, Any] = field(default_factory=dict)
     cost: ProfileCost = ProfileCost.CORE
     bbox_type: Literal["hbb", "obb"] | None = None
     empty_targets: frozenset[str] = frozenset()
     channel_count: int | None = 3
+    primary_data_adapter: PrimaryDataAdapter | None = None
 
     def __post_init__(self) -> None:
         if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", self.profile_id):
             raise ValueError(f"Invalid target profile_id: {self.profile_id!r}")
+        if (self.data_factory is None) == (self.primary_data_adapter is None):
+            raise ValueError(f"{self.profile_id}: provide exactly one data factory")
         object.__setattr__(self, "compose_kwargs", MappingProxyType(copy.deepcopy(dict(self.compose_kwargs))))
 
 
@@ -340,20 +361,23 @@ IMAGE_ONLY_TENSOR_TARGET_PROFILES = (
     TargetProfile(
         profile_id="image",
         required_targets=frozenset({"image"}),
-        data_factory=make_target_image_data,
+        data_factory=None,
         assert_result=_assert_image_shape,
+        primary_data_adapter=_image_from_primary_data,
     ),
     TargetProfile(
         profile_id="images-batch",
         required_targets=frozenset({"images"}),
-        data_factory=make_target_image_batch_data,
+        data_factory=None,
         assert_result=_assert_images_shape,
+        primary_data_adapter=_images_from_primary_data,
     ),
     TargetProfile(
         profile_id="volume",
         required_targets=frozenset({"volume"}),
-        data_factory=make_target_volume_only_data,
+        data_factory=None,
         assert_result=_assert_volume_shape,
+        primary_data_adapter=_volume_from_primary_data,
     ),
 )
 

--- a/tests/helpers/target_profiles.py
+++ b/tests/helpers/target_profiles.py
@@ -23,6 +23,7 @@ from tests.helpers.contract_data import (
     make_target_grayscale_image_mask_data,
     make_target_hbb_data,
     make_target_image_batch_data,
+    make_target_image_data,
     make_target_image_mask_data,
     make_target_keypoint_data,
     make_target_mask_batch_data,
@@ -31,6 +32,7 @@ from tests.helpers.contract_data import (
     make_target_obb_data,
     make_target_readonly_image_mask_data,
     make_target_volume_data,
+    make_target_volume_only_data,
 )
 
 if TYPE_CHECKING:
@@ -145,6 +147,28 @@ def _assert_images(case: TransformContractCase, source: dict[str, Any], result: 
     assert images.ndim == 4
     assert images.shape[0] == source["images"].shape[0]
     assert images.dtype == source["images"].dtype
+
+
+def _assert_image_shape(case: TransformContractCase, source: dict[str, Any], result: dict[str, Any]) -> None:
+    image = result["image"]
+    assert image.ndim == source["image"].ndim
+    assert _image_spatial_shape(image) == _image_spatial_shape(source["image"])
+
+
+def _assert_images_shape(case: TransformContractCase, source: dict[str, Any], result: dict[str, Any]) -> None:
+    images = result["images"]
+    assert images.ndim == source["images"].ndim
+    assert images.shape[0] == source["images"].shape[0]
+    if isinstance(images, torch.Tensor):
+        assert images.shape[-2:] == source["images"].shape[-2:]
+    else:
+        assert images.shape[1:3] == source["images"].shape[1:3]
+
+
+def _assert_volume_shape(case: TransformContractCase, source: dict[str, Any], result: dict[str, Any]) -> None:
+    volume = result["volume"]
+    assert volume.ndim == source["volume"].ndim
+    assert get_volume_shape(volume) == get_volume_shape(source["volume"])
 
 
 def _assert_masks(case: TransformContractCase, source: dict[str, Any], result: dict[str, Any]) -> None:
@@ -308,6 +332,28 @@ TARGET_CONTRACT_PROFILES = (
         data_factory=make_target_readonly_image_mask_data,
         assert_result=_assert_image_mask,
         cost=ProfileCost.EXTENDED,
+    ),
+)
+
+
+IMAGE_ONLY_TENSOR_TARGET_PROFILES = (
+    TargetProfile(
+        profile_id="image",
+        required_targets=frozenset({"image"}),
+        data_factory=make_target_image_data,
+        assert_result=_assert_image_shape,
+    ),
+    TargetProfile(
+        profile_id="images-batch",
+        required_targets=frozenset({"images"}),
+        data_factory=make_target_image_batch_data,
+        assert_result=_assert_images_shape,
+    ),
+    TargetProfile(
+        profile_id="volume",
+        required_targets=frozenset({"volume"}),
+        data_factory=make_target_volume_only_data,
+        assert_result=_assert_volume_shape,
     ),
 )
 

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -1534,3 +1534,7 @@ ALL_DUAL_TRANSFORM_CONTRACT_CASES = tuple(
 PRIMARY_DUAL_TRANSFORM_CONTRACT_CASES = tuple(
     case for case in PRIMARY_TRANSFORM_CONTRACT_CASES if issubclass(case.transform_cls, A.DualTransform)
 )
+
+PRIMARY_IMAGE_ONLY_TRANSFORM_CONTRACT_CASES = tuple(
+    case for case in PRIMARY_TRANSFORM_CONTRACT_CASES if issubclass(case.transform_cls, A.ImageOnlyTransform)
+)


### PR DESCRIPTION
ImageOnlyTransform cases were excluded from the Tensor contract matrix because it collected only DualTransform cases.

This PR generates image, images, and volume Tensor contracts for every primary ImageOnly case and fails collection if any route is missing. KSpaceSpikeNoise receives the same coverage automatically after #475 merges.

Validated: tests/contracts/test_target_cluster_contract.py — 2086 passed; pre-commit on the changed files passed.

## Summary by Sourcery

Cover primary ImageOnlyTransform cases in the generated Tensor contract matrix across image, batched-image, and volume targets.

Enhancements:
- Extend generated Tensor target contracts to cover every primary ImageOnlyTransform across image, batched images, and volume routes.
- Add dedicated image-only Tensor profiles and data adapters while preserving the shared contract case inventory and validating primary image data across routes.

Documentation:
- Document Tensor routing coverage and collection guarantees for ImageOnlyTransform cases.

Tests:
- Enforce complete Tensor coverage for primary ImageOnlyTransform cases and verify image data preservation across all dedicated Tensor profiles.