### PR TITLE
feat(pixel): support explicit full stain bases in HEStain

### DIFF
--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -62,7 +62,7 @@ for size_name, (h, w) in SIZES.items():
 
         old_t = timeit.timeit(lambda img=img: old_func(img, **params), number=N)
         new_t = timeit.timeit(lambda img=img: new_func(img, **params), number=N)
-        print(f"{size_name} {h}x{w}x{ch}: old={old_t:.4f}s new={new_t:.4f}s speedup={old_t/new_t:.2f}x")
+        print(f"{size_name} {h}x{w}x{ch}: old={old_t:.4f}s new={new_t:.4f}s speedup={old_t / new_t:.2f}x")
 ```
 
 ## Template: Full Pipeline (Compose)

--- a/.codex/skills/mixing-transforms/SKILL.md
+++ b/.codex/skills/mixing-transforms/SKILL.md
@@ -70,12 +70,12 @@ For **CopyAndPaste** (one object per dict), values are scalars (one bbox, one ob
 {
     "image": src_image,
     "mask": obj_mask,
-    "bbox": [10, 20, 50, 80],        # same coord_format as BboxParams
+    "bbox": [10, 20, 50, 80],  # same coord_format as BboxParams
     "bbox_labels": {
         "class_id": 3,
         "is_crowd": 0,
     },
-    "keypoints": [[25, 40]],         # same coord_format as KeypointParams
+    "keypoints": [[25, 40]],  # same coord_format as KeypointParams
     "keypoint_labels": {
         "joint_name": "left_eye",
     },

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,7 @@ repos:
         language: system
         files: ^(pyproject\.toml|conda\.recipe/meta\.yaml|tools/check_conda_dependencies\.py)$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.4
+    rev: v0.16.5
     hooks:
       - id: ruff
         exclude: '__pycache__/'
@@ -138,7 +138,7 @@ repos:
         args:
           [ --config-file=pyproject.toml ]
   - repo: https://github.com/facebook/pyrefly-pre-commit
-    rev: 1.3.0.dev2
+    rev: 1.3.0.dev3
     hooks:
       - id: pyrefly-check
         name: Pyrefly type check

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ pip install "albumentationsx[headless]"
 import albumentations as A
 
 # Create your augmentation pipeline
-transform = A.Compose([
-    A.RandomCrop(width=256, height=256),
-    A.HorizontalFlip(p=0.5),
-    A.RandomBrightnessContrast(p=0.2),
-])
+transform = A.Compose(
+    [
+        A.RandomCrop(width=256, height=256),
+        A.HorizontalFlip(p=0.5),
+        A.RandomBrightnessContrast(p=0.2),
+    ]
+)
 ```
 
 For commercial licensing inquiries, please visit [our pricing page](https://albumentations.ai/pricing?utm_source=github&utm_medium=referral&utm_campaign=readme).
@@ -202,11 +204,13 @@ import albumentations as A
 import cv2
 
 # Declare an augmentation pipeline
-transform = A.Compose([
-    A.RandomCrop(width=256, height=256),
-    A.HorizontalFlip(p=0.5),
-    A.RandomBrightnessContrast(p=0.2),
-])
+transform = A.Compose(
+    [
+        A.RandomCrop(width=256, height=256),
+        A.HorizontalFlip(p=0.5),
+        A.RandomBrightnessContrast(p=0.2),
+    ]
+)
 
 # Read an image with OpenCV and convert it to the RGB colorspace
 image = cv2.imread("image.jpg")

--- a/albumentations/augmentations/pixel/_functional_histology.py
+++ b/albumentations/augmentations/pixel/_functional_histology.py
@@ -457,12 +457,17 @@ def _validate_stain_augmentation_inputs(
     residual_mode: Literal["project", "preserve", "augment"],
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     stain_matrix = np.ascontiguousarray(stain_matrix, dtype=np.float32)
-    if stain_matrix.shape != (2, 3):
-        raise ValueError(f"stain_matrix must have shape (2, 3), got {stain_matrix.shape}")
+    if stain_matrix.shape not in {(2, 3), (3, 3)}:
+        raise ValueError(f"stain_matrix must have shape (2, 3) or (3, 3), got {stain_matrix.shape}")
     if not np.isfinite(stain_matrix).all():
         raise ValueError("stain_matrix must contain only finite values")
     if residual_mode not in {"project", "preserve", "augment"}:
         raise ValueError(f"Invalid residual_mode: {residual_mode}")
+    if stain_matrix.shape == (3, 3):
+        if residual_mode == "project":
+            raise ValueError("A full stain basis is incompatible with residual_mode='project'")
+        if np.linalg.matrix_rank(stain_matrix) < 3:
+            raise ValueError("stain_matrix rows must be linearly independent")
 
     component_count = 2 if residual_mode == "project" else 3
     scale_factors = np.asarray(scale_factors)
@@ -573,21 +578,23 @@ def apply_he_stain_augmentation(
     augment_background: bool,
     residual_mode: Literal["project", "preserve", "augment"] = "project",
 ) -> ImageType:
-    """Perturb H&E concentrations in optical-density space, with an optional residual channel
-    for stain-variation augmentation in histology pipelines.
+    """Perturb stain concentrations in optical-density space with a two-stain H&E basis or an explicit
+    three-stain basis for histology augmentation.
 
-    The two-row stain matrix always defines hematoxylin and eosin. Residual modes derive a normalized third vector
-    from their cross product, so callers do not need to provide a redundant three-row matrix.
+    A two-row matrix defines hematoxylin and eosin. Residual modes derive a normalized third vector from their cross
+    product. A three-row matrix supplies the third stain directly for full-basis operations such as HED jitter.
 
     Args:
         img (ImageType): RGB image with values in the dtype's standard range.
-        stain_matrix (np.ndarray): H&E optical-density basis with shape `(2, 3)`.
+        stain_matrix (np.ndarray): Optical-density basis with shape `(2, 3)` for H&E or `(3, 3)` for an explicit
+            three-stain basis. A three-row matrix must have full rank.
         scale_factors (np.ndarray): Per-component multiplicative factors. Supply two values for `"project"` and
             three values for the residual modes.
         shift_values (np.ndarray): Per-component additive shifts, with the same length as `scale_factors`.
         augment_background (bool): Whether to adjust concentrations outside the tissue mask.
-        residual_mode (Literal['project', 'preserve', 'augment']): Residual-channel policy. `"project"` reconstructs
-            from H&E only; `"preserve"` keeps the residual unchanged; `"augment"` adjusts all three components.
+        residual_mode (Literal['project', 'preserve', 'augment']): Third-component policy. `"project"` reconstructs
+            from H&E only and requires a two-row matrix. `"preserve"` keeps the derived or explicit third component
+            unchanged. `"augment"` adjusts all three components.
 
     Returns:
         ImageType: RGB image with the input shape and dtype.
@@ -597,14 +604,19 @@ def apply_he_stain_augmentation(
 
     Note:
         - `"project"` solves the regularized two-stain model used by earlier releases.
-        - The residual modes use `R = normalize(cross(H, E))` and solve the full H&E+R basis.
-        - If H and E are nearly collinear, residual modes fall back to the regularized `"project"` model.
+        - With a two-row matrix, the residual modes use `R = normalize(cross(H, E))` and solve the full H&E+R basis.
+        - With a three-row matrix, the residual modes use the supplied third row without deriving a replacement.
+        - If H and E in a two-row matrix are nearly collinear, residual modes fall back to the regularized
+          `"project"` model.
 
     Examples:
         >>> import numpy as np
         >>> from albumentations.augmentations.pixel import functional as fpixel
         >>> image = np.full((8, 8, 3), 0.5, dtype=np.float32)
-        >>> stain_matrix = np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32)
+        >>> stain_matrix = np.array(
+        ...     [[0.65, 0.70, 0.29], [0.07, 0.99, 0.11], [0.27, 0.57, 0.78]],
+        ...     dtype=np.float32,
+        ... )
         >>> result = fpixel.apply_he_stain_augmentation(
         ...     image,
         ...     stain_matrix,
@@ -622,9 +634,12 @@ def apply_he_stain_augmentation(
         residual_mode,
     )
     regularization = 1e-6
-    reconstruction_matrix = (
-        None if residual_mode == "project" else _build_residual_stain_matrix(stain_matrix, regularization)
-    )
+    if residual_mode == "project":
+        reconstruction_matrix = None
+    elif stain_matrix.shape == (3, 3):
+        reconstruction_matrix = stain_matrix
+    else:
+        reconstruction_matrix = _build_residual_stain_matrix(stain_matrix, regularization)
     optical_density = rgb_to_optical_density(img)
 
     # Suppress numerical warnings for edge cases with extreme optical densities

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -767,12 +767,12 @@ class RGBShift(AdditiveNoise):
 
 
 class HEStain(ImageOnlyTransform):
-    """Perturb hematoxylin and eosin concentrations in H&E histology images to simulate stain variation across
-    laboratories, scanners, and protocols.
+    """Perturb stain concentrations in histology images to simulate color variation across laboratories,
+    scanners, protocols, and staining panels.
 
     Use this transform to train pathology models against expected staining variation. It converts RGB values to
-    optical density, separates hematoxylin and eosin with the selected stain basis, perturbs both concentrations, and
-    reconstructs the RGB image.
+    optical density, separates the stain concentrations with the selected basis, perturbs the configured components,
+    and reconstructs the RGB image.
 
     Args:
         method (Literal["preset", "random_preset", "vahadane", "macenko", "custom"]): Selects the stain basis:
@@ -795,24 +795,25 @@ class HEStain(ImageOnlyTransform):
             When None with `method="preset"`, "standard" is used. Default: None.
 
         intensity_scale_range (tuple[float, float]): Non-negative range for the multiplicative concentration factor
-            sampled independently for hematoxylin and eosin. For example, `(0.7, 1.3)` varies each concentration from
-            70% to 130%. Default: (0.7, 1.3).
+            sampled independently for hematoxylin, eosin, and any augmented third component. For example,
+            `(0.7, 1.3)` varies each concentration from 70% to 130%. Default: (0.7, 1.3).
 
         intensity_shift_range (tuple[float, float]): Range within `[-1.0, 1.0]` for the additive concentration shift
-            sampled independently for hematoxylin and eosin. Default: (-0.2, 0.2).
+            sampled independently for hematoxylin, eosin, and any augmented third component. Default: (-0.2, 0.2).
 
         augment_background (bool): Whether to perturb background pixels along with tissue pixels. Default: False.
-        residual_mode (Literal["project", "preserve", "augment"]): Controls the optical-density component orthogonal
-            to the H&E plane:
+        residual_mode (Literal["project", "preserve", "augment"]): Controls the third optical-density component:
             - `"project"`: Reconstruct from H&E only, retaining the two-stain model from earlier releases.
-            - `"preserve"`: Derive the residual basis vector and keep its concentration unchanged.
-            - `"augment"`: Independently perturb the derived residual along with H&E.
+            - `"preserve"`: Keep the derived residual or explicit third-stain concentration unchanged.
+            - `"augment"`: Independently perturb the derived residual or explicit third stain along with H&E.
             Default: `"project"`.
         p (float): Probability of applying the transform. Default: 0.5.
-        stain_matrix (np.ndarray | None): Fixed H&E stain basis used when `method="custom"`. The matrix must have
-            shape `(2, 3)`: row 0 is the hematoxylin RGB optical-density vector and row 1 is the eosin vector. Both
-            rows must contain finite values, be non-zero, and be linearly independent. The transform copies the
-            matrix as `float32` and uses its values without row normalization. Default: None.
+        stain_matrix (np.ndarray | None): Fixed stain basis used when `method="custom"`. A `(2, 3)` matrix contains
+            hematoxylin and eosin RGB optical-density vectors; `"preserve"` and `"augment"` derive the third vector
+            as `normalize(cross(H, E))`. A `(3, 3)` matrix supplies the third stain directly and requires
+            `residual_mode="preserve"` or `"augment"`. Every row must contain finite values and be non-zero, and the
+            matrix must have full row rank. The transform copies the matrix as `float32` without row normalization.
+            Default: None.
 
     Targets:
         image, volume
@@ -824,10 +825,10 @@ class HEStain(ImageOnlyTransform):
         uint8, float32
 
     Note:
-        - Let `M` be the `(2, 3)` H&E matrix and `C` the per-pixel concentrations. `"project"` solves
+        - Let `M` be the stain matrix and `C` the per-pixel concentrations. `"project"` solves
           `OD ~= C @ M`, perturbs H&E, and reconstructs `RGB = exp(-(C * scale + shift) @ M)`.
-        - `"preserve"` and `"augment"` derive `R = normalize(cross(H, E))`, solve the full H&E+R basis, and either
-          retain or perturb the residual concentration.
+        - For a `(2, 3)` matrix, `"preserve"` and `"augment"` derive `R = normalize(cross(H, E))` and solve the full
+          H&E+R basis. A `(3, 3)` matrix uses its third row directly.
         - A custom matrix is fixed for the lifetime of the transform. Per-image callable extraction is not supported.
 
     References:
@@ -849,20 +850,23 @@ class HEStain(ImageOnlyTransform):
         >>> image[50:150, 50:150] = np.array([120, 140, 180], dtype=np.uint8)  # Hematoxylin-rich region
         >>> image[150:250, 150:250] = np.array([140, 160, 120], dtype=np.uint8)  # Eosin-rich region
         >>>
-        >>> # Example 1: Using a custom stain matrix calibrated for an acquisition pipeline
-        >>> stain_matrix = np.array(
+        >>> # Example 1: Map HEDJitter(theta) to a full H&E+DAB basis
+        >>> theta = 0.05
+        >>> hed_basis = np.array(
         ...     [
-        ...         [0.71, 0.65, 0.27],  # Hematoxylin
-        ...         [0.18, 0.91, 0.37],  # Eosin
+        ...         [0.65, 0.70, 0.29],  # Hematoxylin
+        ...         [0.07, 0.99, 0.11],  # Eosin
+        ...         [0.27, 0.57, 0.78],  # DAB
         ...     ],
         ...     dtype=np.float32,
         ... )
         >>> transform = A.HEStain(
         ...     method="custom",
-        ...     stain_matrix=stain_matrix,
+        ...     stain_matrix=hed_basis,
         ...     residual_mode="augment",
-        ...     intensity_scale_range=(0.8, 1.2),
-        ...     intensity_shift_range=(-0.1, 0.1),
+        ...     intensity_scale_range=(1 - theta, 1 + theta),
+        ...     intensity_shift_range=(-theta, theta),
+        ...     augment_background=True,
         ...     p=1.0,
         ... )
         >>> transformed_image = transform(image=image)["image"]
@@ -951,13 +955,13 @@ class HEStain(ImageOnlyTransform):
                 stain_matrix = np.array(value, dtype=np.float32, copy=True)
             except (TypeError, ValueError) as exc:
                 raise ValueError("stain_matrix must contain numeric values") from exc
-            if stain_matrix.shape != (2, 3):
-                raise ValueError(f"stain_matrix must have shape (2, 3), got {stain_matrix.shape}")
+            if stain_matrix.shape not in {(2, 3), (3, 3)}:
+                raise ValueError(f"stain_matrix must have shape (2, 3) or (3, 3), got {stain_matrix.shape}")
             if not np.isfinite(stain_matrix).all():
                 raise ValueError("stain_matrix must contain only finite values")
             if np.any(np.linalg.norm(stain_matrix, axis=1) == 0):
                 raise ValueError("stain_matrix rows must be non-zero stain vectors")
-            if np.linalg.matrix_rank(stain_matrix) < 2:
+            if np.linalg.matrix_rank(stain_matrix) < stain_matrix.shape[0]:
                 raise ValueError("stain_matrix rows must be linearly independent")
             return stain_matrix
 
@@ -967,6 +971,13 @@ class HEStain(ImageOnlyTransform):
                 raise ValueError("stain_matrix is required when method='custom'")
             if self.method != "custom" and self.stain_matrix is not None:
                 raise ValueError("stain_matrix is only valid when method='custom'")
+            if (
+                self.method == "custom"
+                and self.stain_matrix is not None
+                and self.stain_matrix.shape == (3, 3)
+                and self.residual_mode == "project"
+            ):
+                raise ValueError("A full stain basis is incompatible with residual_mode='project'")
             if self.method == "preset" and self.preset is None:
                 self.preset = "standard"
             elif self.method in {"random_preset", "custom"} and self.preset is not None:

--- a/docs/design/bounding_boxes.md
+++ b/docs/design/bounding_boxes.md
@@ -122,9 +122,9 @@ All bounding boxes are converted to **normalized Albumentations format** interna
 from albumentations import BboxParams
 
 bbox_params = BboxParams(
-    coord_format='pascal_voc',     # Input format
-    bbox_type='hbb',               # 'hbb' or 'obb'
-    label_fields=['class_labels'], # Names of label arrays
+    coord_format="pascal_voc",  # Input format
+    bbox_type="hbb",  # 'hbb' or 'obb'
+    label_fields=["class_labels"],  # Names of label arrays
 )
 ```
 
@@ -145,39 +145,39 @@ Type of bounding box:
 #### `label_fields: list[str] | None = None`
 Names of additional arrays that correspond to bboxes (e.g., class labels, track IDs):
 ```python
-BboxParams(coord_format='yolo', label_fields=['class_ids', 'track_ids'])
+BboxParams(coord_format="yolo", label_fields=["class_ids", "track_ids"])
 
 # Usage:
 transform(
     image=image,
     bboxes=bboxes,
-    class_ids=[1, 2, 3],    # Must match length of bboxes
-    track_ids=[10, 11, 12]  # Must match length of bboxes
+    class_ids=[1, 2, 3],  # Must match length of bboxes
+    track_ids=[10, 11, 12],  # Must match length of bboxes
 )
 ```
 
 #### `min_area: float = 0.0`
 Minimum area (in pixels²) for a bbox to be kept after transformation.
 ```python
-BboxParams(coord_format='pascal_voc', min_area=100.0)  # Remove boxes smaller than 100px²
+BboxParams(coord_format="pascal_voc", min_area=100.0)  # Remove boxes smaller than 100px²
 ```
 
 #### `min_visibility: float = 0.0`
 Minimum visible area ratio [0.0, 1.0] after transformation:
 ```python
-BboxParams(coord_format='pascal_voc', min_visibility=0.3)  # Remove boxes with <30% visible area
+BboxParams(coord_format="pascal_voc", min_visibility=0.3)  # Remove boxes with <30% visible area
 ```
 
 #### `min_width: float = 0.0` and `min_height: float = 0.0`
 Minimum dimensions (in pixels) after transformation:
 ```python
-BboxParams(coord_format='pascal_voc', min_width=10.0, min_height=10.0)  # Remove tiny boxes
+BboxParams(coord_format="pascal_voc", min_width=10.0, min_height=10.0)  # Remove tiny boxes
 ```
 
 #### `max_accept_ratio: float | None = None`
 Maximum aspect ratio (width/height or height/width) to accept:
 ```python
-BboxParams(coord_format='pascal_voc', max_accept_ratio=3.0)  # Remove boxes with aspect ratio > 3:1
+BboxParams(coord_format="pascal_voc", max_accept_ratio=3.0)  # Remove boxes with aspect ratio > 3:1
 ```
 
 #### `check_each_transform: bool = True`
@@ -186,7 +186,7 @@ If `True`, validates bbox compatibility with each transform at pipeline creation
 #### `clip_bboxes_on_input: bool = False`
 If `True`, clips bboxes to image boundaries **once at pipeline start** (before any transforms):
 ```python
-BboxParams(coord_format='yolo', clip_bboxes_on_input=True)  # Fix invalid input coordinates (e.g., YOLO -1e-6)
+BboxParams(coord_format="yolo", clip_bboxes_on_input=True)  # Fix invalid input coordinates (e.g., YOLO -1e-6)
 ```
 - Runs during `preprocess()` only
 - Fixes malformed input bboxes
@@ -213,15 +213,15 @@ Controls how bboxes are clipped after a transform that can change bboxes, and du
 ```python
 # Strict: clip input errors AND after each transform
 BboxParams(
-    coord_format='yolo',
+    coord_format="yolo",
     clip_bboxes_on_input=True,  # Fix input errors once
     clip_after_transform=True,  # Clip after each transform
 )
 
 # Lenient: allow temporary excursions
 BboxParams(
-    coord_format='albumentations',
-    clip_bboxes_on_input=True,   # Fix input errors once
+    coord_format="albumentations",
+    clip_bboxes_on_input=True,  # Fix input errors once
     clip_after_transform=False,  # Allow boxes outside [0,1] during pipeline
 )
 ```
@@ -264,14 +264,14 @@ bboxes = [[10, 20, 100, 150], [50, 60, 200, 250]]  # pascal_voc
 
 # Convert to Albumentations format (normalized)
 bboxes_normalized = [
-    [0.05, 0.1, 0.5, 0.75],   # x/width, y/height
-    [0.25, 0.3, 1.0, 1.25]    # Note: x_max > 1.0 (outside image!)
+    [0.05, 0.1, 0.5, 0.75],  # x/width, y/height
+    [0.25, 0.3, 1.0, 1.25],  # Note: x_max > 1.0 (outside image!)
 ]
 
 # If clip_bboxes_on_input=True: clip to [0, 1]
 bboxes_clipped = [
     [0.05, 0.1, 0.5, 0.75],
-    [0.25, 0.3, 1.0, 1.0]     # x_max clipped to 1.0
+    [0.25, 0.3, 1.0, 1.0],  # x_max clipped to 1.0
 ]
 
 # If filter_invalid_bboxes=True: remove invalid boxes
@@ -358,7 +358,7 @@ Understanding the difference between `clip_bboxes_on_input` and `clip_after_tran
 
 ```python
 # Example: Fix bad YOLO coordinates
-BboxParams(coord_format='yolo', clip_bboxes_on_input=True)
+BboxParams(coord_format="yolo", clip_bboxes_on_input=True)
 # Input:  [0.5, 0.5, 0.4, 0.4, -0.000001]  # Tiny negative value
 # After:  [0.5, 0.5, 0.4, 0.4, 0.0]        # Clipped to [0, 1]
 ```
@@ -371,11 +371,11 @@ BboxParams(coord_format='yolo', clip_bboxes_on_input=True)
 
 ```python
 # Example: Crop that moves bbox outside bounds
-BboxParams(coord_format='pascal_voc', clip_after_transform=True)
+BboxParams(coord_format="pascal_voc", clip_after_transform=True)
 # After crop: [-0.1, -0.1, 1.1, 1.1]  # Outside bounds
 # After clip: [0.0, 0.0, 1.0, 1.0]   # Clipped to [0, 1]
 
-BboxParams(coord_format='pascal_voc', clip_after_transform=False)
+BboxParams(coord_format="pascal_voc", clip_after_transform=False)
 # After crop: [-0.1, -0.1, 1.1, 1.1]  # Left as-is
 # Later transform (e.g., pad) may bring it back inside
 ```
@@ -400,7 +400,7 @@ Filters are applied after each transform (after clamping):
 
 ```python
 # Remove boxes smaller than 100px²
-BboxParams(coord_format='pascal_voc', min_area=100.0)
+BboxParams(coord_format="pascal_voc", min_area=100.0)
 
 # Example:
 # Box: [0.1, 0.1, 0.2, 0.15] on 1000x1000 image
@@ -412,7 +412,7 @@ BboxParams(coord_format='pascal_voc', min_area=100.0)
 
 ```python
 # Remove boxes with less than 30% visible area
-BboxParams(coord_format='pascal_voc', min_visibility=0.3)
+BboxParams(coord_format="pascal_voc", min_visibility=0.3)
 
 # Example after crop:
 # Original box area: 1000px²
@@ -425,7 +425,7 @@ BboxParams(coord_format='pascal_voc', min_visibility=0.3)
 
 ```python
 # Remove boxes smaller than 10px in either dimension
-BboxParams(coord_format='pascal_voc', min_width=10.0, min_height=10.0)
+BboxParams(coord_format="pascal_voc", min_width=10.0, min_height=10.0)
 
 # Example:
 # Box: [0.1, 0.1, 0.105, 0.2] on 1000x1000 image
@@ -438,7 +438,7 @@ BboxParams(coord_format='pascal_voc', min_width=10.0, min_height=10.0)
 
 ```python
 # Remove boxes with aspect ratio > 5:1
-BboxParams(coord_format='pascal_voc', max_accept_ratio=5.0)
+BboxParams(coord_format="pascal_voc", max_accept_ratio=5.0)
 
 # Example:
 # Box: [0.1, 0.1, 0.7, 0.15] on 1000x1000 image
@@ -505,13 +505,13 @@ For OBB, transforms only affect the bounding rectangle coordinates:
 ```python
 # ❌ BAD: Assuming format without validation
 bboxes = load_bboxes_from_file()  # Unknown format!
-transform = A.Compose([...], bbox_params=A.BboxParams(coord_format='pascal_voc'))
+transform = A.Compose([...], bbox_params=A.BboxParams(coord_format="pascal_voc"))
 
 # ✅ GOOD: Explicit format handling
 bboxes = load_bboxes_from_file()
-coord_format = 'yolo'  # Declared by the dataset
-if coord_format == 'yolo':
-    bbox_params = A.BboxParams(coord_format='yolo', bbox_type='obb')
+coord_format = "yolo"  # Declared by the dataset
+if coord_format == "yolo":
+    bbox_params = A.BboxParams(coord_format="yolo", bbox_type="obb")
 ```
 
 ### 2. Use `clip_bboxes_on_input=True` for External Data
@@ -519,7 +519,7 @@ if coord_format == 'yolo':
 ```python
 # ✅ GOOD: Clip malformed external data
 bbox_params = A.BboxParams(
-    coord_format='yolo',
+    coord_format="yolo",
     clip_bboxes_on_input=True,  # Fix rounding errors from external sources
 )
 ```
@@ -528,26 +528,26 @@ bbox_params = A.BboxParams(
 
 ```python
 # Strict pipeline - always keep boxes in bounds
-bbox_params = A.BboxParams(coord_format='pascal_voc', clip_after_transform=True)
+bbox_params = A.BboxParams(coord_format="pascal_voc", clip_after_transform=True)
 
 # Lenient pipeline - allow temporary excursions
-bbox_params = A.BboxParams(coord_format='pascal_voc', clip_after_transform=False)
+bbox_params = A.BboxParams(coord_format="pascal_voc", clip_after_transform=False)
 ```
 
 ### 4. Set Meaningful Filters
 
 ```python
 # ❌ BAD: No filtering (tiny/invalid boxes may remain)
-bbox_params = A.BboxParams(coord_format='pascal_voc')
+bbox_params = A.BboxParams(coord_format="pascal_voc")
 
 # ✅ GOOD: Filter out problematic boxes
 bbox_params = A.BboxParams(
-    coord_format='pascal_voc',
-    min_area=100.0,        # Remove tiny boxes
-    min_visibility=0.3,    # Remove heavily cropped boxes
-    min_width=5.0,         # Remove thin boxes
+    coord_format="pascal_voc",
+    min_area=100.0,  # Remove tiny boxes
+    min_visibility=0.3,  # Remove heavily cropped boxes
+    min_width=5.0,  # Remove thin boxes
     min_height=5.0,
-    max_accept_ratio=10.0, # Remove extreme aspect ratios
+    max_accept_ratio=10.0,  # Remove extreme aspect ratios
 )
 ```
 
@@ -556,13 +556,13 @@ bbox_params = A.BboxParams(
 ```python
 # ❌ BAD: Detecting from number of columns
 if bboxes.shape[1] >= 5:
-    bbox_type = 'obb'  # WRONG! Could be HBB with extra labels
+    bbox_type = "obb"  # WRONG! Could be HBB with extra labels
 
 # ✅ GOOD: Explicit configuration
 bbox_params = A.BboxParams(
-    coord_format='albumentations',
-    bbox_type='obb',  # User knows their data format
-    label_fields=['class_ids', 'track_ids'],  # May add columns
+    coord_format="albumentations",
+    bbox_type="obb",  # User knows their data format
+    label_fields=["class_ids", "track_ids"],  # May add columns
 )
 ```
 
@@ -570,18 +570,18 @@ bbox_params = A.BboxParams(
 
 ```python
 # ✅ GOOD: Keep labels in separate arrays
-transform = A.Compose([
-    A.RandomCrop(width=512, height=512),
-], bbox_params=A.BboxParams(
-    coord_format='pascal_voc',
-    label_fields=['class_labels', 'track_ids']
-))
+transform = A.Compose(
+    [
+        A.RandomCrop(width=512, height=512),
+    ],
+    bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_labels", "track_ids"]),
+)
 
 result = transform(
     image=image,
-    bboxes=bboxes,              # Shape: (N, 4) or (N, 5) for OBB
+    bboxes=bboxes,  # Shape: (N, 4) or (N, 5) for OBB
     class_labels=class_labels,  # Shape: (N,)
-    track_ids=track_ids,        # Shape: (N,)
+    track_ids=track_ids,  # Shape: (N,)
 )
 ```
 
@@ -590,7 +590,7 @@ result = transform(
 ```python
 result = transform(image=image, bboxes=bboxes)
 
-if len(result['bboxes']) == 0:
+if len(result["bboxes"]) == 0:
     # All boxes were filtered out!
     # Handle gracefully (skip image, use backup, etc.)
     pass
@@ -623,7 +623,7 @@ test_cases = [
 
 for bbox in test_cases:
     result = transform(image=image, bboxes=[bbox])
-    assert validate_bbox(result['bboxes'])
+    assert validate_bbox(result["bboxes"])
 ```
 
 ### 10. Performance Considerations
@@ -631,21 +631,21 @@ for bbox in test_cases:
 ```python
 # For HBB with many boxes and strict bounds:
 bbox_params = A.BboxParams(
-    coord_format='yolo',
-    bbox_type='hbb',
+    coord_format="yolo",
+    bbox_type="hbb",
     clip_after_transform=True,  # Fast for HBB
 )
 
 # For OBB geometry that must remain oriented:
 bbox_params = A.BboxParams(
-    coord_format='albumentations',
-    bbox_type='obb',
+    coord_format="albumentations",
+    bbox_type="obb",
     clip_after_transform=False,  # Preserve orientation; a later transform may bring corners back in bounds
 )
 
 # For maximum performance (careful!):
 bbox_params = A.BboxParams(
-    coord_format='albumentations',
+    coord_format="albumentations",
     clip_after_transform=False,  # No clipping after transforms
 )
 ```

--- a/docs/design/numpy-tensor-routing.md
+++ b/docs/design/numpy-tensor-routing.md
@@ -158,8 +158,7 @@ A skipped leaf performs no conversion. Two consecutive fallback leaves may each 
 for Tensor input when its primary data argument includes `torch.Tensor`:
 
 ```python
-def apply(self, image: ImageType | torch.Tensor, **params: Any) -> ImageType:
-    ...
+def apply(self, image: ImageType | torch.Tensor, **params: Any) -> ImageType: ...
 ```
 
 Handlers without a Tensor input annotation use the leaf-local NumPy fallback. This keeps the declaration with the code

--- a/tests/helpers/transform_cases.py
+++ b/tests/helpers/transform_cases.py
@@ -989,6 +989,19 @@ _PARAMETER_MODE_SPECS: list[tuple[str, type[A.BasicTransform], dict[str, Any]]] 
             "augment_background": True,
         },
     ),
+    (
+        "explicit-third-stain",
+        A.HEStain,
+        {
+            "method": "custom",
+            "stain_matrix": np.array(
+                [[0.65, 0.70, 0.29], [0.07, 0.99, 0.11], [0.27, 0.57, 0.78]],
+                dtype=np.float32,
+            ),
+            "residual_mode": "augment",
+            "augment_background": True,
+        },
+    ),
     ("custom-reference", A.HistogramMatching, {"blend_ratio": (0.2, 0.4), "metadata_key": "references"}),
     (
         "gaussian-darken",

--- a/tests/test_hestain.py
+++ b/tests/test_hestain.py
@@ -9,9 +9,17 @@ from albumentations.core.transform_params import SampledParams
 from tests.helpers import TestDataFactory
 
 CUSTOM_STAIN_MATRIX = np.array([[0.71, 0.65, 0.27], [0.18, 0.91, 0.37]], dtype=np.float32)
+HED_STAIN_MATRIX = np.array(
+    [
+        [0.65, 0.70, 0.29],
+        [0.07, 0.99, 0.11],
+        [0.27, 0.57, 0.78],
+    ],
+    dtype=np.float32,
+)
 
 
-def _apply_he_residual_reference(
+def _apply_three_stain_reference(
     image: np.ndarray,
     stain_matrix: np.ndarray,
     scale_factors: np.ndarray,
@@ -21,12 +29,13 @@ def _apply_he_residual_reference(
     pixel_matrix = image.reshape(-1, 3).astype(np.float32) / max_value
     pixel_matrix = np.maximum(pixel_matrix, np.float32(1e-6))
     optical_density = -np.log(pixel_matrix)
-    residual_vector = np.cross(stain_matrix[0], stain_matrix[1])
-    residual_vector /= np.linalg.norm(residual_vector)
-    full_stain_matrix = np.vstack([stain_matrix, residual_vector]).astype(np.float32)
-    stain_concentrations = np.linalg.solve(full_stain_matrix.T, optical_density.T).T
+    if stain_matrix.shape == (2, 3):
+        residual_vector = np.cross(stain_matrix[0], stain_matrix[1])
+        residual_vector /= np.linalg.norm(residual_vector)
+        stain_matrix = np.vstack([stain_matrix, residual_vector]).astype(np.float32)
+    stain_concentrations = np.linalg.solve(stain_matrix.T, optical_density.T).T
     augmented_concentrations = stain_concentrations * scale_factors + shift_values
-    result = np.clip(np.exp(-(augmented_concentrations @ full_stain_matrix)), 0, 1).reshape(image.shape)
+    result = np.clip(np.exp(-(augmented_concentrations @ stain_matrix)), 0, 1).reshape(image.shape)
     if image.dtype == np.uint8:
         return np.rint(result * 255).astype(np.uint8)
     return result
@@ -81,7 +90,7 @@ def test_hestain_augment_residual_matches_full_basis_reference(dtype: type[np.ge
 
     assert params["scale_factors"].shape == (3,)
     assert params["shift_values"].shape == (3,)
-    expected = _apply_he_residual_reference(
+    expected = _apply_three_stain_reference(
         image,
         CUSTOM_STAIN_MATRIX,
         params["scale_factors"],
@@ -89,6 +98,55 @@ def test_hestain_augment_residual_matches_full_basis_reference(dtype: type[np.ge
     )
     tolerance = 1 if dtype == np.uint8 else 1e-6
     np.testing.assert_allclose(result, expected, rtol=1e-5, atol=tolerance)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_hestain_explicit_full_basis_matches_direct_reference(dtype: type[np.generic]) -> None:
+    image = TestDataFactory.create_image((12, 10, 3), dtype=dtype, seed=137)
+    transform = A.HEStain(
+        method="custom",
+        stain_matrix=HED_STAIN_MATRIX,
+        residual_mode="augment",
+        intensity_scale_range=(0.8, 1.2),
+        intensity_shift_range=(-0.1, 0.1),
+        augment_background=True,
+        p=1.0,
+    )
+    transform.set_random_seed(137)
+
+    result = transform(image=image)["image"]
+    params = SampledParams.from_dict(transform.get_applied_params()).params
+
+    np.testing.assert_array_equal(params["stain_matrix"], HED_STAIN_MATRIX)
+    assert params["scale_factors"][2] not in params["scale_factors"][:2]
+    assert params["shift_values"][2] not in params["shift_values"][:2]
+    expected = _apply_three_stain_reference(
+        image,
+        HED_STAIN_MATRIX,
+        params["scale_factors"],
+        params["shift_values"],
+    )
+    tolerance = 1 if dtype == np.uint8 else 1e-6
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=tolerance)
+
+
+def test_hestain_explicit_full_basis_preserves_third_stain_parameters() -> None:
+    image = np.full((8, 8, 3), 0.5, dtype=np.float32)
+    transform = A.HEStain(
+        method="custom",
+        stain_matrix=HED_STAIN_MATRIX,
+        residual_mode="preserve",
+        intensity_scale_range=(1.2, 1.2),
+        intensity_shift_range=(0.1, 0.1),
+        augment_background=True,
+        p=1.0,
+    )
+
+    transform(image=image)
+    params = SampledParams.from_dict(transform.get_applied_params()).params
+
+    np.testing.assert_array_equal(params["scale_factors"], np.array([1.2, 1.2, 1.0], dtype=np.float32))
+    np.testing.assert_array_equal(params["shift_values"], np.array([0.1, 0.1, 0.0], dtype=np.float32))
 
 
 def test_hestain_preserve_residual_reconstructs_identity() -> None:
@@ -206,6 +264,37 @@ def test_apply_he_stain_augmentation_rejects_mismatched_residual_parameters(
         )
 
 
+@pytest.mark.parametrize(
+    ("stain_matrix", "residual_mode", "parameter_count", "message"),
+    [
+        (HED_STAIN_MATRIX, "project", 2, "full stain basis.*residual_mode='project'"),
+        (
+            np.vstack([HED_STAIN_MATRIX[:2], HED_STAIN_MATRIX[0] + HED_STAIN_MATRIX[1]]),
+            "augment",
+            3,
+            "linearly independent",
+        ),
+    ],
+)
+def test_apply_he_stain_augmentation_rejects_invalid_full_basis(
+    stain_matrix: np.ndarray,
+    residual_mode: str,
+    parameter_count: int,
+    message: str,
+) -> None:
+    image = np.full((8, 8, 3), 0.5, dtype=np.float32)
+
+    with pytest.raises(ValueError, match=message):
+        fpixel.apply_he_stain_augmentation(
+            image,
+            stain_matrix,
+            np.ones(parameter_count, dtype=np.float32),
+            np.zeros(parameter_count, dtype=np.float32),
+            augment_background=True,
+            residual_mode=residual_mode,
+        )
+
+
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])
 @pytest.mark.parametrize("augment_background", [False, True])
 def test_hestain_project_mode_stays_within_accepted_legacy_tolerance(
@@ -238,23 +327,26 @@ def test_hestain_project_mode_stays_within_accepted_legacy_tolerance(
 
 
 @pytest.mark.parametrize(
-    ("target", "shape"),
+    ("stain_matrix", "target", "shape"),
     [
-        ("image", (12, 10, 3)),
-        ("images", (2, 12, 10, 3)),
-        ("volume", (2, 12, 10, 3)),
+        (CUSTOM_STAIN_MATRIX, "image", (12, 10, 3)),
+        (CUSTOM_STAIN_MATRIX, "images", (2, 12, 10, 3)),
+        (CUSTOM_STAIN_MATRIX, "volume", (2, 12, 10, 3)),
+        (HED_STAIN_MATRIX, "image", (12, 10, 3)),
     ],
+    ids=["derived-image", "derived-images", "derived-volume", "explicit-full-basis"],
 )
-def test_hestain_augment_residual_replay_reuses_all_sampled_parameters(
+def test_hestain_augment_replay_reuses_all_sampled_parameters(
     target: str,
     shape: tuple[int, ...],
+    stain_matrix: np.ndarray,
 ) -> None:
     data = TestDataFactory.create_image(shape, dtype=np.uint8, seed=137)
     pipeline = A.ReplayCompose(
         [
             A.HEStain(
                 method="custom",
-                stain_matrix=CUSTOM_STAIN_MATRIX,
+                stain_matrix=stain_matrix,
                 residual_mode="augment",
                 augment_background=True,
                 p=1.0,
@@ -357,10 +449,13 @@ def test_hestain_converts_custom_stain_matrix_to_owned_float32_array() -> None:
 @pytest.mark.parametrize(
     ("stain_matrix", "message"),
     [
-        (np.ones((3, 3)), "shape"),
+        (np.ones((4, 3)), "shape"),
         (np.array([[0.71, np.nan, 0.27], [0.18, 0.91, 0.37]]), "finite"),
         (np.array([[0.0, 0.0, 0.0], [0.18, 0.91, 0.37]]), "non-zero"),
         (np.array([[0.71, 0.65, 0.27], [1.42, 1.30, 0.54]]), "linearly independent"),
+        (np.vstack([HED_STAIN_MATRIX[:2], [np.nan, 0.57, 0.78]]), "finite"),
+        (np.vstack([HED_STAIN_MATRIX[:2], np.zeros(3)]), "non-zero"),
+        (np.vstack([HED_STAIN_MATRIX[:2], HED_STAIN_MATRIX[0] + HED_STAIN_MATRIX[1]]), "linearly independent"),
     ],
 )
 def test_hestain_rejects_invalid_custom_stain_matrix(stain_matrix: np.ndarray, message: str) -> None:
@@ -368,9 +463,22 @@ def test_hestain_rejects_invalid_custom_stain_matrix(stain_matrix: np.ndarray, m
         A.HEStain(method="custom", stain_matrix=stain_matrix)
 
 
-def test_hestain_custom_stain_matrix_survives_json_serialization() -> None:
+def test_hestain_rejects_full_stain_matrix_with_project_mode() -> None:
+    with pytest.raises(ValueError, match=r"full stain basis.*residual_mode='project'"):
+        A.HEStain(method="custom", stain_matrix=HED_STAIN_MATRIX, residual_mode="project")
+
+
+@pytest.mark.parametrize(
+    ("stain_matrix", "residual_mode"),
+    [(CUSTOM_STAIN_MATRIX, "project"), (HED_STAIN_MATRIX, "augment")],
+    ids=["two-stain", "full-basis"],
+)
+def test_hestain_custom_stain_matrix_survives_json_serialization(
+    stain_matrix: np.ndarray,
+    residual_mode: str,
+) -> None:
     pipeline = A.Compose(
-        [A.HEStain(method="custom", stain_matrix=CUSTOM_STAIN_MATRIX, p=1.0)],
+        [A.HEStain(method="custom", stain_matrix=stain_matrix, residual_mode=residual_mode, p=1.0)],
         seed=137,
         strict=True,
     )
@@ -382,7 +490,7 @@ def test_hestain_custom_stain_matrix_survives_json_serialization() -> None:
     assert isinstance(restored_transform, A.HEStain)
     assert restored_transform.stain_matrix is not None
     assert restored_transform.stain_matrix.dtype == np.float32
-    np.testing.assert_array_equal(restored_transform.stain_matrix, CUSTOM_STAIN_MATRIX)
+    np.testing.assert_array_equal(restored_transform.stain_matrix, stain_matrix)
 
 
 @pytest.mark.parametrize("residual_mode", ["preserve", "augment"])


### PR DESCRIPTION
Closes #480

## Summary

- accept finite, non-zero, full-rank custom `(3, 3)` stain bases for `residual_mode="preserve"` and `"augment"`
- use an explicit third stain directly; preserve it unchanged or sample its affine parameters independently
- retain the existing `(2, 3)` H&E path and reject `residual_mode="project"` with a full basis
- document the HEDJitter theta mapping, add direct OD, replay, serialization, validation, and generated-contract coverage
- autoupdate Ruff and Pyrefly pre-commit hooks in a separate commit

## Validation

- `uv run pytest -q` — 15,913 passed, 32 skipped, 9 xfailed, 3 xpassed
- `pre-commit run --files …` — passed with the updated hooks
- legacy two-row performance comparison across 256–1024 px, uint8/float32, direct/Compose routes: 3.54% worst-case change

No `scikit-image` runtime dependency added.

## Summary by Sourcery

Enable HEStain to use validated explicit three-stain optical-density bases while preserving the existing two-stain H&E behavior.

New Features:
- Support explicit full-rank `(3, 3)` custom stain bases in HEStain preserve and augment modes, including independent augmentation of the third stain.
- Retain compatibility with existing `(2, 3)` H&E stain matrices while documenting full-basis HED jitter configuration.

Bug Fixes:
- Reject invalid full stain bases, including non-finite, zero, rank-deficient, and project-mode-incompatible matrices.

Enhancements:
- Preserve explicit third-stain parameters unchanged in preserve mode and include them in replay and serialization workflows.

Build:
- Update Ruff and Pyrefly pre-commit hook versions.

Documentation:
- Update HEStain API documentation and examples for explicit three-stain bases and HEDJitter theta mapping.
- Apply formatting updates across README and design documentation.

Tests:
- Add coverage for direct optical-density results, validation, replay, serialization, generated transform contracts, and legacy compatibility.