### PR TITLE
chore(release): bump version to 2.4.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.4.3"
+version = "2.4.4"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.4.3"
+version = "2.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## Summary

- Bump the package version from 2.4.3 to 2.4.4.
- Keep the editable package version in uv.lock synchronized.

## Validation

- `uv lock --check`
- `uv run python -m tools.ci_matrix check`
- `uv run pytest -q tests/test_release_workflow.py tests/test_release_bundle.py tests/test_correctness_report.py tests/test_release_benchmark_profile.py`
- `uv run python -m tools.benchmark_coverage check --no-smoke`
- `pre-commit run --all-files --show-diff-on-failure`

This is a version-only patch release change; release publication remains governed by the release workflow after merge.

## Summary by Sourcery

Build:
- Bump the package version to 2.4.4 and synchronize the locked editable package version.