### PR TITLE
chore(release): bump version to 2.4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.4.4"
+version = "2.4.5"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.4.4"
+version = "2.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## Summary

- Bump the package version from 2.4.4 to 2.4.5.
- Refresh the corresponding editable package version in uv.lock.
- This version-only PR activates the release preflight described in docs/maintaining/release-process.md.

## Validation

- UV_CACHE_DIR=/private/tmp/ax-release-uv-cache uv lock --check
- UV_CACHE_DIR=/private/tmp/ax-release-uv-cache uv run pytest -q — 15913 passed, 32 skipped, 9 xfailed, 3 xpassed
- PRE_COMMIT_HOME=/private/tmp/ax-release-pre-commit pre-commit run --all-files

## Summary by Sourcery

Chores:
- Bump the package version to 2.4.5 and update the corresponding lockfile metadata.