### PR TITLE
refactor: unslop repository code, docs, and skills

### DIFF
--- a/.codex/skills/add-transform/SKILL.md
+++ b/.codex/skills/add-transform/SKILL.md
@@ -25,19 +25,11 @@ Put the transform in the most specific matching subpackage:
 Read `../performance-optimization/SKILL.md` and its required reference completely before implementing the functional
 kernel.
 
-Add the pure function in the corresponding `functional.py` file (no class state, no RNG):
-
-```python
-def my_transform(img: np.ndarray, param1: float, param2: int) -> np.ndarray: ...
-```
+Implement the operation in the corresponding functional module, without transform state or invocation sampling.
 
 - Keep the functional layer deterministic; define stochastic behavior at the transform sampling boundary.
-- Delete redundant work and full-array passes before selecting a backend
-- Compare applicable NumPy, OpenCV, NumKong, StringZilla, and LUT implementations
-- Consider `np.bincount` for repeated reductions over dense non-negative integer labels
-- Move a reusable atomic image operation into Albucore instead of duplicating it locally
-- Use in-place operations only when ownership and aliasing make mutation safe
-- Use `@uint8_io` / `@float32_io` decorators if dtype conversion is needed
+- Use the performance workflow to compare kernels, remove redundant work, and check Albucore ownership.
+- Use `@uint8_io` / `@float32_io` on the owning functional operation when dtype conversion is needed.
 
 ## 3. Write the transform class
 
@@ -48,39 +40,19 @@ def my_transform(img: np.ndarray, param1: float, param2: int) -> np.ndarray: ...
   mechanical violations.
 - Use relative parameters where users should transfer a policy across image sizes.
 - Use `ImageType` for image, mask, and volume signatures; reserve `np.ndarray` for bboxes and keypoints.
-- Compose inputs always have a channel dimension: `(H, W, C)`, `(N, H, W, C)`, and `(D, H, W, C)`; grayscale is
-  `(H, W, 1)`. Do not add Compose-path compatibility branches for two-dimensional grayscale data.
+- NumPy inputs inside transform execution have explicit channel-last layouts: `(H, W, C)`, `(N, H, W, C)`, and
+  `(D, H, W, C)`; grayscale is `(H, W, 1)`. Compose normalizes public channel-free inputs before dispatch. Native
+  Tensor handlers use the channel-first layouts in [NumPy and Tensor routing](../../../docs/design/numpy-tensor-routing.md).
 - Keep reusable pixel arithmetic in `functional.py`, not in a transform class.
 
 ## 4. Add batch optimization (`apply_to_images`)
 
-Override `apply_to_images` only if you can beat the default per-image loop. Priority patterns:
+Override `apply_to_images` only when measurement shows an advantage over the default per-image loop. Keep the
+method as a thin dispatcher with explicit sampled parameters. Put the complete batch operation in a functional
+helper: shared kernel or LUT setup, direct batch indexing, empty-batch handling, and any preallocated per-image loop.
 
-**Pre-compute expensive setup once per batch** (kernels, LUTs, gradient maps):
-```python
-def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
-    kernel = create_kernel(params["size"])  # once, not N times
-    return self._apply_to_batch(images, lambda img: convolve(img, kernel))
-```
-
-**Direct 4D indexing** for simple array ops:
-```python
-def apply_to_images(self, images: ImageType, channels_to_drop: list[int], **params: Any) -> ImageType:
-    result = images.copy()
-    result[:, :, :, channels_to_drop] = self.fill
-    return result
-```
-
-**Pre-allocated loop** as fallback when params vary per image:
-```python
-def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
-    result = np.empty_like(images)
-    for i, image in enumerate(images):
-        result[i] = self.apply(image, **params)
-    return result
-```
-
-> **DO NOT** reshape `(N,H,W,1)` to `(H,W,N)` to call cv2 once — this is 2–4× slower in practice (transpose → non-contiguous copy + cv2 sequential channel processing).
+Keep batch and channel axes distinct; do not reshape `(N, H, W, 1)` into `(H, W, N)` to make one OpenCV call.
+Use [Benchmark](../benchmark/SKILL.md) to compare the direct operation and public Compose route.
 
 ## 5. Export the transform
 

--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -1,193 +1,56 @@
 ---
 name: benchmark
-description: Run performance benchmarks for transform changes. Use when the user asks to benchmark, measure performance, compare speed, or when changes affect apply methods, functional layer, parameter generation, or core pipeline code.
+description: Measure AlbumentationsX runtime changes with paired baseline and candidate benchmarks on the affected routes.
 ---
 
-# Benchmark
+# Benchmark a runtime change
 
-Benchmark a change to `apply_*`, `functional.py`, `sample_parameters`, `composition.py`, or
-`transforms_interface.py` when it can change executed runtime work. Do not benchmark a documentation-only or
-mechanical refactor with no plausible runtime effect.
+Benchmark when a change can alter executed work in a functional operation, sampling, target dispatch, or Compose.
+Documentation and mechanical refactors with no plausible runtime effect need no timing run.
 
-Before designing the benchmark, read `../performance-optimization/SKILL.md` and its required reference completely.
-Use that workflow to define candidates and the dimension that controls each candidate, such as label density for
-`bincount`, channel layout for LUTs, or output size and dtype for random generation.
+Read [Performance Optimization](../performance-optimization/SKILL.md) and its required reference before selecting
+candidates. Define the changed route and the workload dimension that could falsify the proposed speedup.
 
-For `Compose` executor work, add a control-plane matrix alongside the image matrix: root `p=0`, no-op `p=1`, no-op
-with `0<p<1`, an always-applied cheap leaf, `save_applied_params=True`, trace, Tensor route, processors, and concurrent
-calls. Construction time and retained allocations for one-leaf, one-node, and ten-node pipelines are optional context
-when RNG or graph ownership changes. They are never an acceptance metric: prefer slower construction when it makes
-repeated training calls faster. For annotation work, include image-only and bbox/keypoint-affecting chains at empty, one,
-and representative dense annotation counts. Compare the same cells against the baseline checkout in one environment.
-The full-size image matrix remains required when the change touches pixel arithmetic, conversions, or layout work.
+## Select the workload
 
-## Standard Matrix
+For pixel arithmetic, dtype conversion, layout, or backend routing, use the nine combinations of square sizes
+`256`, `512`, and `1024` with `1`, `3`, and `5` channels. Skip explicitly unsupported channel counts. Keep grayscale
+NumPy inputs `(H, W, 1)`.
 
-For pixel arithmetic, dtype conversion, memory layout, or backend routing, benchmark all 9 combinations:
+For other changes, vary the controlling axis: label count and density, random-output size, annotation count, or both
+sides of a routing threshold. Explain why the chosen matrix covers the claim.
 
-| Size       | Channels | Use case                              |
-|------------|----------|---------------------------------------|
-| 256×256    | 1        | Grayscale classification              |
-| 256×256    | 3        | RGB classification                    |
-| 256×256    | 5        | Multispectral                         |
-| 512×512    | 1        | Depth maps                            |
-| 512×512    | 3        | Detection/segmentation (YOLO, U-Net)  |
-| 512×512    | 5        | Multispectral segmentation            |
-| 1024×1024  | 1        | Medical imaging                       |
-| 1024×1024  | 3        | High-res segmentation                 |
-| 1024×1024  | 5        | Satellite imagery                     |
+- Measure the direct functional call and the public Compose route when both are affected.
+- For batch changes, compare per-image dispatch with the batch route at batch sizes `4`, `8`, and `16`.
+- For dtype routing, measure uint8 and float32. A change confined to one dtype may time that dtype and use correctness
+  tests to verify the other dtype's wrapper round-trip.
+- For Compose changes, include root skip, no-op, probabilistic no-op, an always-applied cheap leaf, applied-parameter
+  capture, trace, Tensor, processors, and concurrent calls. For annotation changes, include empty, single, and dense
+  annotations alongside image-only inputs.
+- Construction time and retained allocations are optional context when RNG or graph ownership changes. Judge the
+  result by repeated-call performance; a measured call-time gain can justify slower construction.
 
-Skip channel counts the transform explicitly doesn't support. Always include the channel axis: grayscale inputs are
-`(H, W, 1)`, not `(H, W)`. For another proposal, vary the dimension that controls the candidate—such as label density,
-random-output size, or the sides of a routing threshold—and explain the bounded matrix.
+## Use the existing catalog
 
-If the optimization changes dtype conversion or a `@uint8_io` / `@float32_io` wrapped function, benchmark the hot dtype
-and add correctness tests for the other supported dtype. For example, a uint8-only speedup in a `@uint8_io` function
-still needs a float32 regression test that verifies wrapper round-tripping.
+Start with [benchmark/README.md](../../../benchmark/README.md) for ASV commands and
+[Performance Coverage](../../../docs/maintaining/performance-coverage.md) for case ownership.
 
-## Template: Isolated Function
+`release-core` supplies the fixed weekly and release profile. `changed` selects affected families for requested PR
+comparisons. Resolve these profiles with `tools/select_benchmark_filters.py`. Use ASV `continuous` with explicit
+baseline and candidate refs. An empty selection does not authorize a full-catalog run; choose an explicit regex for
+a larger investigation.
 
-```python
-import timeit
-import numpy as np
+If the catalog cannot express the question, keep a focused local measurement under `_internal/`. Save matching
+before/after cells with shape, dtype, channels, parameters, allocation mode, elapsed time, and iteration count.
 
-SIZES = {"small": (256, 256), "medium": (512, 512), "large": (1024, 1024)}
-CHANNELS = [1, 3, 5]
-N = 100
+## Compare and report
 
-for size_name, (h, w) in SIZES.items():
-    for ch in CHANNELS:
-        shape = (h, w, ch)
-        img = np.random.randint(0, 256, shape, dtype=np.uint8)
+1. Run baseline and candidate on the same machine and environment, back-to-back, with controlled OpenCV and BLAS
+   threads and warm-up.
+2. Use at least 100 iterations for fast functions. For slow functions, choose enough repetitions for stable timing,
+   aiming for more than one second per cell.
+3. Verify correctness, seeded behavior, and aliasing before accepting a faster path.
+4. Report every before/after cell, speedup, exact revisions, command or ASV filter, environment, and rejected candidates.
+5. Investigate any regression above 5%; rework it or explain the measured trade-off.
 
-        old_t = timeit.timeit(lambda img=img: old_func(img, **params), number=N)
-        new_t = timeit.timeit(lambda img=img: new_func(img, **params), number=N)
-        print(f"{size_name} {h}x{w}x{ch}: old={old_t:.4f}s new={new_t:.4f}s speedup={old_t / new_t:.2f}x")
-```
-
-## Template: Full Pipeline (Compose)
-
-```python
-import timeit
-import numpy as np
-import albumentations as A
-
-SIZES = {"small": (256, 256), "medium": (512, 512), "large": (1024, 1024)}
-CHANNELS = [1, 3, 5]
-
-transform = A.Compose([A.YourTransform(p=1.0)])
-
-for size_name, (h, w) in SIZES.items():
-    for ch in CHANNELS:
-        shape = (h, w, ch)
-        img = np.random.randint(0, 256, shape, dtype=np.uint8)
-
-        t = timeit.timeit(lambda img=img: transform(image=img), number=100)
-        print(f"{size_name} {h}x{w}x{ch}: {t:.4f}s (100 calls)")
-```
-
-## Workflow
-
-1. **Before**: run benchmark on the current `main` / original code, save output to a JSON file
-2. **After**: run benchmark on the modified code, save output to a JSON file
-3. **Compare**: load both JSON files, compute speedup = old_time / new_time for each transform/size combo
-4. **Report** results in the PR/commit message body
-
-## Repository CI Profiles
-
-AlbumentationsX keeps benchmark definitions catalog-wide, but times only the
-profile that answers the current evidence question:
-
-- `release-core`: fixed core-pipeline, target-processor, transform-family, and
-  peak-memory cases for the weekly schedule and release preflight;
-- `changed`: affected-family patterns selected from changed files for a
-  `run-performance` PR label or a maintainer-requested deep comparison.
-
-Resolve profiles with `tools/select_benchmark_filters.py`. Timed CI evidence
-must compare an explicit baseline ref with an explicit candidate ref using ASV
-`continuous`. Do not use a single-revision snapshot or treat an empty filter
-as permission to run the entire catalog. A full-family run requires an
-explicit regex so its cost is visible before execution.
-
-### JSON Output Format
-
-Save benchmark results as JSON for automated comparison:
-
-```python
-import json
-
-results = {}
-for transform_name, (h, w), ch, elapsed in all_results:
-    key = f"{transform_name}_{h}x{w}x{ch}"
-    results[key] = {"time": elapsed, "iterations": N}
-
-with open("benchmark_results.json", "w") as f:
-    json.dump(results, f, indent=2)
-```
-
-### Comparison Script Pattern
-
-```python
-import json
-
-with open("bench_old.json") as f:
-    old = json.load(f)
-with open("bench_new.json") as f:
-    new = json.load(f)
-
-for key in sorted(old):
-    if key in new:
-        speedup = old[key]["time"] / new[key]["time"]
-        indicator = "FASTER" if speedup > 1.05 else "SLOWER" if speedup < 0.95 else "SAME"
-        print(f"{key}: {old[key]['time']:.4f}s -> {new[key]['time']:.4f}s  {speedup:.2f}x  {indicator}")
-```
-
-## Reporting Format
-
-```
-Benchmark (uint8, 100 iterations):
-
-Function direct:
-  256x256x1   — Before: 0.0200s After: 0.0100s Speedup: 2.00x
-  256x256x3   — Before: 0.0500s After: 0.0300s Speedup: 1.67x
-  ...
-
-Compose single:
-  256x256x1   — 0.0120s
-  256x256x3   — 0.0340s
-  ...
-```
-
-## Template: Batch (apply_to_images)
-
-When benchmarking batch optimizations (kernel pre-computation, 4D indexing, pre-allocated loops):
-
-```python
-import timeit
-import numpy as np
-import albumentations as A
-
-BATCH_SIZES = [4, 8, 16]
-SIZES = {"small": (256, 256), "medium": (512, 512), "large": (1024, 1024)}
-CHANNELS = [1, 3, 5]
-
-transform = A.Compose([A.YourTransform(p=1.0)])
-
-for batch_size in BATCH_SIZES:
-    for size_name, (h, w) in SIZES.items():
-        for channels in CHANNELS:
-            images = np.random.randint(0, 256, (batch_size, h, w, channels), dtype=np.uint8)
-            t = timeit.timeit(lambda images=images: transform(images=images), number=50)
-            print(f"batch={batch_size} {size_name} {h}x{w}x{channels}: {t:.4f}s")
-```
-
-## Rules
-
-- Run on the **same machine**, back-to-back, same conditions
-- Use at least **100 iterations** for fast functions; fewer for slow ones (aim for >1s total)
-- Test **both uint8 and float32** if the change affects dtype handling. If benchmarking only the hot dtype, add
-  correctness tests for the other dtype.
-- A **>5% regression** on any combination requires justification or rework
-- For batch optimizations, compare 1-channel, 3-channel RGB, and 5-channel multichannel inputs to verify speedup
-  holds across channel counts
-- Keep channel-last shapes throughout: images `(H,W,C)`, image batches `(N,H,W,C)`, and a volume `(D,H,W,C)`
+A one-revision timing is a baseline observation, not evidence of a speedup.

--- a/.codex/skills/docstring-deep-dive/SKILL.md
+++ b/.codex/skills/docstring-deep-dive/SKILL.md
@@ -1,80 +1,38 @@
 ---
 name: docstring-deep-dive
-description: Quality bar for docstrings in albumentations. Use when writing or updating docstrings in albumentations/, especially for transforms and public APIs.
+description: Review public AlbumentationsX docstrings for useful descriptions, runnable examples, parameter semantics, and related transforms.
 ---
 
-# Docstring deep-dive quality
+# Public docstring review
 
-Apply these criteria to **every docstring you write or update** in albumentations: transforms, public functions, and
-APIs that appear on the docs site. The AX guidance hook checks mechanically detectable boundaries, including the plural
-`Examples` heading; this skill owns the reader-facing information that tooling cannot judge.
+Read the complete docstring and implementation before editing. Follow the format in
+[Coding Guidelines](../../../docs/contributing/coding_guidelines.md) and run
+`pre-commit run check-ax-rules --all-files`; the hook owns mechanically checkable requirements.
 
-## 1. First paragraph: 120–160 chars, useful short description (elevator pitch, two lines)
+## Explain the effect and when to use it
 
-The **first paragraph** is the useful short description: an elevator pitch that explains intuitively what the function or transform does. It appears as the web/search preview under the link.
+The first paragraph is the web and search preview. Describe what the operation changes, how it changes it, and the
+problem it helps model. Keep parameter lists, return types, supported targets, and dtype details in their own sections.
+Avoid filling the preview with generic shape-preservation claims or instructions to read the rest of the docstring.
 
-- **Paragraphs are separated by blank lines.** There is no blank line within a paragraph. So the first elevator pitch (120–160 chars) is **one paragraph**: it occupies two lines of text **with no blank line between them** (two lines, not "line + blank line + line").
-- **Length:** **120–160 characters** (under 120 loses value, over 160 gets cut off).
-- **Line limit 120 chars** ⇒ **first paragraph is two lines**. No single line may exceed 120 characters (ruff E501). So the first paragraph must be split across two lines; do not use a single long line with `# noqa: E501`.
-- **Content:** Intuitive, user-facing summary — a true **elevator pitch**: what the transform/function does, how it works in one sentence, and when it's useful. So someone can decide "do I need to click?" Do **not** list parameter names ("Parameters: x, y, z" or "Params: ...") in the first paragraph — that belongs in Args. Do **not** write "Used by X" or "Used in Y". Do **not** use "Preserves X" boilerplate (e.g. "Preserves channel count", "preserves dtype and channels", "preserves shape") — that wastes the short description; describe effect and when to use it instead. Do not put: "Targets: ...", "Same shape", **return type**, or **"Supports uint8 and float32"** / Image types — return type in Returns; dtype/target support in Image types / Targets. All transforms support uint8 and float32 unless noted.
-- **Line wrap:** Break at a word boundary so each line stays under 120 chars.
-- **When shortening:** Do not delete useful information. Move any removed content into the second paragraph, a Note, or the relevant Args/Returns section so it is still documented.
+When shortening the preview, move useful details into the relevant parameter description or note. Remove repetition.
 
-**Good example (first paragraph, elevator pitch, two lines):**
-```text
-    """Sharpen the image via unsharp masking: blur, subtract from original, add back with
-    strength. Use when you need crisp edges without changing overall brightness.
+## Make parameters and examples usable
 
-    More detail...
-```
+- Explain units, ranges, sampling behavior, defaults, and interactions that change the result.
+- Show runnable public calls with imports, input data, and the targets the example claims to support.
+- Use sampled ranges in examples when a parameter accepts a range. Show a fixed range only when fixing that value
+  helps explain the behavior.
+- For base classes, demonstrate a working custom implementation; for functions, show a typical call.
+- Include the key equation or reference when it explains geometry, color, normalization, or another numerical choice.
 
-**Do not include:** "Used by X" or "Used in Y"; "Parameters: ..." or "Params: ..."; "Preserves channel count" / "preserves dtype" / "preserves shape" (boilerplate); return type or "Supports uint8/float32". Describe what it does and when to use it. Keep return type only in Returns; "Targets"/"Same shape" in a later paragraph if needed.
+## Help readers choose related transforms
 
-**Bad example (do not use):** Filling the 120–160 chars with meta boilerplate instead of an elevator pitch:
+Use `See also` for two to four related transforms where useful, with one transform and a short selection hint per
+bullet. Keep cross-links reciprocal. Keep `Note` bullets factual; put recommendations in `See also`.
 
-```text
-    """Apply Gaussian blur using a randomly sized kernel. Params: blur_range, sigma_range.
-    Supports image, volume. See Args and Examples.
-```
+## Final check
 
-- Do **not** use "Params: ...", "Supports ..." (including "Supports uint8 and float32"), or "See Args and Examples" in the first paragraph — that is already in the docstring (Args, Targets, Image types, Examples sections). It wastes the short description and tells the reader nothing about what Gaussian blur *is* or when to use it.
-- **Good first paragraph:** Describe the transform's effect and when it's useful in 120–160 chars, e.g. "Smooth the image with a Gaussian kernel (weighted average; reduces noise and fine detail). Kernel size and sigma are sampled randomly per call."
-
-## 2. Examples
-
-- For transforms, show the public configuration and the targets the example claims to support. Use `>>>` for
-  doctest-style blocks.
-- For non-transform APIs, include a minimal runnable example that shows typical usage.
-
-## 3. Math where possible
-
-- Transforms with a clear mathematical formulation (affine, color, geometric, normalization) should include a short **Note** or inline math with the key equations (e.g. rotation matrix, normalization formula, transfer function).
-- Use standard notation; keep it concise (one or two lines of math is enough when it adds clarity).
-
-## 4. Use-cases / problems
-
-- Include at least one sentence (or a “Use when” / “Typical use cases” line) describing **which problems or tasks** the API is for (e.g. segmentation, object detection, robustness to lighting, data augmentation for medical imaging).
-- Help the reader decide “is this the right transform/function for my use case?”
-
-## 5. Similar transforms / See also
-
-- **Where possible**, mention related or alternative transforms so users who know basic ones discover others.
-- **See also** (and **Related transforms**): Use a **bullet list** (`-` per item) with 2–4 alternatives and brief when-to-use hints (e.g. `- RandomFog: Patch-based fog; use when…`). **One transform per bullet** — do not combine multiple transforms in a single bullet.
-- **Note:** Use a **bullet list** (`-` per point). Note is **pure info** only — no call-to-action (no "Explore other transforms…" or "Consider using…"). Put discoverability in See also, not in Note.
-- **Reciprocal cross-links:** When you add transform X to transform Y's See also, update X's docstring to mention Y in its own See also so discoverability works both ways.
-- Many users rely on a limited set (e.g. RandomResizedCrop, ColorJitter); See also helps them discover alternatives.
-
-## 6. Deep dive (combined bar)
-
-Together, the docstring should give a new user:
-
-- What the API does and how it behaves.
-- What the parameters mean and how to set them.
-- When to pick this over alternatives.
-- What similar transforms or functions exist.
-- A runnable example and, when relevant, the underlying math or references.
-
-## When to use this skill
-
-- When writing or updating docstrings in **albumentations/** (especially transform classes and public APIs).
-- When reviewing or adding new transforms: ensure the docstring meets all sections above (short description length, Args/Returns types, Examples, use-cases, See also where applicable).
+A reader should be able to choose the operation, configure it, and run the example. Re-read the complete docstring
+following the last edit, verify each claim against the public route, and check that examples expose consequential
+behavior without narrating obvious Python statements.

--- a/.codex/skills/release-notes/SKILL.md
+++ b/.codex/skills/release-notes/SKILL.md
@@ -29,35 +29,14 @@ Match the tone of `RELEASE_NOTES_2.1.2.md` and `RELEASE_NOTES_2.2.0.md`: terse, 
 
 ## Transform name → link
 
-**Every mention of a transform name in release notes MUST be a markdown link to its explore page**:
+Link the first meaningful mention of a transform in each section, including headings and table entries:
 
-```
+```markdown
 [TransformName](https://albumentations.ai/explore/transform/TransformName/)
 ```
 
-This applies to:
-- New transforms (in the "New features" section header and prose).
-- Transforms touched by bug fixes.
-- Transforms touched by breaking changes (including in the rename table).
-- The `Commits` table descriptions.
-
-The first mention in each section should be a link. Repeat mentions in the same paragraph can stay as plain backticked names if it would be visually noisy, but err on the side of always linking.
-
-Examples (good):
-
-```markdown
-### [CopyAndPaste](https://albumentations.ai/explore/transform/CopyAndPaste/) (mixing)
-
-[CopyAndPaste](https://albumentations.ai/explore/transform/CopyAndPaste/) was mixing positional indices and `_bbox_instance_id` values...
-
-| `Rotate.limit`, `SafeRotate.limit` | `angle_range` |
-```
-
-Becomes:
-
-```markdown
-| [Rotate](https://albumentations.ai/explore/transform/Rotate/).limit, [SafeRotate](https://albumentations.ai/explore/transform/SafeRotate/).limit | `angle_range` |
-```
+Repeated mentions in the same paragraph may use plain backticked names. Keep code fences runnable, without links.
+For parameter renames, link the transform separately and put the parameter name in code.
 
 Do **not** link:
 - Core classes (`Compose`, `BboxParams`, `KeypointParams`, `BasicTransform`, `BaseDistortion`).

--- a/.codex/skills/review-transform/SKILL.md
+++ b/.codex/skills/review-transform/SKILL.md
@@ -1,104 +1,54 @@
 ---
 name: review-transform
-description: Run the full shared Codex review checklist against a transform. Use when the user asks to review, audit, or check a transform for correctness, performance, or API consistency.
+description: Review an AlbumentationsX transform for correctness, public API coherence, performance, documentation, and test coverage.
 ---
 
-# Review Transform
+# Review a transform
 
-Run these checks in order. Report issues with severity: 🔴 Critical, 🟡 Important, 🟢 Suggestion.
+Start with `pre-commit run check-ax-rules --all-files`. Report failing diagnostics with their rule and location.
+The hook and [Coding Guidelines](../../../docs/contributing/coding_guidelines.md) own deterministic source contracts.
+Then review the behavior the hook cannot prove.
 
-## 1. Dead Code (🔴 Critical)
+## Correctness and API
 
-- Any methods defined but never called within the class or externally
-- Unused imports at the top of the file
-- Unreachable branches (`if False:`, conditions that can never be true)
+- Check the mathematical operation, coordinate boundaries, dtype range, and annotation semantics.
+- Verify that constructor fields, validators, and defaults express a coherent public policy.
+- Check empty inputs, ownership, aliasing, and unsupported input handling through the public route.
+- Distinguish public grayscale inputs from internal execution: Compose normalizes NumPy inputs to explicit channels
+  before dispatch. Use [NumPy and Tensor routing](../../../docs/design/numpy-tensor-routing.md) for boundary changes.
+- Take bbox type from `BboxParams.bbox_type`, never column count. Convert OpenCV rotated rectangles through
+  `cv2.boxPoints` and `polygons_to_obb`.
+- Remove unreachable code and unused helpers after checking external callers and inherited dispatch.
 
-## 2. Correctness
+## Sampling and replay
 
-- Mathematical/logical errors in the transform
-- Off-by-one errors in coordinate handling
-- Incorrect dtype preservation (uint8 in → uint8 out, float32 in → float32 out)
-- BBox/keypoint coordinate correctness after spatial transforms
-- Do not request 2D grayscale compatibility for Compose paths: images and volume data are channel-last with explicit
-  channels (`(H,W,C)`, `(N,H,W,C)`, `(D,H,W,C)`), and grayscale is `(H,W,1)`.
-- **Never auto-detect bbox type from column count** — type comes from `BboxParams.bbox_type`
-- For OBB: never use raw `cv2.minAreaRect` output; use `cv2.boxPoints` then `polygons_to_obb`
+Use [Applied Configuration Replay Contracts](../../../docs/design/applied-config-replay-contracts.md) when reviewing
+constructor serialization, applied configuration, or `ReplayCompose`.
 
-## 3. Mechanical AX contracts (🔴 Critical)
+- Identify what is sampled per invocation and which constructor fields remain policy.
+- Check target prerequisites, deterministic sampling, and representation-dependent parameters.
+- Verify that applied configuration records realized constructor values and clears conflicting source policy fields.
+- Claim exact replay only when the recorded configuration captures every output-changing random value.
+- Reconstruct through the public API and execute on fresh equivalent data without mutating caller-owned inputs.
 
-Run `pre-commit run check-ax-rules --all-files` first. Report a failing `AXG` diagnostic exactly; otherwise record
-that the hook passed. Keep the deterministic contract and its exceptions in
-`docs/contributing/coding_guidelines.md`.
+## Performance
 
-Use human review for what the hook cannot decide: whether constructor fields express a coherent public API, whether
-validators preserve intended semantics, and whether a proposed functional operation belongs in Albucore.
+Read [Performance Optimization](../performance-optimization/SKILL.md) and its required reference before inspecting
+runtime code. Tie each proposed optimization to an affected route and a measurement. Consider removable work,
+existing Albucore primitives, allocation and conversion costs, and setup that can be shared across a batch.
 
-## 4. Sampling design (🔴 Critical)
+## Documentation and tests
 
-Review the policy and replay boundary, not the hook's syntax checks:
+Use [Public docstring review](../docstring-deep-dive/SKILL.md) for reader-facing quality and
+[Generated Transform Target Contracts](../../../docs/design/transform-target-contracts.md) for coverage.
 
-- What is sampled per invocation, and which constructor fields remain policy rather than realized state?
-- Does target-dependent sampling declare its required data and produce the same result for the same invocation seed?
-- Does `applied_config` record every realized constructor value needed for reconstruction and clear a conflicting source
-  policy field?
-- Is `ReplayProfile.EXACT` claimed only when the emitted configuration captures every output-changing random value?
-- Does the reconstructed transform execute on fresh equivalent data without mutating caller-owned inputs?
+- Register each public constructor mode, including mutually exclusive behavior.
+- Derive target-profile applicability from declared capabilities and prerequisites.
+- Keep focused tests for semantic properties the generated profiles cannot express.
+- Check strict JSON transport, public reconstruction, fresh-data execution, and the declared replay strength.
 
-Read `docs/design/applied-config-replay-contracts.md` when a finding concerns constructor serialization, applied
-configuration, or `ReplayCompose` rather than local sampling logic.
+## Report
 
-## 5. Type Safety (🔴 Critical)
-
-- [ ] All methods have complete type hints
-- [ ] `ImageType` used for image/mask/volume params and return types (not `np.ndarray`)
-- [ ] `np.ndarray` used for bboxes and keypoints only
-- [ ] No unsafe type conversions or missing dtype handling
-
-## 6. Performance (🟡 Important)
-
-Read `../performance-optimization/SKILL.md` and its required reference completely before reviewing this section.
-
-Report only an applicable missed candidate: work that can be deleted, an existing Albucore primitive, an unsafe
-allocation or conversion, an unexamined backend, or setup that can be shared across a batch. Tie the finding to the
-affected public route and benchmark evidence; do not request an optimization merely because its pattern is generally
-faster.
-
-## 7. Documentation (🟡 Important)
-
-Use `docstring-deep-dive` for public-docstring quality. Review whether the description lets a user choose the transform,
-and whether each example demonstrates the targets and configuration that the transform actually supports.
-
-## 8. Test Coverage (🟡 Important)
-
-- Does every public constructor mode have a named registry case, including mutually exclusive behavior?
-- Do declared targets, bbox types, metadata prerequisites, and genuine channel restrictions produce the expected
-  generated target-profile pairs without class-name branches or skips?
-- Does a focused test state a stronger semantic property than the generated cluster already covers?
-- Does replay cross strict JSON, reconstruct publicly, and execute on fresh data at the declared strength?
-
-Use `docs/design/transform-target-contracts.md` and `docs/design/applied-config-replay-contracts.md` for the exact
-registry and profile contracts.
-
-## 9. Code Quality (🟢 Suggestion)
-
-- [ ] No unused imports
-- [ ] No overly complex logic that could be simplified
-- [ ] Relative parameters (fractions) preferred over fixed pixel values
-- [ ] Consistent style with similar existing transforms
-
-## Reporting Format
-
-```
-## Review: <TransformName>
-
-### 🔴 Critical
-- **Dead code**: `_unused_method` is never called (line 42)
-- **AXG diagnostic**: report the exact hook rule and location (for example, `AXG008`)
-
-### 🟡 Important
-- **Performance**: The public Compose route has no baseline comparison for the proposed LUT candidate
-- **Docs**: Example does not explain the transform's target semantics
-
-### 🟢 Suggestions
-- Consider using relative `noise_range` instead of absolute pixel values
-```
+For each finding, give severity, file and line, the affected public behavior, and evidence that demonstrates the issue.
+Distinguish confirmed defects from benchmark hypotheses or design decisions. Report checks actually run and any
+unresolved validation limits. If there are no actionable findings, say so.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,7 +162,7 @@ repos:
         exclude: ^build/
         additional_dependencies: ["tomli>=2.4.1"]
   - repo: https://github.com/frnmst/md-toc
-    rev: 9.0.0  # or latest version
+    rev: 9.0.0
     hooks:
       - id: md-toc
         args: ["-p", "github", "-l", "6"]  # GitHub style, up to 6 levels deep

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,52 +1,20 @@
 # Contributing to AlbumentationsX
 
-Thank you for your interest in contributing to [AlbumentationsX](https://albumentations.ai/)! This guide will help you get started with contributing to our image augmentation library.
+For small bug fixes, submit a pull request directly. For larger changes, open an
+[issue](https://github.com/albumentations-team/AlbumentationsX/issues) describing the problem and proposed behavior
+before implementation. You can discuss it in [Discord](https://discord.gg/e6zHCXTvaN).
 
-## Quick Start
+## Prepare and submit a change
 
-For small changes (e.g., bug fixes), feel free to submit a PR directly.
+1. Fork the repository and follow the [Environment Setup Guide](docs/contributing/environment_setup.md).
+2. Create a branch in your fork: `git checkout -b feature/my-new-feature`.
+3. Follow the [Coding Guidelines](docs/contributing/coding_guidelines.md). Keep transform policy and dispatch in the
+   transform class and image operations in the functional layer.
+4. Add or update tests that demonstrate the changed behavior, then run the relevant tests and pre-commit hooks.
+5. Open a pull request explaining the problem, resulting behavior, and validation. Address review feedback before merge.
 
-For larger changes:
-
-1. Create an [issue](https://github.com/albumentations-team/AlbumentationsX/issues) outlining your proposed change
-2. Join our [Discord community](https://discord.gg/e6zHCXTvaN) to discuss your idea
-
-## Contribution Guides
-
-We've organized our contribution guidelines into focused documents:
-
-- [Environment Setup Guide](docs/contributing/environment_setup.md) - How to set up your development environment
-- [Coding Guidelines](docs/contributing/coding_guidelines.md) - Code style, best practices, and technical requirements
-
-## Contribution Process
-
-1. **Find an Issue**: Look for open issues or propose a new one. For newcomers, look for issues labeled "good first issue"
-2. **Fork & Set Up**: Fork the repository and follow our [Environment Setup Guide](docs/contributing/environment_setup.md)
-3. **Create a Branch**: In your fork, create a new branch: `git checkout -b feature/my-new-feature`
-4. **Make Changes**: Write code following our [Coding Guidelines](docs/contributing/coding_guidelines.md). Image
-   operations must preserve their dtype range; clip the operation itself, never through a forwarding wrapper added
-   only to attach a decorator. Keep `apply*` methods as short dispatchers: move image arithmetic, routing, and clipping
-   into a functional helper.
-5. **Test**: Add tests and ensure all tests pass
-6. **Submit**: Open a Pull Request from your fork with a clear description of your changes
-
-## Code Review Process
-
-1. Maintainers will review your contribution
-2. Address any feedback or questions
-3. Once approved, your code will be merged
-
-## Project Structure
-
-- `albumentations/` - Main source code
-- `tests/` - Test suite
-- `docs/` - Documentation
-
-## Getting Help
-
-- Join our [Discord community](https://discord.gg/e6zHCXTvaN)
-- Open a GitHub [issue](https://github.com/albumentations-team/AlbumentationsX/issues)
-- Ask questions in your pull request
+Source code is in `albumentations/`, tests in `tests/`, and documentation in `docs/`.
+For help, ask in the issue, pull request, or Discord discussion.
 
 ## Contributor License Agreement
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![Docs](https://img.shields.io/badge/docs-albumentations.ai-blue)](https://albumentations.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme) [![Discord](https://img.shields.io/badge/Discord-join-7289da?logo=discord&logoColor=white)](https://discord.gg/AKPrrDYNAt) [![Twitter](https://img.shields.io/badge/Twitter-follow-1da1f2?logo=twitter&logoColor=white)](https://twitter.com/albumentations) [![LinkedIn](https://img.shields.io/badge/LinkedIn-connect-0077b5?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/albumentations/) [![Reddit](https://img.shields.io/badge/Reddit-join-ff4500?logo=reddit&logoColor=white)](https://www.reddit.com/r/Albumentations/)
 
-**AlbumentationsX** is a Python library for image augmentation. It provides high-performance, robust implementations and cutting-edge features for computer vision tasks. Image augmentation is used in deep learning and computer vision to increase the quality of trained models. The purpose of image augmentation is to create new training samples from the existing data.
+**AlbumentationsX** is a Python augmentation library for images and volumes. It applies sampled transformations to training data while keeping related masks, bounding boxes, keypoints, and labels synchronized.
 
 ## Citing
 
@@ -62,7 +62,6 @@ pip install "albumentationsx[headless]"
 ```python
 import albumentations as A
 
-# Create your augmentation pipeline
 transform = A.Compose(
     [
         A.RandomCrop(width=256, height=256),
@@ -81,41 +80,35 @@ Here is an example of how you can apply some [pixel-level](#pixel-level-transfor
 
 ## Why AlbumentationsX
 
-- **Complete Computer Vision Support**: Works with all major CV tasks
-- **Simple, Unified API**: [One consistent interface](#a-simple-example) for all data types - RGB/grayscale/multispectral images, masks, bounding boxes, and keypoints.
-- **Rich Augmentation Library**: [70+ high-quality augmentations](https://albumentations.ai/docs/reference/supported-targets-by-transform/?utm_source=github&utm_medium=referral&utm_campaign=readme) to enhance your training data.
-- **Fast**: Consistently benchmarked as the [fastest augmentation library](https://albumentations.ai/docs/benchmarks/image-benchmarks/?utm_source=github&utm_medium=referral&utm_campaign=readme) also shown [below section](#performance-comparison), with optimizations for production use.
-- **Deep Learning Integration**: Works with [PyTorch](https://pytorch.org/), [TensorFlow](https://www.tensorflow.org/), and other frameworks. Part of the [PyTorch ecosystem](https://pytorch.org/ecosystem/).
-- **Created by Experts**: Built by [developers with deep experience in computer vision and machine learning competitions](#authors).
+- **Synchronized targets:** Transform images, masks, bounding boxes, keypoints, and volumes through one pipeline.
+- **Image and volume operations:** Choose geometry, color, blur, noise, dropout, mixing, and 3D transforms from the
+  [transform catalog](#list-of-augmentations).
+- **NumPy and Tensor inputs:** Use arrays or CPU PyTorch tensors with the
+  [documented layouts](docs/design/numpy-tensor-routing.md).
+- **Measured performance:** Compare the [published benchmarks](https://albumentations.ai/docs/benchmarks/image-benchmarks/?utm_source=github&utm_medium=referral&utm_campaign=readme)
+  for the workload and library versions you use.
 
 ## Table of contents
 
-- [AlbumentationsX](#albumentationsx)
-  - [Why AlbumentationsX](#why-albumentationsx)
-  - [Table of contents](#table-of-contents)
-  - [Authors](#authors)
-    - [Current Maintainer](#current-maintainer)
-    - [Emeritus Core Team Members](#emeritus-core-team-members)
-  - [Installation](#installation)
-  - [Documentation](#documentation)
-  - [A simple example](#a-simple-example)
-  - [List of augmentations](#list-of-augmentations)
-    - [Pixel-level transforms](#pixel-level-transforms)
-    - [Spatial-level transforms](#spatial-level-transforms)
-  - [A few more examples of **augmentations**](#a-few-more-examples-of-augmentations)
-    - [Semantic segmentation on the Inria dataset](#semantic-segmentation-on-the-inria-dataset)
-    - [Medical imaging](#medical-imaging)
-    - [Object detection and semantic segmentation on the Mapillary Vistas dataset](#object-detection-and-semantic-segmentation-on-the-mapillary-vistas-dataset)
-    - [Keypoints augmentation](#keypoints-augmentation)
-  - [Benchmarking results](#benchmark-results)
-    - [System Information](#system-information)
-    - [Benchmark Parameters](#benchmark-parameters)
-    - [Library Versions](#library-versions)
-  - [Performance Comparison](#performance-comparison)
-  - [🤝 Contribute](#-contribute)
-  - [📜 License](#-license)
-  - [📞 Contact](#-contact)
-  - [Citing](#citing)
+- [Citing](#citing)
+- [Licensing](#-licensing-commercial-use-is-allowed)
+- [Quick Start](#quick-start)
+- [Why AlbumentationsX](#why-albumentationsx)
+- [Authors](#authors)
+- [Installation](#installation)
+- [Documentation](#documentation)
+- [A simple example](#a-simple-example)
+- [List of augmentations](#list-of-augmentations)
+  - [Pixel-level transforms](#pixel-level-transforms)
+  - [Spatial-level transforms](#spatial-level-transforms)
+  - [3D transforms](#3d-transforms)
+- [Augmentation examples](#a-few-more-examples-of-augmentations)
+- [Benchmark results](#benchmark-results)
+- [Performance comparison](#performance-comparison)
+- [Contribute](#-contribute)
+- [License](#-license)
+- [Contact](#-contact)
+- [Newsletter](#-stay-connected)
 
 ## Authors
 
@@ -203,7 +196,6 @@ AlbumentationsX pipelines.
 import albumentations as A
 import cv2
 
-# Declare an augmentation pipeline
 transform = A.Compose(
     [
         A.RandomCrop(width=256, height=256),
@@ -212,11 +204,8 @@ transform = A.Compose(
     ]
 )
 
-# Read an image with OpenCV and convert it to the RGB colorspace
-image = cv2.imread("image.jpg")
-image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+image = cv2.imread("image.jpg", cv2.IMREAD_COLOR_RGB)
 
-# Augment an image
 transformed = transform(image=image)
 transformed_image = transformed["image"]
 ```
@@ -419,6 +408,8 @@ Where:
 
 ## Benchmark Results
 
+These results cover the library versions listed below.
+
 ### Image Benchmark Results
 
 ### System Information
@@ -504,11 +495,9 @@ library for each transform.
 
 ## 🤝 Contribute
 
-We thrive on community collaboration! AlbumentationsX wouldn't be the powerful augmentation library it is without contributions from developers like you. Please see our [Contributing Guide](CONTRIBUTING.md) to get started. A huge **Thank You** 🙏 to everyone who contributes!
+See the [Contributing Guide](CONTRIBUTING.md) to report a bug, improve documentation, or submit a code change.
 
 [![AlbumentationsX open-source contributors](https://contrib.rocks/image?repo=albumentations-team/AlbumentationsX)](https://github.com/albumentations-team/AlbumentationsX/graphs/contributors)
-
-We look forward to your contributions to help make the AlbumentationsX ecosystem even better!
 
 ## 📜 License
 
@@ -525,10 +514,13 @@ repository-level details.
 
 ## 📞 Contact
 
-For bug reports and feature requests related to AlbumentationsX, please visit [GitHub Issues](https://github.com/albumentations-team/AlbumentationsX/issues). For questions, discussions, and community support, join our active communities on [Discord](https://discord.gg/AKPrrDYNAt), [Twitter](https://twitter.com/albumentations), [LinkedIn](https://www.linkedin.com/company/albumentations/), and [Reddit](https://www.reddit.com/r/Albumentations/). We're here to help with all things AlbumentationsX!
+Report bugs and request features in [GitHub Issues](https://github.com/albumentations-team/AlbumentationsX/issues).
+For questions and discussion, use [Discord](https://discord.gg/AKPrrDYNAt) or
+[Reddit](https://www.reddit.com/r/Albumentations/). Follow release and project updates on
+[Twitter](https://twitter.com/albumentations) and [LinkedIn](https://www.linkedin.com/company/albumentations/).
 
 ---
 
 ## 📫 Stay Connected
 
-Never miss updates, tutorials, and tips from the AlbumentationsX team! [Subscribe to our newsletter](https://albumentations.ai/subscribe?utm_source=github&utm_medium=referral&utm_campaign=readme).
+For releases, tutorials, and tips, [subscribe to the newsletter](https://albumentations.ai/subscribe?utm_source=github&utm_medium=referral&utm_campaign=readme).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![Docs](https://img.shields.io/badge/docs-albumentations.ai-blue)](https://albumentations.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme) [![Discord](https://img.shields.io/badge/Discord-join-7289da?logo=discord&logoColor=white)](https://discord.gg/AKPrrDYNAt) [![Twitter](https://img.shields.io/badge/Twitter-follow-1da1f2?logo=twitter&logoColor=white)](https://twitter.com/albumentations) [![LinkedIn](https://img.shields.io/badge/LinkedIn-connect-0077b5?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/albumentations/) [![Reddit](https://img.shields.io/badge/Reddit-join-ff4500?logo=reddit&logoColor=white)](https://www.reddit.com/r/Albumentations/)
 
-**AlbumentationsX** is a Python augmentation library for images and volumes. It applies sampled transformations to training data while keeping related masks, bounding boxes, keypoints, and labels synchronized.
+**AlbumentationsX** is a Python library for image augmentation. It provides high-performance, robust implementations and cutting-edge features for computer vision tasks. Image augmentation is used in deep learning and computer vision to increase the quality of trained models. The purpose of image augmentation is to create new training samples from the existing data.
 
 ## Citing
 
@@ -80,13 +80,12 @@ Here is an example of how you can apply some [pixel-level](#pixel-level-transfor
 
 ## Why AlbumentationsX
 
-- **Synchronized targets:** Transform images, masks, bounding boxes, keypoints, and volumes through one pipeline.
-- **Image and volume operations:** Choose geometry, color, blur, noise, dropout, mixing, and 3D transforms from the
-  [transform catalog](#list-of-augmentations).
-- **NumPy and Tensor inputs:** Use arrays or CPU PyTorch tensors with the
-  [documented layouts](docs/design/numpy-tensor-routing.md).
-- **Measured performance:** Compare the [published benchmarks](https://albumentations.ai/docs/benchmarks/image-benchmarks/?utm_source=github&utm_medium=referral&utm_campaign=readme)
-  for the workload and library versions you use.
+- **Complete Computer Vision Support**: Works with all major CV tasks
+- **Simple, Unified API**: [One consistent interface](#a-simple-example) for all data types - RGB/grayscale/multispectral images, masks, bounding boxes, and keypoints.
+- **Rich Augmentation Library**: [70+ high-quality augmentations](https://albumentations.ai/docs/reference/supported-targets-by-transform/?utm_source=github&utm_medium=referral&utm_campaign=readme) to enhance your training data.
+- **Fast**: Consistently benchmarked as the [fastest augmentation library](https://albumentations.ai/docs/benchmarks/image-benchmarks/?utm_source=github&utm_medium=referral&utm_campaign=readme) also shown [below section](#performance-comparison), with optimizations for production use.
+- **Deep Learning Integration**: Works with [PyTorch](https://pytorch.org/), [TensorFlow](https://www.tensorflow.org/), and other frameworks. Part of the [PyTorch ecosystem](https://pytorch.org/ecosystem/).
+- **Created by Experts**: Built by [developers with deep experience in computer vision and machine learning competitions](#authors).
 
 ## Table of contents
 
@@ -495,9 +494,11 @@ library for each transform.
 
 ## 🤝 Contribute
 
-See the [Contributing Guide](CONTRIBUTING.md) to report a bug, improve documentation, or submit a code change.
+We thrive on community collaboration! AlbumentationsX wouldn't be the powerful augmentation library it is without contributions from developers like you. Please see our [Contributing Guide](CONTRIBUTING.md) to get started. A huge **Thank You** 🙏 to everyone who contributes!
 
 [![AlbumentationsX open-source contributors](https://contrib.rocks/image?repo=albumentations-team/AlbumentationsX)](https://github.com/albumentations-team/AlbumentationsX/graphs/contributors)
+
+We look forward to your contributions to help make the AlbumentationsX ecosystem even better!
 
 ## 📜 License
 
@@ -514,13 +515,10 @@ repository-level details.
 
 ## 📞 Contact
 
-Report bugs and request features in [GitHub Issues](https://github.com/albumentations-team/AlbumentationsX/issues).
-For questions and discussion, use [Discord](https://discord.gg/AKPrrDYNAt) or
-[Reddit](https://www.reddit.com/r/Albumentations/). Follow release and project updates on
-[Twitter](https://twitter.com/albumentations) and [LinkedIn](https://www.linkedin.com/company/albumentations/).
+For bug reports and feature requests related to AlbumentationsX, please visit [GitHub Issues](https://github.com/albumentations-team/AlbumentationsX/issues). For questions, discussions, and community support, join our active communities on [Discord](https://discord.gg/AKPrrDYNAt), [Twitter](https://twitter.com/albumentations), [LinkedIn](https://www.linkedin.com/company/albumentations/), and [Reddit](https://www.reddit.com/r/Albumentations/). We're here to help with all things AlbumentationsX!
 
 ---
 
 ## 📫 Stay Connected
 
-For releases, tutorials, and tips, [subscribe to the newsletter](https://albumentations.ai/subscribe?utm_source=github&utm_medium=referral&utm_campaign=readme).
+Never miss updates, tutorials, and tips from the AlbumentationsX team! [Subscribe to our newsletter](https://albumentations.ai/subscribe?utm_source=github&utm_medium=referral&utm_campaign=readme).

--- a/albumentations/augmentations/blur/functional.py
+++ b/albumentations/augmentations/blur/functional.py
@@ -306,17 +306,13 @@ def create_motion_kernel(
     kernel = np.zeros((kernel_size, kernel_size), dtype=np.float32)
     center = kernel_size // 2
 
-    # Convert angle to radians
     angle_rad = radians(angle)
 
-    # Calculate direction vector
     dx = cos(angle_rad)
     dy = sin(angle_rad)
 
-    # Create line points with direction bias
     line_length = kernel_size // 2
 
-    # Apply direction bias to control the distribution of blur
     if direction < 0:
         # Backward bias: interpolate between symmetric and backward-only
         # direction = -1: only backward, direction = 0: symmetric
@@ -341,7 +337,6 @@ def create_motion_kernel(
     x = center + dx * t
     y = center + dy * t
 
-    # Apply random shift if allowed
     if allow_shifted:
         shift_x = random_state.uniform(-1, 1) * line_length / 2
         shift_y = random_state.uniform(-1, 1) * line_length / 2
@@ -356,7 +351,6 @@ def create_motion_kernel(
     points = np.unique(np.column_stack([y, x]), axis=0)
     kernel[points[:, 0], points[:, 1]] = 1
 
-    # Ensure at least one point is set
     if not kernel.any():
         kernel[center, center] = 1
 
@@ -387,13 +381,11 @@ def sample_odd_from_range(random_state: random.Random, low: int, high: int) -> i
     # Normalize high value
     high = max(3, high + (high % 2 == 0))
 
-    # Ensure high >= low after normalization
     high = max(high, low)
 
     if low == high:
         return low
 
-    # Calculate number of possible odd values
     num_odd_values = (high - low) // 2 + 1
     # Generate random index and convert to corresponding odd number
     rand_idx = random_state.randint(0, num_odd_values - 1)
@@ -415,17 +407,13 @@ def create_gaussian_kernel(sigma: float, ksize: int = 0) -> np.ndarray:
     """
     size = int(sigma * 3.5) * 2 + 1 if ksize == 0 else ksize
 
-    # Ensure odd size
     size = size + 1 if size % 2 == 0 else size
 
-    # Create x coordinates
     x = np.linspace(-(size // 2), size // 2, size)
 
-    # Compute 1D kernel using vectorized operations
     kernel_1d = np.exp(-0.5 * (x / sigma) ** 2)
     kernel_1d = kernel_1d / reduce_sum(kernel_1d)
 
-    # Create 2D kernel
     return kernel_1d[:, np.newaxis] @ kernel_1d[np.newaxis, :]
 
 
@@ -444,10 +432,8 @@ def create_gaussian_kernel_1d(sigma: float, ksize: int = 0) -> np.ndarray:
     """
     size = int(sigma * 3.5) * 2 + 1 if ksize == 0 else ksize
 
-    # Ensure odd size
     size = size + 1 if size % 2 == 0 else size
 
-    # Create x coordinates
     x = create_gaussian_kernel_input_array(size=size)
 
     # Guard against sigma=0 (would cause division by zero)

--- a/albumentations/augmentations/crops/base.py
+++ b/albumentations/augmentations/crops/base.py
@@ -154,7 +154,6 @@ class BaseCrop(DualTransform):
         **params: Any,
     ) -> ImageType:
         if mask.size == 0:
-            # Return empty array with cropped dimensions
             # Assume mask shape is (H, W, C)
             crop_height = crop_coords[3] - crop_coords[1]
             crop_width = crop_coords[2] - crop_coords[0]
@@ -196,7 +195,6 @@ class BaseCrop(DualTransform):
         **params: Any,
     ) -> VolumeType:
         if mask3d.size == 0:
-            # Return empty array with cropped dimensions
             # Assume mask3d shape is (D, H, W, C)
             crop_height = crop_coords[3] - crop_coords[1]
             crop_width = crop_coords[2] - crop_coords[0]
@@ -545,7 +543,6 @@ class BaseCropAndPad(BaseCrop):
         image_shape = shape[:2]
 
         if pad_params is not None:
-            # Calculate padded dimensions
             padded_height = image_shape[0] + pad_params["pad_top"] + pad_params["pad_bottom"]
             padded_width = image_shape[1] + pad_params["pad_left"] + pad_params["pad_right"]
 
@@ -735,7 +732,6 @@ class _BaseRandomSizedCrop(DualTransform):
             target_type == "mask" and self.area_for_downscale == "image_mask"
         ):
             return cv2.INTER_AREA
-        # Get base interpolation
         return self.interpolation if target_type == "image" else self.mask_interpolation
 
     def apply(
@@ -777,11 +773,9 @@ class _BaseRandomSizedCrop(DualTransform):
         # First, crop the keypoints
         cropped_keypoints = fcrops.crop_keypoints_by_coords(keypoints, crop_coords)
 
-        # Calculate the dimensions of the crop
         crop_height = crop_coords[3] - crop_coords[1]
         crop_width = crop_coords[2] - crop_coords[0]
 
-        # Calculate scaling factors
         scale_x = self.size[1] / crop_width
         scale_y = self.size[0] / crop_height
 
@@ -797,7 +791,6 @@ class _BaseRandomSizedCrop(DualTransform):
         # First crop the volume using volume_crop_yx (reduces data size)
         crop = fcrops.volume_crop_yx(images, *crop_coords)
 
-        # Get interpolation method based on crop dimensions
         interpolation = self._get_interpolation_for_resize(cast("tuple[int, int]", crop.shape[1:3]), "image")
 
         # Then resize the smaller cropped volume using the selected interpolation

--- a/albumentations/augmentations/crops/basic.py
+++ b/albumentations/augmentations/crops/basic.py
@@ -179,7 +179,6 @@ class RandomCrop(BaseCropAndPad):
                 f" {(self.height, self.width)} vs {image_shape[:2]}",
             )
 
-        # Get padding params first if needed
         pad_params = self._get_pad_params(image_shape, (self.height, self.width), sampling)
 
         # If padding is needed, adjust the image shape for crop calculation
@@ -193,12 +192,10 @@ class RandomCrop(BaseCropAndPad):
             padded_width = image_width + pad_left + pad_right
             padded_shape = (padded_height, padded_width)
 
-            # Get random crop coordinates based on padded dimensions
             h_start = sampling.py_random.random()
             w_start = sampling.py_random.random()
             crop_coords = fcrops.get_crop_coords(padded_shape, (self.height, self.width), h_start, w_start)
         else:
-            # Get random crop coordinates based on original dimensions
             h_start = sampling.py_random.random()
             w_start = sampling.py_random.random()
             crop_coords = fcrops.get_crop_coords(image_shape, (self.height, self.width), h_start, w_start)
@@ -359,7 +356,6 @@ class CenterCrop(BaseCropAndPad):
                 f" {(self.height, self.width)} vs {image_shape[:2]}",
             )
 
-        # Get padding params first if needed
         pad_params = self._get_pad_params(image_shape, (self.height, self.width), sampling)
 
         # If padding is needed, adjust the image shape for crop calculation
@@ -373,10 +369,8 @@ class CenterCrop(BaseCropAndPad):
             padded_width = image_width + pad_left + pad_right
             padded_shape = (padded_height, padded_width)
 
-            # Get crop coordinates based on padded dimensions
             crop_coords = fcrops.get_center_crop_coords(padded_shape, (self.height, self.width))
         else:
-            # Get crop coordinates based on original dimensions
             crop_coords = fcrops.get_center_crop_coords(image_shape, (self.height, self.width))
 
         return SampledParams(

--- a/albumentations/augmentations/crops/functional.py
+++ b/albumentations/augmentations/crops/functional.py
@@ -443,7 +443,6 @@ def pad_along_axes(
     pad_width[h_axis] = (pad_top, pad_bottom)
     pad_width[w_axis] = (pad_left, pad_right)
 
-    # Initialize kwargs with mode
     kwargs: dict[str, Any] = {"mode": np_mode}
     # Add constant_values only if mode is constant
     if np_mode == "constant":

--- a/albumentations/augmentations/crops/special.py
+++ b/albumentations/augmentations/crops/special.py
@@ -208,7 +208,6 @@ class CropNonEmptyMaskIfExists(BaseCrop):
             non_zero_yx = non_zero_xy.reshape(-1, 2)[:, ::-1]
             y, x = sampling.py_random.choice(non_zero_yx)
 
-            # Calculate crop coordinates centered around chosen point
             x_min = x - sampling.py_random.randint(0, self.width - 1)
             y_min = y - sampling.py_random.randint(0, self.height - 1)
             x_min = np.clip(x_min, 0, mask_width - self.width)

--- a/albumentations/augmentations/dropout/coarse_dropout.py
+++ b/albumentations/augmentations/dropout/coarse_dropout.py
@@ -507,7 +507,6 @@ class ConstrainedCoarseDropout(BaseDropout):
         if len(bboxes) == 0 or self.bbox_labels is None:
             return None
 
-        # Get label encoder from BboxProcessor if needed
         bbox_processor = self.get_processor("bboxes")
         if bbox_processor is None:
             return None

--- a/albumentations/augmentations/dropout/functional.py
+++ b/albumentations/augmentations/dropout/functional.py
@@ -134,7 +134,6 @@ def apply_inpainting(img: ImageType, holes: np.ndarray, method: Literal["inpaint
 
     """
     num_channels = get_num_channels(img)
-    # Create inpainting mask
     mask = np.zeros(img.shape[:2], dtype=np.uint8)
     for x_min, y_min, x_max, y_max in holes:
         mask[y_min:y_max, x_min:x_max] = 255
@@ -412,7 +411,6 @@ def cutout(
             return fill_holes_with_grayscale(img, holes)
         raise ValueError(f"Unsupported string fill: {fill}")
 
-    # Convert numeric fill values to numpy array
     if isinstance(fill, (int, float)):
         fill_array = np.array(fill, dtype=img.dtype)
         return fill_holes_with_value(img, holes, fill_array)
@@ -463,7 +461,6 @@ def cutout_on_volume(
         if fill in {"inpaint_telea", "inpaint_ns"}:
             processed_images = [apply_inpainting(img, holes, fill) for img in volume]
             result = np.array(processed_images)
-            # Reshape to original volume shape: (D, H, W, C) or (D, H, W)
             return cast("ImageType", result.reshape(volume.shape))
         if fill == "random":
             return fill_volume_holes_with_random(volume, holes, random_generator, uniform=False)
@@ -473,7 +470,6 @@ def cutout_on_volume(
             return fill_volume_holes_with_grayscale(volume, holes)
         raise ValueError(f"Unsupported string fill: {fill}")
 
-    # Convert numeric fill values to numpy array
     if isinstance(fill, (int, float)):
         fill_array = np.array(fill, dtype=volume.dtype)
         return fill_volume_holes_with_value(volume, holes, fill_array)
@@ -517,7 +513,6 @@ def filter_keypoints_in_holes(keypoints: np.ndarray, holes: np.ndarray) -> np.nd
     hole_x2 = holes[:, 2]  # Shape: (num_holes,)
     hole_y2 = holes[:, 3]  # Shape: (num_holes,)
 
-    # Check if each keypoint is inside each hole
     inside_hole = (kp_x >= hole_x1) & (kp_x < hole_x2) & (kp_y >= hole_y1) & (kp_y < hole_y2)
 
     # A keypoint is valid if it's not inside any hole
@@ -534,7 +529,6 @@ def resize_boxes_to_visible_area(
     """Resize boxes to largest visible rectangular region inside hole_mask. boxes (N,4);
     hole_mask: binary. Returns resized boxes for dropout bbox handling.
     """
-    # Extract box coordinates
     x1 = boxes[:, 0].astype(int)
     y1 = boxes[:, 1].astype(int)
     x2 = boxes[:, 2].astype(int)
@@ -566,8 +560,6 @@ def resize_boxes_to_visible_area(
 
         new_boxes.append(new_box)
 
-        # Return empty array with correct shape if all boxes were removed
-
     return np.array(new_boxes) if new_boxes else np.zeros((0, boxes.shape[1]), dtype=boxes.dtype)
 
 
@@ -597,7 +589,6 @@ def filter_bboxes_by_holes(
     if len(bboxes) == 0 or len(holes) == 0:
         return bboxes
 
-    # Create hole mask
     hole_mask = np.zeros(image_shape, dtype=np.uint8)
     for hole in holes:
         x_min, y_min, x_max, y_max = hole.astype(int)
@@ -750,13 +741,11 @@ def generate_grid_holes(
     # Generate the uniform grid
     cells = split_uniform_grid(image_shape, grid, random_generator)
 
-    # Calculate hole sizes based on the ratio
     cell_heights = cells[:, 2] - cells[:, 0]
     cell_widths = cells[:, 3] - cells[:, 1]
     hole_heights = np.clip(cell_heights * ratio, 1, cell_heights - 1).astype(int)
     hole_widths = np.clip(cell_widths * ratio, 1, cell_widths - 1).astype(int)
 
-    # Calculate maximum possible offsets
     max_offset_y = cell_heights - hole_heights
     max_offset_x = cell_widths - hole_widths
 
@@ -769,7 +758,6 @@ def generate_grid_holes(
         offset_y = np.full_like(max_offset_y, shift_xy[1])
         offset_x = np.full_like(max_offset_x, shift_xy[0])
 
-    # Calculate hole coordinates
     x_min = np.clip(cells[:, 1] + offset_x, 0, width - hole_widths)
     y_min = np.clip(cells[:, 0] + offset_y, 0, height - hole_heights)
     x_max = np.minimum(x_min + hole_widths, width)
@@ -802,7 +790,6 @@ def mask_dropout_bboxes(
     """
     height, width = image_shape
 
-    # Ensure dropout_mask is 2D
     if dropout_mask.ndim > 2:
         if dropout_mask.shape[0] == 1:  # Shape is (1, H, W)
             dropout_mask = dropout_mask.squeeze(0)
@@ -850,7 +837,6 @@ def mask_dropout_bboxes(
         where=box_areas != 0,
     )
 
-    # Create a boolean mask for boxes to keep
     keep_mask = (visible_areas >= min_area) & (visibility_ratio >= min_visibility)
 
     return bboxes[keep_mask]
@@ -872,7 +858,6 @@ def mask_dropout_keypoints(
         np.ndarray: Filtered keypoints
 
     """
-    # Ensure dropout_mask is 2D
     if dropout_mask.ndim > 2:
         if dropout_mask.shape[0] == 1:  # Shape is (1, H, W)
             dropout_mask = dropout_mask.squeeze(0)
@@ -881,7 +866,6 @@ def mask_dropout_keypoints(
         else:  # Shape is (C, H, W)
             dropout_mask = np.any(dropout_mask, axis=0)
 
-    # Get coordinates as integers
     coords = keypoints[:, :2].astype(int)
 
     # Filter out keypoints that are outside the mask dimensions
@@ -918,10 +902,8 @@ def label(mask: np.ndarray, return_num: bool = False, connectivity: int = 2) -> 
         assigned the same integer value. If return_num is True, it also returns the number of labels.
 
     """
-    # Create a copy of the original mask
     labeled = np.zeros_like(mask, dtype=np.int32)
 
-    # Get unique non-zero values from the original mask
     unique_values = np.unique(mask[mask != 0])
 
     # Label each unique value separately
@@ -929,7 +911,6 @@ def label(mask: np.ndarray, return_num: bool = False, connectivity: int = 2) -> 
     for value in unique_values:
         binary_mask = (mask == value).astype(np.uint8)
 
-        # Set connectivity for OpenCV (4 or 8)
         cv2_connectivity = 4 if connectivity == 1 else 8
 
         # Use OpenCV's connectedComponents
@@ -957,7 +938,6 @@ def get_holes_from_boxes(
     """
     num_boxes = len(target_boxes)
 
-    # Get box dimensions (N, )
     box_widths = target_boxes[:, 2] - target_boxes[:, 0]
     box_heights = target_boxes[:, 3] - target_boxes[:, 1]
 
@@ -988,7 +968,6 @@ def get_holes_from_boxes(
         box_heights[:, None] - hole_heights
     )
 
-    # Calculate final coordinates (N, num_holes)
     x_min = target_boxes[:, 0, None] + x_offsets
     y_min = target_boxes[:, 1, None] + y_offsets
     x_max = x_min + hole_widths
@@ -1076,7 +1055,6 @@ def get_holes_from_mask(
         np.ndarray: Holes (n, 4) [x1,y1,x2,y2].
 
     """
-    # Create binary mask for target indices
     binary_mask = np.isin(mask[:, :, 0], np.array(mask_indices))
     if not np.any(binary_mask):  # If no target objects found
         return np.array([], dtype=np.int32).reshape((0, 4))
@@ -1107,7 +1085,6 @@ def get_holes_from_mask(
         * obj_sizes
     )
 
-    # Calculate hole coordinates around centers
     half_heights = hole_heights // 2
     half_widths = hole_widths // 2
 

--- a/albumentations/augmentations/geometric/_functional_bboxes.py
+++ b/albumentations/augmentations/geometric/_functional_bboxes.py
@@ -123,14 +123,12 @@ def resize_bboxes(
     bboxes_px = denormalize_bboxes(bboxes, image_shape)
     extras = bboxes_px[:, 5:] if bboxes_px.shape[1] > BBOX_OBB_MIN_COLUMNS else None
 
-    # Convert to polygons in pixel space
     polygons_px = obb_to_polygons(bboxes_px)
 
     # Scale the polygons
     polygons_px[..., 0] *= scale_x
     polygons_px[..., 1] *= scale_y
 
-    # Convert back to OBB in pixel space
     transformed_bboxes_px = polygons_to_obb(polygons_px, extra_fields=extras)
 
     # Normalize back to [0, 1]
@@ -394,7 +392,6 @@ def bboxes_affine_largest_box(
         transformed = apply_affine_to_points(polygons.reshape(-1, 2), matrix).reshape(polygons.shape)
         return polygons_to_obb(transformed, extra_fields=extras)
 
-    # Extract corners of all bboxes
     x_min, y_min, x_max, y_max = bboxes[:, 0], bboxes[:, 1], bboxes[:, 2], bboxes[:, 3]
 
     corners = (
@@ -404,7 +401,6 @@ def bboxes_affine_largest_box(
     # Transform all corners at once
     transformed_corners = apply_affine_to_points(corners, matrix).reshape(-1, 4, 2)
 
-    # Compute new bounding boxes
     new_x_min = np.min(transformed_corners[:, :, 0], axis=1)
     new_x_max = np.max(transformed_corners[:, :, 0], axis=1)
     new_y_min = np.min(transformed_corners[:, :, 1], axis=1)
@@ -472,7 +468,6 @@ def bboxes_affine_ellipse(
 
     transformed_points = transformed_points.reshape(len(bboxes), -1, 2)
 
-    # Compute new bounding boxes
     new_x_min = np.min(transformed_points[:, :, 0], axis=1)
     new_x_max = np.max(transformed_points[:, :, 0], axis=1)
     new_y_min = np.min(transformed_points[:, :, 1], axis=1)
@@ -535,7 +530,6 @@ def bboxes_affine(
     bboxes = denormalize_bboxes(bboxes, image_shape)
 
     if border_mode in REFLECT_BORDER_MODES:
-        # Step 1: Compute affine transform padding
         pad_left, pad_right, pad_top, pad_bottom = calculate_affine_transform_padding(
             matrix,
             image_shape,
@@ -554,7 +548,6 @@ def bboxes_affine(
             center_in_origin=True,
         )
 
-    # Apply affine transform
     if rotate_method == "largest_box":
         transformed_bboxes = bboxes_affine_largest_box(bboxes, matrix, bbox_type=bbox_type)
     elif rotate_method == "ellipse":
@@ -665,10 +658,8 @@ def remap_bboxes(
         np.ndarray: Remapped bounding boxes.
 
     """
-    # Convert bboxes to mask
     bbox_masks = bboxes_to_mask(bboxes, image_shape)
 
-    # Ensure maps are float32
     map_x = map_x.astype(np.float32)
     map_y = map_y.astype(np.float32)
 
@@ -681,7 +672,6 @@ def remap_bboxes(
         border_value=0,
     )
 
-    # Convert masks back to bboxes
     return mask_to_bboxes(transformed_masks, bboxes, bbox_type=bbox_type)
 
 
@@ -728,7 +718,6 @@ def pad_bboxes(
 
     bboxes = generate_reflected_bboxes(bboxes, grid_dimensions, image_shape)
 
-    # Calculate the number of grid cells added on each side
     original_row, original_col = grid_dimensions["original_position"]
 
     image_height, image_width = image_shape[:2]
@@ -788,7 +777,6 @@ def shift_bboxes(bboxes: np.ndarray, shift_vector: np.ndarray) -> np.ndarray:
         np.ndarray: Shifted bounding boxes with the same shape as input.
 
     """
-    # Create a copy of the input array to avoid modifying it in-place
     shifted_bboxes = bboxes.copy()
 
     # Add the shift vector to the first 4 columns
@@ -1028,10 +1016,8 @@ def bboxes_grid_shuffle(
         np.ndarray: Shuffled bounding boxes
 
     """
-    # Convert bboxes to masks
     masks = masks_from_bboxes(bboxes, image_shape)
 
-    # Apply grid shuffle to each mask and handle split components
     all_component_masks = []
     extra_bbox_data = []  # Store additional bbox data for each component
 
@@ -1050,9 +1036,7 @@ def bboxes_grid_shuffle(
         for comp_idx in range(1, num_components):  # Skip background (0)
             component_mask = (components == comp_idx).astype(np.uint8)
 
-            # Calculate area and visibility ratio
             component_area = float(reduce_sum(component_mask))
-            # Check if component meets minimum requirements
             if is_valid_component(
                 component_area,
                 original_area,
@@ -1064,7 +1048,6 @@ def bboxes_grid_shuffle(
                 if bboxes.shape[1] > NUM_BBOXES_COLUMNS_IN_ALBUMENTATIONS:
                     extra_bbox_data.append(bboxes[idx, 4:])
 
-    # Convert all component masks to bboxes
     if all_component_masks:
         all_component_masks = np.array(all_component_masks)
         shuffled_bboxes = bboxes_from_masks(all_component_masks)

--- a/albumentations/augmentations/geometric/_functional_distortion.py
+++ b/albumentations/augmentations/geometric/_functional_distortion.py
@@ -393,7 +393,6 @@ def generate_distorted_grid_polygons(
     grid_height, grid_width = dimensions.shape[:2]
     total_cells = grid_height * grid_width
 
-    # Initialize polygons
     polygons = np.zeros((total_cells, 8), dtype=np.float32)
     polygons[:, 0:2] = dimensions.reshape(-1, 4)[:, [0, 1]]  # x1, y1
     polygons[:, 2:4] = dimensions.reshape(-1, 4)[:, [2, 1]]  # x2, y1
@@ -461,7 +460,6 @@ def create_piecewise_affine_maps(
     if scale <= 0:
         return None, None
 
-    # Create source points grid
     y = np.linspace(0, height - 1, nb_rows, dtype=np.float32)
     x = np.linspace(0, width - 1, nb_cols, dtype=np.float32)
     xx_src, yy_src = np.meshgrid(x, y)
@@ -547,7 +545,6 @@ def compute_tps_weights(
     """
     num_points = src_points.shape[0]
 
-    # Compute pairwise distances
     distances = pairwise_distances_squared(src_points, src_points)
     kernel_matrix = _compute_tps_kernel(distances)
 
@@ -580,7 +577,6 @@ def tps_transform(
     """Apply TPS transformation to target_points given control_points and
     nonlinear_weights, affine_weights. All float32. For ThinPlateSpline remap.
     """
-    # Ensure float32 type for all inputs
     target_points = np.ascontiguousarray(target_points, dtype=np.float32)
     control_points = np.ascontiguousarray(control_points, dtype=np.float32)
     nonlinear_weights = np.ascontiguousarray(nonlinear_weights, dtype=np.float32)

--- a/albumentations/augmentations/geometric/_functional_grid.py
+++ b/albumentations/augmentations/geometric/_functional_grid.py
@@ -163,7 +163,6 @@ def almost_equal_intervals(n: int, parts: int) -> np.ndarray:
 
     """
     part_size, remainder = divmod(n, parts)
-    # Create an array with the base part size and adjust the first `remainder` parts by adding 1
     return np.array(
         [part_size + 1 if i < remainder else part_size for i in range(parts)],
     )
@@ -227,7 +226,6 @@ def split_uniform_grid(
         random_generator=random_generator,
     )
 
-    # Calculate tiles coordinates
     tiles = [
         (height_splits[i], width_splits[j], height_splits[i + 1], width_splits[j + 1])
         for i in range(n_rows)
@@ -518,7 +516,6 @@ def swap_tiles_on_image(
     if tiles.size == 0 or mapping is None:
         return image.copy()
 
-    # Create a copy of the image to retain original for reference
     new_image = np.empty_like(image)
     for num, new_index in enumerate(mapping):
         start_y, start_x, end_y, end_x = tiles[new_index]
@@ -559,7 +556,6 @@ def shuffle_tiles_within_shape_groups(
         list[int]: A list where each index is mapped to the new index of the tile after shuffling.
 
     """
-    # Initialize the output list with the same size as the total number of tiles, filled with -1
     num_tiles = sum(len(indices) for indices in shape_groups.values())
     mapping = [-1] * num_tiles
 

--- a/albumentations/augmentations/geometric/_functional_images.py
+++ b/albumentations/augmentations/geometric/_functional_images.py
@@ -215,7 +215,6 @@ def resize_pil(
         warn(f"Interpolation method {interpolation} is not supported by PIL backend, using BILINEAR", stacklevel=2)
         pil_interpolation = Image.Resampling.BILINEAR
 
-    # Convert numpy array to PIL Image
     # Images always have ndim=3 in albumentations
     if img.ndim != 3:
         raise ValueError(f"Expected 3D array, got shape: {img.shape}")
@@ -229,7 +228,6 @@ def resize_pil(
             (target_width, target_height),
             resample=pil_interpolation,
         )
-        # Convert back to (H, W, 1)
         result = np.array(resized_pil_img)[:, :, np.newaxis]
     elif num_channels == 3:
         # RGB image
@@ -259,7 +257,6 @@ def resize_pil(
             channels.append(np.array(resized_channel))
         result = np.stack(channels, axis=-1)
 
-    # Convert back to original dtype
     if needs_conversion:
         result = to_float(result)
     elif result.dtype != original_dtype:
@@ -488,10 +485,8 @@ def perspective_keypoints(
         keypoints[:, 4],
     )
 
-    # Reshape keypoints for perspective transform
     keypoint_vector = np.column_stack((x, y)).astype(np.float32).reshape(-1, 1, 2)
 
-    # Apply perspective transform
     transformed_points = cv2.perspectiveTransform(keypoint_vector, matrix).squeeze()
 
     # Unsqueeze if we have a single keypoint
@@ -503,7 +498,6 @@ def perspective_keypoints(
     # Update angles
     angle += rotation2d_matrix_to_euler_angles(matrix[:2, :2], y_up=True)
 
-    # Calculate scale factors
     scale_x = np.sign(matrix[0, 0]) * np.sqrt(matrix[0, 0] ** 2 + matrix[0, 1] ** 2)
     scale_y = np.sign(matrix[1, 1]) * np.sqrt(matrix[1, 0] ** 2 + matrix[1, 1] ** 2)
     scale *= max(scale_x, scale_y)
@@ -515,7 +509,6 @@ def perspective_keypoints(
         y *= scale_y
         scale *= max(scale_x, scale_y)
 
-    # Create the output array with unchanged z coordinate
     transformed_keypoints = np.column_stack([x, y, z, angle, scale])
 
     # If there are additional columns, preserve them
@@ -584,7 +577,6 @@ def calculate_affine_transform_padding(
     """
     height, width = image_shape[:2]
 
-    # Check for identity transform
     if is_identity_matrix(matrix):
         return (0, 0, 0, 0)
 
@@ -594,7 +586,6 @@ def calculate_affine_transform_padding(
     # Transform corners
     transformed_corners = apply_affine_to_points(corners, matrix)
 
-    # Ensure transformed_corners is 2D
     transformed_corners = transformed_corners.reshape(-1, 2)
 
     # Find box that includes both original and transformed corners
@@ -602,10 +593,8 @@ def calculate_affine_transform_padding(
     min_x, min_y = all_corners.min(axis=0)
     max_x, max_y = all_corners.max(axis=0)
 
-    # Compute the inverse transform
     inverse_matrix = np.linalg.inv(matrix)
 
-    # Apply inverse transform to all corners of the bounding box
     bbox_corners = np.array(
         [[min_x, min_y], [max_x, min_y], [max_x, max_y], [min_x, max_y]],
     )
@@ -1087,20 +1076,15 @@ def create_affine_transformation_matrix(
         np.ndarray: The resulting 3x3 affine transformation matrix.
 
     """
-    # Convert angles to radians
     rotate_rad = np.deg2rad(rotate % 360)
 
     shear_x_rad = np.deg2rad(shear["x"])
     shear_y_rad = np.deg2rad(shear["y"])
 
-    # Create individual transformation matrices
-    # 1. Shift to top-left
     m_shift_topleft = np.array([[1, 0, -shift[0]], [0, 1, -shift[1]], [0, 0, 1]])
 
-    # 2. Scale
     m_scale = np.array([[scale["x"], 0, 0], [0, scale["y"], 0], [0, 0, 1]])
 
-    # 3. Rotation
     m_rotate = np.array(
         [
             [np.cos(rotate_rad), np.sin(rotate_rad), 0],
@@ -1109,22 +1093,18 @@ def create_affine_transformation_matrix(
         ],
     )
 
-    # 4. Shear
     m_shear = np.array(
         [[1, np.tan(shear_x_rad), 0], [np.tan(shear_y_rad), 1, 0], [0, 0, 1]],
     )
 
-    # 5. Translation
     m_translate = np.array([[1, 0, translate["x"]], [0, 1, translate["y"]], [0, 0, 1]])
 
-    # 6. Shift back to center
     m_shift_center = np.array([[1, 0, shift[0]], [0, 1, shift[1]], [0, 0, 1]])
 
     # Combine all transformations
     # The order is important: transformations are applied from right to left
     m = m_shift_center @ m_translate @ m_shear @ m_rotate @ m_scale @ m_shift_topleft
 
-    # Ensure the last row is exactly [0, 0, 1]
     m[2] = [0, 0, 1]
 
     return m
@@ -1149,14 +1129,12 @@ def compute_transformed_image_bounds(
     """
     height, width = image_shape[:2]
 
-    # Define the corners of the image
     corners = np.array([[0, 0, 1], [width, 0, 1], [width, height, 1], [0, height, 1]])
 
     # Transform the corners
     transformed_corners = corners @ matrix.T
     transformed_corners = transformed_corners[:, :2] / transformed_corners[:, 2:]
 
-    # Calculate the bounding box of the transformed corners
     min_coords = np.floor(transformed_corners.min(axis=0)).astype(int)
     max_coords = np.ceil(transformed_corners.max(axis=0)).astype(int)
 

--- a/albumentations/augmentations/geometric/_functional_keypoints.py
+++ b/albumentations/augmentations/geometric/_functional_keypoints.py
@@ -148,7 +148,6 @@ def keypoints_scale(
         np.ndarray: Scaled keypoints
 
     """
-    # Extract x, y, z, angle, and scale
     x, y, z, angle, scale = (
         keypoints[:, 0],
         keypoints[:, 1],
@@ -164,7 +163,6 @@ def keypoints_scale(
     # Scale the keypoint scale by the maximum of scale_x and scale_y
     scale_scaled = scale * max(scale_x, scale_y)
 
-    # Create the output array
     scaled_keypoints = np.column_stack([x_scaled, y_scaled, z, angle, scale_scaled])
 
     # If there are additional columns, preserve them
@@ -224,7 +222,6 @@ def keypoints_affine(
         return keypoints
 
     if border_mode in REFLECT_BORDER_MODES:
-        # Step 1: Compute affine transform padding
         pad_left, pad_right, pad_top, pad_bottom = calculate_affine_transform_padding(
             matrix,
             image_shape,
@@ -243,7 +240,6 @@ def keypoints_affine(
             center_in_origin=True,
         )
 
-    # Extract x, y coordinates (z is preserved)
     xy = keypoints[:, :2]
 
     # Transform x, y coordinates (same code path as bboxes_affine OBB)
@@ -295,7 +291,6 @@ def to_distance_maps(
     if len(keypoints) == 0:
         return np.zeros((height, width, 0), dtype=np.float32)
 
-    # Convert keypoints to numpy array
     keypoints_array = np.asarray(keypoints, dtype=np.float32)
     if len(keypoints_array) > CV2_DISTANCE_MAP_MAX_KEYPOINTS:
         x_distances = np.arange(width, dtype=np.float32)[np.newaxis, :, np.newaxis] - keypoints_array[:, 0]
@@ -310,7 +305,6 @@ def to_distance_maps(
             np.reciprocal(distances, out=distances)
         return distances
 
-    # Create coordinate grids
     yy, xx = np.mgrid[:height, :width]
     xx = xx.astype(np.float32)
     yy = yy.astype(np.float32)
@@ -427,14 +421,11 @@ def from_distance_maps(
             axis=0,
         )
 
-    # Convert flat indices to 2D coordinates
     hitidx_y, hitidx_x = np.unravel_index(hitidx_flat, (height, width))
 
-    # Create keypoints array
     keypoints = np.column_stack((hitidx_x, hitidx_y)).astype(float)
 
     if threshold is not None:
-        # Check threshold condition
         if inverted:
             valid_mask = distance_maps[hitidx_y, hitidx_x, np.arange(nb_keypoints)] >= threshold
         else:
@@ -556,13 +547,11 @@ def remap_keypoints_via_mask(
         interpolation=cv2.INTER_NEAREST,
     )[..., 0]
 
-    # Extract transformed keypoints
     new_points = []
     for idx, kp in enumerate(keypoints, start=1):
         # Find points with this index
         points = np.where(transformed_kp_mask == idx)
         if len(points[0]) > 0:
-            # Convert back to (x,y) coordinates
             new_points.append(np.concatenate([[points[1][0], points[0][0]], kp[2:]]))
 
     return np.array(new_points) if new_points else np.zeros((0, keypoints.shape[1]))
@@ -597,17 +586,14 @@ def remap_keypoints(
     """
     height, width = image_shape[:2]
 
-    # Extract x and y coordinates
     x, y = keypoints[:, 0], keypoints[:, 1]
 
     # Clip coordinates to image boundaries
     x = np.clip(x, 0, width - 1)
     y = np.clip(y, 0, height - 1)
 
-    # Convert to integer indices
     x_idx, y_idx = x.astype(int), y.astype(int)
     inv_map_x, inv_map_y = generate_inverse_distortion_map(map_x, map_y, image_shape[:2])
-    # Apply the inverse mapping
     new_x = inv_map_x[y_idx, x_idx]
     new_y = inv_map_y[y_idx, x_idx]
 
@@ -615,7 +601,6 @@ def remap_keypoints(
     new_x = np.clip(new_x, 0, width - 1)
     new_y = np.clip(new_y, 0, height - 1)
 
-    # Create the transformed keypoints array
     return np.column_stack([new_x, new_y, keypoints[:, 2:]])
 
 
@@ -663,7 +648,6 @@ def distort_image_keypoints(
         cell_keypoints = keypoints[mask]
 
         if len(cell_keypoints) > 0:
-            # Convert to float32 before applying the transformation
             points_float32 = cell_keypoints[:, :2].astype(np.float32).reshape(-1, 1, 2)
             transformed_points = cv2.perspectiveTransform(
                 points_float32,
@@ -735,7 +719,6 @@ def pad_keypoints(
 
     rows, cols = image_shape[:2]
 
-    # Calculate the number of grid cells added on each side
     original_row, original_col = grid_dimensions["original_position"]
 
     # Subtract the offset based on the number of added grid cells
@@ -968,13 +951,11 @@ def swap_tiles_on_keypoints(
 
     start_y, start_x, end_y, end_x = tiles.T  # Each shape: (num_tiles,)
 
-    # Check if each keypoint is inside each tile
     in_tile = (kp_y >= start_y) & (kp_y < end_y) & (kp_x >= start_x) & (kp_x < end_x)
 
     # Find which tile each keypoint belongs to
     tile_indices = np.argmax(in_tile, axis=1)
 
-    # Check if any keypoint is not in any tile
     not_in_any_tile = ~np.any(in_tile, axis=1)
     if np.any(not_in_any_tile):
         warn(
@@ -984,16 +965,13 @@ def swap_tiles_on_keypoints(
             stacklevel=2,
         )
 
-    # Get the new tile indices
     new_tile_indices = np.array(mapping)[tile_indices]
 
-    # Calculate the offsets
     old_start_x = tiles[tile_indices, 1]
     old_start_y = tiles[tile_indices, 0]
     new_start_x = tiles[new_tile_indices, 1]
     new_start_y = tiles[new_tile_indices, 0]
 
-    # Apply the transformation
     new_keypoints = keypoints.copy()
     new_keypoints[:, 0] = (keypoints[:, 0] - old_start_x) + new_start_x
     new_keypoints[:, 1] = (keypoints[:, 1] - old_start_y) + new_start_y

--- a/albumentations/augmentations/geometric/rotate.py
+++ b/albumentations/augmentations/geometric/rotate.py
@@ -713,7 +713,6 @@ class SafeRotate(Affine):
         height, width = image_shape[:2]
         rotation_mat = cv2.getRotationMatrix2D(center, angle, 1.0)
 
-        # Calculate new image size
         abs_cos = abs(rotation_mat[0, 0])
         abs_sin = abs(rotation_mat[0, 1])
         new_w = int(height * abs_sin + width * abs_cos)
@@ -723,11 +722,9 @@ class SafeRotate(Affine):
         rotation_mat[0, 2] += new_w / 2 - center[0]
         rotation_mat[1, 2] += new_h / 2 - center[1]
 
-        # Calculate scaling factors
         scale_x = width / new_w
         scale_y = height / new_h
 
-        # Create scaling matrix
         scale_mat = np.array([[scale_x, 0, 0], [0, scale_y, 0], [0, 0, 1]])
 
         # Combine rotation and scaling

--- a/albumentations/augmentations/geometric/transforms.py
+++ b/albumentations/augmentations/geometric/transforms.py
@@ -1157,7 +1157,6 @@ class GridElasticDeform(DualTransform):
             sampling.random_generator,
         )
 
-        # Convert tiles to the format expected by generate_distorted_grid_polygons
         dimensions = np.array(
             [
                 [

--- a/albumentations/augmentations/mixing/domain_adaptation_functional.py
+++ b/albumentations/augmentations/mixing/domain_adaptation_functional.py
@@ -533,7 +533,6 @@ def fourier_domain_adaptation(img: ImageType, target_img: ImageType, beta: float
         fft_src_shifted = np.fft.fftshift(fft_src)
         fft_trg_shifted = np.fft.fftshift(fft_trg)
 
-        # Extract amplitude and phase
         amp_src, pha_src = np.abs(fft_src_shifted), np.angle(fft_src_shifted)
         amp_trg = np.abs(fft_trg_shifted)
 

--- a/albumentations/augmentations/mixing/functional.py
+++ b/albumentations/augmentations/mixing/functional.py
@@ -360,14 +360,12 @@ def calculate_mosaic_center_point(
     large_grid_h = rows * cell_h
     large_grid_w = cols * cell_w
 
-    # Define valid center range bounds (inclusive)
     # The center must be far enough from edges so the crop window fits
     min_cx = target_w // 2
     max_cx = large_grid_w - (target_w + 1) // 2
     min_cy = target_h // 2
     max_cy = large_grid_h - (target_h + 1) // 2
 
-    # Calculate valid range dimensions (size of the safe zone)
     valid_w = max_cx - min_cx + 1
     valid_h = max_cy - min_cy + 1
 
@@ -375,12 +373,10 @@ def calculate_mosaic_center_point(
     rel_x = py_random.uniform(*center_range)
     rel_y = py_random.uniform(*center_range)
 
-    # Calculate center coordinates by scaling relative position within valid range
     # Add the minimum bound to shift the range start
     center_x = min_cx + int(valid_w * rel_x)
     center_y = min_cy + int(valid_h * rel_y)
 
-    # Ensure the result is strictly within the calculated bounds after int conversion
     # (This clip is mostly a safety measure, shouldn't be needed with correct int conversion)
     center_x = max(min_cx, min(center_x, max_cx))
     center_y = max(min_cy, min(center_y, max_cy))
@@ -415,11 +411,9 @@ def calculate_cell_placements(
     target_h, target_w = target_size
     center_x, center_y = center_xy
 
-    # 1. Generate grid line coordinates using arange for the large grid
     y_coords_large = np.arange(rows + 1) * cell_h
     x_coords_large = np.arange(cols + 1) * cell_w
 
-    # 2. Calculate Crop Window boundaries
     crop_x_min = center_x - target_w // 2
     crop_y_min = center_y - target_h // 2
     crop_x_max = crop_x_min + target_w
@@ -434,7 +428,6 @@ def calculate_cell_placements(
     y_coords_clipped = _clip_coords(y_coords_large, crop_y_min, crop_y_max)
     x_coords_clipped = _clip_coords(x_coords_large, crop_x_min, crop_x_max)
 
-    # 4. Form all cell coordinates efficiently
     num_x_intervals = len(x_coords_clipped) - 1
     num_y_intervals = len(y_coords_clipped) - 1
     result = []
@@ -458,12 +451,10 @@ def _check_data_compatibility(
     """Check if item_data dimensions and channels match primary_data. Returns (ok, error_msg);
     used to validate mosaic/mixup additional items.
     """
-    # 1. Check if item has the required data (image is always required)
     if item_data is None:
         is_required = data_key == "image"
         return not is_required, "Item is missing required key 'image'" if is_required else None
 
-    # 2. If item data exists, check against primary data (if primary data exists)
     if primary_data is None:  # No primary data to compare against
         return True, None
 
@@ -1059,9 +1050,7 @@ def assemble_mosaic_from_processed_cells(
     # Use 0 as default fill if None is provided
     actual_fill = fill if fill is not None else 0
 
-    # Convert fill to numpy array to handle broadcasting in np.full
     fill_value = np.array(actual_fill, dtype=dtype)
-    # Initialize canvas with the fill value.
     # If fill_value shape is incompatible with target_shape, np.full will raise ValueError.
     canvas = np.full(target_shape, fill_value=fill_value, dtype=dtype)
 
@@ -1322,7 +1311,6 @@ def process_all_mosaic_geometries(
 
         cell_position = get_cell_relative_position(placement_coords, canvas_shape)
 
-        # Apply geometric processing (crop/pad)
         processed_cells_geom[placement_coords] = process_cell_geometry(
             cell_shape=cell_shape,
             item=item,
@@ -1429,7 +1417,6 @@ def shift_all_coordinates(
         cell_width = placement_coords[2] - placement_coords[0]
         cell_height = placement_coords[3] - placement_coords[1]
 
-        # Extract geometrically processed bboxes/keypoints
         bboxes_geom = cell_data_geom.get("bboxes")
         keypoints_geom = cell_data_geom.get("keypoints")
 
@@ -1455,7 +1442,6 @@ def shift_all_coordinates(
         if keypoints_geom is not None and keypoints_geom.size > 0:
             keypoints_geom_arr = np.asarray(keypoints_geom)
 
-            # Ensure shift vector matches keypoint dtype (usually float)
             kp_shift_vector = np.array([tgt_x1, tgt_y1, 0], dtype=keypoints_geom_arr.dtype)
 
             shifted_keypoints = fgeometric.shift_keypoints(keypoints_geom_arr, kp_shift_vector)

--- a/albumentations/augmentations/mixing/mosaic.py
+++ b/albumentations/augmentations/mixing/mosaic.py
@@ -291,7 +291,6 @@ class Mosaic(DualTransform):
         data: dict[str, Any],
         sampling: SamplingContext,
     ) -> list[tuple[int, int, int, int]]:
-        # Step 1: Calculate Geometry & Cell Placements
         center_xy = fmixing.calculate_mosaic_center_point(
             grid_yx=self.grid_yx,
             cell_shape=self.cell_shape,

--- a/albumentations/augmentations/pixel/_functional_color.py
+++ b/albumentations/augmentations/pixel/_functional_color.py
@@ -99,11 +99,9 @@ def shift_hsv(
         hue = sz_lut(cast("ImageUInt8", hue), lut_hue, inplace=False)
 
     if sat_shift != 0:
-        # Create a mask for all grayscale pixels (S=0)
         # These should remain grayscale regardless of saturation change
         grayscale_mask = sat == 0
 
-        # Apply saturation shift only to non-white pixels
         sat = add_constant(sat, sat_shift, inplace=True)
 
         # Reset saturation for white pixels
@@ -309,7 +307,6 @@ def _handle_mask(
         np.uint8,
         copy=False,
     )  # Use copy=False to avoid unnecessary copying
-    # Check for grayscale image and avoid slicing if i is None
     if i is not None and not is_grayscale_image(mask):
         mask = mask[..., i]
 
@@ -386,7 +383,6 @@ def equalize(
     result_img = np.empty_like(img)
     for i in range(get_num_channels(img)):
         _mask = _handle_mask(mask, i)
-        # Extract channel, process, and ensure we maintain 2D shape
         channel_result = function(img[..., i], _mask)
         # Remove any extra dimensions that might have been added
         if channel_result.ndim > 2:
@@ -1195,14 +1191,12 @@ def to_gray_pca(img: ImageType) -> ImageType:
 
     """
     dtype = img.dtype
-    # Reshape the image to a 2D array of pixels
     pixels = img.reshape(-1, img.shape[-1])
 
     # Perform PCA
     pca = PCA(n_components=1, dtype=np.float32)
     pca_result = pca.fit_transform(pixels)
 
-    # Reshape back to image dimensions and scale to 0-255
     grayscale = pca_result.reshape(img.shape[:-1])
     grayscale = normalize_per_image(grayscale, "min_max")
 

--- a/albumentations/augmentations/pixel/_functional_histology.py
+++ b/albumentations/augmentations/pixel/_functional_histology.py
@@ -160,7 +160,6 @@ class SimpleNMF:
         # Start with known H&E colors
         stain_colors = self.initial_colors.copy()
 
-        # Initialize concentrations based on projection onto initial colors
         # This gives us a physically meaningful starting point
         stain_colors_normalized = normalize_vectors(stain_colors)
 
@@ -176,7 +175,6 @@ class SimpleNMF:
                 denominator = stain_concentrations @ (stain_colors @ stain_colors.T)
                 stain_concentrations *= numerator / (denominator + eps)
 
-                # Ensure non-negativity
                 stain_concentrations = np.maximum(stain_concentrations, 0)
 
                 # Update colors
@@ -184,7 +182,6 @@ class SimpleNMF:
                 denominator = (stain_concentrations.T @ stain_concentrations) @ stain_colors
                 stain_colors *= numerator / (denominator + eps)
 
-                # Ensure non-negativity and normalize
                 stain_colors = np.maximum(stain_colors, 0)
                 stain_colors = normalize_vectors(stain_colors)
 
@@ -319,10 +316,8 @@ class MacenkoNormalizer(StainNormalizer):
             angular_percentile (float): Angular percentile.
 
         """
-        # Step 1: Convert RGB to optical density (OD) space
         optical_density = rgb_to_optical_density(img)
 
-        # Step 2: Remove background pixels
         od_threshold = 0.05
         threshold_mask = (optical_density > od_threshold).any(axis=1)
         tissue_density = optical_density[threshold_mask]
@@ -330,7 +325,6 @@ class MacenkoNormalizer(StainNormalizer):
         if len(tissue_density) < 1:
             raise ValueError(f"No tissue pixels found (threshold={od_threshold})")
 
-        # Step 3: Compute covariance matrix
         tissue_density = np.ascontiguousarray(tissue_density, dtype=np.float32)
         covariance_mean = np.empty((0,), dtype=np.float32)
         od_covariance = cast(
@@ -342,12 +336,10 @@ class MacenkoNormalizer(StainNormalizer):
             )[0],
         )
 
-        # Step 4: Get principal components
         eigenvalues, eigenvectors = cv2.eigen(od_covariance)[1:]
         idx = np.argsort(eigenvalues.ravel())[-2:]
         principal_eigenvectors = np.ascontiguousarray(eigenvectors[:, idx], dtype=np.float32)
 
-        # Step 5: Project onto eigenvector plane
         # Add small epsilon to avoid numerical instability
         epsilon = 1e-8
         if np.any(np.abs(principal_eigenvectors) < epsilon):
@@ -365,17 +357,14 @@ class MacenkoNormalizer(StainNormalizer):
         with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
             plane_coordinates = safe_tissue_density @ principal_eigenvectors
 
-        # Step 6: Find angles of extreme points
         polar_angles = np.arctan2(
             plane_coordinates[:, 1],
             plane_coordinates[:, 0],
         )
 
-        # Get robust angle estimates
         hematoxylin_angle = np.percentile(polar_angles, 100 - angular_percentile)
         eosin_angle = np.percentile(polar_angles, angular_percentile)
 
-        # Step 7: Convert angles back to RGB space
         hem_cos, hem_sin = np.cos(hematoxylin_angle), np.sin(hematoxylin_angle)
         eos_cos, eos_sin = np.cos(eosin_angle), np.sin(eosin_angle)
 
@@ -384,7 +373,6 @@ class MacenkoNormalizer(StainNormalizer):
             dtype=np.float32,
         )
 
-        # Ensure both matrices have the same data type for cv2.gemm
         principal_eigenvectors_t = np.ascontiguousarray(principal_eigenvectors.T, dtype=np.float32)
         empty_matrix = np.empty((0,), dtype=np.float32)
         stain_vectors = cast(
@@ -398,10 +386,8 @@ class MacenkoNormalizer(StainNormalizer):
             ),
         )
 
-        # Step 8: Ensure non-negativity by taking absolute values
         stain_vectors = np.abs(stain_vectors)
 
-        # Step 9: Normalize vectors to unit length
         stain_norms = np.sqrt(
             np.asarray(reduce_sum(stain_vectors**2, axis=1, keepdims=True), dtype=np.float32) + epsilon,
         )
@@ -423,7 +409,6 @@ def get_tissue_mask(img: ImageType, threshold: float = 0.85) -> np.ndarray:
         np.ndarray: Binary mask where True indicates tissue regions
 
     """
-    # Convert to grayscale using RGB weights: R*0.299 + G*0.587 + B*0.114
     luminosity = img[..., 0] * 0.299 + img[..., 1] * 0.587 + img[..., 2] * 0.114
 
     # Tissue is darker, so we want pixels below threshold

--- a/albumentations/augmentations/pixel/_functional_illumination.py
+++ b/albumentations/augmentations/pixel/_functional_illumination.py
@@ -115,7 +115,6 @@ def generate_plasma_pattern(
     total_steps = int(np.log2(power_of_two_size - 1) - 1)
     noise_scales = np.asarray([roughness**i for i in range(total_steps)], dtype=np.float32)
 
-    # Initialize with small random grid
     plasma_grid = random_generator.uniform(-1, 1, (3, 3)).astype(np.float32)
 
     # Recursively apply diamond-square steps
@@ -162,12 +161,10 @@ def apply_plasma_brightness_contrast(
     if img.ndim > MONO_CHANNEL_DIMENSIONS:
         plasma_pattern = np.tile(plasma_pattern[..., np.newaxis], (1, 1, img.shape[-1]))
 
-    # Apply brightness adjustment
     if brightness_factor != 0:
         brightness_adjustment = multiply(plasma_pattern, brightness_factor, inplace=False)
         img = add(img, brightness_adjustment, inplace=True)
 
-    # Apply contrast adjustment
     if contrast_factor != 0:
         img_mean = mean(img)
         contrast_weights = multiply(plasma_pattern, contrast_factor, inplace=False) + 1
@@ -996,7 +993,6 @@ def create_contrast_lut(
         # Normalize CDF to full range
         cdf = (cdf - cdf[0]) * max_value / (cdf[-1] - cdf[0])
 
-        # Create lookup table
         lut = np.zeros(256, dtype=np.uint8)
         lut[min_intensity : max_intensity + 1] = np.clip(np.round(cdf), 0, max_value).astype(np.uint8)
         lut[max_intensity + 1 :] = max_value

--- a/albumentations/augmentations/pixel/_functional_torchvision.py
+++ b/albumentations/augmentations/pixel/_functional_torchvision.py
@@ -151,7 +151,6 @@ def fancy_pca(img: ImageType, alpha_vector: np.ndarray) -> ImageType:
     orig_shape = img.shape
     num_channels = get_num_channels(img)
 
-    # Reshape image to 2D array of pixels
     img_reshaped = img.reshape(-1, num_channels)
 
     # Center the pixel values
@@ -163,10 +162,8 @@ def fancy_pca(img: ImageType, alpha_vector: np.ndarray) -> ImageType:
         std_dev = std(img_centered, eps=0)
         noise = alpha_vector[0] * std_dev * img_centered
     else:
-        # Compute covariance matrix
         img_cov = np.cov(img_centered, rowvar=False)
 
-        # Compute eigenvectors & eigenvalues of the covariance matrix
         eig_vals, eig_vecs = np.linalg.eigh(img_cov)
 
         # Sort eigenvectors by eigenvalues in descending order
@@ -174,7 +171,6 @@ def fancy_pca(img: ImageType, alpha_vector: np.ndarray) -> ImageType:
         eig_vals = eig_vals[sort_perm]
         eig_vecs = eig_vecs[:, sort_perm]
 
-        # Create noise vector
         noise = np.dot(
             np.dot(eig_vecs, np.diag(alpha_vector * eig_vals)),
             img_centered.T,
@@ -183,7 +179,6 @@ def fancy_pca(img: ImageType, alpha_vector: np.ndarray) -> ImageType:
     # Add noise to the image
     img_pca = img_reshaped + noise
 
-    # Reshape back to original shape
     img_pca = img_pca.reshape(orig_shape)
 
     # Clip values to [0, 1] range
@@ -556,10 +551,8 @@ def slic(
     np.divide(image_normalized, max_value + np.float32(1e-6), out=image_normalized)
     single_channel = image_normalized.shape[-1] == 1
 
-    # Initialize cluster centers on a regular grid.
     centers = _initialize_slic_centers(height, width, grid_step)
 
-    # Initialize labels and distances
     labels = np.full((height, width), -1, dtype=np.int32)
 
     x_coordinates_flat = np.tile(np.arange(width, dtype=np.float32), height)

--- a/albumentations/augmentations/pixel/_functional_weather.py
+++ b/albumentations/augmentations/pixel/_functional_weather.py
@@ -195,7 +195,6 @@ def add_snow_texture(
     """
     max_value = MAX_VALUES_BY_DTYPE[np.dtype(img.dtype)]
 
-    # Convert to HSV for better color control
     img_hsv = cv2.cvtColor(img, cv2.COLOR_RGB2HSV).astype(np.float32)
 
     # Increase brightness
@@ -213,7 +212,6 @@ def add_snow_texture(
     depth_effect = np.linspace(1, 0.2, rows, dtype=np.float32)[:, np.newaxis]
     snow_texture *= depth_effect
 
-    # Apply snow texture
     snow_layer = (snow_texture[:, :, np.newaxis] * (max_value * snow_point)).astype(
         np.float32,
     )
@@ -286,7 +284,6 @@ def add_rain(
     # Pre-allocate rain layer
     rain_layer = np.zeros_like(img, dtype=np.uint8)
 
-    # Calculate end points correctly
     end_points = rain_drops + np.array([[slant, drop_length]])  # This creates correct shape
 
     # Stack arrays properly - both must be same shape arrays
@@ -368,7 +365,6 @@ def add_fog(
     """
     result = img.copy()
 
-    # Apply fog particles progressively like in old version
     for (x, y), radius in zip(fog_particle_positions, fog_particle_radiuses, strict=True):
         overlay = result.copy()
         cv2.circle(
@@ -566,7 +562,6 @@ def add_sun_flare_physics_based(
     output = img.copy()
     height, width = img.shape[:2]
 
-    # Create a separate flare layer
     flare_layer = np.zeros_like(img, dtype=np.float32)
 
     # Add the main sun
@@ -584,10 +579,8 @@ def add_sun_flare_physics_based(
     for _, center, size, color in circles:
         cv2.circle(flare_layer, center, int(size**0.33), color, -1)
 
-    # Apply gaussian blur to soften the flare
     flare_layer = cv2.GaussianBlur(flare_layer, (0, 0), sigmaX=15, sigmaY=15)
 
-    # Create a radial gradient mask
     y = np.arange(height, dtype=np.float32)[:, np.newaxis] - flare_center[1]
     x = np.arange(width, dtype=np.float32)[np.newaxis, :] - flare_center[0]
     mask = x * x + y * y
@@ -596,7 +589,6 @@ def add_sun_flare_physics_based(
     np.clip(mask, 0, 1, out=mask)
     np.subtract(1, mask, out=mask)
 
-    # Apply the mask to the flare layer
     flare_layer *= mask[..., np.newaxis]
 
     # Add chromatic aberration
@@ -896,7 +888,6 @@ def get_rain_params(
         dtype=np.float32,
     )
 
-    # Apply convolution with better precision
     dist = convolve(dist, ker)
 
     # Final blur with larger kernel for smoother drops
@@ -908,7 +899,6 @@ def get_rain_params(
         borderType=cv2.BORDER_REPLICATE,
     ).astype(np.float32)
 
-    # Calculate final rain mask with better blending
     m = liquid_layer.astype(np.float32) * dist
 
     # Normalize with better handling of edge cases
@@ -918,7 +908,6 @@ def get_rain_params(
     else:
         m = np.zeros_like(m)
 
-    # Apply color with adjusted intensity for more natural look
     drops = m[:, :, None] * color.astype(np.float32, copy=False) * np.float32(intensity * 0.9)
 
     return {
@@ -953,7 +942,6 @@ def get_mud_params(
     """
     height, width = liquid_layer.shape
 
-    # Create initial mask (ensure we have some non-zero values)
     mask = (liquid_layer > cutout_threshold).astype(np.float32)
     if reduce_sum(mask) == 0:  # If mask is all zeros
         # Force minimum coverage of 10%
@@ -963,7 +951,6 @@ def get_mud_params(
         mask = np.zeros_like(liquid_layer, dtype=np.float32)
         mask.flat[flat_indices] = 1.0
 
-    # Apply Gaussian blur if sigma > 0
     if sigma > 0:
         mask = cv2.GaussianBlur(
             mask,
@@ -984,14 +971,11 @@ def get_mud_params(
     # Scale by intensity directly (no minimum)
     mask = mask * intensity
 
-    # Create mud effect array
     mud = np.zeros((height, width, 3), dtype=np.float32)
 
-    # Apply color directly - the intensity scaling is already handled
     for i in range(3):
         mud[..., i] = mask * color[i]
 
-    # Create complementary non-mud array
     non_mud = np.ones_like(mud)
     for i in range(3):
         if color[i] > 0:

--- a/albumentations/augmentations/pixel/color_advanced.py
+++ b/albumentations/augmentations/pixel/color_advanced.py
@@ -593,7 +593,6 @@ class PlanckianJitter(ImageOnlyTransform):
         else:
             raise ValueError(f"Unknown sampling method: {self.sampling_method}")
 
-        # Ensure temperature is within the valid range
         temperature = np.clip(
             temperature,
             self.temperature_range[0],
@@ -708,7 +707,6 @@ class RGBShift(AdditiveNoise):
             normalize_range(b_shift_range),
         ]
 
-        # Initialize with fixed noise type and spatial mode
         super().__init__(
             noise_type="uniform",
             spatial_mode="constant",
@@ -1015,7 +1013,6 @@ class HEStain(ImageOnlyTransform):
         self.residual_mode = residual_mode
         self.stain_matrix = stain_matrix
 
-        # Initialize stain extractor here if needed
         if method in ["vahadane", "macenko"]:
             self.stain_extractor = fpixel.get_normalizer(method)
 

--- a/albumentations/augmentations/pixel/color_gray.py
+++ b/albumentations/augmentations/pixel/color_gray.py
@@ -214,7 +214,6 @@ class ToGray(ImageOnlyTransform):
         return fpixel.to_gray(img, self.num_output_channels, self.method)
 
     def apply_to_images(self, images: ImageType, **params: Any) -> ImageType:
-        # Check if images are already grayscale by checking number of channels
         if images.shape[-1] == 1:
             warnings.warn("The image is already gray.", stacklevel=2)
             return images

--- a/albumentations/augmentations/pixel/dithering_functional.py
+++ b/albumentations/augmentations/pixel/dithering_functional.py
@@ -330,11 +330,9 @@ def random_dither_uint8(
         lut_binary[128:] = 255
         return sz_lut(noisy, lut_binary, inplace=False)
 
-    # Create LUT for quantization directly in uint8 space
     lut = np.round(np.arange(256) * (n_colors - 1) / 255) / (n_colors - 1) * 255
     lut = lut.astype(np.uint8)
 
-    # Apply LUT directly - this is the fastest path
     return sz_lut(noisy, lut, inplace=False)
 
 
@@ -500,7 +498,6 @@ def ordered_dither(
     # Expand for color channels
     tiled = np.expand_dims(tiled, axis=2)
 
-    # Apply threshold with Bayer matrix
     if n_colors == 2:
         return (img > tiled).astype(np.float32)
 
@@ -515,7 +512,6 @@ def ordered_dither(
     # Quantize to n_colors levels using vectorized numpy operations
     # Since @float32_io guarantees float32 input, use direct numpy operations
     quantized = np.floor(dithered * n_colors) / n_colors
-    # Ensure proper clipping to max quantized value
     return np.clip(quantized, 0, (n_colors - 1) / n_colors).astype(np.float32)
 
 
@@ -569,14 +565,12 @@ def error_diffusion_dither(
                 x_offsets = offsets
 
             for col_idx in col_range:
-                # Get current pixel value
                 old_val = channel[row_idx, col_idx]
 
                 # Quantize
                 new_val = (1.0 if old_val >= 0.5 else 0.0) if is_binary else round(old_val * max_level) / max_level
                 channel[row_idx, col_idx] = new_val
 
-                # Calculate error
                 error = old_val - new_val
 
                 # Distribute error to neighbors
@@ -604,7 +598,6 @@ def _apply_dithering_to_grayscale(
     # Store original number of channels
     original_channels = img.shape[2]
 
-    # Convert to grayscale
     if img.shape[2] == 3:
         gray = to_gray_weighted_average(img)
     elif img.shape[2] == 1:
@@ -612,11 +605,9 @@ def _apply_dithering_to_grayscale(
     else:
         gray = to_gray_average(img)
 
-    # Ensure gray has shape (H, W, 1)
     if gray.ndim == 2:
         gray = gray[:, :, np.newaxis]
 
-    # Apply dithering method
     dithered = _apply_single_dithering_method(gray, method, n_colors, **kwargs)
 
     # Expand back to original number of channels (handle both 2D and 3D cases)
@@ -713,5 +704,4 @@ def apply_dithering(
     if color_mode == "grayscale":
         return _apply_dithering_to_grayscale(img, method, n_colors, **kwargs)
 
-    # Apply dithering directly (per_channel mode)
     return _apply_single_dithering_method(img, method, n_colors, **kwargs)

--- a/albumentations/augmentations/pixel/noise.py
+++ b/albumentations/augmentations/pixel/noise.py
@@ -909,7 +909,6 @@ class _AdditiveNoiseInitSchema(BaseTransformInitSchema):
         # Add noise_type to params if not present
         params_dict = {**params_dict, "noise_type": self.noise_type}
 
-        # Convert dict to appropriate NoiseParams object and validate
         params_class: Any = {
             "uniform": UniformParams,
             "gaussian": GaussianParams,

--- a/albumentations/augmentations/text/functional.py
+++ b/albumentations/augmentations/text/functional.py
@@ -178,7 +178,6 @@ def draw_text_on_multi_channel_image(image: ImageType, metadata_list: list[dict[
         font_color = metadata["font_color"]
 
         # Handle font_color as tuple[float, ...]
-        # Ensure we have enough color values for all channels
         if len(font_color) < image.shape[2]:
             # If fewer values than channels, pad with zeros
             font_color = tuple(list(font_color) + [0] * (image.shape[2] - len(font_color)))
@@ -186,7 +185,6 @@ def draw_text_on_multi_channel_image(image: ImageType, metadata_list: list[dict[
             # If more values than channels, truncate
             font_color = font_color[: image.shape[2]]
 
-        # Convert to integers for PIL
         font_color = [int(c) for c in font_color]
 
         position = bbox_coords[:2]

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -907,7 +907,6 @@ def filter_keypoints_in_holes3d(keypoints: np.ndarray, holes: np.ndarray) -> np.
     hole_y2 = holes[:, 4]
     hole_x2 = holes[:, 5]
 
-    # Check if each keypoint is inside each hole
     inside_hole = (
         (kp_z >= hole_z1)
         & (kp_z < hole_z2)
@@ -920,10 +919,8 @@ def filter_keypoints_in_holes3d(keypoints: np.ndarray, holes: np.ndarray) -> np.
     # A keypoint is valid if it's not inside any hole
     valid_keypoints = ~np.any(inside_hole, axis=1)
 
-    # Return filtered keypoints with same dtype as input
     result = keypoints[valid_keypoints]
     if len(result) == 0:
-        # Ensure empty result has correct shape and dtype
         return np.array([], dtype=keypoints.dtype).reshape(0, keypoints.shape[1])
     return result
 
@@ -956,14 +953,11 @@ def keypoints_rot90(
 
     result = keypoints.copy()
 
-    # Get dimensions for the rotation axes
     dims = [volume_shape[ax] for ax in axes]
 
-    # Get coordinates to rotate
     coords1 = result[:, axes[0]].copy()
     coords2 = result[:, axes[1]].copy()
 
-    # Apply rotation based on factor (counterclockwise)
     if k == 1:  # 90 degrees CCW
         result[:, axes[0]] = (dims[1] - 1) - coords2
         result[:, axes[1]] = coords1
@@ -999,7 +993,6 @@ def transform_cube_keypoints(
     if not (0 <= index < 48):
         raise ValueError("Index must be between 0 and 47")
 
-    # Create working copy preserving all columns
     working_points = keypoints.copy()
 
     # Convert only XYZ coordinates to HWD, keeping other columns unchanged
@@ -1087,7 +1080,6 @@ def split_uniform_grid_3d(
         random_generator=random_generator,
     )
 
-    # Calculate tiles coordinates
     tiles = [
         (
             depth_splits[d],
@@ -1173,7 +1165,6 @@ def swap_tiles_on_volume(
     if tiles.size == 0:
         return volume.copy()
 
-    # Create a copy of the volume to retain original for reference
     new_volume = np.empty_like(volume)
 
     # Note: Loop is necessary as tiles may have different sizes (edge tiles can be smaller)
@@ -1182,9 +1173,7 @@ def swap_tiles_on_volume(
         # mapping[dest_idx] = src_idx means:
         # "position dest_idx in output gets content from position src_idx in input"
 
-        # Get the destination tile position in the output volume
         z1_dest, y1_dest, x1_dest, z2_dest, y2_dest, x2_dest = tiles[dest_idx]
-        # Get the source tile position in the input volume
         z1_src, y1_src, x1_src, z2_src, y2_src, x2_src = tiles[src_idx]
 
         # Copy tile from source position in input to destination position in output
@@ -1238,7 +1227,6 @@ def swap_tiles_on_keypoints_3d(
         )
         tile_indices[mask] = i
 
-    # Check if any keypoint is not in any tile
     not_in_any_tile = tile_indices < 0
     if np.any(not_in_any_tile):
         from warnings import warn
@@ -1272,7 +1260,6 @@ def swap_tiles_on_keypoints_3d(
         new_starts_y = tiles[new_tile_indices, 1]
         new_starts_x = tiles[new_tile_indices, 2]
 
-        # Apply the transformation
         new_keypoints[valid_mask, 0] += new_starts_x - old_starts_x
         new_keypoints[valid_mask, 1] += new_starts_y - old_starts_y
         new_keypoints[valid_mask, 2] += new_starts_z - old_starts_z

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -1278,7 +1278,6 @@ class BaseCropAndPad3D(Transform3D):
         z, h, w = image_shape
         target_z, target_h, target_w = target_shape
 
-        # Calculate total padding needed for each dimension
         z_pad = max(0, target_z - z)
         h_pad = max(0, target_h - h)
         w_pad = max(0, target_w - w)
@@ -1369,10 +1368,8 @@ class BaseCropAndPad3D(Transform3D):
         pad_params: dict[str, int] | None,
         **params: Any,
     ) -> np.ndarray:
-        # Extract crop start coordinates (z1,y1,x1)
         crop_z1, _, crop_y1, _, crop_x1, _ = crop_coords
 
-        # Initialize shift vector with negative crop coordinates
         shift = np.array(
             [
                 -crop_x1,  # X shift
@@ -1391,7 +1388,6 @@ class BaseCropAndPad3D(Transform3D):
                 ],
             )
 
-        # Apply combined shift
         return fgeometric.shift_keypoints(keypoints, shift)
 
 
@@ -1515,7 +1511,6 @@ class CenterCrop3D(BaseCropAndPad3D):
         z, h, w = _sampling_volume_shape(targets)
         target_z, target_h, target_w = self.size
 
-        # Get padding params if needed
         pad_params = self._get_pad_params(
             image_shape=(z, h, w),
             target_shape=self.size,
@@ -1665,7 +1660,6 @@ class RandomCrop3D(BaseCropAndPad3D):
         z, h, w = _sampling_volume_shape(targets)
         target_z, target_h, target_w = self.size
 
-        # Get padding params if needed
         pad_params = self._get_pad_params(
             image_shape=(z, h, w),
             target_shape=self.size,
@@ -1678,7 +1672,6 @@ class RandomCrop3D(BaseCropAndPad3D):
             h = h + pad_params["pad_top"] + pad_params["pad_bottom"]
             w = w + pad_params["pad_left"] + pad_params["pad_right"]
 
-        # Calculate random crop coordinates
         z_start = sampling.py_random.randint(0, max(0, z - target_z))
         h_start = sampling.py_random.randint(0, max(0, h - target_h))
         w_start = sampling.py_random.randint(0, max(0, w - target_w))

--- a/albumentations/augmentations/utils.py
+++ b/albumentations/augmentations/utils.py
@@ -456,10 +456,8 @@ def handle_empty_array(param_name: str) -> Callable[[F], F]:
     def decorator(func: F) -> F:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            # Check if the parameter is passed as positional argument
             if len(args) > 0:
                 array = args[0]
-            # Check if the parameter is passed as keyword argument
             elif param_name in kwargs:
                 array = kwargs[param_name]
             else:

--- a/albumentations/core/analytics/collectors.py
+++ b/albumentations/core/analytics/collectors.py
@@ -42,29 +42,24 @@ def detect_environment() -> str:
         str: Environment name.
 
     """
-    # Check CI first
     if is_ci_environment():
         return "ci"
 
-    # Check Colab
     if _check_module("google.colab"):
         return "colab"
 
-    # Check Kaggle
     try:
         if Path("/kaggle/working").exists():
             return "kaggle"
     except OSError:
         pass
 
-    # Check Docker
     try:
         if Path("/.dockerenv").exists() or Path("/proc/self/cgroup").is_file():
             return "docker"
     except OSError:
         pass
 
-    # Check Jupyter
     if _check_jupyter():
         return "jupyter"
 
@@ -169,7 +164,6 @@ def get_cpu_model() -> str:
     # Special handling for Apple Silicon on macOS
     if platform.system() == "Darwin":
         try:
-            # Check for Apple Silicon
             result = subprocess.run(
                 ["sysctl", "-n", "machdep.cpu.brand_string"],  # noqa: S607
                 check=False,
@@ -345,7 +339,6 @@ def _extract_transform_names(transform: Any, transforms: list[str]) -> None:
     """Append one transform's class name to the list; recurse into nested compose.
     Skips Lambda and ReplayCompose. Mutates list.
     """
-    # Get the class name
     class_name = transform.__class__.__name__
 
     # Skip Lambda transforms
@@ -399,7 +392,6 @@ def collect_pipeline_info(compose: "Compose") -> dict[str, Any]:
     """
     transforms: list[str] = []
 
-    # Extract all transforms
     for transform in compose.transforms:
         _extract_transform_names(transform, transforms)
 

--- a/albumentations/core/analytics/settings.py
+++ b/albumentations/core/analytics/settings.py
@@ -33,7 +33,6 @@ class SettingsManager:
         """
         settings = self.defaults.copy()
 
-        # Load from file if exists
         if self.settings_file.exists():
             try:
                 with self.settings_file.open() as f:

--- a/albumentations/core/analytics/user_id.py
+++ b/albumentations/core/analytics/user_id.py
@@ -18,7 +18,6 @@ def get_user_config_dir() -> Path:
     """Return the base config directory: XDG_CONFIG_HOME on Unix, APPDATA on Windows.
     Overridable with ALBUMENTATIONS_CONFIG_DIR.
     """
-    # Check for environment variable override
     if config_dir := os.environ.get("ALBUMENTATIONS_CONFIG_DIR"):
         return Path(config_dir)
 
@@ -81,7 +80,6 @@ class UserIDManager:
             bool: True if write was successful, False otherwise.
 
         """
-        # Create directory if it doesn't exist
         try:
             self.config_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
         except OSError:
@@ -131,11 +129,9 @@ class UserIDManager:
             str | None: User ID string or None if user has opted out.
 
         """
-        # Return cached value if already loaded
         if self._cache_loaded:
             return self._cached_user_id
 
-        # Check if user has opted out by looking at the file directly
         if self.user_id_file.exists():
             try:
                 with self.user_id_file.open("r", encoding="utf-8") as f:

--- a/albumentations/core/bbox_utils.py
+++ b/albumentations/core/bbox_utils.py
@@ -399,13 +399,11 @@ class BboxProcessor(DataProcessor[BboxParams]):
                     check_transform(t)
                 return
 
-            # Check DualTransforms
             if isinstance(transform, DualTransform):
                 supported_types = getattr(transform, "_supported_bbox_types", frozenset({"hbb"}))
                 if "obb" not in supported_types:
                     unsupported.append(transform.__class__.__name__)
 
-        # Check all transforms
         for transform in transforms:
             check_transform(transform)
 
@@ -1033,7 +1031,6 @@ def check_bboxes(bboxes: np.ndarray) -> None:
         ValueError: If any bounding box is invalid.
 
     """
-    # Check if all values are in range [0, 1]
     in_range = (bboxes[:, :4] >= 0) & (bboxes[:, :4] <= 1)
     close_to_zero = np.isclose(bboxes[:, :4], 0)
     close_to_one = np.isclose(bboxes[:, :4], 1)
@@ -1048,7 +1045,6 @@ def check_bboxes(bboxes: np.ndarray) -> None:
             f"Expected {invalid_coord} for bbox {invalid_bbox} to be in the range [0.0, 1.0], got {invalid_value}.",
         )
 
-    # Check if x_max > x_min and y_max > y_min
     valid_order = (bboxes[:, 2] > bboxes[:, 0]) & (bboxes[:, 3] > bboxes[:, 1])
 
     if not np.all(valid_order):
@@ -1120,10 +1116,8 @@ def clip_bboxes_geometry(bboxes: np.ndarray, shape: tuple[int, int], bbox_type: 
         return clip_bboxes(bboxes, shape)
 
     # OBB path - clip corners and return wrapping HBB with angle=0
-    # Convert OBB to polygons (4 corners each)
     polygons = obb_to_polygons(bboxes)  # Shape: (N, 4, 2) in normalized coords
 
-    # Check if clipping is needed for each bbox
     needs_clipping = (polygons < 0) | (polygons > 1)
     needs_clipping_per_bbox = needs_clipping.any(axis=(1, 2))  # Shape: (N,)
 
@@ -1459,7 +1453,6 @@ def bboxes_to_mask(
     height, width = image_shape[:2]
     num_boxes = len(bboxes)
 
-    # Create multi-channel mask where each channel represents one bbox
     bbox_masks = np.zeros((height, width, num_boxes), dtype=np.uint8)
 
     # Fill each bbox in its channel
@@ -1498,7 +1491,6 @@ def mask_to_bboxes(
     new_bboxes = []
 
     if num_boxes == 0:
-        # Return empty array with correct shape
         return np.zeros((0, original_bboxes.shape[1]), dtype=original_bboxes.dtype)
 
     for idx in range(num_boxes):

--- a/albumentations/core/cache_utils.py
+++ b/albumentations/core/cache_utils.py
@@ -12,7 +12,6 @@ def get_cache_dir() -> Path:
         Path: Path to the cache directory for AlbumentationsX.
 
     """
-    # Check for environment variable override
     if cache_dir := os.environ.get("ALBUMENTATIONS_CACHE_DIR"):
         return Path(cache_dir)
 

--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -3350,7 +3350,6 @@ class Compose(BaseCompose, HubMixin):
         volume_shapes: list[tuple[int, ...]] = []  # For D,H,W checks
 
         for data_name, data in kwargs.items():
-            # Get internal name for additional targets
             internal_name = self._additional_targets.get(data_name, data_name)
 
             # Always check bbox/keypoint params for all data items
@@ -3390,10 +3389,8 @@ class Compose(BaseCompose, HubMixin):
         """Check consistency of shapes. When is_check_shapes, ensures all 2D shapes match
         and all 3D shapes match. Raises ValueError if inconsistent.
         """
-        # Check H,W consistency
         self._check_shapes(shapes, self.is_check_shapes)
 
-        # Check D,H,W consistency for volume data and 3D masks
         if self.is_check_shapes and volume_shapes and volume_shapes.count(volume_shapes[0]) != len(volume_shapes):
             raise ValueError(
                 "Depth, Height and Width of volume and mask3d should be equal. "
@@ -3682,7 +3679,6 @@ class RandomOrder(SomeOf):
     """
 
     def __init__(self, transforms: TransformsSeqType, n: int = 1, replace: bool = False, p: float = 1):
-        # Initialize using SomeOf's logic (which now does uniform selection setup)
         super().__init__(transforms=transforms, n=n, replace=replace, p=p)
 
     def sample_indices(self, invocation: InvocationContext) -> NDArray[np.int_]:

--- a/albumentations/core/keypoints_utils.py
+++ b/albumentations/core/keypoints_utils.py
@@ -339,7 +339,6 @@ class KeypointsProcessor(DataProcessor[KeypointParams]):
         encoded_mapping: dict[int, int] = {}
 
         if metadata.encoder is not None:
-            # Convert string mapping to encoded integers
             # Pre-filter valid labels to avoid repeated lookups
             encoder_classes = set(metadata.encoder.classes_)
             valid_from_labels = set(mapping.keys()) & encoder_classes
@@ -348,7 +347,6 @@ class KeypointsProcessor(DataProcessor[KeypointParams]):
             # Filter to only valid mappings where both from and to exist
             valid_mappings = {k: v for k, v in mapping.items() if k in valid_from_labels and v in valid_to_labels}
 
-            # Convert valid mappings in batch
             if valid_mappings:
                 from_labels = list(valid_mappings.keys())
                 to_labels = list(valid_mappings.values())
@@ -599,14 +597,12 @@ def filter_keypoints(
     if len(shape) == 3:
         depth, height, width = shape
 
-        # Create boolean mask for visible keypoints
         x, y, z = keypoints[:, 0], keypoints[:, 1], keypoints[:, 2]
         visible = (x >= 0) & (x < width) & (y >= 0) & (y < height) & (z >= 0) & (z < depth)
     else:
         # Handle 2D case (height, width)
         height, width = shape
 
-        # Create boolean mask for visible keypoints
         x, y = keypoints[:, 0], keypoints[:, 1]
         visible = (x >= 0) & (x < width) & (y >= 0) & (y < height)
 

--- a/albumentations/core/label_manager.py
+++ b/albumentations/core/label_manager.py
@@ -356,7 +356,6 @@ class LabelManager:
         """
         if data_name in self.metadata and label_field in self.metadata[data_name]:
             encoder = self.metadata[data_name][label_field].encoder
-            # Ensure encoder is LabelEncoder or None, handle potential type issues
             if isinstance(encoder, LabelEncoder):
                 return encoder
         return None

--- a/albumentations/core/serialization.py
+++ b/albumentations/core/serialization.py
@@ -49,7 +49,6 @@ def shorten_class_name(class_fullname: str) -> str:
     if split_index == -1 or not class_fullname.startswith("albumentations."):
         return class_fullname
 
-    # Extract the class name after the last '.'
     return class_fullname[split_index + 1 :]
 
 
@@ -225,7 +224,6 @@ def from_dict(
     name = transform["__class_fullname__"]
     args = {k: v for k, v in transform.items() if k != "__class_fullname__"}
 
-    # Get the transform class from registry
     cls = SERIALIZABLE_REGISTRY[shorten_class_name(name)]
 
     # Handle nested transforms
@@ -423,7 +421,6 @@ def register_additional_transforms() -> None:
     """
     if importlib.util.find_spec("torch") is not None:
         try:
-            # Import `albumentations.pytorch` only if `torch` is installed.
             import albumentations.pytorch
 
             # Use a dummy operation to acknowledge the use of the imported module and avoid linting errors.

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -436,12 +436,10 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
 
         # Only validate if strict is being set to True and we have stored init args
         if value and hasattr(self, "_init_args"):
-            # Get the list of valid arguments for this transform
             valid_args = {"p", "strict"}  # Base valid args
             if hasattr(self, "InitSchema"):
                 valid_args.update(self.InitSchema.model_fields.keys())
 
-            # Check for invalid arguments
             invalid_args = [name_arg for name_arg in self._init_args if name_arg not in valid_args]
 
             if invalid_args:
@@ -1342,10 +1340,8 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         Returns a dictionary of parameter names and their values, excluding parameters
         that are not actually set on the instance or that shouldn't be serialized.
         """
-        # Get the parameter names
         arg_names = self.get_transform_init_args_names()
 
-        # Create a dictionary of parameter values
         args = {}
         for name in arg_names:
             # Only include parameters that are actually set as instance attributes
@@ -1368,7 +1364,6 @@ class BasicTransform(InvocationRngOwner, Serializable, metaclass=CombinedMeta):
         state = {"__class_fullname__": self.get_class_fullname()}
         state.update(self.get_base_init_args())
 
-        # Get transform init args (our improved method handles all types of transforms)
         transform_args = self.get_transform_init_args()
 
         # Add transform args to state
@@ -1623,12 +1618,10 @@ class DualTransform(BasicTransform):
             np.ndarray: Keypoints array with rows reordered based on label mapping
 
         """
-        # Get the keypoint processor
         processor = self.get_processor("keypoints")
         if not processor or not hasattr(processor, "encoded_label_mappings"):
             return keypoints
 
-        # Check if there are label fields and the array has extra columns
         if not processor.params.label_fields or keypoints.size == 0 or keypoints.shape[1] <= 5:
             return keypoints
 
@@ -1787,7 +1780,6 @@ class DualTransform(BasicTransform):
         """
         res = super().apply_with_params(sampled_params, *args, **kwargs)
 
-        # Apply label mapping to keypoints if they were transformed
         if "keypoints" in res and res["keypoints"] is not None:
             res["keypoints"] = self._apply_label_mapping_to_keypoints(
                 res["keypoints"],

--- a/albumentations/core/utils.py
+++ b/albumentations/core/utils.py
@@ -316,13 +316,11 @@ class DataProcessor(ABC, Generic[ParamsT]):
         """
         shape = get_shape(data)
 
-        # Convert all sequences (including empty lists) to numpy arrays with proper shape
         for data_name in set(self.data_fields) & set(data.keys()):
             if isinstance(data[data_name], Sequence) and not isinstance(data[data_name], np.ndarray):
                 if len(data[data_name]) > 0:
                     data[data_name] = np.array(data[data_name], dtype=np.float32)
                 else:
-                    # Convert empty list to properly shaped empty array
                     data[data_name] = self._create_empty_array()
 
         data = self.add_label_fields_to_data(data)

--- a/albumentations/core/validation.py
+++ b/albumentations/core/validation.py
@@ -39,7 +39,6 @@ class ValidatedTransformMeta(type):
         # Note: Cannot use strict=True here because args may be shorter than param_names (defaults)
         full_kwargs: dict[str, Any] = dict(zip(param_names, args)) | kwargs  # noqa: B905
 
-        # Get strict value before validation
         strict = full_kwargs.pop("strict", False)
 
         # Add default values if not provided

--- a/docs/contributing/codex_guidelines.md
+++ b/docs/contributing/codex_guidelines.md
@@ -1,8 +1,7 @@
 # Codex Working Guide for AlbumentationsX
 
-This is a routing guide, not a second coding rulebook. Deterministic AX source contracts are owned by the
-`coding-guidance` rule in `check-ax-rules`; read its diagnostic and the canonical explanation in
-`docs/contributing/coding_guidelines.md` rather than duplicating a checklist in a prompt.
+Use this guide to select the workflow for your task. The `coding-guidance` rule in `check-ax-rules` owns deterministic
+AX source contracts; [Coding Guidelines](coding_guidelines.md) explains its diagnostics.
 
 ## Choose the owning workflow
 

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -1,19 +1,7 @@
 # Coding Guidelines
 
-This document outlines the coding standards and best practices for contributing to AlbumentationsX.
-
-## Important Note About Guidelines
-
-These guidelines define the required standard for code that enters or is revised in the AlbumentationsX codebase.
-
-**For new contributions:**
-
-- All new code must follow these guidelines
-- All revised code must follow these guidelines within the scope of the change
-- Pull requests that introduce non-conforming patterns will not be accepted
-
-Apply the same standard when changing existing code: do not preserve a non-conforming pattern merely because it is
-already present.
+Apply these standards to new and revised code within the scope of a change. The repository hooks enforce the
+mechanical rules; the linked skills and design documents explain decisions that require review.
 
 ## Code Style and Formatting
 
@@ -192,32 +180,8 @@ The decorators will:
 - Pass through images that are already in the target type without conversion
 - Convert other types as needed and convert back after processing
 
-```python
-@uint8_io  # If input is uint8 => use as is; if float32 => convert to uint8, process, convert back
-def apply(self, img: np.ndarray, **params) -> np.ndarray:
-    # img is guaranteed to be uint8
-    # if input was float32 => result will be converted back to float32
-    # if input was uint8 => result will stay uint8
-    return cv2.blur(img, (3, 3))
-
-
-@float32_io  # If input is float32 => use as is; if uint8 => convert to float32, process, convert back
-def apply(self, img: np.ndarray, **params) -> np.ndarray:
-    # img is guaranteed to be float32 in range [0, 1]
-    # if input was uint8 => result will be converted back to uint8
-    # if input was float32 => result will stay float32
-    return img * 0.5
-
-
-# Avoid - manual type conversion
-def apply(self, img: np.ndarray, **params) -> np.ndarray:
-    if img.dtype != np.uint8:
-        img = (img * 255).clip(0, 255).astype(np.uint8)
-    result = cv2.blur(img, (3, 3))
-    if img.dtype != np.uint8:
-        result = result.astype(np.float32) / 255
-    return result
-```
+Apply the decorator to the functional operation that owns the dtype-specific kernel. Keep transform application
+methods as dispatchers; do not add manual conversion or a forwarding wrapper just to attach a decorator.
 
 ### Image Value Ranges and `@clipped`
 
@@ -230,21 +194,9 @@ def apply(self, img: np.ndarray, **params) -> np.ndarray:
 
 ### Channel Flexibility
 
-- Support arbitrary number of channels unless specifically constrained:
-
-  ```python
-  # Correct - works with any number of channels
-  def apply(self, img: np.ndarray, **params) -> np.ndarray:
-      # img shape is (H, W, C), works for any C
-      return img * self.factor
-
-
-  # Also correct - explicitly requires RGB
-  def apply(self, img: np.ndarray, **params) -> np.ndarray:
-      if img.shape[-1] != 3:
-          raise ValueError("Transform requires RGB image")
-      return rgb_to_hsv(img)  # RGB-specific processing
-  ```
+Support arbitrary channel counts unless the operation requires a specific layout, such as RGB. Validate that
+transform-specific requirement before dispatching to the functional operation. Keep channel arithmetic in the
+functional layer.
 
 ### Image and Volume Shape Invariants
 
@@ -456,12 +408,6 @@ def sample_parameters(
 ) -> SampledParams:
     height, width = targets.require_aligned_spatial_shape(2)
 
-    image = data.get("image")
-    mask = data.get("mask")
-    bboxes = data.get("bboxes")
-    keypoints = data.get("keypoints")
-
-    # Example: Calculate parameters based on image size
     crop_size = min(height, width) // 2
     center_x = width // 2
     center_y = height // 2
@@ -476,12 +422,6 @@ The method receives:
 - `targets`: The ordered `TargetSet`; use `require_aligned_spatial_shape(2)` or `require_aligned_spatial_shape(3)` for synchronized geometry
 - `sampling`: Call-local Python and NumPy RNG streams plus the applied-configuration sink
 
-Use this method when you need to:
-
-- Calculate parameters based on image dimensions
-- Access target data for parameter generation
-- Ensure transform parameters are appropriate for the input data
-
 Never return a plain dictionary. For target-specific materialization, group by a transform-defined compatibility key and
 return `TargetParams(targets=..., params=..., requirements=...)`. The core stores the resulting schema in replay and
 rejects legacy flat payloads.
@@ -495,29 +435,6 @@ explicitly forwards those inputs does not need a new schema. The schema is respo
 - Validating input parameters before `__init__` execution
 - Converting parameter types if needed
 - Ensuring consistent parameter handling
-
-  ```python
-  # Correct - full parameter validation
-  class RandomGravel(ImageOnlyTransform):
-      class InitSchema(BaseTransformInitSchema):
-        slant_range: Annotated[tuple[float, float], AfterValidator(nondecreasing)]
-        brightness_coefficient: float = Field(gt=0, le=1)
-
-
-    def __init__(self, slant_range: tuple[float, float], brightness_coefficient: float, p: float = 0.5):
-        super().__init__(p=p)
-        self.slant_range = slant_range
-        self.brightness_coefficient = brightness_coefficient
-  ```
-
-  ```python
-  # Incorrect - missing InitSchema
-  class RandomGravel(ImageOnlyTransform):
-      def __init__(self, slant_range: tuple[float, float], brightness_coefficient: float, p: float = 0.5):
-          super().__init__(p=p)
-          self.slant_range = slant_range
-          self.brightness_coefficient = brightness_coefficient
-  ```
 
 #### No Default Values in InitSchema
 
@@ -570,38 +487,20 @@ serialization or applied-configuration boundary. Overriding this method can caus
 
 ### Batch Performance (`apply_to_images`)
 
-Images in batch mode are always `(N, H, W, C)`. Never check `ndim == 4` — it's always true.
+NumPy image batches inside transform execution have shape `(N, H, W, C)`. Native Tensor handlers receive
+`(N, C, H, W)`. Both have rank four; do not repeat that check inside `apply_to_images`.
 
 Keep `apply_to_images` as a short delegation method. Put the complete batch image operation—including empty-batch
 handling, shared setup, routing between native and per-image kernels, and clipping—in one functional helper so it has a
 single direct correctness and benchmark boundary.
 
-Override `apply_to_images` when you can do better than the default per-image loop:
+Override `apply_to_images` only when measurement shows an advantage over the default per-image loop. In the
+functional helper, compare shared setup, direct batch indexing, and a preallocated loop. Do not construct kernels or
+read sampled values from `**params` inside the transform method.
 
-1. **Pre-compute expensive setup once** (kernels, LUTs, gradient maps):
-
-```python
-def apply_to_images(self, images: ImageType, *args: Any, **params: Any) -> ImageType:
-    kernel = create_kernel(params["size"])  # once per batch
-    return self._apply_to_batch(images, lambda img: convolve(img, kernel))
-```
-
-2. **Direct 4D indexing** for simple array ops:
-
-```python
-result = images.copy()
-result[:, :, :, channels] = fill  # vectorized across N
-```
-
-3. **Pre-allocated loop** to avoid repeated allocations:
-
-```python
-result = np.empty_like(images)
-for i, image in enumerate(images):
-    result[i] = self.apply(image, **params)
-```
-
-> **Anti-pattern**: Do NOT reshape `(N,H,W,1)` to `(H,W,N)` to call a cv2 function once — transpose yields non-contiguous memory (requiring a full copy), and cv2 processes channels sequentially so an N-channel call is not faster than N single-channel calls. Benchmarks show 2–4× regression.
+Keep batch and channel axes distinct. Reshaping `(N, H, W, 1)` into `(H, W, N)` adds a transpose and may require a
+copy; OpenCV processes those channels sequentially. Use the
+[benchmark skill](../../.codex/skills/benchmark/SKILL.md) for the required direct and Compose measurements.
 
 ### Coordinate Systems
 
@@ -648,54 +547,27 @@ This small difference is crucial for pixel-perfect accuracy. Always use the appr
 
 ### Docstrings
 
-- Use Google-style docstrings
-- **Transform apply methods:** Do not add docstrings to `apply`, `apply_to_image`, `apply_to_mask`, or other `apply_to_*` methods in transform classes. The transform class docstring and the base interface in `transforms_interface` are sufficient.
-- **First paragraph (120–160 characters):** A **useful short description** — an elevator pitch: what the function or transform does, how it works in one sentence, and when to use it. This is the web/search preview. Paragraphs are separated by blank lines; there is no blank line within a paragraph. So the first paragraph occupies **two lines of text with no blank line between them** (not "line, blank line, line"). **Line limit 120 chars** ⇒ the first paragraph must be two lines (no single line over 120; do not use `# noqa: E501`). Wrap at a word boundary. Do **not** list parameter names ("Parameters: x, y, z" or "Params: ...") in the first paragraph — that belongs in Args. Do **not** use "Preserves X" boilerplate (e.g. "Preserves channel count", "preserves dtype and channels") in the first paragraph — describe effect and when to use it instead. Do not put "Targets: ...", "Same shape", "Used by X", return type (e.g. "Returns np.ndarray"), or "Supports uint8/float32" (or Image types) in the first paragraph — return type belongs in Returns; dtype/target support has a separate Image types section, and all transforms support uint8 and float32 unless noted. Both length (120–160) and usefulness matter for discoverability.
-- **Similar transforms / See also:** Use a **bullet list** (`-` per item) listing 2–4 related transforms with brief when-to-use hints, so users discover more than a limited set (e.g. RandomResizedCrop, ColorJitter). **One transform per bullet** — do not combine multiple transforms in one bullet. When you add transform X to transform Y's See also, update X's docstring to mention Y (reciprocal cross-links).
-- **Note:** Use a **bullet list** (`-` per point). Note is **pure info** only — no call-to-action (e.g. no "Explore other transforms…" or "Consider using…"); put discoverability in See also.
-- Include type information, parameter descriptions, and examples:
+Use Google-style docstrings. Concrete transform `apply*` methods inherit their documentation from the class and base
+interface; do not repeat it on each override.
 
-  ```python
-  def transform(self, image: np.ndarray) -> np.ndarray:
-      """Apply brightness transformation to the image.
+- The first paragraph is a 120–160 character web/search preview. Explain the effect and when to use it. Wrap at a word
+  boundary within the 120-character line limit, with no blank line inside the paragraph.
+- Put parameter names and units in `Args`, return details in `Returns`, and supported targets and dtypes in their own
+  sections. Generic preservation claims and directions to read other sections do not belong in the preview.
+- Use `See also` for two to four related transforms, one per bullet with a selection hint. Keep cross-links reciprocal.
+- Use `Note` bullets for factual details. Put recommendations in `See also`.
 
-      Args:
-          image: Input image in RGB format.
-
-      Returns:
-          Transformed image.
-
-      Examples:
-          >>> transform = Brightness(brightness_range=(-0.2, 0.2))
-          >>> transformed = transform(image=image)
-      """
-  ```
+Use the [docstring review skill](../../.codex/skills/docstring-deep-dive/SKILL.md) to review reader-facing quality.
 
 ### Examples in Docstrings
 
-Every transform class that is a descendant of `ImageOnlyTransform`, `DualTransform`, or `Transform3D` **must** include a comprehensive Examples section in its docstring. The examples should follow these guidelines:
+Every transform class descending from `ImageOnlyTransform`, `DualTransform`, or `Transform3D` needs an `Examples`
+section. Use doctest syntax: `>>>` for statements, `...` for continuations, and no prefix for output.
 
-1. **Section Naming**: The section should be titled "Examples" (not "Example").
-
-2. **Jupyter Notebook Format**: Examples should mimic Jupyter notebook format, using `>>>` for code lines and no prefix for output lines.
-
-3. **Comprehensiveness**: Examples should be fully reproducible, including:
-   - Initialization of sample data
-   - Creation of transform(s)
-   - Application of transform(s)
-   - Retrieving results from the transform
-
-4. **Target-Specific Requirements**:
-   - For `ImageOnlyTransform`: Pass and demonstrate transformation of image data. Including how to get all transformed targets.
-   - For `DualTransform`: Pass and demonstrate transformation of image, mask, bboxes, keypoints, bbox_labels, class_labels (where supported). Including how to get all transformed targets including bbox_labels and keypoints_labels
-   - For `Transform3D`: Pass and demonstrate transformation of volume and mask3d data. Including how to get all transformed targets.
-    Including keypoint_labels
-
-5. **For Base Classes**: Examples for base classes should show:
-   - How to initialize a custom transform that inherits from the base class
-   - How to use the custom transform as part of a Compose pipeline
-
-6. **Parameter Examples**: When a parameter accepts both a single value and a tuple of values (to be sampled from), always use a tuple in the example.
+Include imports, sample data, transform construction, a public call, and result access. Demonstrate the supported
+targets: images for image-only transforms; images, masks, bboxes, keypoints, and their labels for dual transforms;
+volumes, 3D masks, and keypoint labels where supported for 3D transforms. Use tuple ranges for sampled parameters.
+Base-class examples should implement a working subclass and execute it through Compose.
 
 Here's an example for a `DualTransform`:
 
@@ -704,21 +576,25 @@ Here's an example for a `DualTransform`:
 Examples:
     >>> import numpy as np
     >>> import albumentations as A
-    >>> # Prepare sample data
-    >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-    >>> mask = np.random.randint(0, 2, (100, 100), dtype=np.uint8)
+    >>> rng = np.random.default_rng(137)
+    >>> image = rng.integers(0, 256, (100, 100, 3), dtype=np.uint8)
+    >>> mask = rng.integers(0, 2, (100, 100), dtype=np.uint8)
     >>> bboxes = np.array([[10, 10, 50, 50], [40, 40, 80, 80]], dtype=np.float32)
     >>> bbox_labels = [1, 2]
     >>> keypoints = np.array([[20, 30], [60, 70]], dtype=np.float32)
-    >>> keypoint_labels = [0, 1]
+    >>> keypoint_labels = ['left_eye', 'right_eye']
     >>>
-    >>> # Define transform with parameters as tuples when possible
     >>> transform = A.Compose([
     ...     A.HorizontalFlip(p=1.0),
     ... ], bbox_params=A.BboxParams(coord_format='pascal_voc', label_fields=['bbox_labels']),
-    ...    keypoint_params=A.KeypointParams(coord_format='xy', label_fields=['keypoint_labels']))
+    ...    keypoint_params=A.KeypointParams(
+    ...        coord_format='xy',
+    ...        label_fields=['keypoint_labels'],
+    ...        label_mapping={'HorizontalFlip': {
+    ...            'keypoint_labels': {'left_eye': 'right_eye', 'right_eye': 'left_eye'},
+    ...        }},
+    ...    ))
     >>>
-    >>> # Apply the transform
     >>> transformed = transform(
     ...     image=image,
     ...     mask=mask,
@@ -728,72 +604,55 @@ Examples:
     ...     keypoint_labels=keypoint_labels
     ... )
     >>>
-    >>> # Get the transformed data
-    >>> transformed_image = transformed['image']  # Horizontally flipped image
-    >>> transformed_mask = transformed['mask']    # Horizontally flipped mask
-    >>> transformed_bboxes = transformed['bboxes']  # Horizontally flipped bounding boxes
-    >>> transformed_keypoints = transformed['keypoints']  # Horizontally flipped keypoints
-"""
-```
-
-Examples for a base class showing custom implementation:
-
-```python
-"""
-Examples:
-    # Example of a custom distortion subclass
-    >>> import numpy as np
-    >>> import albumentations as A
-    >>>
-    >>> class CustomDistortion(A.BaseDistortion):
-    ...     def __init__(self, *args, **kwargs):
-    ...         super().__init__(*args, **kwargs)
-    ...         # Add custom parameters here
-    ...
-    ...     def sample_parameters(self, params, data, targets, sampling):
-    ...         height, width = targets.require_aligned_spatial_shape(2)
-    ...         # Generate distortion maps
-    ...         map_x = np.zeros((height, width), dtype=np.float32)
-    ...         map_y = np.zeros((height, width), dtype=np.float32)
-    ...         # Apply your custom distortion logic here
-    ...         # ...
-    ...         return SampledParams(params={"map_x": map_x, "map_y": map_y})
-    >>>
-    >>> # Prepare sample data
-    >>> image = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
-    >>> mask = np.random.randint(0, 2, (100, 100), dtype=np.uint8)
-    >>> bboxes = np.array([[10, 10, 50, 50], [40, 40, 80, 80]], dtype=np.float32)
-    >>> bbox_labels = [1, 2]
-    >>> keypoints = np.array([[20, 30], [60, 70]], dtype=np.float32)
-    >>> keypoint_labels = [0, 1]
-    >>>
-    >>> # Apply the custom distortion
-    >>> transform = A.Compose([
-    ...     CustomDistortion(
-    ...         interpolation=A.cv2.INTER_LINEAR,
-    ...         mask_interpolation=A.cv2.INTER_NEAREST,
-    ...         keypoint_remapping_method="mask",
-    ...         p=1.0
-    ...     )
-    ... ], bbox_params=A.BboxParams(coord_format='pascal_voc', label_fields=['bbox_labels']),
-    ...    keypoint_params=A.KeypointParams(coord_format='xy', label_fields=['keypoint_labels']))
-    >>>
-    >>> # Apply the transform
-    >>> transformed = transform(
-    ...     image=image,
-    ...     mask=mask,
-    ...     bboxes=bboxes,
-    ...     bbox_labels=bbox_labels,
-    ...     keypoints=keypoints,
-    ...     keypoint_labels=keypoint_labels
-    ... )
-    >>>
-    >>> # Get results
     >>> transformed_image = transformed['image']
     >>> transformed_mask = transformed['mask']
     >>> transformed_bboxes = transformed['bboxes']
     >>> transformed_keypoints = transformed['keypoints']
+    >>> transformed_bbox_labels = transformed['bbox_labels']
+    >>> transformed_keypoint_labels = transformed['keypoint_labels']
 """
+```
+
+A base-class example can start with identity maps so the reader can verify the remapping before adding distortion:
+
+```python
+from typing import Any
+
+import cv2
+import numpy as np
+
+import albumentations as A
+from albumentations.augmentations.geometric.distortion import BaseDistortion
+from albumentations.core.invocation import SamplingContext
+from albumentations.core.transform_params import SampledParams, TargetSet
+
+
+class IdentityDistortion(BaseDistortion):
+    def sample_parameters(
+        self,
+        params: dict[str, Any],
+        data: dict[str, Any],
+        targets: TargetSet,
+        sampling: SamplingContext,
+    ) -> SampledParams:
+        height, width = targets.require_aligned_spatial_shape(2)
+        map_y, map_x = np.mgrid[:height, :width].astype(np.float32)
+        return SampledParams(params={"map_x": map_x, "map_y": map_y})
+
+
+image = np.random.default_rng(137).integers(0, 256, (100, 100, 3), dtype=np.uint8)
+transform = A.Compose(
+    [
+        IdentityDistortion(
+            interpolation=cv2.INTER_LINEAR,
+            mask_interpolation=cv2.INTER_NEAREST,
+            keypoint_remapping_method="mask",
+            p=1.0,
+        ),
+    ]
+)
+transformed_image = transform(image=image)["image"]
+np.testing.assert_array_equal(transformed_image, image)
 ```
 
 ### Comments
@@ -802,153 +661,14 @@ Examples:
 - Explain why, not what (the code shows what)
 - Keep comments up to date with code changes
 
-## Performance Optimization Checklist
+## Performance Optimization
 
-Runtime performance is an evidence problem, not a list of automatic rewrites. For functional-layer code, `apply`
-methods, and core pipeline paths, use the techniques below to form candidates, then measure them on the affected public
-route. The repo-local `performance-optimization` skill provides the full workflow: delete-first review, backend
-comparison, correctness baseline, and representative benchmarks. Use the `benchmark` skill to record the baseline,
-candidate, public route, and every relevant measured cell.
+Use [Performance Optimization](../../.codex/skills/performance-optimization/SKILL.md) and its synchronized reference
+for runtime audits. The workflow covers removable work, memory traffic, vectorization, grouped reductions, LUTs,
+random generation, backend selection, Albucore ownership, and aliasing.
 
-### 1. Eliminate Python Loops Over Pixels
-
-Python `for y in range(h): for x in range(w):` loops are much slower than vectorized NumPy. Prefer:
-
-- `np.mgrid` / `np.meshgrid` plus broadcasting for grid computations;
-- `np.einsum` for weighted sums over control points; and
-- scatter updates via fancy indexing (`arr[ys, xs] = values`) instead of per-pixel assignment.
-
-### 2. Eliminate Per-Label Full-Array Scans
-
-When integer labels are dense and non-negative, `np.bincount` can be a grouped reduction instead of constructing one
-full-image mask per label:
-
-```python
-counts = np.bincount(labels, minlength=num_labels)
-weighted_sums = np.bincount(labels, weights=values, minlength=num_labels)
-means = weighted_sums / counts
-```
-
-This can replace `for label: mask = labels == label` for component sizes, sums, means, histograms, and cluster-centre
-updates. Benchmark small label counts too: sparse IDs require remapping, `weights=` changes accumulation precision, and
-`np.unique(..., return_inverse=True)` can cost more than the scans it replaces.
-
-### 3. Consider `cv2.LUT` / `sz_lut` for uint8 Pixel-Wise Transforms
-
-For a uint8 operation of the form `f(pixel) -> pixel`, compare a 256-entry LUT applied with
-`sz_lut(image, lut, inplace=...)` to direct array arithmetic. LUTs often win, but the complete operation and the input
-layout decide the result.
-
-An operation that is literally a bit mask is a common exception:
-
-```python
-# Often fast for posterization-style bit masks.
-mask = ~np.uint8(2 ** (8 - num_bits) - 1)
-result = image & mask
-```
-
-For multichannel bit masks, benchmark broadcasted `image & masks` against a preallocated per-channel implementation.
-Broadcasting small per-channel masks can create slow strided operations.
-
-### 4. Vectorize LUT and Array Construction
-
-Replace Python list comprehensions with NumPy vectorized equivalents when constructing arrays in a hot path:
-
-```python
-# Slow
-lut = np.array([max_value - i if i >= threshold else i for i in range(256)])
-
-# Fast
-indices = np.arange(256, dtype=np.uint8)
-lut = np.where(indices >= threshold, max_value - indices, indices)
-```
-
-### 5. Use `out=` for In-Place Operations
-
-Avoid unnecessary temporaries on image-sized arrays:
-
-```python
-# Allocates a temporary.
-result = np.clip(image + noise, 0, 1)
-
-# Reuses the result buffer.
-result = image + noise
-np.clip(result, 0, 1, out=result)
-```
-
-Useful functions with `out=` include `np.clip`, `np.multiply`, `np.add`, and `np.divide`. Only use in-place mutation when
-the public contract permits it.
-
-### 6. Avoid Float64 Waste
-
-NumPy defaults to float64. Specify `dtype=np.float32` for float arrays when float32 is sufficient, including
-`np.arange`, `np.linspace`, `np.zeros`, `np.ones`, `np.full`, and mesh-grid inputs.
-
-### 7. Fuse Multi-Step Operations
-
-Replace chains of temporary allocations with a fused helper where its semantics match:
-
-```python
-# Two temporaries.
-result = image + alpha * (image - blurred)
-
-# A fused weighted sum.
-result = add_weighted(image, 1.0 + alpha, blurred, -alpha)
-```
-
-### 8. Choose Backends by Benchmark
-
-Compare NumPy, OpenCV, NumKong, StringZilla, and LUT implementations that express the complete operation. Include
-dispatch, conversion, contiguity, clipping, and allocation costs, and benchmark the exact dtype, shape, and channel
-matrix before switching.
-
-- Use scalar NumPy bitwise operations, such as `image & np.uint8(mask)`, for a scalar mask.
-- Use `cv2.bitwise_*` when both operands are dense contiguous arrays and `dst=` can reuse output.
-- Do not allocate a full image-sized mask merely to call OpenCV; that allocation often loses.
-- For a single-source Euclidean distance field, direct coordinate math with `np.arange(..., dtype=np.float32)` and
-  `cv2.sqrt(..., dst=...)` may be simpler and faster than `cv2.distanceTransform`.
-- For sparse multi-channel replacement, copy plus masked assignment can beat nested `np.where`; measure the density
-  threshold.
-
-### 9. Preallocate Outside Loops
-
-Move repeated allocations outside loops and reset reusable buffers:
-
-```python
-# Slow — allocates every iteration.
-for item in items:
-    mask = np.zeros((height, width), dtype=np.uint8)
-    cv2.fillPoly(mask, ...)
-
-# Reuse one allocation.
-mask = np.zeros((height, width), dtype=np.uint8)
-for item in items:
-    mask[:] = 0
-    cv2.fillPoly(mask, ...)
-```
-
-### 10. Skip Redundant Work in Hot Paths
-
-- Guard `np.ascontiguousarray` with `if not array.flags["C_CONTIGUOUS"]`.
-- Use `first_result[np.newaxis]` instead of `np.array([first_result])` for a batch of one.
-- Precompute loop-invariant expressions, for example `inverse_squared_step = 1.0 / (step * step)`.
-- Prefer `np.where(mask)` to `np.argwhere(mask)` when a tuple of one-dimensional index arrays is enough.
-
-### 11. Compare and Vectorize Random Number Generation
-
-Use Python `random.Random` for a few scalar choices and a NumPy `Generator` for arrays as starting candidates. When
-multiple generators can express the workload, benchmark them while preserving transform-local seeded isolation and
-replay behaviour; a global OpenCV RNG can be ineligible even if its kernel is fast.
-
-Replace per-element Python RNG loops with one NumPy call when an array draw is appropriate:
-
-```python
-# Slow
-steps = [1 + sampling.py_random.uniform(*limit) for _ in range(n)]
-
-# Fast
-steps = (1 + sampling.random_generator.uniform(*limit, size=n)).tolist()
-```
+Treat each candidate as a hypothesis. Use the [benchmark skill](../../.codex/skills/benchmark/SKILL.md) to compare
+baseline and candidate on the affected public routes, and record every measured cell and any regressions.
 
 ### Updating Transform Documentation
 

--- a/docs/contributing/environment_setup.md
+++ b/docs/contributing/environment_setup.md
@@ -1,60 +1,42 @@
-# Setting Up Your Development Environment
+# Set up a development environment
 
-This guide will help you set up your development environment for contributing to AlbumentationsX.
-
-## Prerequisites
-
-- Python 3.10 or higher
-- Git
-- [uv](https://docs.astral.sh/uv/)
-- A GitHub account
-
-## Step-by-Step Setup
-
-### 1. Fork and Clone the Repository
-
-1. Fork the [AlbumentationsX repository](https://github.com/albumentations-team/AlbumentationsX) on GitHub
-2. Clone your fork locally:
+Use Python 3.10 or higher, Git, and [uv](https://docs.astral.sh/uv/). Fork the
+[repository](https://github.com/albumentations-team/AlbumentationsX), then clone your fork:
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/AlbumentationsX.git
 cd AlbumentationsX
 ```
 
-### 2. Install Dependencies With uv
+## Install dependencies
 
-Create a local virtual environment and install the project plus development tools:
+Install the project and development tools from the lockfile:
 
 ```bash
 uv sync --locked --group dev --inexact
 ```
 
-This is the canonical setup path for contributors and coding agents. It installs the same toolchain used by CI,
-including Ruff, mypy, Pyrefly, pytest, pre-commit, and security tooling. It does not choose a Torch build. Install
-the CPU, CUDA, or MPS Torch build required by your development environment before running code that imports
-AlbumentationsX.
+This installs Ruff, mypy, Pyrefly, pytest, pre-commit, and security tooling. Install the PyTorch build for your CPU,
+CUDA, or MPS environment before importing AlbumentationsX. The development group leaves that runtime choice to you.
 
-To reproduce the CPU-only runtime used by CI, add its explicit profile:
+To use the CPU-only runtime profile used by CI:
 
 ```bash
 uv sync --locked --group dev --group ci-torch-cpu --inexact
 ```
 
-CI itself uses smaller locked groups so unrelated jobs do not install the full
-toolchain: `ci-test`, `ci-quality`, `ci-types`, `ci-security`, `ci-package`,
-`ci-benchmark`, `ci-release`, and `ci-torch-cpu`. Tool groups never select a
-runtime. Jobs that import AlbumentationsX add `ci-torch-cpu`; static jobs do
-not. Contributors normally should keep using `dev`; the purpose-specific
-groups are useful when reproducing one CI leaf, for example:
+CI selects smaller groups for individual jobs. Use those groups when reproducing a specific job, for example:
 
 ```bash
 uv sync --locked --no-default-groups --group ci-test --group ci-torch-cpu --inexact
 ```
 
-#### pip fallback
+The tool groups are `ci-test`, `ci-quality`, `ci-types`, `ci-security`, `ci-package`, `ci-benchmark`, and `ci-release`.
+Import-capable jobs add `ci-torch-cpu`; static jobs do not need it.
 
-If you cannot use uv, create and activate a virtual environment manually, then install the project and development
-requirements:
+### pip fallback
+
+If uv is unavailable, create and activate a virtual environment:
 
 ```bash
 python3 -m venv env
@@ -63,125 +45,58 @@ pip install -e .
 pip install -r requirements-dev.txt
 ```
 
-The fallback requirements also leave Torch to you. Install the CPU, CUDA, or
-MPS Torch build before running the test suite.
+On Windows, activate with `env\Scripts\activate.bat` in cmd.exe or `env\Scripts\activate.ps1` in PowerShell.
+Install the appropriate PyTorch build separately. In the commands below, omit `uv run` when using this activated
+pip environment.
 
-On Windows, activate the environment with `env\Scripts\activate.bat` for cmd.exe or `env\Scripts\activate.ps1` for
-PowerShell.
-
-### 3. Set Up Pre-commit Hooks
-
-Pre-commit hooks help maintain code quality by automatically checking your changes before each commit.
-
-1. Set up the hooks:
+## Enable hooks and verify the environment
 
 ```bash
 uv run pre-commit install
+uv run python -c "import albumentations"
+uv run pytest -n 4 -q tests/test_core_utils.py
+uv run pre-commit run --all-files --show-diff-on-failure
 ```
 
-If you used the pip fallback with an activated virtual environment, run:
+The test command checks one module to confirm the environment works. For a change, select tests that can detect its
+failure modes. Use `uv run pytest -n auto` when the change requires the full suite.
 
-```bash
-pre-commit install
-```
+If imports fail, check which interpreter is running with `uv run python -c "import sys; print(sys.executable)"` and
+confirm that the selected environment contains PyTorch and an OpenCV variant. Re-run the appropriate sync command
+above if dependencies are missing. Installation should use the virtual environment without administrator privileges.
 
-1. (Optional) Run hooks manually on all files:
+## Maintenance checks
 
-```bash
-uv run pre-commit run --all-files
-```
-
-With the pip fallback:
-
-```bash
-pre-commit run --all-files
-```
-
-## Verifying Your Setup
-
-### Run Tests
-
-Ensure everything is set up correctly by running the test suite:
-
-```bash
-uv run pytest
-```
-
-With the pip fallback:
-
-```bash
-pytest
-```
-
-For a faster local gate before handing work off, run:
-
-```bash
-pre-commit run --all-files --show-diff-on-failure
-```
-
-With the pip fallback:
-
-```bash
-pre-commit run --all-files --show-diff-on-failure
-```
-
-### Verification Infrastructure Commands
-
-The maintenance verification layer adds focused commands for CI, release, and
-support-policy changes:
+For CI and support-policy changes:
 
 ```bash
 uv run python -m tools.ci_matrix check
 uv run python -m tools.ci_shard check
-uv run python tools/verify_regression_vectors.py --all
-uv run pytest -q tests/regression tests/property --hypothesis-profile=ci-fast
-uv run python tools/generate_correctness_report.py \
-  --allow-missing-evidence \
-  --output _internal/correctness-report-dry-run.md
 ```
 
-Golden regression vectors are updated only by an explicit command:
+For regression contracts:
+
+```bash
+uv run python tools/verify_regression_vectors.py --all
+uv run pytest -n 4 -q tests/regression tests/property --hypothesis-profile=ci-fast
+```
+
+Golden vectors change only through an explicit regeneration command, for example:
 
 ```bash
 uv run python tools/generate_regression_vectors.py --transform HorizontalFlip --epoch 2.4
 ```
 
-Local dry-run reports and other one-off evidence belong under `_internal/`.
+To inspect report generation without release evidence:
 
-### Common Issues and Solutions
+```bash
+uv run python tools/generate_correctness_report.py \
+  --allow-missing-evidence \
+  --output _internal/correctness-report-dry-run.md
+```
 
-#### Permission Errors
+Keep local reports and other temporary artifacts under `_internal/`.
 
-- **Linux/macOS**: If you encounter permission errors, try using `sudo` for system-wide installations or consider using `--user` flag with pip
-- **Windows**: Run your terminal as administrator if you encounter permission issues
-
-#### Virtual Environment Not Activating
-
-- Ensure you're in the correct directory
-- Check that Python is properly installed and in your system PATH
-- Try creating the virtual environment with the full Python path
-
-#### Import Errors After Installation
-
-- Verify that you're using the correct virtual environment
-- Confirm that all dependencies were installed successfully
-- Try reinstalling the package in editable mode
-
-## Next Steps
-
-After setting up your environment:
-
-1. Create a new branch for your work
-2. Make your changes
-3. Run tests and pre-commit hooks
-4. Submit a pull request
-
-For more detailed information about contributing, please refer to [Coding Guidelines](./coding_guidelines.md)
-
-## Getting Help
-
-If you encounter any issues with the setup:
-
-1. Check our [Discord community](https://discord.gg/e6zHCXTvaN)
-2. Open an [issue on GitHub](https://github.com/albumentations-team/AlbumentationsX/issues)
-3. Review existing issues for similar problems and solutions
+Follow the [Coding Guidelines](coding_guidelines.md) and [Contributing Guide](../../CONTRIBUTING.md) for your change.
+For setup problems, check existing [issues](https://github.com/albumentations-team/AlbumentationsX/issues) or ask in
+[Discord](https://discord.gg/e6zHCXTvaN).

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,127 +1,42 @@
-# AlbumentationsX Design Documents
+# AlbumentationsX design documents
 
-This directory contains design documents for significant features and architectural changes in AlbumentationsX.
+Use these references for architectural decisions and behavior spanning multiple transforms or execution routes.
+Document small fixes in their pull requests.
 
-## Purpose
+## Runtime contracts
 
-Design documents are created for:
+| Reference | Scope |
+| --- | --- |
+| [Bounding Box Processing](bounding_boxes.md) | HBB and OBB coordinates, clipping, filtering, and processors. |
+| [Instance Binding](instance_binding.md) | Alignment of masks, boxes, keypoints, and labels during filtering. |
+| [Mosaic](mosaic.md) | Donor data, preprocessing, label encoding, and cell assembly. |
+| [Applied Configuration Replay Contracts](applied-config-replay-contracts.md) | JSON transport, reconstruction, replay strength, and constructor coverage. |
+| [ElasticTransform](elastic-transform.md) | Bounded B-spline deformation, synchronized targets, keypoint inversion, and persistence. |
+| [ElasticTransform3D](elastic-transform3d.md) | Cubic control planes, raster remapping, and NumPy/Tensor volume routes. |
+| [Generated Transform Target Contracts](transform-target-contracts.md) | Transform cases and reusable target profiles. |
+| [Compose Serialization and Execution Tracing](compose-serialization-and-tracing.md) | Composition policy, transport, snapshots, and timing. |
+| [Compose Architecture](compose-greenfield-architecture.md) | Graph compilation and per-invocation execution. |
+| [Target-Specific Parameter Sampling](target-specific-parameter-sampling.md) | Shared parameters, actual-target-key records, determinism, and replay. |
+| [Sampling Inventory](target-specific-parameter-sampling-inventory.md) | Sampler ownership and representation-dependent behavior. |
+| [NumPy and CPU Tensor Routing](numpy-tensor-routing.md) | Container preservation, layouts, and NumPy fallback. |
 
-- Complex features requiring detailed planning
-- Significant architectural changes
-- Features with multiple implementation phases
-- System-wide behavior that needs maintainer documentation
+## CI and dependencies
 
-Document regular bug fixes and small improvements in commit messages and PR descriptions.
+| Reference | Scope |
+| --- | --- |
+| [Pull-Request CI](pr-ci-greenfield.md) | Hook partitions, compatibility gates, and bounded performance evidence. |
+| [Torch Dependency and CI](torch-dependency-and-ci-greenfield.md) | User-selected Torch builds and explicit CI runtime profiles. |
+| [Shared CI Foundation](https://github.com/albumentations-team/ci-foundation/blob/main/docs/architecture.md) | Python/uv bootstrap, CPU-only Torch setup, and trusted review orchestration. |
 
-## Current Architectural References
+Keep implementation status, pending evidence, and revision pins in the owning document or workflow. The foundation
+owns shared setup; AlbumentationsX owns dependency groups, test selection, release policy, legal checks, and its review
+policy.
 
-### [Bounding Box Processing](bounding_boxes.md)
+## Add or revise a design
 
-Reference for HBB and OBB coordinate formats, clipping, filtering, and processor behavior.
+State the problem, required behavior, constraints, decision, and validation that can reject it. Record unresolved
+choices and pending evidence explicitly. Add the document to this index and update the
+[Codex working guide](../contributing/codex_guidelines.md) if it introduces a new workflow boundary.
 
-### [Instance Binding](instance_binding.md)
-
-Structural contract for keeping masks, bounding boxes, keypoints, and labels aligned as instances are filtered.
-
-### [Mosaic Transform](mosaic.md)
-
-Technical specification for the Mosaic transform's data handling, including label encoding and preprocessing for multiple input images.
-
-### [Applied Configuration Replay Contracts](applied-config-replay-contracts.md)
-
-Implemented configuration-centric contract system that verifies strict JSON transport, public transform
-reconstruction, replay execution, exact output where declared, and non-default coverage for every public constructor
-parameter.
-
-### [Bounded 2D ElasticTransform](elastic-transform.md)
-
-Implemented contract for the greenfield 2D elastic transform: bounded cubic B-spline coefficient grids, synchronized
-targets, certificate-bounded keypoint inversion, and separate constructor, applied-config, and `ReplayCompose` persistence rules.
-
-### [ElasticTransform3D](elastic-transform3d.md)
-
-Implemented true 3D elastic deformation from compact orthogonal cubic control planes, one `remap3d` call per raster target,
-a native CPU Tensor route for one channel, and a measured NumPy bridge for multi-channel volumes.
-
-### [Generated Transform Target Contracts](transform-target-contracts.md)
-
-Coverage contract for the shared transform-case registry and reusable target profiles.
-
-### [Compose Serialization and Execution Tracing](compose-serialization-and-tracing.md)
-
-Canonical composition policy, JSON/YAML transport, and opt-in per-step trace paths, snapshots, and timing.
-
-## Compose Architecture
-
-### [Greenfield Compose Architecture](compose-greenfield-architecture.md)
-
-Execution architecture for compiling an immutable `Compose` graph at construction time so repeated training calls perform only
-sample-dependent work, with separate branch-free executors for ordinary, observed, trace, and replay routes.
-
-## Active Design Work
-
-### [Greenfield Pull-Request CI](pr-ci-greenfield.md)
-
-Plan for parallel pre-commit hook jobs, the complete 3 by 5 pull-request compatibility matrix, direct required contexts,
-local large-input evidence for performance-sensitive PRs, bounded release ASV evidence, and removal of Codecov and
-duplicated pull-request work.
-
-**Status**: Implemented.
-
-### [Greenfield Target-Specific Parameter Sampling](target-specific-parameter-sampling.md)
-
-Plan for replacing flat sampled-parameter dictionaries and special `volume_*` fields with parameters plus
-actual-target-key `TargetParams` records, including aliases, mixed representations, deterministic execution, and replay.
-
-**Status**: Implemented (greenfield cutover).
-
-The maintained sampler inventory is in [Target-Specific Sampling Inventory](target-specific-parameter-sampling-inventory.md).
-
-### [Shared CI Foundation](https://github.com/albumentations-team/ci-foundation/blob/main/docs/architecture.md)
-
-The public, SHA-pinned foundation owns Python and uv bootstrap, CPU-only Torch mechanics, and trusted Antigravity
-orchestration. AlbumentationsX keeps its dependency groups, test selection, release policy, legal checks, deployment,
-and project-specific review policy here.
-
-**Status**: Implemented. The local CI profile action and Antigravity caller pin ci-foundation commit
-6b9045dbea58026a1e8f96b0392c411934a27199.
-
-### [Greenfield Torch Dependency and CI Architecture](torch-dependency-and-ci-greenfield.md)
-
-Plan for keeping Torch out of package metadata while making every import-capable CI and documentation job request the
-shared CPU-only runtime profile explicitly.
-
-**Status**: Implemented. The repository uses explicit `none` and `torch-cpu` runtime profiles.
-
-### [NumPy and CPU Tensor Transform Routing](numpy-tensor-routing.md)
-
-Current contract for per-target container preservation, canonical NumPy/Tensor layouts, and transform-level Tensor
-fallback through the existing NumPy paths.
-
-**Status**: Implemented.
-
-## Creating New Design Documents
-
-When creating a new design document:
-
-1. Use the `.md` extension (standard Markdown)
-2. Include these sections:
-   - **Overview** - What is being designed
-   - **Problem Statement** - What problem it solves
-   - **Design Principles** - Core design decisions
-   - **Implementation** - Technical details
-   - **Testing Strategy** - How to validate
-   - **References** - External resources
-
-3. Add a reference to the new document in:
-   - This README
-   - `.codex/rules/albumentations-rules.md` (if relevant for Codex-facing guidance)
-
-4. Keep documents up-to-date as implementation evolves
-
-## Related Documentation
-
-- [Coding Guidelines](../contributing/coding_guidelines.md) - Code standards and best practices
-- [Environment Setup](../contributing/environment_setup.md) - Development environment
-- [Contributing Guide](../../CONTRIBUTING.md) - Contribution process
-- [AGENTS.md](../../AGENTS.md) - Codex guidelines
+Keep references aligned with implementation as it evolves. See [Coding Guidelines](../contributing/coding_guidelines.md),
+[Environment Setup](../contributing/environment_setup.md), and [Contributing](../../CONTRIBUTING.md) for routine work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "albumentationsx"
 
 version = "2.4.5"
 
-description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
+description = "Augmentation for images, volumes, masks, bounding boxes, and keypoints. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"
 keywords = [
   "2D augmentation",
@@ -19,9 +19,7 @@ keywords = [
 
   "autonomous driving",
   "bounding boxes",
-  # Core Computer Vision Tasks
   "classification",
-  # Technical Domains
   "computer vision",
   "computer vision library",
   "data augmentation",
@@ -33,13 +31,10 @@ keywords = [
 
   "depth estimation",
   "face recognition",
-  # Performance & Features
   "fast augmentation",
-  # Data Types & Processing
   "image augmentation",
   "image processing",
   "image transformation",
-  # Data Structures
   "images",
   "instance segmentation",
   "keras",
@@ -48,7 +43,6 @@ keywords = [
   "machine learning",
   "machine learning tools",
   "masks",
-  # Application Domains
   "medical imaging",
   "microscopy",
   "object counting",
@@ -56,9 +50,7 @@ keywords = [
   "optimized performance",
   "panoptic segmentation",
   "pose estimation",
-  # Development
   "python library",
-  # ML Frameworks
   "pytorch",
   "quality inspection",
 
@@ -86,20 +78,16 @@ authors = [ { name = "Vladimir Iglovikov" } ]
 requires-python = ">=3.10"
 
 classifiers = [
-  # Development Status
   "Development Status :: 5 - Production/Stable",
 
-  # Intended Audience
   "Intended Audience :: Developers",
-  "Intended Audience :: Healthcare Industry",    # valid for medical applications
+  "Intended Audience :: Healthcare Industry",
   "Intended Audience :: Information Technology",
 
   "Intended Audience :: Science/Research",
 
-  # Operating System
   "Operating System :: OS Independent",
 
-  # Python Versions
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -107,7 +95,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  # Topics - Scientific
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Scientific/Engineering :: Astronomy",
@@ -117,11 +104,9 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Image Processing",
   "Topic :: Scientific/Engineering :: Physics",
   "Topic :: Scientific/Engineering :: Visualization",
-  # Topics - Software Development
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Python Modules",
 
-  # Typing
   "Typing :: Typed",
 ]
 
@@ -253,13 +238,11 @@ exclude = [
 ]
 
 [tool.ruff]
-# Exclude a variety of commonly ignored directories.
 target-version = "py310"
 
 line-length = 120
 indent-width = 4
 
-# Assume Python 3.10
 exclude = [
   ".bzr",
   ".direnv",
@@ -292,12 +275,9 @@ exclude = [
 ]
 
 format.indent-style = "space"
-# Like Black, respect magic trailing commas.
 format.quote-style = "double"
-# Like Black, indent with spaces, rather than tabs.
 format.line-ending = "auto"
 format.skip-magic-trailing-comma = false
-# Like Black, automatically detect the appropriate line ending.
 lint.select = [ "ALL" ]
 lint.ignore = [
   "ANN001",
@@ -411,7 +391,6 @@ check_untyped_defs = true
 no_implicit_reexport = true
 disable_error_code = [ "valid-type" ]
 
-# for strict mypy: (this is the tricky one :-))
 disallow_untyped_defs = true
 
 # Strict checking for the instance-binding boundary modules so the StackedMasks4D NewType brand
@@ -453,14 +432,11 @@ project-excludes = [
 ]
 
 [tool.pydocstyle]
-# Allow fix for all enabled rules (when `--fix`) is provided.
 
 lint.explicit-preview-rules = true
 lint.fixable = [ "ALL" ]
 lint.unfixable = [  ]
-# Allow unused variables when underscore-prefixed.
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-# Like Black, use double quotes for strings.
 lint.pydocstyle.convention = "google"
 lint.pydocstyle.ignore-magic-methods = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "albumentationsx"
 
 version = "2.4.5"
 
-description = "Augmentation for images, volumes, masks, bounding boxes, and keypoints. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
+description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"
 keywords = [
   "2D augmentation",

--- a/tests/functional/test_affine.py
+++ b/tests/functional/test_affine.py
@@ -11,7 +11,6 @@ import albumentations.augmentations.geometric.functional as fgeometric
 from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 from tests.conftest import SQUARE_UINT8_IMAGE
 
-# Define your parameter sets
 image_shapes = [
     (100, 100, 1),
     (100, 100, 2),
@@ -190,7 +189,6 @@ def test_keypoint_affine(keypoint, expected, angle, scale, dx, dy):
     height, width = 100, 200
     center = fgeometric.center((height, width))
 
-    # Create forward transformation matrix
     forward_matrix = fgeometric.create_affine_transformation_matrix(
         translate={"x": dx * width, "y": dy * height},
         shear={"x": 0, "y": 0},

--- a/tests/functional/test_blur.py
+++ b/tests/functional/test_blur.py
@@ -35,9 +35,7 @@ def test_sample_odd_from_range(low: int, high: int, expected_range: set[int]):
     for _ in range(50):  # Sample multiple times to get all possible values
         value = fblur.sample_odd_from_range(random_state, low, high)
         results.add(value)
-        # Verify each value is odd
         assert value % 2 == 1
-        # Verify value is >= 3
         assert value >= 3
 
     assert results == expected_range, f"Failed for low={low}, high={high}"
@@ -56,7 +54,6 @@ def create_reference_gaussian_kernel(sigma: float) -> np.ndarray:
 
     # Normalize 1D kernel
     kernel = np.array(kernel) / np.sum(kernel)
-    # Create 2D kernel
     return kernel[:, np.newaxis] @ kernel[np.newaxis, :]
 
 

--- a/tests/functional/test_dropout.py
+++ b/tests/functional/test_dropout.py
@@ -22,7 +22,6 @@ from tests.utils import set_seed
 )
 def test_label_function(shape, dtype, connectivity):
     set_seed(137)
-    # Generate a random binary mask
     mask = np.random.randint(0, 2, shape).astype(dtype)
 
     # Compare results with scikit-image
@@ -158,7 +157,16 @@ def test_cutout_with_random_fills(img_shape, fill):
     holes = np.array([[2, 2, 5, 5]])
     generator = np.random.default_rng(137)
 
-    fdropout.cutout(img, holes, fill, generator)
+    result = fdropout.cutout(img, holes, fill, generator)
+    filled_pixels = result[2:5, 2:5].reshape(-1, img_shape[-1])
+    assert np.any(filled_pixels != 0)
+    if fill == "random_uniform":
+        np.testing.assert_array_equal(filled_pixels, np.broadcast_to(filled_pixels[0], filled_pixels.shape))
+    else:
+        assert len(np.unique(filled_pixels, axis=0)) > 1
+    outside_hole = np.ones(img_shape[:2], dtype=bool)
+    outside_hole[2:5, 2:5] = False
+    np.testing.assert_array_equal(result[outside_hole], 0)
 
 
 @pytest.mark.parametrize(
@@ -730,7 +738,6 @@ def test_sample_points_from_components_multiple_components(mask, num_points, exp
 
     points, sizes = result
 
-    # Check basic shapes
     assert len(points) == expected["num_points"]
     assert len(sizes) == expected["num_points"]
     assert points.shape[1] == 2  # (x, y) coordinates

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -184,7 +184,6 @@ def test_scale(target):
 @pytest.mark.parametrize("target", ["image", "mask"])
 def test_scale_downscale(target):
     """Test downscaling with INTER_AREA (best for downscaling)."""
-    # Create a 10x10 image with distinct values
     img = np.arange(100, dtype=np.uint8).reshape(10, 10)
 
     img = convert_2d_to_target_format([img], target=target)
@@ -196,7 +195,6 @@ def test_scale_downscale(target):
     assert scaled.shape[0] == 5
     assert scaled.shape[1] == 5
 
-    # Verify dtype is preserved
     assert scaled.dtype == np.uint8
 
 
@@ -383,7 +381,6 @@ def test_solarize_value_range_property():
     )
     @settings(max_examples=50, deadline=3000)
     def property_test(dtype, shape, threshold):
-        # Generate appropriate data for dtype
         if dtype == np.uint8:
             image = np.random.randint(0, 256, shape, dtype=np.uint8)
         else:
@@ -495,10 +492,8 @@ def test_equalize_uniform_image():
     When the image has a uniform histogram (all pixels same value),
     equalization should return the image unchanged (identity LUT).
     """
-    # Create uniform image (all pixels same value)
     uniform_img = np.full((100, 100, 1), 128, dtype=np.uint8)
 
-    # Apply equalize
     result = fpixel.equalize(uniform_img, mode="cv")
 
     # Should be unchanged (identity operation)
@@ -822,7 +817,6 @@ def test_planckian_jitter_cied():
 
 @pytest.mark.parametrize("mode", ["blackbody", "cied"])
 def test_planckian_jitter_edge_cases(mode):
-    # Create a sample image
     img = np.ones((10, 10, 3), dtype=np.float32)
 
     # Get min and max temperatures for the mode
@@ -1507,7 +1501,6 @@ def test_prepare_drop_values(array, value, expected_shape, expected_dtype, expec
     rng = np.random.default_rng(42)
     result = fpixel.prepare_drop_values(array, value, rng)
 
-    # Check shape and dtype
     assert result.shape == expected_shape
     assert result.dtype == expected_dtype
 
@@ -1601,10 +1594,8 @@ def test_get_drop_mask_shapes_and_properties(
     rng = np.random.default_rng(42)
     mask = fpixel.get_drop_mask(shape, per_channel, dropout_prob, rng)
 
-    # Check shape
     assert mask.shape == expected_shape
 
-    # Check dtype
     assert mask.dtype == bool
 
     # Check if mask is 2D or 3D
@@ -1662,7 +1653,6 @@ def test_get_drop_mask_reproducibility():
 
 def test_pixel_dropout_sequence_per_channel():
     """Test pixel dropout with sequence values and per_channel=True"""
-    # Setup
     image = np.ones((10, 10, 3), dtype=np.uint8) * 255
     drop_values = (1, 2, 3)
 
@@ -1679,7 +1669,6 @@ def test_pixel_dropout_sequence_per_channel():
     # Verify prepared_values shape matches image
     assert prepared_values.shape == image.shape
 
-    # Apply dropout
     result = fpixel.pixel_dropout(image, drop_mask, prepared_values)
 
     # Each channel should be entirely filled with its corresponding value
@@ -2141,7 +2130,6 @@ def test_create_contrast_lut(
     if len(hist) < 256:
         hist = np.pad(hist, (0, 256 - len(hist)))
 
-    # Generate LUT
     lut = fpixel.create_contrast_lut(
         hist=hist,
         min_intensity=min_intensity,
@@ -2533,10 +2521,8 @@ def test_create_corner_illumination_gradient_zero_intensity_returns_ones():
 )
 def test_corner_illumination_brightest_point(corner, intensity, expected_corner):
     """Test that the illumination pattern has maximum intensity at the correct corner."""
-    # Create a constant test image
     image = np.full((10, 10), 0.5, dtype=np.float32)
 
-    # Apply corner illumination
     result = fpixel.apply_corner_illumination(image, intensity, corner)
 
     # Find the brightest point
@@ -2557,12 +2543,10 @@ def test_corner_illumination_brightest_point(corner, intensity, expected_corner)
 )
 def test_corner_illumination_preserves_shape_and_type(shape, dtype):
     """Test that the output maintains the input shape and dtype."""
-    # Create test image
     image = np.ones(shape, dtype=dtype)
     if dtype == np.uint8:
         image *= 255
 
-    # Apply corner illumination
     result = fpixel.apply_corner_illumination(image, intensity=0.2, corner=0)
 
     assert result.shape == shape
@@ -2572,11 +2556,9 @@ def test_corner_illumination_preserves_shape_and_type(shape, dtype):
 @pytest.mark.parametrize("intensity", [-0.2, 0, 0.2])
 def test_corner_illumination_intensity_range(intensity):
     """Test that the output values stay within valid range."""
-    # Create test images with extreme values
     image_zeros = np.zeros((10, 10), dtype=np.float32)
     image_ones = np.ones((10, 10), dtype=np.float32)
 
-    # Apply corner illumination
     result_zeros = fpixel.apply_corner_illumination(image_zeros, intensity, corner=0)
     result_ones = fpixel.apply_corner_illumination(image_ones, intensity, corner=0)
 
@@ -2589,10 +2571,8 @@ def test_corner_illumination_intensity_range(intensity):
 
 def test_corner_illumination_identity_zero_intensity():
     """Test that zero intensity returns the input image unchanged."""
-    # Create random test image
     image = np.random.rand(10, 10).astype(np.float32)
 
-    # Apply corner illumination with zero intensity
     result = fpixel.apply_corner_illumination(image, intensity=0, corner=0)
 
     np.testing.assert_array_almost_equal(result, image, decimal=2)
@@ -2601,10 +2581,8 @@ def test_corner_illumination_identity_zero_intensity():
 @pytest.mark.parametrize("corner", [0, 1, 2, 3])
 def test_corner_illumination_symmetry(corner):
     """Test that the illumination pattern is symmetric around the corner."""
-    # Create test image
     image = np.ones((11, 11), dtype=np.float32)  # Odd dimensions for clear center
 
-    # Apply corner illumination
     result = fpixel.apply_corner_illumination(image, intensity=0.2, corner=corner)
 
     # Get distances from corner to test symmetry
@@ -2626,13 +2604,10 @@ def test_corner_illumination_symmetry(corner):
 
 def test_corner_illumination_multichannel_consistency():
     """Test that all channels are modified identically for RGB images."""
-    # Create RGB test image
     image = np.ones((10, 10, 3), dtype=np.float32)
 
-    # Apply corner illumination
     result = fpixel.apply_corner_illumination(image, intensity=0.2, corner=0)
 
-    # Check that all channels are identical
     np.testing.assert_array_almost_equal(result[..., 0], result[..., 1])
     np.testing.assert_array_almost_equal(result[..., 1], result[..., 2])
 
@@ -2655,10 +2630,8 @@ def test_corner_illumination_multichannel_consistency():
 )
 def test_gaussian_illumination_brightest_point(center, intensity, sigma, expected_brightest):
     """Test that the brightest point is at the expected location."""
-    # Create a constant test image
     image = np.full((10, 10), 0.5, dtype=np.float32)
 
-    # Apply gaussian illumination
     result = fpixel.apply_gaussian_illumination(image, intensity, center, sigma)
 
     # Find the brightest point
@@ -2678,7 +2651,6 @@ def test_gaussian_illumination_brightest_point(center, intensity, sigma, expecte
 )
 def test_gaussian_illumination_preserves_shape_and_type(shape, dtype):
     """Test that output maintains input shape and dtype."""
-    # Create test image
     image = np.ones(shape, dtype=dtype)
     if dtype == np.uint8:
         image *= 255
@@ -2768,7 +2740,6 @@ def test_gaussian_illumination_multichannel_consistency(intensity):
         sigma=0.25,
     )
 
-    # Check that all channels are identical
     np.testing.assert_allclose(result[..., 0], result[..., 1], rtol=1e-5, atol=1e-8, equal_nan=False)
     np.testing.assert_allclose(result[..., 1], result[..., 2], rtol=1e-5, atol=1e-8, equal_nan=False)
 
@@ -3008,7 +2979,6 @@ def test_add_rain_preserves_input():
 )
 def test_rain_params_shapes(shape, color, intensity, expected_shape):
     """Test that output shapes are correct for different input configurations."""
-    # Generate random liquid layer
     liquid_layer = np.random.normal(0.65, 0.3, size=shape)
 
     result = fpixel.get_rain_params(liquid_layer, color, intensity)
@@ -3175,14 +3145,6 @@ def test_mud_params_intensity_and_color(intensity, color, cutout_threshold):
     expected_max = intensity * max_color
     expected_min = 0.8 * expected_max  # Allow 20% tolerance for numerical effects
 
-    # Add diagnostic information
-    if max_effect < expected_min:
-        # Calculate percentage of non-zero mud pixels
-        np.mean(result["mud"] > 0)
-
-        # Show distribution of non-zero mud values
-        result["mud"][result["mud"] > 0]
-
     if max_color > 0:
         assert max_effect >= expected_min, (
             f"Maximum effect ({max_effect:.3f}) is less than expected minimum ({expected_min:.3f}) "
@@ -3293,11 +3255,9 @@ def test_simple_nmf_shape(height, width, n_iter, random_state):
     nmf = fpixel.SimpleNMF(n_iter=n_iter)
     concentrations, colors = nmf.fit_transform(od)
 
-    # Check shapes
     assert concentrations.shape == (height * width, 2)
     assert colors.shape == (2, 3)
 
-    # Check non-negativity
     assert np.all(concentrations >= 0)
     assert np.all(colors >= 0)
 
@@ -3371,7 +3331,6 @@ def synthetic_he_image():
     h_concentration[:20, :20] = 0
     e_concentration[:20, :20] = 0
 
-    # Create image
     concentrations = np.stack([h_concentration, e_concentration], axis=-1)
     optical_density = np.dot(concentrations, stain_matrix)
     img = np.exp(-optical_density) * 255
@@ -3541,10 +3500,8 @@ def test_white_pixels_remain_white_with_saturation_increase(sat_shift, descripti
     This test verifies that increasing saturation doesn't affect white pixels,
     which should remain white regardless of saturation changes.
     """
-    # Create a simple test image with white pixels (255, 255, 255)
     white_image = np.ones((10, 10, 3), dtype=np.uint8) * 255
 
-    # Apply saturation increase
     result = fpixel.shift_hsv(white_image, hue_shift=0, sat_shift=sat_shift, val_shift=0)
 
     # Check that all pixels are still white (255, 255, 255)
@@ -3561,7 +3518,6 @@ def test_white_pixels_remain_white_with_saturation_increase(sat_shift, descripti
 )
 def test_white_pixels_in_mixed_images(image_type, sat_shift):
     """Test that white pixels in mixed images remain white when saturation is increased."""
-    # Create different test images
     if image_type == "white_and_gray":
         # White and gray image
         image = np.ones((10, 10, 3), dtype=np.uint8) * 255
@@ -3579,7 +3535,6 @@ def test_white_pixels_in_mixed_images(image_type, sat_shift):
     # Store original white pixels for comparison
     white_mask = np.all(image == 255, axis=2)
 
-    # Apply saturation increase
     result = fpixel.shift_hsv(image, hue_shift=0, sat_shift=sat_shift, val_shift=0)
 
     # Check that white pixels remain white (vectorized)
@@ -3610,7 +3565,6 @@ def test_white_pixels_in_mixed_images(image_type, sat_shift):
 
 def test_grayscale_image_with_saturation():
     """Test that grayscale images are handled correctly with saturation changes."""
-    # Create a grayscale image
     gray_image = np.ones((10, 10, 1), dtype=np.uint8) * 128
 
     # Apply saturation increase (should be ignored for grayscale)
@@ -3635,10 +3589,8 @@ def test_gray_pixels_remain_gray_with_saturation_increase(gray_value, sat_shift)
     This test verifies that increasing saturation doesn't affect gray pixels,
     which should remain gray regardless of saturation changes.
     """
-    # Create a simple test image with gray pixels
     gray_image = np.ones((10, 10, 3), dtype=np.uint8) * gray_value
 
-    # Apply saturation increase
     result = fpixel.shift_hsv(gray_image, hue_shift=0, sat_shift=sat_shift, val_shift=0)
 
     # Check that all pixels are still the same gray value
@@ -3659,7 +3611,6 @@ def test_gray_pixels_remain_gray_with_saturation_increase(gray_value, sat_shift)
 )
 def test_gray_pixels_in_mixed_images(image_type, sat_shift):
     """Test that gray pixels in mixed images remain gray when saturation is increased."""
-    # Create different test images
     if image_type == "gray_and_color":
         # Gray and colored image
         image = np.ones((10, 10, 3), dtype=np.uint8) * 128  # Medium gray
@@ -3676,7 +3627,6 @@ def test_gray_pixels_in_mixed_images(image_type, sat_shift):
     # Store original values for comparison
     original_values = image.copy()
 
-    # Apply saturation increase
     result = fpixel.shift_hsv(image, hue_shift=0, sat_shift=sat_shift, val_shift=0)
 
     # Check that gray pixels remain unchanged (vectorized)
@@ -3739,7 +3689,6 @@ def test_gray_pixels_in_mixed_images(image_type, sat_shift):
 )
 def test_to_gray_preserves_original_image(shape, dtype, method, num_output_channels):
     """Test that to_gray doesn't modify the original image."""
-    # Create test image
     if dtype == np.uint8:
         original_img = np.random.randint(0, 256, shape, dtype=dtype)
     else:
@@ -3748,7 +3697,6 @@ def test_to_gray_preserves_original_image(shape, dtype, method, num_output_chann
     # Make a copy for comparison
     img_copy = original_img.copy()
 
-    # Apply to_gray
     result = fpixel.to_gray(original_img, num_output_channels, method)
 
     # Check that original image is unchanged
@@ -3790,13 +3738,10 @@ def test_to_gray_preserves_original_image(shape, dtype, method, num_output_chann
 )
 def test_grayscale_to_multichannel_output_channels(input_shape, num_output_channels, expected_shape):
     """Test that grayscale_to_multichannel returns correct number of channels."""
-    # Create grayscale image
     grayscale_img = np.random.random(input_shape).astype(np.float32)
 
-    # Apply grayscale_to_multichannel
     result = fpixel.grayscale_to_multichannel(grayscale_img, num_output_channels)
 
-    # Check output shape
     assert result.shape == expected_shape, f"Expected shape {expected_shape}, got {result.shape}"
 
     # Check that all channels have the same values (replicated from grayscale)
@@ -3822,7 +3767,6 @@ def test_grayscale_to_multichannel_output_channels(input_shape, num_output_chann
 )
 def test_to_gray_all_methods_consistency(method):
     """Test that all to_gray methods produce valid grayscale images."""
-    # Create test images
     rgb_img_uint8 = np.random.randint(0, 256, (50, 50, 3), dtype=np.uint8)
     rgb_img_float32 = rgb_img_uint8.astype(np.float32) / 255.0
 
@@ -3830,11 +3774,9 @@ def test_to_gray_all_methods_consistency(method):
     gray_uint8 = fpixel.to_gray(rgb_img_uint8, 1, method)
     gray_float32 = fpixel.to_gray(rgb_img_float32, 1, method)
 
-    # Check shapes
     assert gray_uint8.shape == (50, 50), f"Incorrect shape for uint8 with method={method}"
     assert gray_float32.shape == (50, 50), f"Incorrect shape for float32 with method={method}"
 
-    # Check dtypes
     assert gray_uint8.dtype == np.uint8, f"Incorrect dtype for uint8 with method={method}"
     assert gray_float32.dtype == np.float32, f"Incorrect dtype for float32 with method={method}"
 
@@ -3850,7 +3792,6 @@ def test_to_gray_all_methods_consistency(method):
     assert gray_multi_uint8.shape == (50, 50, 3), f"Incorrect multi-channel shape for uint8 with method={method}"
     assert gray_multi_float32.shape == (50, 50, 3), f"Incorrect multi-channel shape for float32 with method={method}"
 
-    # Check that all channels are identical
     for i in range(1, 3):
         np.testing.assert_array_equal(
             gray_multi_uint8[..., 0],
@@ -3866,7 +3807,6 @@ def test_to_gray_all_methods_consistency(method):
 
 def test_grayscale_to_multichannel_preserves_values():
     """Test that grayscale_to_multichannel preserves original grayscale values."""
-    # Create test grayscale images
     gray_2d = np.array([[0, 128, 255], [64, 192, 32]], dtype=np.uint8)
     gray_3d = gray_2d[..., np.newaxis]
 
@@ -3891,13 +3831,11 @@ def test_grayscale_to_multichannel_preserves_values():
 
 def test_grayscale_to_multichannel_float_values():
     """Test grayscale_to_multichannel with float values."""
-    # Create float grayscale image
     gray_float = np.array([[0.0, 0.5, 1.0], [0.25, 0.75, 0.1]], dtype=np.float32)
 
     # Test with 3 channels
     result = fpixel.grayscale_to_multichannel(gray_float, 3)
 
-    # Check shape and values
     assert result.shape == (2, 3, 3)
     assert result.dtype == np.float32
 

--- a/tests/functional/test_geometric.py
+++ b/tests/functional/test_geometric.py
@@ -425,7 +425,6 @@ def test_create_piecewise_affine_maps_bounds(
     assert map_x is not None and map_y is not None
     height, width = image_shape
 
-    # Check bounds
     assert np.all(map_x >= 0)
     assert np.all(map_x <= width - 1)
     assert np.all(map_y >= 0)
@@ -721,7 +720,6 @@ def test_create_piecewise_affine_maps_grid_points(
 
 def test_pad_with_params_zero_channels():
     """Test that padding works correctly with 0-channel images."""
-    # Create a 0-channel image
     img = np.zeros((10, 10, 0), dtype=np.uint8)
 
     result = fgeometric.pad_with_params(
@@ -734,7 +732,6 @@ def test_pad_with_params_zero_channels():
         value=0,
     )
 
-    # Check result shape
     assert result.shape == (15, 19, 0)  # 10+2+3, 10+4+5, 0
     assert result.dtype == np.uint8
     assert result.size == 0
@@ -822,7 +819,6 @@ def test_resize_pil_with_cv2_interpolation_constants(input_shape, target_shape, 
     # This should not raise an error
     resized = fgeometric.resize_pil(img, target_shape, interpolation=interpolation)
 
-    # Check output shape
     assert resized.shape[:2] == target_shape
     assert resized.shape[2] == 3
     assert resized.dtype == np.uint8

--- a/tests/functional/test_mixing.py
+++ b/tests/functional/test_mixing.py
@@ -543,7 +543,6 @@ def items_list_geom(base_item_geom, small_item_geom) -> list[dict[str, Any]]:
 
 def test_process_all_geometry_identity(base_item_geom) -> None:
     """Test process_all for a single cell identity case."""
-    # Setup: Map the placement directly to the item index
     placement_to_item_index = {(0, 0, 100, 100): 0}
     final_items = [base_item_geom]
     canvas_shape = (100, 100)  # Added canvas_shape
@@ -575,7 +574,6 @@ def test_process_all_geometry_identity(base_item_geom) -> None:
 
 def test_process_all_geometry_crop(base_item_geom) -> None:
     """Test process_all for a single cell requiring cropping."""
-    # Setup: Map the placement directly to the item index
     placement_to_item_index = {(10, 20, 60, 80): 0}  # Placement is 50x60 within 80x60 canvas
     final_items = [base_item_geom]  # Item is 100x100
     canvas_shape = (80, 60)  # Added canvas_shape (height, width)
@@ -602,7 +600,6 @@ def test_process_all_geometry_crop(base_item_geom) -> None:
 
 def test_process_all_geometry_pad(small_item_geom) -> None:
     """Test process_all for a single cell requiring padding."""
-    # Setup: Map the placement directly to the item index
     placement_to_item_index = {(0, 0, 80, 70): 0}  # Placement 80x70
     final_items = [small_item_geom]  # Item is 50x50
     fill_value = 111
@@ -655,7 +652,6 @@ def test_process_all_geometry_pad(small_item_geom) -> None:
 
 def test_process_all_geometry_multiple_cells(items_list_geom) -> None:
     """Test process_all processing two different items for two cells."""
-    # Setup: Map placements directly to item indices
     placement_to_item_index = {
         (0, 0, 50, 50): 0,  # Crop base_item_geom (idx 0) to 50x50
         (50, 0, 110, 60): 1,  # Pad small_item_geom (idx 1) to 60x60
@@ -829,7 +825,6 @@ def test_assemble_multiple_non_overlapping(processed_cell_data_1, processed_cell
 
 
 def test_preprocess_selected_mosaic_items_basic():
-    # Setup processors
     bbox_processor = BboxProcessor(BboxParams(coord_format="pascal_voc", label_fields=["class_labels"]))
     keypoint_processor = KeypointsProcessor(KeypointParams(coord_format="xy", label_fields=["kp_labels"]))
 
@@ -913,11 +908,9 @@ def test_preprocess_selected_mosaic_items_basic():
 
 
 def test_preprocess_selected_mosaic_items_missing_data():
-    # Setup processors
     bbox_processor = BboxProcessor(BboxParams(coord_format="pascal_voc", label_fields=["class_labels"]))
     keypoint_processor = KeypointsProcessor(KeypointParams(coord_format="xy", label_fields=["kp_labels"]))
 
-    # Setup input data items
     item_bbox_only = {
         "image": np.zeros((50, 50, 3), dtype=np.uint8),
         "bboxes": np.array([[10, 10, 20, 20]], dtype=np.float32),

--- a/tests/test_apply_to_masks.py
+++ b/tests/test_apply_to_masks.py
@@ -21,7 +21,6 @@ def test_crop_apply_to_mask_single(transform_class, init_params, expected_shape,
     transform = transform_class(**init_params, p=1.0)
     mask = np.random.randint(0, 2, mask_shape, dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((100, 120, 3), dtype=np.uint8), mask=mask)
 
@@ -34,10 +33,8 @@ def test_crop_apply_to_mask_single(transform_class, init_params, expected_shape,
 def test_crop_apply_to_mask_empty_channels():
     """Test that apply_to_mask handles empty channel dimension correctly."""
     transform = A.Crop(x_min=10, y_min=10, x_max=60, y_max=60, p=1.0)
-    # Create mask with 0 channels (empty)
     mask = np.empty((100, 100, 0), dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((100, 100, 3), dtype=np.uint8), mask=mask)
 
@@ -68,7 +65,6 @@ def test_crop_apply_to_masks_batch(transform_class, init_params, expected_shape,
 
     masks = np.random.randint(0, 2, masks_shape, dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((100, 120, 3), dtype=np.uint8), masks=masks)
 
@@ -82,10 +78,8 @@ def test_crop_apply_to_masks_batch(transform_class, init_params, expected_shape,
 def test_crop_apply_to_masks_empty_batch():
     """Test that apply_to_masks handles empty batch correctly."""
     transform = A.Crop(x_min=10, y_min=10, x_max=60, y_max=60, p=1.0)
-    # Create empty batch of masks
     masks = np.empty((0, 100, 100), dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((100, 100, 3), dtype=np.uint8), masks=masks)
 
@@ -97,10 +91,8 @@ def test_crop_apply_to_masks_empty_batch():
 def test_crop_apply_to_masks_empty_batch_with_channels():
     """Test that apply_to_masks handles empty batch with channels correctly."""
     transform = A.Crop(x_min=10, y_min=10, x_max=60, y_max=60, p=1.0)
-    # Create empty batch of masks with channels
     masks = np.empty((0, 100, 100, 3), dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((100, 100, 3), dtype=np.uint8), masks=masks)
 
@@ -117,7 +109,6 @@ def test_flip_apply_to_mask_single(transform_class, mask_shape):
     transform = transform_class(p=1.0)
     mask = np.random.randint(0, 2, mask_shape, dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((80, 120, 3), dtype=np.uint8), mask=mask)
 
@@ -138,10 +129,8 @@ def test_flip_apply_to_mask_empty_channels():
     """Test that HorizontalFlip and VerticalFlip handle empty channel dimension correctly."""
     for transform_class in [A.HorizontalFlip, A.VerticalFlip]:
         transform = transform_class(p=1.0)
-        # Create mask with 0 channels (empty)
         mask = np.empty((80, 120, 0), dtype=np.uint8)
 
-        # Apply the transform through Compose
         aug = A.Compose([transform])
         result = aug(image=np.zeros((80, 120, 3), dtype=np.uint8), mask=mask)
 
@@ -178,7 +167,6 @@ def test_flip_apply_to_masks_batch(transform_class, num_masks, channels):
 
     masks = np.random.randint(0, 2, masks_shape, dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((80, 120, 3), dtype=np.uint8), masks=masks)
 
@@ -196,10 +184,8 @@ def test_flip_apply_to_masks_empty_batch():
     """Test that HorizontalFlip and VerticalFlip handle empty batch correctly."""
     for transform_class in [A.HorizontalFlip, A.VerticalFlip]:
         transform = transform_class(p=1.0)
-        # Create empty batch of masks
         masks = np.empty((0, 80, 120), dtype=np.uint8)
 
-        # Apply the transform through Compose
         aug = A.Compose([transform])
         result = aug(image=np.zeros((80, 120, 3), dtype=np.uint8), masks=masks)
 
@@ -322,14 +308,11 @@ def test_d4_empty_mask3d_dimension_handling(group_element, expected_swap):
 def test_crop_apply_to_mask3d_empty():
     """Test that apply_to_mask3d handles empty mask correctly."""
     transform = A.Crop(x_min=10, y_min=10, x_max=60, y_max=60, p=1.0)
-    # Create empty mask3d (0 depth)
     mask3d = np.empty((0, 100, 100), dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((100, 100, 3), dtype=np.uint8), mask3d=mask3d)
 
-    # Check correct shape
     assert result["mask3d"].shape == (0, 50, 50)
     assert result["mask3d"].dtype == np.uint8
 
@@ -342,7 +325,6 @@ def test_flip_apply_to_mask3d(transform_class):
     # mask3d has shape (D, H, W)
     mask3d = np.random.randint(0, 2, (10, 100, 100), dtype=np.uint8)
 
-    # Apply the transform through Compose
     aug = A.Compose([transform])
     result = aug(image=np.zeros((100, 100, 3), dtype=np.uint8), mask3d=mask3d)
 
@@ -357,14 +339,11 @@ def test_flip_apply_to_mask3d_empty():
     """Test that HorizontalFlip and VerticalFlip handle empty mask3d correctly."""
     for transform_class in [A.HorizontalFlip, A.VerticalFlip]:
         transform = transform_class(p=1.0)
-        # Create empty mask3d (0 depth)
         mask3d = np.empty((0, 80, 120), dtype=np.uint8)
 
-        # Apply the transform through Compose
         aug = A.Compose([transform])
         result = aug(image=np.zeros((80, 120, 3), dtype=np.uint8), mask3d=mask3d)
 
-        # Check correct shape
         assert result["mask3d"].shape == (0, 80, 120)
         assert result["mask3d"].dtype == np.uint8
 

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1089,11 +1089,9 @@ def test_image_only_transforms_apply_to_volume(transform_cls, kwargs, dtype):
 
 def test_constrained_coarse_dropout_with_mask():
     """Test ConstrainedCoarseDropout with segmentation mask."""
-    # Create test data
     image = np.zeros((100, 100, 3), dtype=np.uint8)
     mask = np.zeros((100, 100, 1), dtype=np.uint8)
 
-    # Create objects in mask
     mask[10:30, 10:30] = 1  # First object (class 1)
     mask[40:60, 40:60] = 2  # Second object (class 2)
     mask[70:90, 70:90] = 2  # Third object (class 2)
@@ -1107,7 +1105,6 @@ def test_constrained_coarse_dropout_with_mask():
     )
     transform.set_random_seed(137)
 
-    # Apply transform
     _ = transform(image=image, mask=mask)
 
     # Get holes
@@ -1175,7 +1172,6 @@ def test_constrained_coarse_dropout_with_bboxes(bbox_labels, bboxes, expected_nu
     labels = [bbox[4] for bbox in bboxes]
     bboxes_without_labels = [bbox[:4] for bbox in bboxes]
 
-    # Apply transform
     transform(image=image, bboxes=bboxes_without_labels, class_labels=labels)
 
     holes = get_resolved_applied_params(ccd)["holes"]
@@ -1325,7 +1321,6 @@ def test_pixel_dropout_preserves_empty_targets(target: str, shape: tuple[int, ..
 )
 def test_pixel_dropout_mismatched_tuple_dimensions(drop_value, channels, expected_values):
     """Test that PixelDropout handles mismatched tuple dimensions correctly."""
-    # Create image with specified number of channels
     shape = (10, 10, channels) if channels > 1 else (10, 10)
     image = np.ones(shape, dtype=np.uint8) * 128
 
@@ -1333,7 +1328,6 @@ def test_pixel_dropout_mismatched_tuple_dimensions(drop_value, channels, expecte
     transform = A.PixelDropout(dropout_prob=1.0, drop_value=drop_value, p=1.0)
     result = transform(image=image)["image"]
 
-    # Check shape is preserved
     assert result.shape == image.shape
 
     # Check values are as expected
@@ -1535,7 +1529,6 @@ def test_salt_and_pepper_noise():
     )
     transform.set_random_seed(137)
 
-    # Apply transform
     transformed = transform(image=image)["image"]
 
     # Count all changes
@@ -1600,7 +1593,6 @@ def test_salt_and_pepper_grayscale():
 
     transformed = transform(image=image)["image"]
 
-    # Verify shape is preserved
     assert transformed.shape == image.shape, "Transform should preserve single-channel image shape"
 
     # Check noise values
@@ -1620,7 +1612,6 @@ def test_salt_and_pepper_grayscale():
     ],
 )
 def test_random_rain_slant(slant_range, expected_slant_range):
-    # Create a deterministic image
     image = np.zeros((100, 100, 3), dtype=np.uint8)
 
     # Create transform with 100% probability and specific slant range
@@ -1660,7 +1651,6 @@ def test_random_rain_slant(slant_range, expected_slant_range):
 
 @pytest.mark.parametrize("slant", [-10, 0, 10])
 def test_random_rain_visual_effect(slant):
-    # Create a white image
     image = np.full((100, 100, 3), 255, dtype=np.uint8)
 
     # Create transform with fixed slant for visual verification
@@ -1677,7 +1667,6 @@ def test_random_rain_visual_effect(slant):
 
     transform.set_random_seed(137)
 
-    # Apply transform
     result = transform(image=image)["image"]
 
     # Find non-white pixels (rain drops)

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1318,7 +1318,6 @@ def test_crop_boxes_replay_compose() -> None:
 
 def test_bounding_box_partially_outside_no_clip() -> None:
     """Test error is raised when bounding box exceeds image boundaries without clipping."""
-    # Define a transformation with NoOp
     transform = Compose(
         [NoOp()],
         bbox_params={"coord_format": "pascal_voc", "label_fields": ["labels"]},
@@ -2245,10 +2244,8 @@ def test_bboxes_to_mask(test_case):
 
     masks = bboxes_to_mask(bboxes, image_shape)
 
-    # Check shape
     assert masks.shape == expected_shape
 
-    # Check dtype
     assert masks.dtype == np.uint8
 
     # Check if masks are binary
@@ -2326,7 +2323,6 @@ def test_mask_to_bboxes(test_case):
 
     result = mask_to_bboxes(masks, original_bboxes, bbox_type="hbb")
 
-    # Check shape and values
     assert result.shape == expected_bboxes.shape
     np.testing.assert_array_equal(result, expected_bboxes)
 
@@ -3058,7 +3054,6 @@ def test_resize_boxes_to_visible_area_removes_fully_covered_boxes():
     # Update boxes using the function
     updated_boxes = resize_boxes_to_visible_area(boxes, hole_mask)
 
-    # Assertions
     assert len(updated_boxes) == 1, "Should remove fully covered boxes"
     assert updated_boxes.shape == (1, 6), "Should preserve the shape with correct number of columns"
 
@@ -3085,7 +3080,6 @@ def test_resize_boxes_to_visible_area_with_partially_covered_boxes():
     # Update boxes using the function
     updated_boxes = resize_boxes_to_visible_area(boxes, hole_mask)
 
-    # Assertions
     assert len(updated_boxes) == 1, "Should keep partially covered boxes"
     assert updated_boxes.shape == (1, 6), "Should preserve the shape with correct number of columns"
     assert updated_boxes[0, 0] > boxes[0, 0], "X min should increase (left part covered)"
@@ -3111,7 +3105,6 @@ def test_resize_boxes_to_visible_area_with_all_boxes_covered():
     # Update boxes using the function
     updated_boxes = resize_boxes_to_visible_area(boxes, hole_mask)
 
-    # Assertions
     assert len(updated_boxes) == 0, "Should return empty array when all boxes are covered"
     assert updated_boxes.shape == (0, 6), "Empty array should have correct shape with all columns"
 
@@ -3125,7 +3118,6 @@ def test_resize_boxes_to_visible_area_with_empty_input():
     # Update boxes using the function
     updated_boxes = resize_boxes_to_visible_area(boxes, hole_mask)
 
-    # Assertions
     assert len(updated_boxes) == 0, "Should return empty array"
     assert updated_boxes.shape == (0, 6), "Should preserve the shape with correct number of columns"
 
@@ -3327,10 +3319,8 @@ def test_clip_bboxes_geometry_obb_with_extra_columns():
 
     result = clip_bboxes_geometry(bboxes, shape, bbox_type)
 
-    # Check shape preserved
     assert result.shape == bboxes.shape
 
-    # Check extra columns preserved
     assert result[0, 5] == 1.0
     assert result[0, 6] == 2.0
     assert result[1, 5] == 3.0

--- a/tests/test_compose_operators.py
+++ b/tests/test_compose_operators.py
@@ -69,11 +69,9 @@ def test_compose_add_single_transform_equivalence(
     # Base compose kwargs (no seed during init)
     compose_kwargs = {"p": 1.0}
 
-    # Create fresh instances for base compose
     base_transforms = [cls(p=1.0) for cls in base_transform_classes]
     base_compose = compose_class(base_transforms, **compose_kwargs)
 
-    # Create fresh instances for expected compose
     expected_transforms = [cls(p=1.0) for cls in base_transform_classes] + [additional_transform_class(p=1.0)]
     expected_compose = compose_class(expected_transforms, **compose_kwargs)
 
@@ -85,7 +83,6 @@ def test_compose_add_single_transform_equivalence(
     expected_compose.set_random_seed(137)
     result_compose.set_random_seed(137)
 
-    # Apply both compositions to the same data
     data = {"image": sample_image, "mask": sample_mask}
 
     expected_result = expected_compose(**data)
@@ -120,11 +117,9 @@ def test_compose_add_multiple_transforms_equivalence(
     # Base compose kwargs (no seed during init)
     compose_kwargs = {"p": 1.0}
 
-    # Create fresh instances for base compose
     base_transforms = [cls(p=1.0) for cls in base_transform_classes]
     base_compose = compose_class(base_transforms, **compose_kwargs)
 
-    # Create fresh instances for expected compose
     expected_transforms = [cls(p=1.0) for cls in base_transform_classes] + [
         cls(p=1.0) for cls in additional_transform_classes
     ]
@@ -138,7 +133,6 @@ def test_compose_add_multiple_transforms_equivalence(
     expected_compose.set_random_seed(137)
     result_compose.set_random_seed(137)
 
-    # Apply both compositions to the same data
     data = {"image": sample_image, "mask": sample_mask}
 
     expected_result = expected_compose(**data)
@@ -171,11 +165,9 @@ def test_compose_radd_single_transform_equivalence(
     # Base compose kwargs (no seed during init)
     compose_kwargs = {"p": 1.0}
 
-    # Create fresh instances for base compose
     base_transforms = [cls(p=1.0) for cls in base_transform_classes]
     base_compose = compose_class(base_transforms, **compose_kwargs)
 
-    # Create fresh instances for expected compose
     expected_transforms = [additional_transform_class(p=1.0)] + [cls(p=1.0) for cls in base_transform_classes]
     expected_compose = compose_class(expected_transforms, **compose_kwargs)
 
@@ -187,7 +179,6 @@ def test_compose_radd_single_transform_equivalence(
     expected_compose.set_random_seed(137)
     result_compose.set_random_seed(137)
 
-    # Apply both compositions to the same data
     data = {"image": sample_image, "mask": sample_mask}
 
     expected_result = expected_compose(**data)
@@ -220,11 +211,9 @@ def test_compose_radd_multiple_transforms_equivalence(
     # Base compose kwargs (no seed during init)
     compose_kwargs = {"p": 1.0}
 
-    # Create fresh instances for base compose
     base_transforms = [cls(p=1.0) for cls in base_transform_classes]
     base_compose = compose_class(base_transforms, **compose_kwargs)
 
-    # Create fresh instances for expected compose
     expected_transforms = [cls(p=1.0) for cls in additional_transform_classes] + [
         cls(p=1.0) for cls in base_transform_classes
     ]
@@ -238,7 +227,6 @@ def test_compose_radd_multiple_transforms_equivalence(
     expected_compose.set_random_seed(137)
     result_compose.set_random_seed(137)
 
-    # Apply both compositions to the same data
     data = {"image": sample_image, "mask": sample_mask}
 
     expected_result = expected_compose(**data)
@@ -251,7 +239,6 @@ def test_compose_radd_multiple_transforms_equivalence(
 
 def test_compose_subtract_transform_equivalence(sample_image, sample_mask):
     """Test that compose - TransformClass removes the first transform of that class."""
-    # Create compose with different transform types
     compose = A.Compose([A.HorizontalFlip(p=0.5), A.VerticalFlip(p=1.0), A.Blur(p=0.3)], p=1.0)
 
     # Remove HorizontalFlip by class
@@ -264,7 +251,6 @@ def test_compose_subtract_transform_equivalence(sample_image, sample_mask):
     reduced_compose.set_random_seed(137)
     expected_compose.set_random_seed(137)
 
-    # Apply both compositions to the same data
     data = {"image": sample_image, "mask": sample_mask}
 
     expected_result = expected_compose(**data)
@@ -284,7 +270,6 @@ def test_compose_subtract_transform_equivalence(sample_image, sample_mask):
 
 def test_compose_subtract_by_class(sample_image, sample_mask):
     """Test that compose - TransformClass removes the first transform of that class."""
-    # Create compose with different instances of the same class
     transform_a = A.HorizontalFlip(p=0.5)
     transform_b = A.VerticalFlip(p=1.0)
     transform_c = A.HorizontalFlip(p=1.0)  # Different instance, different p value
@@ -301,7 +286,6 @@ def test_compose_subtract_by_class(sample_image, sample_mask):
     reduced_compose.set_random_seed(137)
     expected_compose.set_random_seed(137)
 
-    # Apply both compositions to the same data
     data = {"image": sample_image, "mask": sample_mask}
 
     expected_result = expected_compose(**data)
@@ -419,7 +403,6 @@ def test_compose_operators_preserve_params(
     else:
         assert result_compose.processors.get("keypoints") is None
 
-    # Test functionality with data
     data = {"image": sample_image, "mask": sample_mask}
 
     if bbox_params:
@@ -461,7 +444,6 @@ def test_compose_operators_preserve_additional_targets(sample_image):
     # Verify additional_targets are preserved
     assert result_compose.additional_targets == additional_targets
 
-    # Test functionality
     mask2 = np.random.randint(0, 2, (100, 100), dtype=np.uint8)
     data = {
         "image": sample_image,
@@ -530,11 +512,9 @@ def test_special_compose_classes_add_operations(compose_class, sample_image, sam
     # No seed during initialization
     compose_kwargs = {"p": 1.0}
 
-    # Create fresh instances for base compose
     base_transforms = [A.HorizontalFlip(p=1.0), A.VerticalFlip(p=1.0)]
     base_compose = compose_class(base_transforms, **compose_kwargs)
 
-    # Create fresh instances for expected compose
     expected_transforms = [A.HorizontalFlip(p=1.0), A.VerticalFlip(p=1.0), A.Blur(p=1.0)]
     expected_compose = compose_class(expected_transforms, **compose_kwargs)
 
@@ -561,7 +541,6 @@ def test_selective_channel_transform_operators(sample_image):
     assert result_compose.channels == [0, 1]
     assert len(result_compose.transforms) == 2
 
-    # Test functionality
     data = {"image": sample_image}
     result = result_compose(**data)
     assert "image" in result

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -60,21 +60,20 @@ def test_compose():
 
 @pytest.mark.parametrize("target_as_params", ([], ["image"], ["image", "mask"], ["image", "mask", "keypoints"]))
 def test_one_of(target_as_params):
-    # Create a simple transform-like class for testing
-    class DummyTransform:
-        def __init__(self):
-            self.p = 1
-            self.available_keys = {"image"}
-            self.targets_as_params = target_as_params
-            self.params = {}
-
-        def __call__(self, **kwargs):
-            return kwargs
-
-    transforms = [DummyTransform() for _ in range(10)]
+    transforms = [
+        Mock(
+            p=1,
+            side_effect=lambda **kwargs: {"image": kwargs["image"]},
+            available_keys={"image"},
+            targets_as_params=target_as_params,
+        )
+        for _ in range(10)
+    ]
     augmentation = OneOf(transforms, p=1)
     image = np.ones((8, 8))
-    augmentation(image=image)
+    result = augmentation(image=image)
+    assert sum(transform.call_count for transform in transforms) == 1
+    np.testing.assert_array_equal(result["image"], image)
 
 
 @pytest.mark.parametrize("N", [0, 1, 2, 5, 10, 12])
@@ -983,7 +982,6 @@ def test_additional_targets_overwrite():
 @pytest.mark.parametrize("image", IMAGES)
 def test_sequential_with_horizontal_flip_prob_1(image):
     mask = image.copy()
-    # Setup transformations
     transform = Sequential([A.HorizontalFlip(p=1)], p=1)
     expected_transform = Compose([A.HorizontalFlip(p=1)])
 
@@ -1693,41 +1691,6 @@ def test_compose_probability():
     assert len(result["applied_transforms"]) == 0
 
 
-def test_transform_strict_mode_raises_error():
-    # Test that strict=True raises error for invalid parameters
-    with pytest.raises(ValueError, match="Argument\\(s\\) 'invalid_param' are not valid for transform Blur"):
-        A.Blur(strict=True, invalid_param=123)
-
-
-def test_transform_non_strict_mode_shows_warning():
-    # Test that strict=False (default) shows warning for invalid parameters
-    with pytest.warns(UserWarning, match="Argument\\(s\\) 'invalid_param' are not valid for transform Blur"):
-        transform = A.Blur(invalid_param=123)
-        assert transform.p == 0.5  # Check that transform was still created with default values
-
-
-def test_transform_valid_params_no_warning():
-    # Test that no warning/error is raised for valid parameters
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Convert warnings to errors to ensure none are raised
-        transform = A.Blur(p=0.7, blur_range=(3, 5))
-        assert transform.p == 0.7
-        assert transform.blur_range == (3, 5)
-
-
-def test_transform_multiple_invalid_params():
-    # Test handling of multiple invalid parameters
-    with pytest.raises(ValueError, match="Argument\\(s\\) 'invalid1, invalid2' are not valid for transform Blur"):
-        A.Blur(strict=True, invalid1=123, invalid2=456)
-
-
-def test_transform_strict_with_valid_params():
-    # Test that strict mode doesn't affect valid parameters
-    transform = A.Blur(strict=True, p=0.7, blur_range=(3, 5))
-    assert transform.p == 0.7
-    assert transform.blur_range == (3, 5)
-
-
 @pytest.mark.parametrize(
     ["labels", "expected_type", "expected_dtype"],
     [
@@ -1769,7 +1732,6 @@ def test_label_type_preservation(labels, expected_type, expected_dtype):
 
 
 def test_string_labels():
-    # Create sample data
     bboxes = [(0, 0, 10, 10), (10, 10, 20, 20), (20, 20, 30, 30)]
     labels = ["cat", "dog", "bird"]
 
@@ -1884,20 +1846,17 @@ def test_strict_validation_in_compose(
 
 
 def test_transform_strict_mode_raises_error():
-    # Test that strict=True raises error for invalid parameters
     with pytest.raises(ValueError, match="Argument\\(s\\) 'invalid_param' are not valid for transform Blur"):
         A.Blur(strict=True, invalid_param=123)
 
 
 def test_transform_non_strict_mode_shows_warning():
-    # Test that strict=False (default) shows warning for invalid parameters
     with pytest.warns(UserWarning, match="Argument\\(s\\) 'invalid_param' are not valid for transform Blur"):
         transform = A.Blur(invalid_param=123)
         assert transform.p == 0.5  # Check that transform was still created with default values
 
 
 def test_transform_valid_params_no_warning():
-    # Test that no warning/error is raised for valid parameters
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # Convert warnings to errors to ensure none are raised
         transform = A.Blur(p=0.7, blur_range=(3, 5))
@@ -1906,13 +1865,11 @@ def test_transform_valid_params_no_warning():
 
 
 def test_transform_multiple_invalid_params():
-    # Test handling of multiple invalid parameters
     with pytest.raises(ValueError, match="Argument\\(s\\) 'invalid1, invalid2' are not valid for transform Blur"):
         A.Blur(strict=True, invalid1=123, invalid2=456)
 
 
 def test_transform_strict_with_valid_params():
-    # Test that strict mode doesn't affect valid parameters
     transform = A.Blur(strict=True, p=0.7, blur_range=(3, 5))
     assert transform.p == 0.7
     assert transform.blur_range == (3, 5)
@@ -2260,10 +2217,8 @@ def test_compose_with_empty_masks():
 
 def test_grayscale_image_handling():
     """Test that grayscale images are handled correctly."""
-    # Create grayscale image (H, W)
     grayscale_image = np.random.rand(100, 200).astype(np.float32)
 
-    # Create a simple transform pipeline
     transform = A.Compose(
         [
             A.HorizontalFlip(p=1.0),
@@ -2271,7 +2226,6 @@ def test_grayscale_image_handling():
         ],
     )
 
-    # Apply transform
     result = transform(image=grayscale_image)
 
     # Check that output has same shape as input
@@ -2281,11 +2235,9 @@ def test_grayscale_image_handling():
 
 def test_grayscale_images_batch_handling():
     """Test that batches of grayscale images are handled correctly."""
-    # Create batch of grayscale images (N, H, W)
     batch_size = 4
     grayscale_images = np.random.rand(batch_size, 100, 200).astype(np.float32)
 
-    # Create a simple transform pipeline
     transform = A.Compose(
         [
             A.HorizontalFlip(p=1.0),
@@ -2293,7 +2245,6 @@ def test_grayscale_images_batch_handling():
         ],
     )
 
-    # Apply transform
     result = transform(images=grayscale_images)
 
     # Check that output has same shape as input
@@ -2303,17 +2254,14 @@ def test_grayscale_images_batch_handling():
 
 def test_grayscale_volume_handling():
     """Test that grayscale volume data is handled correctly."""
-    # Create grayscale volume (D, H, W)
     grayscale_volume = np.random.rand(50, 100, 200).astype(np.float32)
 
-    # Create a simple transform pipeline that works with volume data
     transform = A.Compose(
         [
             A.NoOp(p=1.0),  # NoOp supports all canonical targets
         ],
     )
 
-    # Apply transform
     result = transform(volume=grayscale_volume)
 
     # Check that output has same shape as input
@@ -2323,31 +2271,25 @@ def test_grayscale_volume_handling():
 
 def test_mixed_grayscale_rgb_handling():
     """Test that mixed grayscale and RGB data are handled correctly."""
-    # Create grayscale image and RGB mask
     grayscale_image = np.random.rand(100, 200).astype(np.float32)
     rgb_mask = np.random.rand(100, 200, 3).astype(np.float32)
 
-    # Create a simple transform pipeline
     transform = A.Compose(
         [
             A.HorizontalFlip(p=1.0),
         ],
     )
 
-    # Apply transform
     result = transform(image=grayscale_image, mask=rgb_mask)
 
-    # Check shapes
     assert result["image"].shape == grayscale_image.shape
     assert result["mask"].shape == rgb_mask.shape
 
 
 def test_grayscale_with_channel_dimension():
     """Test that data with explicit channel dimension is preserved."""
-    # Create grayscale image with explicit channel dimension (H, W, 1)
     image_with_channel = np.random.rand(100, 200, 1).astype(np.float32)
 
-    # Create a simple transform pipeline
     transform = A.Compose(
         [
             A.HorizontalFlip(p=1.0),
@@ -2355,7 +2297,6 @@ def test_grayscale_with_channel_dimension():
         ],
     )
 
-    # Apply transform
     result = transform(image=image_with_channel)
 
     # Check that shape is preserved (channel dimension remains)
@@ -2365,17 +2306,14 @@ def test_grayscale_with_channel_dimension():
 
 def test_grayscale_array_handling():
     """Test that arrays of grayscale images are handled correctly."""
-    # Create array of grayscale images (N, H, W)
     grayscale_array = np.random.rand(3, 100, 200).astype(np.float32)
 
-    # Create a simple transform pipeline
     transform = A.Compose(
         [
             A.HorizontalFlip(p=1.0),
         ],
     )
 
-    # Apply transform
     result = transform(images=grayscale_array)
 
     # Check the output
@@ -2387,10 +2325,8 @@ def test_grayscale_array_handling():
 
 def test_uint8_grayscale_handling():
     """Test that uint8 grayscale images work correctly."""
-    # Create uint8 grayscale image
     grayscale_uint8 = np.random.randint(0, 256, (100, 200), dtype=np.uint8)
 
-    # Create a transform that works with uint8
     transform = A.Compose(
         [
             A.HorizontalFlip(p=1.0),
@@ -2398,17 +2334,14 @@ def test_uint8_grayscale_handling():
         ],
     )
 
-    # Apply transform
     result = transform(image=grayscale_uint8)
 
-    # Check shape and dtype
     assert result["image"].shape == grayscale_uint8.shape
     assert result["image"].dtype == np.uint8
 
 
 def test_grayscale_with_transforms_expecting_channels():
     """Test transforms that expect channel information work with grayscale."""
-    # Create grayscale image
     grayscale_image = np.random.rand(100, 200).astype(np.float32)
 
     # Create transform that typically expects channels
@@ -2419,16 +2352,13 @@ def test_grayscale_with_transforms_expecting_channels():
         ],
     )
 
-    # Apply transform - should not raise errors
     result = transform(image=grayscale_image)
 
-    # Check output shape
     assert result["image"].shape == grayscale_image.shape
 
 
 def test_grayscale_shape_check_with_strict():
     """Test that shape checking works correctly with grayscale images."""
-    # Create grayscale image and mask with same H,W
     grayscale_image = np.random.rand(100, 200).astype(np.float32)
     grayscale_mask = np.random.rand(100, 200).astype(np.float32)
 
@@ -2466,7 +2396,6 @@ def test_grayscale_with_bbox_params():
 
     result = transform(image=grayscale_image, bboxes=bboxes)
 
-    # Check that image shape is preserved
     assert result["image"].shape == grayscale_image.shape
     assert result["image"].ndim == 2
     # Check that bboxes were transformed
@@ -2487,19 +2416,15 @@ def test_grayscale_with_keypoint_params():
 
     result = transform(image=grayscale_image, keypoints=keypoints)
 
-    # Check that image shape is preserved
     assert result["image"].shape == grayscale_image.shape
     assert result["image"].ndim == 2
-    # Check that keypoints were transformed
     assert len(result["keypoints"]) == len(keypoints)
 
 
 def test_grayscale_mask_handling():
     """Test that grayscale masks are handled correctly."""
-    # Create grayscale mask (H, W)
     grayscale_mask = np.random.randint(0, 2, (100, 200)).astype(np.uint8)
 
-    # Create a simple transform pipeline
     transform = A.Compose(
         [
             A.HorizontalFlip(p=1.0),
@@ -2507,7 +2432,6 @@ def test_grayscale_mask_handling():
         ],
     )
 
-    # Apply transform
     result = transform(mask=grayscale_mask)
 
     # Check that output has same shape as input
@@ -2517,11 +2441,9 @@ def test_grayscale_mask_handling():
 
 def test_grayscale_masks_batch_handling():
     """Test that batches of grayscale masks are handled correctly."""
-    # Create batch of grayscale masks (N, H, W)
     batch_size = 4
     grayscale_masks = np.random.randint(0, 2, (batch_size, 100, 200)).astype(np.uint8)
 
-    # Create a simple transform pipeline
     transform = A.Compose(
         [
             A.HorizontalFlip(p=1.0),
@@ -2529,7 +2451,6 @@ def test_grayscale_masks_batch_handling():
         ],
     )
 
-    # Apply transform
     result = transform(masks=grayscale_masks)
 
     # Check that output has same shape as input
@@ -2539,17 +2460,14 @@ def test_grayscale_masks_batch_handling():
 
 def test_grayscale_mask3d_handling():
     """Test that grayscale 3D masks are handled correctly."""
-    # Create grayscale 3D mask (D, H, W)
     grayscale_mask3d = np.random.randint(0, 2, (50, 100, 200)).astype(np.uint8)
 
-    # Create a simple transform pipeline that works with 3D masks
     transform = A.Compose(
         [
             A.NoOp(p=1.0),  # NoOp supports all targets including mask3d
         ],
     )
 
-    # Apply transform
     result = transform(mask3d=grayscale_mask3d)
 
     # Check that output has same shape as input

--- a/tests/test_distortion_obb.py
+++ b/tests/test_distortion_obb.py
@@ -162,7 +162,6 @@ def test_distortion_transforms_obb_format_consistency(transform_cls, params, bbo
                 f"Expected normalized coords for {bbox_format}, got {output_bbox}"
             )
 
-        # Check OBB has angle
         assert len(output_bbox) == 5, f"Expected 5 values for OBB, got {len(output_bbox)}"
 
 

--- a/tests/test_dithering.py
+++ b/tests/test_dithering.py
@@ -91,7 +91,6 @@ class TestDitheringFunctional:
 
     def test_ordered_dither(self):
         """Test ordered dithering with Bayer matrix."""
-        # Create uniform gray image
         img = np.full((8, 8, 1), 0.5, dtype=np.float32)
 
         # Test with 4x4 Bayer matrix
@@ -127,7 +126,6 @@ class TestDitheringFunctional:
 
     def test_error_diffusion_dither(self):
         """Test error diffusion dithering."""
-        # Create gradient image
         img = np.linspace(0, 1, 100).reshape(10, 10, 1).astype(np.float32)
 
         # Test Floyd-Steinberg
@@ -183,7 +181,6 @@ class TestDitheringFunctional:
     def test_apply_dithering_grayscale_mode(self):
         """Test dithering with grayscale conversion."""
         rng = np.random.default_rng(137)
-        # Create color image
         img = np.random.rand(10, 10, 3).astype(np.float32)
 
         # Test grayscale mode
@@ -203,7 +200,6 @@ class TestDitheringFunctional:
     def test_apply_dithering_per_channel(self):
         """Test per-channel dithering."""
         np.random.default_rng(137)
-        # Create color image
         img = np.random.rand(10, 10, 3).astype(np.float32)
 
         # Test per-channel mode
@@ -230,19 +226,15 @@ class TestDitheringTransform:
     @pytest.mark.parametrize("img_dtype", [np.uint8, np.float32])
     def test_dithering_methods(self, method, n_colors, img_dtype):
         """Test different dithering methods with various parameters."""
-        # Create test image
         if img_dtype == np.uint8:
             img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
         else:
             img = np.random.rand(100, 100, 3).astype(np.float32)
 
-        # Create transform
         transform = A.Dithering(method=method, n_colors=n_colors, p=1.0)
 
-        # Apply transform
         result = transform(image=img)["image"]
 
-        # Check output
         np.testing.assert_equal(result.shape, img.shape)
         np.testing.assert_equal(result.dtype, img.dtype)
 
@@ -385,7 +377,6 @@ class TestDitheringTransform:
         # Deserialize
         deserialized = A.from_dict(serialized)
 
-        # Check parameters
         np.testing.assert_equal(deserialized.method, transform.method)
         np.testing.assert_equal(deserialized.n_colors, transform.n_colors)
         np.testing.assert_equal(deserialized.error_diffusion_algorithm, transform.error_diffusion_algorithm)

--- a/tests/test_domain_adaptation.py
+++ b/tests/test_domain_adaptation.py
@@ -419,7 +419,6 @@ def test_match_histograms(shape, channel_axis):
     our_result = our_match_histograms(source, reference)
     skimage_result = skimage_match_histograms(source, reference, channel_axis=channel_axis)
 
-    # Check shape and dtype
     assert our_result.shape == skimage_result.shape
     assert our_result.dtype == source.dtype
 

--- a/tests/test_keypoint.py
+++ b/tests/test_keypoint.py
@@ -29,7 +29,7 @@ from tests.conftest import RECTANGULAR_UINT8_IMAGE
         (np.array([10 * np.pi, 100 * np.pi]), np.array([0, 0])),
     ],
 )
-def test_angle_to_2pi_range(input_angles, expected_angles):
+def test_angle_to_2pi_range_arrays(input_angles, expected_angles):
     result = angle_to_2pi_range(input_angles)
     np.testing.assert_allclose(result, expected_angles, atol=1e-7)
 
@@ -281,22 +281,6 @@ def test_convert_keypoints_to_albumentations(
 def test_convert_keypoints_to_albumentations_invalid_format():
     with pytest.raises(ValueError, match="Unknown source_format"):
         convert_keypoints_to_albumentations(np.array([[10, 20]]), "invalid_format", (100, 100))
-
-
-@pytest.mark.parametrize(
-    "angle, expected",
-    [
-        (0, 0),
-        (np.pi, np.pi),
-        (2 * np.pi, 0),
-        (3 * np.pi, np.pi),
-        (-np.pi, np.pi),
-        (-2 * np.pi, 0),
-    ],
-)
-def test_angle_to_2pi_range(angle, expected):
-    result = angle_to_2pi_range(np.array([angle]))
-    np.testing.assert_allclose(result, [expected], rtol=1e-5, atol=1e-8)
 
 
 @pytest.mark.parametrize(
@@ -655,6 +639,7 @@ def test_compose_with_additional_targets() -> None:
         [np.pi, np.pi],
         [3 * np.pi / 2, 3 * np.pi / 2],
         [2 * np.pi, 0],
+        [3 * np.pi, np.pi],
         [-np.pi / 2, 3 * np.pi / 2],
         [-np.pi, np.pi],
         [-3 * np.pi / 2, np.pi / 2],

--- a/tests/test_keypoint_label_swapping.py
+++ b/tests/test_keypoint_label_swapping.py
@@ -19,7 +19,6 @@ class TestKeypointLabelSwapping:
     )
     def test_basic_label_mapping_string_labels(self, transform_class, expected_swaps):
         """Test basic label mapping with string labels."""
-        # Setup
         keypoints = np.array([[50, 25], [75, 30]], dtype=np.float32)
         labels = list(expected_swaps.keys())
 
@@ -38,14 +37,12 @@ class TestKeypointLabelSwapping:
             ),
         )
 
-        # Apply transform
         result = transform(image=np.ones((100, 100, 3), dtype=np.uint8), keypoints=keypoints, keypoint_labels=labels)
 
         # Check that labels were swapped correctly
         expected_labels = [expected_swaps[label] for label in labels]
         assert result["keypoint_labels"] == expected_labels
 
-        # Check that keypoints were transformed
         assert not np.array_equal(result["keypoints"], keypoints)
 
     @pytest.mark.parametrize(
@@ -58,7 +55,6 @@ class TestKeypointLabelSwapping:
     )
     def test_basic_label_mapping_integer_labels(self, transform_class, expected_swaps):
         """Test basic label mapping with integer labels."""
-        # Setup
         keypoints = np.array([[50, 25], [75, 30]], dtype=np.float32)
         labels = list(expected_swaps.keys())
 
@@ -77,7 +73,6 @@ class TestKeypointLabelSwapping:
             ),
         )
 
-        # Apply transform
         result = transform(image=np.ones((100, 100, 3), dtype=np.uint8), keypoints=keypoints, keypoint_labels=labels)
 
         # Check that labels were swapped correctly

--- a/tests/test_mixpanel_backend.py
+++ b/tests/test_mixpanel_backend.py
@@ -59,7 +59,6 @@ class TestMixpanelBackend:
         # Should not raise
         backend.send_event(event)
 
-        # Check request was made
         mock_urlopen.assert_called_once()
 
         # Check request details
@@ -118,7 +117,6 @@ class TestMixpanelBackend:
         assert props["token"] == backend.PROJECT_TOKEN
         assert props["$insert_id"] == "session-456"  # For deduplication
 
-        # Check all fields are included
         assert props["pipeline_hash"] == "test_hash"
         assert props["version"] == "2.0.0"
         assert props["python_version"] == "3.10"

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -155,11 +155,9 @@ def test_mosaic_identity_with_targets() -> None:
 
     result = pipeline(**data)
 
-    # Check image
     assert result["image"].shape == img.shape
     np.testing.assert_array_equal(result["image"], img)
 
-    # Check mask
     assert result["mask"].shape == mask.shape
     np.testing.assert_array_equal(result["mask"], mask)
 
@@ -294,7 +292,6 @@ def test_mosaic_obb_basic() -> None:
 
     result = transform(**data)
 
-    # Check OBB format is preserved (5 columns)
     assert result["bboxes"].shape[1] == 5
 
 
@@ -354,7 +351,6 @@ def test_mosaic_obb_with_metadata() -> None:
 
     result = transform(**data)
 
-    # Check OBB format is preserved
     assert result["bboxes"].shape[1] == 5
     # Should have bboxes from multiple cells
     assert len(result["bboxes"]) > 0
@@ -569,7 +565,6 @@ def test_mosaic_simplified_deterministic() -> None:
     assert not np.all(result["mask"][:, :split_col] == 0)
     assert not np.all(result["mask"][:, split_col:] == 0)
 
-    # Check bboxes
     assert "bboxes" in result
     np.testing.assert_allclose(result["bboxes"], expected_bboxes, atol=1e-6)
 

--- a/tests/test_obb_analytical_masks.py
+++ b/tests/test_obb_analytical_masks.py
@@ -50,7 +50,6 @@ def obb_to_mask(
     polygon_px[:, 1] *= height
     polygon_px = np.int32(polygon_px)
 
-    # Create mask
     mask = np.zeros(image_shape, dtype=np.uint8)
 
     # Fill the polygon
@@ -85,7 +84,6 @@ def test_obb_rotation_centered_square_analytical(rotation_deg: int) -> None:
         initial_angle,
     ]
 
-    # Create input mask from OBB
     input_mask = obb_to_mask(input_obb, image_shape)
 
     # Apply rotation to OBB
@@ -100,7 +98,6 @@ def test_obb_rotation_centered_square_analytical(rotation_deg: int) -> None:
     output_obb = result["bboxes"][0]
     rotated_mask = result["mask"]
 
-    # Create mask from output OBB
     output_mask = obb_to_mask(output_obb, image_shape)
 
     # Compare masks - they should be very similar (allowing for discretization)
@@ -462,7 +459,6 @@ def test_obb_rot90_centered_box_analytical(k: int) -> None:
     result_bboxes = fgeometric.bboxes_rot90(bboxes, k_to_group_element[k], bbox_type="obb")
     output_obb = result_bboxes[0]
 
-    # Create mask from output OBB
     output_mask = obb_to_mask(output_obb, image_shape)
 
     intersection = np.logical_and(rotated_mask, output_mask).sum()
@@ -750,7 +746,6 @@ def test_obb_mask_conversion_roundtrip(width: float, height: float, angle: float
         angle,
     ]
 
-    # Create mask from OBB
     mask = obb_to_mask(input_obb, image_shape)
 
     # Basic sanity checks

--- a/tests/test_per_worker_seed.py
+++ b/tests/test_per_worker_seed.py
@@ -154,7 +154,6 @@ def _assert_any_epoch_differs(first_batches: list[list[list[int]]]) -> None:
 
 def test_worker_seed_without_torch():
     """Test that worker seed functionality works when PyTorch is not available."""
-    # Create compose (worker-aware seed is now always enabled)
     transform = A.Compose(
         [
             A.HorizontalFlip(p=0.5),
@@ -554,7 +553,6 @@ def test_deterministic_behavior_property():
 
 def test_multiple_compose_instances():
     """Test that multiple Compose instances with same seed produce same results."""
-    # Create two instances with same configuration
     transform1 = A.Compose(
         [
             A.HorizontalFlip(p=0.5),

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -176,10 +176,8 @@ def test_post_data_check():
 
 
 def test_to_tensor_v2_on_non_contiguous_array():
-    # Create a contiguous array
     img = np.random.randint(0, 256, [100, 100, 3], dtype=np.uint8)
 
-    # Create a non-contiguous array by slicing
     non_contiguous_img = img[::2, ::2, :]
     assert not non_contiguous_img.flags["C_CONTIGUOUS"]
 
@@ -191,7 +189,6 @@ def test_to_tensor_v2_on_non_contiguous_array():
     assert transformed["image"].shape == (3, 50, 50)  # Shape changed due to slicing
     assert transformed["image"].dtype == torch.uint8
 
-    # Check masks
     assert isinstance(transformed["masks"], torch.Tensor)
     assert transformed["masks"].shape == (2, 50, 50, 3)  # (N, H, W, C) - masks remain in original format
     assert transformed["masks"].dtype == torch.uint8
@@ -216,7 +213,10 @@ def test_to_tensor_v2_on_non_contiguous_array_with_horizontal_flip():
 
     masks = np.stack([image[:, :, 0]] * 2)
 
-    transform(image=image, masks=masks)
+    result = transform(image=image, masks=masks)
+    expected_image = np.flip(image, axis=1).transpose(2, 0, 1).astype(np.float32) / 255
+    np.testing.assert_allclose(result["image"].numpy(), expected_image)
+    np.testing.assert_array_equal(result["masks"].numpy(), np.flip(masks, axis=2))
 
 
 def test_to_tensor_v2_on_non_contiguous_array_with_random_rotate90():
@@ -256,7 +256,6 @@ def test_to_tensor_v2_images_masks():
     assert isinstance(transformed["masks"], torch.Tensor)
     assert isinstance(transformed["images"], torch.Tensor)  # Now checking single tensor
 
-    # Check shapes
     assert transformed["image"].shape == (3, 100, 100)  # (C, H, W)
     assert transformed["mask"].shape == (100, 100)  # (H, W)
     assert transformed["masks"].shape == (2, 100, 100)  # (N, H, W)

--- a/tests/test_random_crop_volume_bug.py
+++ b/tests/test_random_crop_volume_bug.py
@@ -61,7 +61,6 @@ def test_random_crop_edge_case_exact_size_after_scale():
 
 def test_random_crop_pad_if_needed_false_with_larger_volume():
     """Test that RandomCrop works correctly when volume is larger than crop size."""
-    # Create a large volume
     volume = np.random.randint(0, 256, (8, 300, 300), dtype=np.uint8)
 
     transform = A.RandomCrop(height=256, width=256, pad_if_needed=False, p=1.0)

--- a/tests/test_resize_obb.py
+++ b/tests/test_resize_obb.py
@@ -51,7 +51,6 @@ class TestRandomScaleOBB:
 
         result = transform(image=image, bboxes=obb_boxes, bbox_labels=bbox_labels)
 
-        # Check all boxes are preserved
         assert len(result["bboxes"]) == 3
         np.testing.assert_allclose(result["bboxes"], obb_boxes, atol=1e-6, rtol=1e-5, equal_nan=False)
 
@@ -275,7 +274,6 @@ class TestResizeOBB:
 
         # Check shape is preserved (including extra fields)
         assert result["bboxes"].shape == obb_boxes.shape
-        # Check extra fields are preserved
         assert np.isclose(result["bboxes"][0][5], 0.95)
         assert result["bboxes"][0][6] == 137
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -82,12 +82,6 @@ class TestTelemetryClient:
         client2 = TelemetryClient()
         assert client1 is client2
 
-    def test_client_enabled_by_default(self):
-        """Test that client is disabled during pytest runs."""
-        client = TelemetryClient()
-        # Since we're running under pytest, telemetry should be disabled
-        assert client.enabled is False
-
     def test_disable_enable_client(self):
         """Test disabling and enabling the client."""
         client = TelemetryClient()
@@ -247,16 +241,12 @@ class TestCIEnvironmentDetection:
         # Set CI environment
         monkeypatch.setenv("GITHUB_ACTIONS", "true")
 
-        # Create new client
         client = TelemetryClient()
         assert client.enabled is False
 
-    def test_telemetry_disabled_in_pytest(self, monkeypatch):
+    def test_telemetry_disabled_in_pytest(self):
         """Test that telemetry is disabled when pytest is running."""
-        # The client should already be disabled since we're running in pytest
-        # Just verify this behavior
         client = TelemetryClient()
-        # Since we're running under pytest, telemetry should be disabled
         assert client.enabled is False
 
     def test_environment_returns_ci(self, monkeypatch):
@@ -319,7 +309,6 @@ class TestComposeIntegration:
                 telemetry=True,
             )
 
-            # Verify telemetry was tracked
             mock_client.track_compose_init.assert_called_once()
             args = mock_client.track_compose_init.call_args
             # First argument should be the telemetry data dict
@@ -379,7 +368,6 @@ class TestDataCollectors:
         """Test environment info collection."""
         info = get_environment_info()
 
-        # Check basic fields exist
         assert "albumentationsx_version" in info
         assert "python_version" in info
         assert "os" in info
@@ -584,7 +572,6 @@ class TestComposeInitEvent:
 
     def test_event_many_transforms(self):
         """Test event with many transforms - no limits with Mixpanel!"""
-        # Create 20 transforms
         transforms = [f"Transform{i}" for i in range(20)]
 
         event = ComposeInitEvent(
@@ -659,7 +646,6 @@ class TestComplexPipelines:
                 additional_targets={"image2": "image", "mask2": "mask"},
             )
 
-            # Verify telemetry was called
             mock_client.track_compose_init.assert_called_once()
 
             # Verify the data was passed correctly
@@ -698,7 +684,6 @@ class TestComplexPipelines:
             mock_client.track_compose_init = track_call
 
             with patch("albumentations.core.composition.get_telemetry_client", return_value=mock_client):
-                # Create compose with nested structure
                 main_compose = A.Compose(
                     [
                         A.Compose(
@@ -765,7 +750,6 @@ def test_settings_manager():
         temp_path = Path(f.name)
 
     try:
-        # Create settings with custom file
         settings = SettingsManager(settings_file=temp_path)
 
         # Test defaults
@@ -795,7 +779,6 @@ class TestTelemetryIntegration:
         """Test creating and using a simple pipeline with telemetry enabled."""
         # Enable telemetry
         settings.update(telemetry=True)
-        # Create a simple pipeline
         transform = A.Compose(
             [
                 A.RandomCrop(256, 256),
@@ -804,14 +787,12 @@ class TestTelemetryIntegration:
             ],
         )
 
-        # Test the pipeline works
         image = np.random.randint(0, 255, (512, 512, 3), dtype=np.uint8)
         result = transform(image=image)
         assert result["image"].shape == (256, 256, 3)
 
     def test_pipeline_with_telemetry_disabled(self):
         """Test creating a pipeline with telemetry explicitly disabled."""
-        # Create a pipeline with telemetry disabled
         transform = A.Compose(
             [
                 A.RandomCrop(256, 256),
@@ -820,7 +801,6 @@ class TestTelemetryIntegration:
             telemetry=False,
         )
 
-        # Test it works
         image = np.random.randint(0, 255, (512, 512, 3), dtype=np.uint8)
         result = transform(image=image)
         assert result["image"].shape == (256, 256, 3)
@@ -873,7 +853,6 @@ class TestTelemetryIntegration:
             keypoint_labels=keypoint_labels,
         )
 
-        # Check all outputs are present
         assert "image" in result
         assert "mask" in result
         assert "bboxes" in result
@@ -885,7 +864,6 @@ class TestTelemetryIntegration:
         """Test that Lambda transforms are excluded from telemetry."""
         from albumentations.augmentations.other.lambda_transform import Lambda
 
-        # Create pipeline with Lambda
         transform = A.Compose(
             [
                 A.RandomCrop(256, 256),
@@ -904,7 +882,6 @@ class TestTelemetryIntegration:
 
     def test_normalize_totensor_included(self):
         """Test that Normalize and ToTensorV2 are included with Mixpanel."""
-        # Create event with Normalize and ToTensorV2
         event = ComposeInitEvent(
             transforms=["RandomCrop", "Normalize", "HorizontalFlip", "ToTensorV2", "Blur"],
             albumentationsx_version="2.0.0",
@@ -930,7 +907,6 @@ class TestTelemetryIntegration:
 
     def test_serialization_with_telemetry(self):
         """Test that telemetry doesn't interfere with serialization."""
-        # Create a pipeline
         transform = A.Compose(
             [
                 A.RandomCrop(256, 256),

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2066,12 +2066,10 @@ def test_selective_channel(
     ],
 )
 def test_pad_if_needed_functionality(params, expected):
-    # Setup the augmentation with the provided parameters
     aug = A.PadIfNeeded(**params, p=1)
     # Get the initialization arguments to check against expected
     aug_dict = {key: getattr(aug, key) for key in expected}
 
-    # Assert each expected key/value pair
     for key, value in expected.items():
         assert aug_dict[key] == value, f"Failed on {key} with value {value}"
 
@@ -2847,7 +2845,6 @@ def test_return_nonzero(augmentation_cls, params):
 )
 @pytest.mark.parametrize("num_channels", [1, 3, 5])
 def test_padding_color(transform, num_channels):
-    # Create an image with zeros
     if num_channels == 1:
         image = np.zeros((4, 4), dtype=np.uint8)
     else:
@@ -2855,7 +2852,6 @@ def test_padding_color(transform, num_channels):
 
     pipeline = A.Compose([transform], seed=137, strict=True)
 
-    # Apply the transform
     augmented = pipeline(image=image)["image"]
 
     # Check the unique values in each channel of the padded image
@@ -3441,13 +3437,11 @@ def test_random_snow_dtype_preservation(method, dtype):
     transform = A.RandomSnow(p=1.0, method=method)
     res = transform(image=img)["image"]
 
-    # Assert dtype is preserved
     assert res.dtype == dtype, f"Expected {dtype}, got {res.dtype}"
 
     # Assert the image actually changed (non-uniform input ensures this won't spuriously fail)
     assert not np.array_equal(res, img), "Image was not modified by RandomSnow"
 
-    # Assert valid range
     if dtype == np.float32:
         assert res.min() >= 0.0
         assert res.max() <= 1.0

--- a/tests/test_type_consistency.py
+++ b/tests/test_type_consistency.py
@@ -78,7 +78,6 @@ def test_init_vs_initschema_types(transform_class):
                     f"    Mismatch: {mismatch}",
                 )
 
-    # Assert no mismatches found
     if mismatches:
         error_msg = f"\n\nType mismatches in {transform_name}:\n" + "\n".join(mismatches)
         pytest.fail(error_msg)

--- a/tests/transforms3d/test_functions.py
+++ b/tests/transforms3d/test_functions.py
@@ -115,7 +115,6 @@ def test_filter_keypoints_in_holes3d_random():
     """Test with random data to ensure robustness."""
     rng = np.random.default_rng(42)
 
-    # Generate random keypoints and holes
     num_keypoints = 100
     num_holes = 10
     volume_size = 100
@@ -138,7 +137,6 @@ def test_filter_keypoints_in_holes3d_random():
     # Ensure z2>z1, y2>y1, x2>x1 for each hole
     holes[:, 3:] = holes[:, :3] + holes[:, 3:]
 
-    # Test function
     result = f3d.filter_keypoints_in_holes3d(keypoints, holes)
 
     # Verify each surviving point is actually outside all holes

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -532,7 +532,6 @@ def test_crop_3d_fill_values(transform_cls, size, fill, fill_mask):
     padded_volume = transformed["volume"]
     padded_mask = transformed["mask3d"]
 
-    # Verify shapes
     assert padded_volume.shape == size
     assert padded_mask.shape == size
 
@@ -739,7 +738,6 @@ def test_keypoints_xy_xyz(augmentation_cls, params):
     aug1 = A.Compose([augmentation_cls(**params, p=1)], seed=seed, keypoint_params={"coord_format": "xy"})
     aug2 = A.Compose([augmentation_cls(**params, p=1)], seed=seed, keypoint_params={"coord_format": "xyz"})
 
-    # Create test keypoints
     keypoints_xy = np.array(
         [
             [0, 0],  # corner
@@ -749,7 +747,6 @@ def test_keypoints_xy_xyz(augmentation_cls, params):
         ],
     )
 
-    # Create xyz version by adding z coordinates
     keypoints_xyz = np.column_stack(
         [
             keypoints_xy,
@@ -829,11 +826,9 @@ def test_pad3d_keypoints(padding, initial_coords, expected_coords):
     # Create keypoint at the same location
     keypoints = np.array([[x, y, z]])  # XYZ order
 
-    # Apply padding transform
     transform = A.Compose([A.Pad3D(padding=padding, p=1.0)], seed=42, keypoint_params={"coord_format": "xyz"})
     transformed = transform(volume=volume, keypoints=keypoints)
 
-    # Verify keypoint transformation
     np.testing.assert_array_almost_equal(
         transformed["keypoints"][0],
         expected_coords,
@@ -897,7 +892,6 @@ def test_pad_if_needed3d_keypoints(params, volume_shape, initial_coords, expecte
     # Create keypoint at the same location
     keypoints = np.array([[x, y, z]])  # XYZ order
 
-    # Apply padding transform
     transform = A.Compose(
         [
             A.PadIfNeeded3D(position="center", **params, p=1.0),
@@ -907,7 +901,6 @@ def test_pad_if_needed3d_keypoints(params, volume_shape, initial_coords, expecte
 
     transformed = transform(volume=volume, keypoints=keypoints)
 
-    # Verify keypoint transformation
     np.testing.assert_array_almost_equal(
         transformed["keypoints"][0],
         expected_coords,
@@ -981,17 +974,14 @@ def test_center_crop3d_keypoints(
        - Keypoints at volume borders
        - Keypoints that get cropped out
     """
-    # Create test volume
     volume = np.zeros(volume_shape, dtype=np.uint8)
 
-    # Create keypoint
     x, y, z = initial_coords
     keypoints = np.array([[x, y, z]])  # XYZ format
 
     # Mark keypoint in volume for visual verification
     volume[z, y, x] = 1
 
-    # Apply transform
     transform = A.Compose(
         [
             A.CenterCrop3D(
@@ -1071,7 +1061,6 @@ def test_3d_transforms_keypoint_positions(augmentation_cls, params):
     for x, y, z in keypoints:
         volume[int(z), int(y), int(x)] = 1
 
-    # Apply transform
     transform = A.Compose(
         [
             augmentation_cls(p=1, **params),
@@ -1143,7 +1132,6 @@ def test_grid_shuffle_3d_various_grids(grid_zyx):
     transform = A.GridShuffle3D(grid_zyx=grid_zyx, p=1.0)
     transformed = transform(volume=volume)
 
-    # Check shape preservation
     assert transformed["volume"].shape == volume.shape
 
     # Check content preservation

--- a/tools/ax_coding_guidance/rules.py
+++ b/tools/ax_coding_guidance/rules.py
@@ -96,10 +96,6 @@ def _unit_d(rule: str, unit, node: ast.AST, message: str, symbol: str = "") -> D
     return Diagnostic(rule, unit.key, getattr(node, "lineno", 1), getattr(node, "col_offset", 0) + 1, symbol, message)
 
 
-def _function_defs(info: ClassInfo) -> Iterable[ast.FunctionDef | ast.AsyncFunctionDef]:
-    return info.methods.values()
-
-
 def _method_targets(info: ClassInfo) -> Iterable[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]]:
     for name, node in info.methods.items():
         if name == "apply" or name.startswith("apply_to_"):
@@ -668,7 +664,7 @@ def rule_fill_naming(index: SourceIndex) -> list[Diagnostic]:
     result: list[Diagnostic] = []
     public_transforms = {info.qname for info in index.concrete_transforms()}
     for info in index.classes.values():
-        for node in _function_defs(info):
+        for node in info.methods.values():
             for arg in argument_nodes(node):
                 if arg.arg in {"fill_value", "fill_mask_value"}:
                     replacement = "fill" if arg.arg == "fill_value" else "fill_mask"
@@ -870,7 +866,7 @@ def rule_cv2(index: SourceIndex) -> list[Diagnostic]:
 def rule_bbox_defaults(index: SourceIndex) -> list[Diagnostic]:
     result: list[Diagnostic] = []
     for info in index.classes.values():
-        for node in _function_defs(info):
+        for node in info.methods.values():
             for arg, _value in _defaults(node):
                 if arg.arg != "bbox_type":
                     continue
@@ -1220,7 +1216,7 @@ def rule_method_docstrings(index: SourceIndex) -> list[Diagnostic]:
         if info.file.key.startswith("albumentations/core/") and info.name.startswith("Base")
     ]
     for info in selected:
-        for node in _function_defs(info):
+        for node in info.methods.values():
             if node.name.startswith("_") or node.name in OPTIONAL_METHOD_DOCS or _property_method(node):
                 continue
             args = [*node.args.posonlyargs, *node.args.args]

--- a/tools/check_albucore_version.py
+++ b/tools/check_albucore_version.py
@@ -7,7 +7,6 @@ def check_albucore_version(filename: str) -> int:
     with Path(filename).open() as file:
         content = file.read()
 
-    # Look for albucore in dependencies array
     match = re.search(r'"albucore([^"]*)"', content)
     if not match:
         print(f"Error: albucore not found in {filename}")

--- a/tools/pytest_summary.py
+++ b/tools/pytest_summary.py
@@ -15,10 +15,6 @@ def _as_int(value: str | None) -> int:
     return int(float(value or 0))
 
 
-def _as_float(value: str | None) -> float:
-    return float(value or 0)
-
-
 def _suite_summaries(root: ET.Element) -> list[dict[str, Any]]:
     suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
 
@@ -29,7 +25,7 @@ def _suite_summaries(root: ET.Element) -> list[dict[str, Any]]:
             "failures": _as_int(suite.attrib.get("failures")),
             "errors": _as_int(suite.attrib.get("errors")),
             "skipped": _as_int(suite.attrib.get("skipped")),
-            "time": _as_float(suite.attrib.get("time")),
+            "time": float(suite.attrib.get("time") or 0),
         }
         for suite in suites
     ]


### PR DESCRIPTION
## Summary

- remove redundant narrator comments, duplicate tests, dead helpers, and unused diagnostics across runtime code and tests
- simplify contributor documentation and repository skills while preserving public behavior and legal text
- preserve the evidence-backed project positioning in the README and package metadata while keeping the README's technical example and navigation improvements
- strengthen previously call-only tests and repair the runnable transform examples

## Validation

- `15,918 passed, 32 skipped, 9 xfailed, 3 xpassed`
- `pre-commit run --all-files`
- runtime Python AST unchanged across all modified runtime modules
