### PR TITLE
perf(transforms3d): route padding through Albucore 0.2.18

### DIFF
--- a/.codex/skills/benchmark/SKILL.md
+++ b/.codex/skills/benchmark/SKILL.md
@@ -45,8 +45,9 @@ before/after cells with shape, dtype, channels, parameters, allocation mode, ela
 
 ## Compare and report
 
-1. Run baseline and candidate on the same machine and environment, back-to-back, with controlled OpenCV and BLAS
-   threads and warm-up.
+1. Run baseline and candidate on the same machine and environment, back-to-back, with warm-up and exactly one
+   CPU thread per process. Follow the thread controls in the required performance guide. Benchmark additional
+   thread counts only when the user explicitly requests a thread-scaling experiment.
 2. Use at least 100 iterations for fast functions. For slow functions, choose enough repetitions for stable timing,
    aiming for more than one second per cell.
 3. Verify correctness, seeded behavior, and aliasing before accepting a faster path.

--- a/.codex/skills/performance-optimization/references/performance-optimization.md
+++ b/.codex/skills/performance-optimization/references/performance-optimization.md
@@ -273,10 +273,16 @@ does not justify an unreviewed output change.
 
 ## Benchmark every candidate, including rejected ones
 
-Use the repository benchmark skill and policy. At minimum:
+Use the repository benchmark skill and policy. CPU comparisons run with exactly one thread per process for every
+candidate. Disable OpenCV internal parallelism with `cv2.setNumThreads(0)` and, when used, set both Torch intra-op and
+inter-op threads to one before work starts. Set `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`,
+`VECLIB_MAXIMUM_THREADS`, and `NUMEXPR_NUM_THREADS` to `1` before importing numerical libraries. Record effective
+library thread settings; do not rely on environment variables alone. Benchmark additional thread counts only when the
+user explicitly requests a thread-scaling experiment.
+
+At minimum:
 
 - run old and new code on the same machine and environment;
-- control OpenCV and BLAS threads;
 - include warmup and enough repetitions for stable timing;
 - report versions, dtype, shape, channels, parameters, and allocation mode;
 - cover the full required size and channel matrix;

--- a/albumentations/augmentations/geometric/_functional_grid.py
+++ b/albumentations/augmentations/geometric/_functional_grid.py
@@ -396,8 +396,7 @@ def get_dimension_padding(
     min_size: int | None,
     divisor: int | None,
 ) -> tuple[int, int]:
-    """Calculate padding (pad_before, pad_after) for one dimension. current_size,
-    optional min_size or divisor. For PadIfNeeded / divisible sizes.
+    """Calculate centered padding to satisfy the minimum size and divisibility constraints.
 
     Args:
         current_size (int): Current size of the dimension
@@ -408,20 +407,13 @@ def get_dimension_padding(
         tuple[int, int]: (pad_before, pad_after)
 
     """
-    if min_size is not None:
-        if current_size < min_size:
-            pad_before = int((min_size - current_size) / 2.0)
-            pad_after = min_size - current_size - pad_before
-            return pad_before, pad_after
-    elif divisor is not None:
-        remainder = current_size % divisor
-        if remainder > 0:
-            total_pad = divisor - remainder
-            pad_before = total_pad // 2
-            pad_after = total_pad - pad_before
-            return pad_before, pad_after
+    target_size = max(current_size, min_size) if min_size is not None else current_size
+    if divisor is not None:
+        target_size += -target_size % divisor
 
-    return 0, 0
+    total_pad = target_size - current_size
+    pad_before = total_pad // 2
+    return pad_before, total_pad - pad_before
 
 
 def get_padding_params(

--- a/albumentations/augmentations/transforms3d/functional.py
+++ b/albumentations/augmentations/transforms3d/functional.py
@@ -15,7 +15,7 @@ from typing import Any, Literal, cast
 import cv2
 import numpy as np
 import torch
-from albucore import clip, remap3d, resize3d, warp_affine3d
+from albucore import clip, pad3d, remap3d, resize3d, warp_affine3d
 
 from albumentations.augmentations.geometric import functional as fgeometric
 from albumentations.augmentations.utils import handle_empty_array
@@ -641,74 +641,46 @@ def adjust_padding_by_position3d(
             paddings[2][1],  # w_right
         )
 
-    # For random position, redistribute padding for each dimension
     d_pad = sum(paddings[0])
     h_pad = sum(paddings[1])
     w_pad = sum(paddings[2])
+    d_front = py_random.randint(0, d_pad)
+    h_top = py_random.randint(0, h_pad)
+    w_left = py_random.randint(0, w_pad)
 
     return (
-        py_random.randint(0, d_pad),  # d_front
-        d_pad - py_random.randint(0, d_pad),  # d_back
-        py_random.randint(0, h_pad),  # h_top
-        h_pad - py_random.randint(0, h_pad),  # h_bottom
-        py_random.randint(0, w_pad),  # w_left
-        w_pad - py_random.randint(0, w_pad),  # w_right
+        d_front,
+        d_pad - d_front,
+        h_top,
+        h_pad - h_top,
+        w_left,
+        w_pad - w_left,
     )
 
 
 def pad_3d_with_params(
-    volume: VolumeType,
+    volume: VolumeType | torch.Tensor,
     padding: tuple[int, int, int, int, int, int],
     value: tuple[float, ...] | float,
-) -> VolumeType:
-    """Pad 3D volume. padding (d_front, d_back, h_top, h_bottom, w_left, w_right); value: fill.
-    (D,H,W) or (D,H,W,C). Used by Pad3D and PadIfNeeded3D.
+) -> VolumeType | torch.Tensor:
+    """Pad a NumPy DHWC volume or CPU Tensor CDHW volume, preserving its container and rank.
 
     Args:
-        volume (VolumeType): Input volume with shape (depth, height, width) or (depth, height, width, channels)
-        padding (tuple[int, int, int, int, int, int]): Padding values in format:
-            (depth_front, depth_back, height_top, height_bottom, width_left, width_right)
-            where:
-            - depth_front/back: padding at start/end of depth axis (z)
-            - height_top/bottom: padding at start/end of height axis (y)
-            - width_left/right: padding at start/end of width axis (x)
-        value (tuple[float, ...] | float): Value to fill the padding
+        volume (VolumeType | torch.Tensor): Input volume or mask.
+        padding (tuple[int, int, int, int, int, int]): Front, back, top, bottom, left, and right padding.
+        value (tuple[float, ...] | float): Scalar fill or before/after fill values shared by spatial axes.
 
     Returns:
-        VolumeType: Padded volume with same number of dimensions as input
-
-    Note:
-        The padding order matches the volume dimensions (depth, height, width).
-        For each dimension, the first value is padding at the start (smaller indices),
-        and the second value is padding at the end (larger indices).
+        VolumeType | torch.Tensor: Padded volume with the input dtype and channel count.
 
     """
-    depth_front, depth_back, height_top, height_bottom, width_left, width_right = padding
-
-    # Skip if no padding is needed
-    if all(p == 0 for p in padding):
+    if not any(padding):
         return volume
-
-    # Handle both 3D and 4D arrays
-    pad_width = [
-        (depth_front, depth_back),  # depth (z) padding
-        (height_top, height_bottom),  # height (y) padding
-        (width_left, width_right),  # width (x) padding
-    ]
-
-    # Add channel padding if 4D array
-    if volume.ndim == NUM_VOLUME_DIMENSIONS:
-        pad_width.append((0, 0))  # no padding for channels
-
-    return cast(
-        "VolumeType",
-        np.pad(
-            volume,
-            pad_width=pad_width,
-            mode="constant",
-            constant_values=value,
-        ),
-    )
+    # NumPy masks may use dtypes outside Albucore's uint8/float32/int16 contract.
+    if isinstance(volume, np.ndarray) and volume.dtype not in (np.uint8, np.float32, np.int16):
+        pad_width = [*zip(padding[::2], padding[1::2], strict=True), (0, 0)]
+        return cast("VolumeType", np.pad(volume, pad_width, constant_values=value))
+    return pad3d(volume, padding, value)
 
 
 def crop3d(

--- a/albumentations/augmentations/transforms3d/transforms.py
+++ b/albumentations/augmentations/transforms3d/transforms.py
@@ -785,30 +785,32 @@ class BasePad3D(Transform3D):
 
     def apply_to_volume(
         self,
-        volume: VolumeType,
+        volume: VolumeType | torch.Tensor,
         padding: tuple[int, int, int, int, int, int],
         **params: Any,
     ) -> VolumeType:
-        if padding == (0, 0, 0, 0, 0, 0):
-            return volume
-        return f3d.pad_3d_with_params(
-            volume=volume,
-            padding=padding,
-            value=self.fill,
+        return cast(
+            "VolumeType",
+            f3d.pad_3d_with_params(
+                volume=volume,
+                padding=padding,
+                value=self.fill,
+            ),
         )
 
     def apply_to_mask3d(
         self,
-        mask3d: VolumeType,
+        mask3d: VolumeType | torch.Tensor,
         padding: tuple[int, int, int, int, int, int],
         **params: Any,
     ) -> VolumeType:
-        if padding == (0, 0, 0, 0, 0, 0):
-            return mask3d
-        return f3d.pad_3d_with_params(
-            volume=mask3d,
-            padding=padding,
-            value=cast("tuple[float, ...] | float", self.fill_mask),
+        return cast(
+            "VolumeType",
+            f3d.pad_3d_with_params(
+                volume=mask3d,
+                padding=padding,
+                value=cast("tuple[float, ...] | float", self.fill_mask),
+            ),
         )
 
     def apply_to_keypoints(
@@ -846,8 +848,8 @@ class Pad3D(BasePad3D):
         uint8, float32
 
     Note:
-        Input volume should be a numpy array with dimensions ordered as (z, y, x) or (depth, height, width),
-        with optional channel dimension as the last axis.
+        NumPy input uses (depth, height, width) with an optional channel-last axis. CPU Tensor input uses
+        channel-first (channels, depth, height, width); Compose adds the channel axis for channel-less inputs.
 
     Examples:
         >>> import numpy as np
@@ -971,6 +973,7 @@ class PadIfNeeded3D(BasePad3D):
             If not specified, pad_divisor_zyx must be provided.
         pad_divisor_zyx (tuple[int, int, int] | None): If set, pads each dimension to make it
             divisible by corresponding value in format (depth_div, height_div, width_div).
+            When min_zyx is also set, rounds each minimum-adjusted dimension up to a multiple of its divisor.
             If not specified, min_zyx must be provided.
         position (Literal['center', 'random']): Position where the volume is to be placed after padding.
             Default is 'center'.
@@ -985,8 +988,8 @@ class PadIfNeeded3D(BasePad3D):
         uint8, float32
 
     Note:
-        Input volume should be a numpy array with dimensions ordered as (z, y, x) or (depth, height, width),
-        with optional channel dimension as the last axis.
+        NumPy input uses (depth, height, width) with an optional channel-last axis. CPU Tensor input uses
+        channel-first (channels, depth, height, width); Compose adds the channel axis for channel-less inputs.
 
     Examples:
         >>> import numpy as np
@@ -1033,8 +1036,7 @@ class PadIfNeeded3D(BasePad3D):
 
         @model_validator(mode="after")
         def validate_params(self) -> Self:
-            """Validate that exactly one of min_zyx or pad_divisor_zyx is provided. Raises ValueError
-            if both None or both set. For PadIfNeeded3D InitSchema.
+            """Validate that at least one of min_zyx or pad_divisor_zyx is provided.
 
             Returns:
                 Self: Self reference for method chaining
@@ -1325,10 +1327,13 @@ class BaseCropAndPad3D(Transform3D):
                 pad_params["pad_left"],
                 pad_params["pad_right"],
             )
-            return f3d.pad_3d_with_params(
-                cropped,
-                padding=padding,
-                value=self.fill,
+            return cast(
+                "VolumeType",
+                f3d.pad_3d_with_params(
+                    cropped,
+                    padding=padding,
+                    value=self.fill,
+                ),
             )
 
         return cropped
@@ -1353,10 +1358,13 @@ class BaseCropAndPad3D(Transform3D):
                 pad_params["pad_left"],
                 pad_params["pad_right"],
             )
-            return f3d.pad_3d_with_params(
-                cropped,
-                padding=padding,
-                value=cast("tuple[float, ...] | float", self.fill_mask),
+            return cast(
+                "VolumeType",
+                f3d.pad_3d_with_params(
+                    cropped,
+                    padding=padding,
+                    value=cast("tuple[float, ...] | float", self.fill_mask),
+                ),
             )
 
         return cropped

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=5.0.0.93
-    - albucore==0.2.16
+    - albucore==0.2.18
     - numkong>=7.8.0
 
 suggests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "albucore==0.2.16",
+  "albucore==0.2.18",
   "numkong>=7.8.0",
   "numpy>=2.2.6",
   "pydantic>=2.12.4",

--- a/tests/transforms3d/test_transforms.py
+++ b/tests/transforms3d/test_transforms.py
@@ -1,10 +1,12 @@
 from typing import Any
+from unittest.mock import Mock
 
 import cv2
 import numpy as np
 import pytest
 import torch
 import torch.nn.functional as torch_f
+from albucore import pad3d
 
 import albumentations as A
 from albumentations.augmentations.transforms3d import functional as f3d
@@ -141,46 +143,116 @@ def test_resize_3d_rejects_unsupported_interpolation(interpolation):
         A.Resize3D(size=(2, 3, 4), interpolation=interpolation)
 
 
+@pytest.mark.parametrize("dtype", [np.int32, np.int64])
+def test_pad_if_needed_3d_preserves_large_integer_mask_labels(dtype):
+    mask = np.full((64, 96, 128), 2**24 + 137, dtype=dtype)
+    result = A.Compose([A.PadIfNeeded3D(min_zyx=(66, 98, 130), fill_mask=-137)])(mask3d=mask)["mask3d"]
+    expected = np.pad(mask, 1, constant_values=-137)
+    assert result.dtype == mask.dtype
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("tensor_volume", [False, True])
+@pytest.mark.parametrize("tensor_mask", [False, True])
+@pytest.mark.parametrize("fill", [-1.0, (3.0, 7.0)])
+def test_pad_if_needed_3d_albucore_dispatch(monkeypatch, tensor_volume, tensor_mask, fill):
+    volume = np.arange(72, dtype=np.uint8).reshape(2, 3, 4, 3)
+    mask = np.arange(24, dtype=np.int16).reshape(2, 3, 4, 1)
+    source = torch.from_numpy(volume).permute(3, 0, 1, 2).contiguous() if tensor_volume else volume
+    source_mask = torch.from_numpy(mask).permute(3, 0, 1, 2).contiguous() if tensor_mask else mask
+    padding = ((3, 3), (2, 3), (2, 2), (0, 0))
+    expected = np.pad(volume, padding, constant_values=fill)
+    expected_mask = np.pad(mask, padding, constant_values=-137)
+    kernel = Mock(wraps=pad3d)
+    monkeypatch.setattr(f3d, "pad3d", kernel)
+
+    result = A.PadIfNeeded3D(min_zyx=(7, 7, 7), pad_divisor_zyx=(4, 4, 4), fill=fill, fill_mask=-137)(
+        volume=source,
+        mask3d=source_mask,
+    )
+
+    assert kernel.call_count == 2
+    assert kernel.call_args_list[0].args[0] is source
+    assert kernel.call_args_list[1].args[0] is source_mask
+    for name, original, reference in (("volume", source, expected), ("mask3d", source_mask, expected_mask)):
+        actual = result[name]
+        assert type(actual) is type(original)
+        assert actual.dtype == original.dtype
+        if isinstance(actual, torch.Tensor):
+            actual = actual.permute(1, 2, 3, 0).numpy()
+        np.testing.assert_array_equal(actual, reference)
+    original_volume = source.permute(1, 2, 3, 0).numpy() if tensor_volume else source
+    np.testing.assert_array_equal(original_volume, np.arange(72, dtype=np.uint8).reshape(2, 3, 4, 3))
+    original_mask = source_mask.permute(1, 2, 3, 0).numpy() if tensor_mask else source_mask
+    np.testing.assert_array_equal(original_mask, np.arange(24, dtype=np.int16).reshape(2, 3, 4, 1))
+
+
 @pytest.mark.parametrize(
     ["volume_shape", "min_zyx", "pad_divisor_zyx", "expected_shape"],
     [
-        # Test no padding needed
-        ((10, 100, 100), (10, 100, 100), None, (10, 100, 100)),
-        # Test 2D-like behavior (no z padding)
-        ((10, 100, 100), (10, 128, 128), None, (10, 128, 128)),
-        # Test padding in all dimensions
-        ((10, 100, 100), (16, 128, 128), None, (16, 128, 128)),
-        # Test divisibility padding
-        ((10, 100, 100), None, (8, 32, 32), (16, 128, 128)),
-        # Test mixed min_size and divisibility
-        ((10, 100, 100), (16, 128, 128), (8, 32, 32), (16, 128, 128)),
+        ((2, 3, 4), (2, 3, 4), None, (2, 3, 4)),
+        ((2, 3, 4), (1, 2, 3), None, (2, 3, 4)),
+        ((2, 3, 4), (2, 8, 8), None, (2, 8, 8)),
+        ((2, 3, 4), (8, 8, 8), None, (8, 8, 8)),
+        ((2, 3, 4), (5, 3, 4), None, (5, 3, 4)),
+        ((2, 3, 4), (2, 8, 4), None, (2, 8, 4)),
+        ((2, 3, 4), (2, 3, 9), None, (2, 3, 9)),
+        ((2, 3, 4), None, (3, 4, 5), (3, 4, 5)),
+        ((4, 6, 8), None, (2, 3, 4), (4, 6, 8)),
+        ((2, 3, 4), (7, 8, 9), (4, 3, 2), (8, 9, 10)),
+        ((9, 8, 7), (3, 4, 5), (4, 3, 2), (12, 9, 8)),
     ],
 )
-def test_pad_if_needed_3d_shapes(volume_shape, min_zyx, pad_divisor_zyx, expected_shape):
-    volume = np.random.randint(0, 256, volume_shape, dtype=np.uint8)
-    transform = A.PadIfNeeded3D(
-        min_zyx=min_zyx,
-        pad_divisor_zyx=pad_divisor_zyx,
-        position="center",
-        fill=0,
-        fill_mask=0,
+@pytest.mark.parametrize("position", ["center", "random"])
+@pytest.mark.parametrize("seed", [137, 42])
+def test_pad_if_needed_3d_shapes(volume_shape, min_zyx, pad_divisor_zyx, expected_shape, position, seed):
+    volume = np.zeros(volume_shape, dtype=np.uint8)
+    transform = A.Compose(
+        [A.PadIfNeeded3D(min_zyx=min_zyx, pad_divisor_zyx=pad_divisor_zyx, position=position)],
+        seed=seed,
+        strict=True,
     )
     transformed = transform(volume=volume)
     assert transformed["volume"].shape == expected_shape
 
 
 @pytest.mark.parametrize("position", ["center", "random"])
-def test_pad_if_needed_3d_positions(position):
-    volume = np.ones((5, 50, 50), dtype=np.uint8)
-    transform = A.PadIfNeeded3D(
-        min_zyx=(10, 100, 100),
-        position=position,
-        fill=0,
-        fill_mask=0,
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+@pytest.mark.parametrize("seed", [137, 42])
+def test_pad_if_needed_3d_positions(position, dtype, seed):
+    volume = np.arange(1, 25, dtype=dtype).reshape(2, 3, 4)
+    if dtype == np.float32:
+        volume /= 32
+    mask3d = (np.arange(24, dtype=np.uint8).reshape(2, 3, 4) % 3) + 1
+    keypoints = np.array([[0, 0, 0], [3, 2, 1]], dtype=np.float32)
+    transform = A.Compose(
+        [A.PadIfNeeded3D(min_zyx=(8, 8, 8), position=position, fill=0, fill_mask=0)],
+        keypoint_params=A.KeypointParams(coord_format="xyz"),
+        seed=seed,
+        strict=True,
     )
-    transformed = transform(volume=volume)
-    # Check that the original volume is preserved somewhere in the padded volume
-    assert np.any(transformed["volume"] == 1)
+    transformed = transform(volume=volume, mask3d=mask3d, keypoints=keypoints)
+    padded_volume = transformed["volume"]
+    assert padded_volume.shape == (8, 8, 8)
+    assert padded_volume.dtype == volume.dtype
+    assert transformed["mask3d"].dtype == mask3d.dtype
+
+    offset = np.argwhere(padded_volume != 0).min(axis=0)
+    if position == "center":
+        np.testing.assert_array_equal(offset, [3, 2, 2])
+    region = tuple(slice(start, start + size) for start, size in zip(offset, volume.shape, strict=True))
+    expected_volume = np.zeros((8, 8, 8), dtype=dtype)
+    expected_volume[region] = volume
+    expected_mask = np.zeros((8, 8, 8), dtype=mask3d.dtype)
+    expected_mask[region] = mask3d
+    np.testing.assert_array_equal(padded_volume, expected_volume)
+    np.testing.assert_array_equal(transformed["mask3d"], expected_mask)
+    np.testing.assert_array_equal(transformed["keypoints"], keypoints + offset[::-1])
+
+    transform.set_random_seed(seed)
+    repeated = transform(volume=volume, mask3d=mask3d, keypoints=keypoints)
+    for target in ("volume", "mask3d", "keypoints"):
+        np.testing.assert_array_equal(repeated[target], transformed[target])
 
 
 def test_pad_if_needed_3d_2d_equivalence():
@@ -218,8 +290,8 @@ def test_pad_if_needed_3d_2d_equivalence():
 
 
 def test_pad_if_needed_3d_fill_values():
-    volume = np.zeros((5, 50, 50), dtype=np.uint8)
-    mask3d = np.ones((5, 50, 50), dtype=np.uint8)
+    volume = np.zeros((5, 50, 50, 1), dtype=np.uint8)
+    mask3d = np.ones((5, 50, 50, 1), dtype=np.uint8)
 
     transform = A.PadIfNeeded3D(
         min_zyx=(10, 100, 100),
@@ -316,7 +388,7 @@ def test_pad3d_fill_values(fill, fill_mask):
 )
 def test_pad3d_different_shapes(volume_shape):
     volume = np.ones(volume_shape, dtype=np.float32)
-    augmentation = A.Pad3D(padding=2)
+    augmentation = A.Compose([A.Pad3D(padding=2)])
     padded = augmentation(volume=volume)["volume"]
 
     expected_shape = tuple(s + 4 for s in volume_shape[:3])  # +4 because padding=2 on each side
@@ -328,7 +400,7 @@ def test_pad3d_different_shapes(volume_shape):
 
 def test_pad3d_different_dtypes():
     for dtype in [np.uint8, np.float32]:
-        volume = np.ones((5, 5, 5), dtype=dtype)
+        volume = np.ones((5, 5, 5, 1), dtype=dtype)
         augmentation = A.Pad3D(padding=1)
         padded = augmentation(volume=volume)["volume"]
         assert padded.dtype == dtype
@@ -336,7 +408,7 @@ def test_pad3d_different_dtypes():
 
 def test_pad3d_preservation():
     """Test that the original data is preserved in the non-padded region"""
-    volume = np.random.randint(0, 255, (5, 5, 5), dtype=np.uint8)
+    volume = np.random.randint(0, 255, (5, 5, 5, 1), dtype=np.uint8)
     augmentation = A.Pad3D(padding=2)
     padded = augmentation(volume=volume)["volume"]
 
@@ -365,7 +437,7 @@ def test_pad3d_2d_equivalence(pad3d_padding, pad2d_padding):
     """Test that Pad3D behaves like Pad when no z-padding is applied"""
     # Create a volume with multiple identical slices
     num_slices = 4
-    slice_2d = np.random.randint(0, 256, (3, 3), dtype=np.uint8)
+    slice_2d = np.random.randint(0, 256, (3, 3, 1), dtype=np.uint8)
     volume_3d = np.stack([slice_2d] * num_slices)  # 10 identical slices
 
     # Apply 3D padding with no z-axis changes

--- a/uv.lock
+++ b/uv.lock
@@ -29,7 +29,7 @@ wheels = [
 
 [[package]]
 name = "albucore"
-version = "0.2.16"
+version = "0.2.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numkong" },
@@ -38,9 +38,9 @@ dependencies = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "stringzilla" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a3/b97df8aea6611d446761084c80f272c836060859564180168abcd061aef8/albucore-0.2.16.tar.gz", hash = "sha256:37176c8386975dcfe0a317407bfb9b5585c679192e6a051dbfc0adfa995cdfed", size = 194964, upload-time = "2026-08-28T09:10:37.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/6a/9273b5d40c154cfdaffc4b2770bc85b948902aff61901b2dc1aaeab637f4/albucore-0.2.18.tar.gz", hash = "sha256:51bebe730d3ea22d4e6d8f704fecf89f1378f5ef55deddc5bfc6c64d19f10705", size = 197239, upload-time = "2026-09-06T18:49:54.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/6e/daab9387f9c12dbb6192d6c99bf70a6c03b935f5fe7692f60384d2a7c5fc/albucore-0.2.16-py3-none-any.whl", hash = "sha256:ec65662c95daf54d6a090ef5d4a2eed29cc5dae26768d00d0d9a4fb4dd7e58d0", size = 58139, upload-time = "2026-08-28T09:10:36.128Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e3/062af4bc56efc7dc609318f059fa3c212bed4b845ed7a605a480e65b2424/albucore-0.2.18-py3-none-any.whl", hash = "sha256:515dc6aae53b999a5e0359aced9afac2ac73967e7b3f78bc5cde09107eb83449", size = 60261, upload-time = "2026-09-06T18:49:52.803Z" },
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "albucore", specifier = "==0.2.16" },
+    { name = "albucore", specifier = "==0.2.18" },
     { name = "huggingface-hub", marker = "extra == 'hub'" },
     { name = "numkong", specifier = ">=7.8.0" },
     { name = "numpy", specifier = ">=2.2.6" },


### PR DESCRIPTION
## What does this PR do?

Routes 3D constant padding through Albucore 0.2.18 for both NumPy DHWC and CPU Tensor CDHW inputs. `Pad3D`, `PadIfNeeded3D`, and the shared crop-and-pad path use the same functional helper; channel normalization remains owned by Compose.

This also fixes two `PadIfNeeded3D` correctness bugs:

- random placement now preserves the sampled total padding on every axis;
- when `min_zyx` and `pad_divisor_zyx` are both set, each minimum-adjusted dimension is rounded up to its divisor.

Closes #494. The shared Albucore operation is tracked in [albucore#159](https://github.com/albumentations-team/albucore/issues/159).

## Validation

- 304 focused transform and target-contract tests pass with `pytest -n 4`.
- `pre-commit run --all-files` equivalent checks pass for the changed files: AX rules, Ruff, formatting, mypy, Pyrefly, docstrings, dependency consistency, and license integrity.
- Built and inspected wheel and sdist; legal integrity passed and the wheel installed with Albucore 0.2.18.
- One-thread direct-transform benchmark on Apple M4 Max: median 1.32x faster for NumPy and 2.06x faster for CPU Tensor across 40 cases each, with no regression over 5%.

## Summary by Sourcery

Accelerate 3D constant padding through Albucore and ensure PadIfNeeded3D applies sizing and placement constraints correctly.

New Features:
- Route 3D constant padding for NumPy volumes and CPU tensors through the shared Albucore operation.

Bug Fixes:
- Correct random 3D padding placement to preserve total padding on each axis.
- Round minimum-adjusted dimensions up to their configured divisors in PadIfNeeded3D.
- Preserve large integer mask labels through 3D padding.

Enhancements:
- Support combined minimum-size and divisibility constraints for PadIfNeeded3D while preserving container types, dtypes, and channel layouts.

Build:
- Upgrade the Albucore dependency to version 0.2.18.

Documentation:
- Update 3D padding documentation for NumPy channel-last and CPU Tensor channel-first inputs and combined sizing constraints.

Tests:
- Expand 3D padding coverage for Albucore dispatch, tensor inputs, fill values, divisibility, random placement, dtype preservation, and target alignment.

Chores:
- Standardize benchmark guidance on single-threaded CPU comparisons and explicit library thread controls.