### PR TITLE
chore(release): bump version to 2.4.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.4.5"
+version = "2.4.6"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.4.5"
+version = "2.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
## Summary

- Bump the package version from 2.4.5 to 2.4.6.
- Keep the editable root entry in `uv.lock` synchronized.

## Validation

- `uv lock --check`
- `pre-commit run --all-files`
- `uv run pytest` — 15973 passed, 32 skipped, 9 xfailed, 3 xpassed

## Summary by Sourcery

Build:
- Bump the package version to 2.4.6 and synchronize the lockfile metadata.