### PR TITLE
Add custom augmentation migration recipes

### DIFF
--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -358,6 +358,9 @@ those decisions from the first-target `params["shape"]` field.
 
 ## Transform Development
 
+For tested replacements of historical frame loops, target synchronization wrappers, manual replay, and channel
+splitting, see [Migrating custom augmentation wrappers](../integrations/custom-augmentation-migration.md).
+
 ### Method Definitions
 
 - Don't use default arguments in `apply_xxx` methods:

--- a/docs/design/applied-config-replay-contracts.md
+++ b/docs/design/applied-config-replay-contracts.md
@@ -1,5 +1,8 @@
 # Applied Configuration Replay Contracts
 
+For a runnable migration from manual parameter reuse to `ReplayCompose`, see
+[Migrating custom augmentation wrappers](../integrations/custom-augmentation-migration.md).
+
 **Status:** Implemented
 **Scope:** `BasicTransform.applied_config`, `Compose(save_applied_params=True)`, constructor serialization, and
 `Compose.from_applied_transforms()`

--- a/docs/design/numpy-tensor-routing.md
+++ b/docs/design/numpy-tensor-routing.md
@@ -1,5 +1,8 @@
 # NumPy and CPU Tensor Transform Routing
 
+For runnable migrations from frame, slice, and paired-input wrappers to public targets, see
+[Migrating custom augmentation wrappers](../integrations/custom-augmentation-migration.md).
+
 **Status:** Implemented
 
 ## Public behavior

--- a/docs/integrations/custom-augmentation-migration.md
+++ b/docs/integrations/custom-augmentation-migration.md
@@ -1,0 +1,255 @@
+# Migrating custom augmentation wrappers
+
+AlbumentationsX 2.4.6 and later can replace many wrappers that historical training code used to synchronize inputs,
+reuse random parameters, or isolate selected channels. This guide maps each pattern to a current public API and states
+where custom code is still required.
+
+Every recipe uses one of these classifications:
+
+- **Exact replacement:** the current API preserves the historical behavior.
+- **Same intent:** the current API owns the synchronization or state, with a documented representation difference.
+- **Partial replacement:** AlbumentationsX owns the augmentation step, while workload-specific code remains outside it.
+
+## Sequence and video synchronization
+
+**Classification: exact replacement for framewise spatial and pixel transforms.**
+
+Historical code often sampled one transform and then reached into private parameters or reset random seeds before each
+frame. Pass the complete sequence through `images` instead. NumPy sequences use `(N, H, W, C)`. AlbumentationsX samples
+one realization and applies it to every frame.
+
+### Before: rebuild a seeded pipeline for every frame
+
+```python
+import albumentations as A
+import numpy as np
+
+
+def augment_frames_one_by_one(frames: np.ndarray) -> np.ndarray:
+    outputs = []
+    for frame in frames:
+        transform = A.Compose(
+            [A.RandomCrop(height=20, width=28, p=1.0), A.HorizontalFlip(p=0.5)],
+            seed=137,
+            strict=True,
+        )
+        outputs.append(transform(image=frame)["image"])
+    return np.stack(outputs)
+```
+
+This wrapper is runnable, but rebuilding the pipeline couples synchronization to an implementation detail and repeats
+setup work.
+
+### After: pass the sequence as one public target
+
+```python
+frames = np.arange(4 * 24 * 32 * 3, dtype=np.uint8).reshape(4, 24, 32, 3)
+
+video_transform = A.Compose(
+    [
+        A.RandomCrop(height=20, width=28, p=1.0),
+        A.HorizontalFlip(p=0.5),
+        A.RandomBrightnessContrast(p=0.2),
+    ],
+    seed=137,
+    strict=True,
+)
+
+augmented_frames = video_transform(images=frames)["images"]
+assert augmented_frames.shape == (4, 20, 28, 3)
+```
+
+This contract synchronizes augmentation parameters, not video decoding or temporal sampling. Decode clips and choose
+timestamps before calling `Compose`.
+
+## Ordered slices and volumes
+
+**Classification: same intent with explicit volume semantics.**
+
+A Python loop over ordered slices can accidentally sample a different crop or flip for each slice. Pass a NumPy volume
+as `(D, H, W, C)` through `volume`. A 2D transform uses one realization across depth. Native 3D transforms can also
+change the depth axis when their API documents that behavior.
+
+```python
+volume = np.arange(8 * 32 * 40, dtype=np.float32).reshape(8, 32, 40, 1)
+
+slice_transform = A.Compose(
+    [A.HorizontalFlip(p=1.0)],
+    strict=True,
+)
+
+augmented_volume = slice_transform(volume=volume)["volume"]
+assert augmented_volume.shape == (8, 32, 40, 1)
+```
+
+The volume target does not replace acquisition-aware resampling, voxel-spacing correction, registration, or framework
+container adapters. Perform those workload-specific operations at the dataset boundary.
+
+## Parallel image-like inputs
+
+**Classification: exact replacement when inputs share geometry.**
+
+Use plural targets for a homogeneous stack. Use `additional_targets` when named arrays have separate meanings but must
+receive the same sampled geometry.
+
+```python
+image = np.zeros((48, 64, 3), dtype=np.uint8)
+depth = np.arange(48 * 64, dtype=np.float32).reshape(48, 64, 1)
+
+paired_transform = A.Compose(
+    [A.HorizontalFlip(p=1.0)],
+    additional_targets={"depth": "image"},
+    strict=True,
+)
+
+paired = paired_transform(image=image, depth=depth)
+assert paired["image"].shape == image.shape
+assert paired["depth"].shape == depth.shape
+```
+
+Mapping depth to `image` is appropriate for geometry in this example. Pixel transforms would also run on the alias.
+Use a mask alias or a separate pipeline when interpolation and pixel behavior must differ.
+
+## Structured target alignment
+
+**Classification: exact replacement for supported boxes, masks, keypoints, and label fields.**
+
+`BboxParams` and `KeypointParams` convert coordinates and filter invalid annotations. `instance_binding` groups each
+instance mask, box, keypoint collection, and label record so crop-induced filtering removes one complete instance.
+
+```python
+image = np.zeros((80, 80, 3), dtype=np.uint8)
+instances = [
+    {
+        "mask": np.pad(np.ones((20, 20), dtype=np.uint8), ((5, 55), (5, 55))),
+        "bbox": np.array([5, 5, 25, 25], dtype=np.float32),
+        "keypoints": np.array([[15.0, 15.0]], dtype=np.float32),
+        "bbox_labels": {"class_id": "cat"},
+    },
+]
+
+structured_transform = A.Compose(
+    [A.Crop(x_min=0, y_min=0, x_max=40, y_max=40, p=1.0)],
+    bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+    keypoint_params=A.KeypointParams(coord_format="xy"),
+    instance_binding=["masks", "bboxes", "keypoints"],
+    strict=True,
+)
+
+result = structured_transform(image=image, instances=instances)
+assert result["instances"][0]["bbox_labels"]["class_id"] == "cat"
+```
+
+Use ordinary `bboxes`, `masks`, and `keypoints` when those collections do not share a one-instance-per-row contract.
+Do not infer alignment from matching lengths.
+
+## Metadata propagation
+
+**Classification: exact replacement for metadata that augmentation should pass through unchanged.**
+
+Use `user_data` for captions, identifiers, timestamps, or other values that do not participate in spatial processors.
+The default handler preserves the object.
+
+```python
+metadata = {"clip_id": "train-137", "start_seconds": 4.5}
+result = A.Compose([A.HorizontalFlip(p=1.0)], strict=True)(
+    image=image,
+    user_data=metadata,
+)
+assert result["user_data"] == metadata
+```
+
+A custom transform may implement `apply_to_user_data` when the metadata must describe a realized augmentation. Keep
+domain-specific parsing and storage outside the transform.
+
+## Reusing sampled parameters
+
+**Classification: exact replacement for replay, same intent for logging.**
+
+Use `ReplayCompose` when another input must receive the exact realized transform parameters. Use
+`save_applied_params=True` when the goal is inspection or logging rather than executable replay.
+
+```python
+tta = A.ReplayCompose(
+    [A.RandomRotate90(p=1.0), A.HorizontalFlip(p=0.5)],
+    seed=137,
+    strict=True,
+)
+
+first = tta(image=image)
+same_realization = A.ReplayCompose.replay(first["replay"], image=image)
+np.testing.assert_array_equal(first["image"], same_realization["image"])
+```
+
+`ReplayCompose` records sampled execution. `A.to_dict` and `A.from_dict` serialize constructor configuration. Test both
+boundaries when a stored pipeline must later reproduce policy and a saved invocation must reproduce one realization.
+
+## RGB-only transforms inside multi-channel arrays
+
+**Classification: exact replacement when the selected channel indices form the intended RGB view.**
+
+Use `SelectiveChannelTransform` instead of splitting, augmenting, and concatenating channels manually.
+
+### Before: split and concatenate channels
+
+```python
+multichannel = np.zeros((32, 32, 5), dtype=np.uint8)
+multichannel[..., 3:] = 137
+
+rgb = multichannel[..., :3]
+extra = multichannel[..., 3:]
+augmented_rgb = A.InvertImg(p=1.0)(image=rgb)["image"]
+selected = np.concatenate([augmented_rgb, extra], axis=-1)
+```
+
+### After: select channels inside the pipeline
+
+```python
+multichannel = np.zeros((32, 32, 5), dtype=np.uint8)
+multichannel[..., 3:] = 137
+
+rgb_only = A.Compose(
+    [
+        A.SelectiveChannelTransform(
+            [A.InvertImg(p=1.0)],
+            channels=(0, 1, 2),
+            p=1.0,
+        ),
+    ],
+    strict=True,
+)
+
+selected = rgb_only(image=multichannel)["image"]
+np.testing.assert_array_equal(selected[..., 3:], multichannel[..., 3:])
+```
+
+The channel selection defines representation, not semantics. Confirm that the selected channels are actually RGB
+before using color transforms.
+
+## Historical custom transforms with built-in replacements
+
+| Historical pattern | Current API | Classification | Important difference |
+| --- | --- | --- | --- |
+| Manual time-axis flip | `TimeReverse` or the matching geometric flip | Exact replacement | The image axis must match time. |
+| Time or frequency strip dropout | `XYMasking` | Exact replacement | Float ranges scale with the selected axis; integer ranges use pixels. |
+| One realization over video frames | `images` | Exact replacement | Temporal decoding and frame selection remain external. |
+| One realization over ordered slices | `volume` | Same intent | Native 3D transforms have separate depth semantics. |
+| Paired image and depth geometry | `additional_targets` | Exact replacement for geometry | Pixel transforms follow the alias type too. |
+| Manual random-state capture | `ReplayCompose` | Exact replacement | Replay data and constructor serialization are separate contracts. |
+| Split RGB from extra bands | `SelectiveChannelTransform` | Exact replacement | Channel order remains the caller's responsibility. |
+| Custom caption passthrough | `user_data` | Exact replacement | Metadata transformation needs an explicit custom handler. |
+| Acquisition-aware resampling | External preprocessing plus `Compose` | Partial replacement | Image interpolation does not preserve domain sampling physics. |
+| Framework-native sample object | Dataset adapter plus public targets | Partial replacement | `Compose` consumes named arrays and metadata, not arbitrary containers. |
+
+## Serialization checklist
+
+Before removing a historical wrapper:
+
+1. Construct the replacement with `strict=True`.
+2. Run representative targets through the public `Compose` call.
+3. Round-trip constructor policy through `A.from_dict(A.to_dict(pipeline))`.
+4. Capture and execute one `ReplayCompose` record when exact invocation replay is required.
+5. Verify shape, dtype, target alignment, caller-input immutability, and deterministic seed behavior.
+6. Keep decoding, resampling, collation, and model tensor conversion at their framework boundaries.
+
+These checks distinguish a real replacement from a wrapper that only appears equivalent on one image.

--- a/docs/integrations/custom-augmentation-migration.md
+++ b/docs/integrations/custom-augmentation-migration.md
@@ -12,11 +12,11 @@ Every recipe uses one of these classifications:
 
 ## Sequence and video synchronization
 
-**Classification: exact replacement for framewise spatial and pixel transforms.**
+**Classification: exact replacement for spatial transforms and pixel transforms with shared batch parameters.**
 
 Historical code often sampled one transform and then reached into private parameters or reset random seeds before each
 frame. Pass the complete sequence through `images` instead. NumPy sequences use `(N, H, W, C)`. AlbumentationsX samples
-one realization and applies it to every frame.
+spatial parameters once and applies the same geometry to every frame.
 
 ### Before: rebuild a seeded pipeline for every frame
 
@@ -43,13 +43,15 @@ setup work.
 ### After: pass the sequence as one public target
 
 ```python
+import albumentations as A
+import numpy as np
+
 frames = np.arange(4 * 24 * 32 * 3, dtype=np.uint8).reshape(4, 24, 32, 3)
 
 video_transform = A.Compose(
     [
         A.RandomCrop(height=20, width=28, p=1.0),
         A.HorizontalFlip(p=0.5),
-        A.RandomBrightnessContrast(p=0.2),
     ],
     seed=137,
     strict=True,
@@ -59,8 +61,10 @@ augmented_frames = video_transform(images=frames)["images"]
 assert augmented_frames.shape == (4, 20, 28, 3)
 ```
 
-This contract synchronizes augmentation parameters, not video decoding or temporal sampling. Decode clips and choose
-timestamps before calling `Compose`.
+Some pixel transforms generate independent per-frame content inside their batch kernel. For example, random dithering
+uses a separate noise map for each frame. Check the transform's batch behavior when temporal consistency matters.
+This contract does not cover video decoding or temporal sampling. Decode clips and choose timestamps before calling
+`Compose`.
 
 ## Ordered slices and volumes
 
@@ -71,6 +75,9 @@ as `(D, H, W, C)` through `volume`. A 2D transform uses one realization across d
 change the depth axis when their API documents that behavior.
 
 ```python
+import albumentations as A
+import numpy as np
+
 volume = np.arange(8 * 32 * 40, dtype=np.float32).reshape(8, 32, 40, 1)
 
 slice_transform = A.Compose(
@@ -93,6 +100,9 @@ Use plural targets for a homogeneous stack. Use `additional_targets` when named 
 receive the same sampled geometry.
 
 ```python
+import albumentations as A
+import numpy as np
+
 image = np.zeros((48, 64, 3), dtype=np.uint8)
 depth = np.arange(48 * 64, dtype=np.float32).reshape(48, 64, 1)
 
@@ -118,6 +128,9 @@ Use a mask alias or a separate pipeline when interpolation and pixel behavior mu
 instance mask, box, keypoint collection, and label record so crop-induced filtering removes one complete instance.
 
 ```python
+import albumentations as A
+import numpy as np
+
 image = np.zeros((80, 80, 3), dtype=np.uint8)
 instances = [
     {
@@ -151,6 +164,10 @@ Use `user_data` for captions, identifiers, timestamps, or other values that do n
 The default handler preserves the object.
 
 ```python
+import albumentations as A
+import numpy as np
+
+image = np.zeros((48, 64, 3), dtype=np.uint8)
 metadata = {"clip_id": "train-137", "start_seconds": 4.5}
 result = A.Compose([A.HorizontalFlip(p=1.0)], strict=True)(
     image=image,
@@ -170,6 +187,10 @@ Use `ReplayCompose` when another input must receive the exact realized transform
 `save_applied_params=True` when the goal is inspection or logging rather than executable replay.
 
 ```python
+import albumentations as A
+import numpy as np
+
+image = np.arange(6 * 8, dtype=np.uint8).reshape(6, 8, 1)
 tta = A.ReplayCompose(
     [A.RandomRotate90(p=1.0), A.HorizontalFlip(p=0.5)],
     seed=137,
@@ -193,6 +214,9 @@ Use `SelectiveChannelTransform` instead of splitting, augmenting, and concatenat
 ### Before: split and concatenate channels
 
 ```python
+import albumentations as A
+import numpy as np
+
 multichannel = np.zeros((32, 32, 5), dtype=np.uint8)
 multichannel[..., 3:] = 137
 
@@ -205,6 +229,9 @@ selected = np.concatenate([augmented_rgb, extra], axis=-1)
 ### After: select channels inside the pipeline
 
 ```python
+import albumentations as A
+import numpy as np
+
 multichannel = np.zeros((32, 32, 5), dtype=np.uint8)
 multichannel[..., 3:] = 137
 
@@ -232,7 +259,7 @@ before using color transforms.
 | --- | --- | --- | --- |
 | Manual time-axis flip | `TimeReverse` or the matching geometric flip | Exact replacement | The image axis must match time. |
 | Time or frequency strip dropout | `XYMasking` | Exact replacement | Float ranges scale with the selected axis; integer ranges use pixels. |
-| One realization over video frames | `images` | Exact replacement | Temporal decoding and frame selection remain external. |
+| One spatial realization over video frames | `images` | Exact replacement for geometry | Pixel transforms may generate per-frame content in their batch kernels. |
 | One realization over ordered slices | `volume` | Same intent | Native 3D transforms have separate depth semantics. |
 | Paired image and depth geometry | `additional_targets` | Exact replacement for geometry | Pixel transforms follow the alias type too. |
 | Manual random-state capture | `ReplayCompose` | Exact replacement | Replay data and constructor serialization are separate contracts. |

--- a/tests/test_custom_augmentation_migration_guide.py
+++ b/tests/test_custom_augmentation_migration_guide.py
@@ -4,36 +4,42 @@ import albumentations as A
 
 
 def test_sequence_recipe_shares_one_spatial_realization() -> None:
-    frames = np.arange(3 * 6 * 8, dtype=np.uint8).reshape(3, 6, 8, 1)
-    transform = A.Compose([A.HorizontalFlip(p=1.0)], strict=True)
+    frame = np.arange(6 * 8, dtype=np.float32).reshape(6, 8, 1)
+    offsets = np.arange(3, dtype=np.float32).reshape(3, 1, 1, 1) * 100
+    frames = frame[np.newaxis, ...] + offsets
+    transform = A.Compose([A.RandomCrop(height=4, width=5, p=1.0)], seed=137, strict=True)
 
     result = transform(images=frames)["images"]
 
-    np.testing.assert_array_equal(result, np.flip(frames, axis=2))
+    normalized = result - offsets
+    np.testing.assert_array_equal(normalized, np.broadcast_to(normalized[:1], normalized.shape))
 
 
 def test_volume_recipe_preserves_depth_and_shares_geometry() -> None:
-    volume = np.arange(4 * 6 * 8, dtype=np.float32).reshape(4, 6, 8, 1)
-    transform = A.Compose([A.HorizontalFlip(p=1.0)], strict=True)
+    slice_data = np.arange(6 * 8, dtype=np.float32).reshape(6, 8, 1)
+    offsets = np.arange(4, dtype=np.float32).reshape(4, 1, 1, 1) * 100
+    volume = slice_data[np.newaxis, ...] + offsets
+    transform = A.Compose([A.RandomCrop(height=4, width=5, p=1.0)], seed=137, strict=True)
 
     result = transform(volume=volume)["volume"]
 
-    np.testing.assert_array_equal(result, np.flip(volume, axis=2))
+    normalized = result - offsets
+    np.testing.assert_array_equal(normalized, np.broadcast_to(normalized[:1], normalized.shape))
 
 
 def test_additional_target_recipe_keeps_paired_geometry_aligned() -> None:
-    image = np.arange(6 * 8, dtype=np.uint8).reshape(6, 8, 1)
-    depth = np.arange(6 * 8, dtype=np.float32).reshape(6, 8, 1)
+    image = np.arange(6 * 8, dtype=np.float32).reshape(6, 8, 1)
+    depth = image.copy()
     transform = A.Compose(
-        [A.HorizontalFlip(p=1.0)],
+        [A.RandomCrop(height=4, width=5, p=1.0)],
         additional_targets={"depth": "image"},
+        seed=137,
         strict=True,
     )
 
     result = transform(image=image, depth=depth)
 
-    np.testing.assert_array_equal(result["image"], np.flip(image, axis=1))
-    np.testing.assert_array_equal(result["depth"], np.flip(depth, axis=1))
+    np.testing.assert_array_equal(result["image"], result["depth"])
 
 
 def test_structured_recipe_filters_complete_bound_instance() -> None:
@@ -61,7 +67,7 @@ def test_structured_recipe_filters_complete_bound_instance() -> None:
     transform = A.Compose(
         [A.Crop(x_min=0, y_min=0, x_max=40, y_max=40, p=1.0)],
         bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
-        keypoint_params=A.KeypointParams(coord_format="xy", remove_invisible=True),
+        keypoint_params=A.KeypointParams(coord_format="xy"),
         instance_binding=["masks", "bboxes", "keypoints"],
         strict=True,
     )
@@ -101,18 +107,22 @@ def test_replay_recipe_reuses_realized_parameters() -> None:
 def test_recipe_constructor_configuration_round_trip() -> None:
     image = np.arange(6 * 8, dtype=np.uint8).reshape(6, 8, 1)
     transform = A.Compose(
-        [A.HorizontalFlip(p=1.0)],
+        [A.RandomCrop(height=4, width=5, p=1.0), A.HorizontalFlip(p=0.5)],
         additional_targets={"paired": "image"},
         seed=137,
         strict=True,
     )
 
     restored = A.from_dict(A.to_dict(transform))
-    expected = transform(image=image, paired=image.copy())
-    actual = restored(image=image, paired=image.copy())
+    assert restored.seed == transform.seed
+    assert restored.additional_targets == transform.additional_targets
 
-    np.testing.assert_array_equal(actual["image"], expected["image"])
-    np.testing.assert_array_equal(actual["paired"], expected["paired"])
+    for _ in range(4):
+        expected = transform(image=image, paired=image.copy())
+        actual = restored(image=image, paired=image.copy())
+
+        np.testing.assert_array_equal(actual["image"], expected["image"])
+        np.testing.assert_array_equal(actual["paired"], expected["paired"])
 
 
 def test_selective_channel_recipe_preserves_unselected_channels() -> None:

--- a/tests/test_custom_augmentation_migration_guide.py
+++ b/tests/test_custom_augmentation_migration_guide.py
@@ -1,0 +1,136 @@
+import numpy as np
+
+import albumentations as A
+
+
+def test_sequence_recipe_shares_one_spatial_realization() -> None:
+    frames = np.arange(3 * 6 * 8, dtype=np.uint8).reshape(3, 6, 8, 1)
+    transform = A.Compose([A.HorizontalFlip(p=1.0)], strict=True)
+
+    result = transform(images=frames)["images"]
+
+    np.testing.assert_array_equal(result, np.flip(frames, axis=2))
+
+
+def test_volume_recipe_preserves_depth_and_shares_geometry() -> None:
+    volume = np.arange(4 * 6 * 8, dtype=np.float32).reshape(4, 6, 8, 1)
+    transform = A.Compose([A.HorizontalFlip(p=1.0)], strict=True)
+
+    result = transform(volume=volume)["volume"]
+
+    np.testing.assert_array_equal(result, np.flip(volume, axis=2))
+
+
+def test_additional_target_recipe_keeps_paired_geometry_aligned() -> None:
+    image = np.arange(6 * 8, dtype=np.uint8).reshape(6, 8, 1)
+    depth = np.arange(6 * 8, dtype=np.float32).reshape(6, 8, 1)
+    transform = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        additional_targets={"depth": "image"},
+        strict=True,
+    )
+
+    result = transform(image=image, depth=depth)
+
+    np.testing.assert_array_equal(result["image"], np.flip(image, axis=1))
+    np.testing.assert_array_equal(result["depth"], np.flip(depth, axis=1))
+
+
+def test_structured_recipe_filters_complete_bound_instance() -> None:
+    image = np.zeros((80, 80, 3), dtype=np.uint8)
+
+    def mask_at(start: int, stop: int) -> np.ndarray:
+        mask = np.zeros((80, 80), dtype=np.uint8)
+        mask[start:stop, start:stop] = 1
+        return mask
+
+    instances = [
+        {
+            "mask": mask_at(5, 25),
+            "bbox": np.array([5, 5, 25, 25], dtype=np.float32),
+            "keypoints": np.array([[15.0, 15.0]], dtype=np.float32),
+            "bbox_labels": {"class_id": "cat"},
+        },
+        {
+            "mask": mask_at(50, 70),
+            "bbox": np.array([50, 50, 70, 70], dtype=np.float32),
+            "keypoints": np.array([[60.0, 60.0]], dtype=np.float32),
+            "bbox_labels": {"class_id": "dog"},
+        },
+    ]
+    transform = A.Compose(
+        [A.Crop(x_min=0, y_min=0, x_max=40, y_max=40, p=1.0)],
+        bbox_params=A.BboxParams(coord_format="pascal_voc", label_fields=["class_id"]),
+        keypoint_params=A.KeypointParams(coord_format="xy", remove_invisible=True),
+        instance_binding=["masks", "bboxes", "keypoints"],
+        strict=True,
+    )
+
+    result = transform(image=image, instances=instances)
+
+    assert len(result["instances"]) == 1
+    assert result["instances"][0]["bbox_labels"]["class_id"] == "cat"
+    assert result["instances"][0]["mask"].shape == (40, 40)
+    np.testing.assert_array_equal(result["instances"][0]["keypoints"], [[15.0, 15.0]])
+
+
+def test_user_data_recipe_preserves_metadata() -> None:
+    image = np.zeros((6, 8, 1), dtype=np.uint8)
+    metadata = {"clip_id": "train-137", "start_seconds": 4.5}
+    transform = A.Compose([A.HorizontalFlip(p=1.0)], strict=True)
+
+    result = transform(image=image, user_data=metadata)
+
+    assert result["user_data"] is metadata
+
+
+def test_replay_recipe_reuses_realized_parameters() -> None:
+    image = np.arange(6 * 8, dtype=np.uint8).reshape(6, 8, 1)
+    transform = A.ReplayCompose(
+        [A.RandomRotate90(p=1.0), A.HorizontalFlip(p=0.5)],
+        seed=137,
+        strict=True,
+    )
+
+    first = transform(image=image)
+    replayed = A.ReplayCompose.replay(first["replay"], image=image)
+
+    np.testing.assert_array_equal(first["image"], replayed["image"])
+
+
+def test_recipe_constructor_configuration_round_trip() -> None:
+    image = np.arange(6 * 8, dtype=np.uint8).reshape(6, 8, 1)
+    transform = A.Compose(
+        [A.HorizontalFlip(p=1.0)],
+        additional_targets={"paired": "image"},
+        seed=137,
+        strict=True,
+    )
+
+    restored = A.from_dict(A.to_dict(transform))
+    expected = transform(image=image, paired=image.copy())
+    actual = restored(image=image, paired=image.copy())
+
+    np.testing.assert_array_equal(actual["image"], expected["image"])
+    np.testing.assert_array_equal(actual["paired"], expected["paired"])
+
+
+def test_selective_channel_recipe_preserves_unselected_channels() -> None:
+    image = np.zeros((6, 8, 5), dtype=np.uint8)
+    image[..., :3] = 10
+    image[..., 3:] = 137
+    transform = A.Compose(
+        [
+            A.SelectiveChannelTransform(
+                [A.InvertImg(p=1.0)],
+                channels=(0, 1, 2),
+                p=1.0,
+            ),
+        ],
+        strict=True,
+    )
+
+    result = transform(image=image)["image"]
+
+    np.testing.assert_array_equal(result[..., :3], 245)
+    np.testing.assert_array_equal(result[..., 3:], image[..., 3:])


### PR DESCRIPTION
Closes #318.

## Summary

- add runnable before-and-after recipes for frame, volume, paired-input, structured-target, replay, metadata, and selected-channel workflows
- classify each migration as an exact replacement, same-intent mapping, or partial replacement with explicit limitations
- add executable coverage for sequence and volume synchronization, paired geometry, instance filtering, replay, configuration serialization, metadata, and channel isolation
- link the guide from the existing target-routing, replay, and transform-development references

## Validation

- `pytest -q tests/test_custom_augmentation_migration_guide.py` (8 passed)
- `pytest -q tests/test_serialization.py -k composition_subclasses_preserve_class_policy_in_roundtrip_and_operators` (1 passed)
- `pytest -q tests/test_instance_binding.py -k basic_roundtrip` (1 passed)
- `ruff check tests/test_custom_augmentation_migration_guide.py`
- `ruff format --check tests/test_custom_augmentation_migration_guide.py`
- all 9 documentation Python blocks executed independently
- `pre-commit run check-ax-rules --all-files`
- local Markdown link check
- `git diff --check`

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.

## Summary by Sourcery

Document and validate public API migrations for common custom augmentation wrappers.

New Features:
- Add a user-facing migration guide with runnable before-and-after recipes for sequence, volume, paired-input, structured-target, metadata, replay, and selective-channel augmentation workflows.

Enhancements:
- Document the classification and limitations of current APIs as replacements for historical custom augmentation wrappers.
- Add executable coverage for target synchronization, structured instance filtering, metadata propagation, replay, serialization, and channel isolation.

Documentation:
- Link the migration guide from transform-development, target-routing, and replay contract documentation.