### PR TITLE
fix(ci): make selective routing merge-safe

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -560,3 +560,52 @@ jobs:
           path: ${{ runner.temp }}/release-bundle/evidence/
           if-no-files-found: ignore
           retention-days: 14
+
+  gate:
+    name: PR gate
+    needs:
+      - plan
+      - pre_commit_ruff
+      - pre_commit_ruff_format
+      - pre_commit_mypy
+      - pre_commit_pyrefly
+      - pre_commit_other
+      - compatibility
+      - targeted
+      - pytorch
+      - dependency_audit
+      - workflow_audit
+      - legal
+      - package
+      - release_preflight
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Validate routed results
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          PLAN_COMPATIBILITY: ${{ needs.plan.outputs.compatibility }}
+          PLAN_TARGETED: ${{ needs.plan.outputs.targeted }}
+          PLAN_PYTORCH: ${{ needs.plan.outputs.pytorch }}
+          PLAN_DEPENDENCY_AUDIT: ${{ needs.plan.outputs.dependency_audit }}
+          PLAN_WORKFLOW_AUDIT: ${{ needs.plan.outputs.workflow_audit }}
+          PLAN_LEGAL: ${{ needs.plan.outputs.legal }}
+          PLAN_PACKAGE: ${{ needs.plan.outputs.package }}
+          PLAN_RELEASE_PREFLIGHT: ${{ needs.plan.outputs.release_preflight }}
+          RESULT_PRE_COMMIT_RUFF: ${{ needs.pre_commit_ruff.result }}
+          RESULT_PRE_COMMIT_RUFF_FORMAT: ${{ needs.pre_commit_ruff_format.result }}
+          RESULT_PRE_COMMIT_MYPY: ${{ needs.pre_commit_mypy.result }}
+          RESULT_PRE_COMMIT_PYREFLY: ${{ needs.pre_commit_pyrefly.result }}
+          RESULT_PRE_COMMIT_OTHER: ${{ needs.pre_commit_other.result }}
+          RESULT_COMPATIBILITY: ${{ needs.compatibility.result }}
+          RESULT_TARGETED: ${{ needs.targeted.result }}
+          RESULT_PYTORCH: ${{ needs.pytorch.result }}
+          RESULT_DEPENDENCY_AUDIT: ${{ needs.dependency_audit.result }}
+          RESULT_WORKFLOW_AUDIT: ${{ needs.workflow_audit.result }}
+          RESULT_LEGAL: ${{ needs.legal.result }}
+          RESULT_PACKAGE: ${{ needs.package.result }}
+          RESULT_RELEASE_PREFLIGHT: ${{ needs.release_preflight.result }}
+        run: python -m tools.ci_gate

--- a/docs/design/pr-ci-greenfield.md
+++ b/docs/design/pr-ci-greenfield.md
@@ -18,9 +18,10 @@ rules, while deleting repeated work that did not add a distinct signal.
 - The dedicated CPU-only PyTorch job owns PyTorch-marked tests once. Base matrix
   jobs exclude those files.
 - Codecov, `pytest-cov`, coverage XML, the coverage-only test run, the duplicate
-  primary suite, clean-install PR matrix, and aggregate gate jobs are removed.
-- A direct leaf job is the merge signal. The ruleset requires direct pre-commit
-  contexts plus the plan; it must not wait for retired aggregate aliases.
+  primary suite, and clean-install PR matrix are removed.
+- A stable `PR gate` validates the router's selected and skipped leaf jobs. The
+  ruleset requires this gate plus the plan and direct pre-commit contexts; it no
+  longer lists path-dependent matrix contexts as static requirements.
 - Routine PR ASV timing is removed. `run-performance` and manual dispatch are
   explicit reproductions. Weekly and release `release-core` comparisons provide
   recurring runtime and memory evidence.
@@ -32,10 +33,9 @@ suite already covered by the compatibility matrix. They did not enforce an
 independent repository policy. A Codecov upload is not a test assertion, so it
 cannot make that duplicate execution useful.
 
-The aggregate jobs also had no independent check. They started after the leaf
-that already contained the actionable failure. Requiring direct job contexts
-therefore shortens the final status and makes a cancellation or timeout visible
-at its owner.
+The old aggregate jobs had no independent check. `PR gate` has a different job:
+it verifies the routing contract, so a path-dependent job cannot be silently
+omitted while the ruleset remains stable.
 
 The compatibility matrix remains intact because an operating system and Python
 version pair is an execution contract, not a duplicate. It has 15 independent
@@ -77,8 +77,10 @@ explicit reproduction; it never expands to a large-input matrix implicitly.
 - `python -m tools.ci_matrix check` validates workflow, matrix, dependency, and
   runtime-profile contracts.
 - No tracked workflow, manifest, lockfile, or dependency group contains Codecov,
-  `pytest-cov`, a coverage XML job, an aggregate gate, or the retired routine PR
-  ASV jobs.
+  `pytest-cov`, a coverage XML job, a duplicate test aggregation job, or the
+  retired routine PR ASV jobs.
+- `PR gate` is always present and validates every selected or skipped routed
+  job before merge.
 - The `release-core` selector returns exactly 21 fixed cases and includes runtime
   plus peak-memory evidence.
 - Maintained CI, benchmark, and release documentation describe the implemented

--- a/docs/maintaining/ci-policy.md
+++ b/docs/maintaining/ci-policy.md
@@ -6,25 +6,28 @@ partitions. Product, package, and policy jobs run only when the changed paths
 can affect their result. Unknown paths select the conservative profile.
 
 The implementation lives in [`.github/workflows/pr.yml`](../../.github/workflows/pr.yml).
-`tools/ci_plan.py` owns path routing. Direct job names are the branch-protection
-contexts; there are no aggregate gate aliases.
+`tools/ci_plan.py` owns path routing. The stable `PR gate` context checks that
+the routed jobs match the plan; it does not run tests itself.
 
 ## Required pull-request contexts
 
 Require these repository-owned contexts and the external `license/cla` check:
 
-- `PR / PR plan`
-- `PR / Pre-commit / Ruff`
-- `PR / Pre-commit / Ruff format`
-- `PR / Pre-commit / mypy`
-- `PR / Pre-commit / Pyrefly`
-- `PR / Pre-commit / Other hooks`
+- `PR plan`
+- `Pre-commit / Ruff`
+- `Pre-commit / Ruff format`
+- `Pre-commit / mypy`
+- `Pre-commit / Pyrefly`
+- `Pre-commit / Other hooks`
+- `PR gate`
 
-For a runtime or shared-test change, also require every visible
-`Compatibility (<OS>, Python <version>)` context and `PyTorch tests`. Package
-and policy contexts are required only when their path rule selects them. CodeQL,
-Antigravity review, and performance workflows are advisory because their path
-filters or explicit triggers can correctly skip them.
+The gate requires every selected product, package, and policy job to succeed and
+requires every unselected routed job to be skipped. The visible compatibility
+and PyTorch contexts therefore remain useful evidence without being static
+ruleset entries that can block a version-only PR.
+
+CodeQL, Antigravity review, and performance workflows are advisory because their
+path filters or explicit triggers can correctly skip them.
 
 ## Pre-commit ownership
 
@@ -75,9 +78,9 @@ coverage-only test run. Benchmark catalog coverage is unrelated: it verifies
 that public transform families have owned performance cases and remains a
 pre-commit contract.
 
-The workflow also has no `Fast checks`, `Correctness`, or `Security and policy`
-aggregation jobs. A failing leaf is already the actionable result; a second job
-only delays the final status and hides the failing owner.
+The workflow has no duplicate test aggregation jobs. `PR gate` is the one
+exception: it validates routing and leaf results, which is the stable contract
+needed by branch protection when the selected leaf set changes by path.
 
 ## Release performance evidence
 

--- a/tests/test_ci_gate.py
+++ b/tests/test_ci_gate.py
@@ -1,0 +1,74 @@
+"""Contracts for the stable pull-request routing gate."""
+
+from tools.ci_gate import ALWAYS_RUN_CHECKS, ROUTED_CHECKS, _read_environment, validate_results
+from tools.ci_plan import CHECK_NAMES
+
+
+def test_gate_check_names_match_the_router() -> None:
+    assert ROUTED_CHECKS == CHECK_NAMES
+
+
+def _results() -> dict[str, str]:
+    return {
+        **dict.fromkeys(ALWAYS_RUN_CHECKS, "success"),
+        **dict.fromkeys(ROUTED_CHECKS, "skipped"),
+    }
+
+
+def test_version_only_release_accepts_only_release_preflight() -> None:
+    selected = dict.fromkeys(ROUTED_CHECKS, False)
+    selected["release_preflight"] = True
+    results = _results()
+    results["release_preflight"] = "success"
+
+    assert validate_results(plan_result="success", selected=selected, results=results) == ()
+
+
+def test_runtime_plan_requires_selected_matrix_and_pytorch_jobs() -> None:
+    selected = dict.fromkeys(ROUTED_CHECKS, False)
+    selected["compatibility"] = True
+    selected["pytorch"] = True
+    results = _results()
+    results["compatibility"] = "success"
+    results["pytorch"] = "success"
+
+    assert validate_results(plan_result="success", selected=selected, results=results) == ()
+
+
+def test_selected_failure_is_reported() -> None:
+    selected = dict.fromkeys(ROUTED_CHECKS, False)
+    selected["compatibility"] = True
+    results = _results()
+    results["compatibility"] = "failure"
+
+    assert validate_results(plan_result="success", selected=selected, results=results) == (
+        "compatibility: expected success, got 'failure'",
+    )
+
+
+def test_unselected_job_must_not_run() -> None:
+    selected = dict.fromkeys(ROUTED_CHECKS, False)
+    results = _results()
+    results["compatibility"] = "success"
+
+    assert validate_results(plan_result="success", selected=selected, results=results) == (
+        "compatibility: expected skipped, got 'success'",
+    )
+
+
+def test_failed_plan_is_not_masked_by_skipped_jobs() -> None:
+    selected = dict.fromkeys(ROUTED_CHECKS, False)
+
+    assert validate_results(plan_result="failure", selected=selected, results=_results()) == (
+        "PR plan finished with 'failure'; routed checks are not trustworthy",
+    )
+
+
+def test_failed_plan_does_not_parse_missing_outputs(monkeypatch) -> None:
+    monkeypatch.setenv("PLAN_RESULT", "failure")
+
+    plan_result, selected, results = _read_environment()
+
+    assert plan_result == "failure"
+    assert selected == dict.fromkeys(ROUTED_CHECKS, False)
+    assert results == {}

--- a/tests/test_pr_workflow.py
+++ b/tests/test_pr_workflow.py
@@ -18,7 +18,7 @@ def _workflow() -> dict[str, Any]:
     return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
-def test_pr_workflow_exposes_direct_required_contexts_without_aggregate_aliases() -> None:
+def test_pr_workflow_exposes_stable_required_contexts_and_routing_gate() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     trigger = text.split("permissions:", maxsplit=1)[0]
     jobs = _workflow()["jobs"]
@@ -42,6 +42,12 @@ def test_pr_workflow_exposes_direct_required_contexts_without_aggregate_aliases(
         "pre_commit_pyrefly": "Pre-commit / Pyrefly",
         "pre_commit_other": "Pre-commit / Other hooks",
     }
+    assert jobs["gate"]["name"] == "PR gate"
+    assert jobs["gate"]["if"] == "always()"
+    assert set(jobs["gate"]["needs"]) == set(jobs) - {"gate"}
+    for job_id in jobs:
+        if job_id != "gate":
+            assert f"needs.{job_id}.result" in text
     assert not {"fast_checks", "correctness", "security_policy"} & set(jobs)
 
 

--- a/tools/ci_gate.py
+++ b/tools/ci_gate.py
@@ -1,0 +1,92 @@
+"""Validate that routed pull-request jobs match the CI plan."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+ROUTED_CHECKS = (
+    "compatibility",
+    "targeted",
+    "pytorch",
+    "dependency_audit",
+    "workflow_audit",
+    "legal",
+    "package",
+    "release_preflight",
+)
+ALWAYS_RUN_CHECKS = (
+    "pre_commit_ruff",
+    "pre_commit_ruff_format",
+    "pre_commit_mypy",
+    "pre_commit_pyrefly",
+    "pre_commit_other",
+)
+
+
+def _parse_selection(value: str, check_name: str) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ValueError(f"Plan output for {check_name} must be true or false, got {value!r}")
+
+
+def validate_results(
+    *,
+    plan_result: str,
+    selected: Mapping[str, bool],
+    results: Mapping[str, str],
+) -> tuple[str, ...]:
+    """Return routing errors for one pull-request run."""
+    if plan_result != "success":
+        return (f"PR plan finished with {plan_result!r}; routed checks are not trustworthy",)
+
+    errors: list[str] = []
+    for check_name in (*ALWAYS_RUN_CHECKS, *ROUTED_CHECKS):
+        result = results.get(check_name)
+        expected = "success" if check_name in ALWAYS_RUN_CHECKS else "success" if selected[check_name] else "skipped"
+        if result != expected:
+            errors.append(f"{check_name}: expected {expected}, got {result!r}")
+    return tuple(errors)
+
+
+def _read_environment() -> tuple[str, dict[str, bool], dict[str, str]]:
+    plan_result = os.environ.get("PLAN_RESULT", "")
+    if plan_result != "success":
+        return plan_result, dict.fromkeys(ROUTED_CHECKS, False), {}
+
+    selected = {
+        check_name: _parse_selection(
+            os.environ.get(f"PLAN_{check_name.upper()}", ""),
+            check_name,
+        )
+        for check_name in ROUTED_CHECKS
+    }
+    results = {
+        check_name: os.environ.get(f"RESULT_{check_name.upper()}", "")
+        for check_name in (*ALWAYS_RUN_CHECKS, *ROUTED_CHECKS)
+    }
+    return plan_result, selected, results
+
+
+def main() -> int:
+    """Validate the GitHub Actions job results exposed through the environment."""
+    try:
+        plan_result, selected, results = _read_environment()
+    except ValueError as error:
+        print(f"::error::{error}")
+        return 1
+
+    errors = validate_results(plan_result=plan_result, selected=selected, results=results)
+    if errors:
+        for error in errors:
+            print(f"::error::{error}")
+        return 1
+
+    print("PR gate passed: every selected check succeeded and every unselected check was skipped.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -600,6 +600,7 @@ def _check_pr_workflow() -> list[str]:
         "pre_commit_mypy": "Pre-commit / mypy",
         "pre_commit_pyrefly": "Pre-commit / Pyrefly",
         "pre_commit_other": "Pre-commit / Other hooks",
+        "gate": "PR gate",
     }
     for job_id, expected_name in expected_stable_jobs.items():
         job = jobs.get(job_id)
@@ -611,6 +612,7 @@ def _check_pr_workflow() -> list[str]:
             PR_WORKFLOW,
             (
                 "python -m tools.ci_plan",
+                "python -m tools.ci_gate",
                 "dependency-group: ci-test",
                 "dependency-group: ci-quality",
                 "dependency-group: ci-types",
@@ -644,7 +646,6 @@ def _check_pr_workflow() -> list[str]:
     )
 
     forbidden = (
-        "tools.ci_gate",
         "tools.quality_gate",
         "codecov/",
         "CODECOV_TOKEN",


### PR DESCRIPTION
## Summary

- Add a stable PR gate that validates the router output against every routed job result.
- Keep version-only and other selective PRs free of unneeded test runners.
- Document the stable branch-protection contract and add focused gate/workflow tests.

## Why

The version-only release route correctly skips the 15-cell compatibility matrix, but the main ruleset currently requires those dynamic matrix contexts. GitHub therefore waits for statuses that the workflow intentionally does not create.

## Validation

- uv run python -m tools.ci_matrix check
- uv run python -m tools.ci_shard check
- uv run pytest -q tests/test_ci_plan.py tests/test_ci_shard.py tests/test_pr_workflow.py tests/test_ci_gate.py (49 passed)
- uv run zizmor --format=plain --min-severity=medium --min-confidence=medium .github
- pre-commit run --all-files --show-diff-on-failure

## Migration

After this PR merges, update the main ruleset to require PR plan, the five pre-commit contexts, PR gate, and license/cla; remove path-dependent matrix and optional leaf contexts from the static required-check list. That external ruleset change is intentionally not hidden in this code PR.

## Summary by Sourcery

Make selective pull requests merge-safe by introducing a stable gate that validates CI routing and leaf-job results.

New Features:
- Add a stable PR gate that validates selected routed jobs succeed and unselected jobs remain skipped.

Bug Fixes:
- Prevent selective pull requests from being blocked by static requirements for jobs that routing intentionally omits.

Enhancements:
- Define the PR gate and routed-job behavior as the stable branch-protection contract.

CI:
- Update CI contract checks to require and validate the PR gate across all pull-request jobs.

Documentation:
- Document the stable required-check set and path-dependent routing behavior for branch protection.

Tests:
- Add focused tests covering gate validation, selective routing, workflow wiring, and failure handling.