### PR TITLE
docs(licensing): present commercial coverage alongside AGPL

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -8,16 +8,27 @@ licensed under the GNU Affero General Public License, version 3 only
 (`AGPL-3.0-only`). Third-party material and its applicable notices are
 identified in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
-The AGPL permits commercial use subject to its terms. Albumentations, LLC also
-offers separately negotiated commercial licenses that provide alternative,
-scope-specific permissions for the versions and uses identified in the
-applicable agreement or order form. A commercial license does not remove the
-AGPL availability of the public repository. Support, warranties, maintenance,
-and service levels are included only when an executed agreement or order form
-expressly says so.
+The AGPL permits commercial use subject to its terms. The public repository
+remains available under AGPL-3.0-only when commercial licenses are also offered.
 
-For commercial licensing inquiries, visit <https://albumentations.ai/pricing>
-or contact <vladimir@albumentations.ai>.
+## Commercial Licensing
+
+Albumentations, LLC offers commercial licenses for proprietary applications
+and services. An agreement can grant rights to use, modify, integrate, host,
+or distribute AlbumentationsX without AGPL source-sharing requirements for
+the use covered by that agreement.
+
+The agreement or order form defines scope-specific permissions for the named
+legal entities, teams, projects or products, versions, deployments, and term,
+including any distribution rights.
+Third-party licenses and notices continue to apply. Support, warranties,
+maintenance, and service levels are included only when an executed agreement
+or order form expressly says so.
+
+[Request a quote](https://albumentations.ai/pricing) for the coverage you need,
+or email <vladimir@albumentations.ai>. To compare the commercial option with
+AGPL, including internal training and model outputs, read the
+[license guide](https://albumentations.ai/docs/license/).
 
 ## License History
 

--- a/README.md
+++ b/README.md
@@ -30,26 +30,20 @@ Your citation makes the project's research impact visible to funders and helps s
 }
 ```
 
-## 📢 Licensing: commercial use is allowed
+<a id="-licensing-commercial-use-is-allowed"></a>
 
-**AlbumentationsX can be used in commercial projects under the AGPL.** The
-current public repository is available under **AGPL-3.0-only**, an open-source
-license. The AGPL permits commercial use subject to its terms.
+## Licensing
 
-Albumentations, LLC also offers separately negotiated commercial licenses with
-alternative, scope-specific permissions for the versions and uses covered by
-an executed agreement. A commercial license is an option when a team needs
-terms different from the AGPL. It is not automatically required because a
-project is commercial, proprietary, in production, or internal.
+AlbumentationsX offers two license options:
 
-Which terms fit depends on the deployment facts, including modification,
-combination, copying or conveyance, and network interaction. Support,
-warranties, maintenance, and service levels are included only when an executed
-agreement or order form expressly says so. See the [AGPL text](LICENSE),
-[licensing details and history](LICENSING.md), and
-[third-party notices](THIRD_PARTY_NOTICES.md).
+- **Commercial license:** use AlbumentationsX in proprietary software under an agreement covering your team,
+  products, and deployments. [Request a quote](https://albumentations.ai/pricing?utm_source=github&utm_medium=referral&utm_campaign=readme).
+- **AGPL-3.0-only:** available at no charge. The AGPL permits commercial use subject to its terms.
+  [Read the license guide](https://albumentations.ai/docs/license/).
 
-### Quick Start
+See the [AGPL text](LICENSE) and [licensing details and history](LICENSING.md) for the applicable terms.
+
+## Quick Start
 
 ```bash
 # Install the PyTorch build for your platform first. For Linux CPU-only:
@@ -71,8 +65,6 @@ transform = A.Compose(
 )
 ```
 
-For commercial licensing inquiries, please visit [our pricing page](https://albumentations.ai/pricing?utm_source=github&utm_medium=referral&utm_campaign=readme).
-
 ---
 
 Here is an example of how you can apply some [pixel-level](#pixel-level-transforms) augmentations to create new images from the original one:
@@ -90,7 +82,7 @@ Here is an example of how you can apply some [pixel-level](#pixel-level-transfor
 ## Table of contents
 
 - [Citing](#citing)
-- [Licensing](#-licensing-commercial-use-is-allowed)
+- [Licensing](#licensing)
 - [Quick Start](#quick-start)
 - [Why AlbumentationsX](#why-albumentationsx)
 - [Authors](#authors)
@@ -502,16 +494,9 @@ We look forward to your contributions to help make the AlbumentationsX ecosystem
 
 ## 📜 License
 
-The current public repository is licensed under **AGPL-3.0-only**. Earlier
-AlbumentationsX releases retain the license terms recorded in the
-[licensing details and history](LICENSING.md). The AGPL permits commercial use subject
-to its terms.
-
-For alternative, scope-specific terms from Albumentations, LLC, visit the
-[pricing page](https://albumentations.ai/pricing?utm_source=github&utm_medium=referral&utm_campaign=readme).
-The [AGPL text](LICENSE), [licensing details](LICENSING.md), and
-[third-party notices](THIRD_PARTY_NOTICES.md) contain the complete
-repository-level details.
+See [Licensing](#licensing) for the two options. The [AGPL text](LICENSE),
+[licensing history](LICENSING.md), and [third-party notices](THIRD_PARTY_NOTICES.md)
+record the applicable terms. Earlier releases retain the permissions that accompanied them.
 
 ## 📞 Contact
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ Your citation makes the project's research impact visible to funders and helps s
 
 AlbumentationsX offers two license options:
 
-- **Commercial license:** use AlbumentationsX in proprietary software under an agreement covering your team,
-  products, and deployments. [Request a quote](https://albumentations.ai/pricing?utm_source=github&utm_medium=referral&utm_campaign=readme).
+- **Commercial license:** choose alternative permissions for proprietary software under an agreement covering your
+  team, products, and deployments. [Request a quote](https://albumentations.ai/pricing?utm_source=github&utm_medium=referral&utm_campaign=readme).
 - **AGPL-3.0-only:** available at no charge. The AGPL permits commercial use subject to its terms.
   [Read the license guide](https://albumentations.ai/docs/license/).
 
+Commercial, proprietary, internal, or production status alone does not require a commercial license.
 See the [AGPL text](LICENSE) and [licensing details and history](LICENSING.md) for the applicable terms.
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "albumentationsx"
 
 version = "2.4.6"
 
-description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Licensed under AGPL-3.0-only; alternative commercial terms are also available."
+description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Available under AGPL-3.0-only or a commercial license with agreed coverage for your team, products, and deployments."
 readme = "README.md"
 keywords = [
   "2D augmentation",
@@ -214,7 +214,7 @@ dev = [
 [project.urls]
 Homepage = "https://albumentations.ai"
 Documentation = "https://albumentations.ai/docs/"
-"Buy Commercial License" = "https://albumentations.ai/pricing"
+"Commercial Licensing" = "https://albumentations.ai/pricing"
 Repository = "https://github.com/albumentations-team/AlbumentationsX"
 Changelog = "https://github.com/albumentations-team/AlbumentationsX/releases"
 Discord = "https://discord.gg/AKPrrDYNAt"


### PR DESCRIPTION
The README leads with a long permission explanation while the commercial offer remains abstract. Present two clear choices: a commercial agreement covering a company's proprietary software, teams, products, and deployments; or AGPL-3.0-only at no charge under its terms.

Update README, LICENSING.md, the package description, and the commercial URL label. Preserve the previous README licensing anchor, license history, exact LICENSE text, SPDX identifier, and third-party notices. No library behavior changes.

Validation: 14 legal integrity tests; source-tree and built wheel/sdist legal integrity; twine check; pre-commit including lock, CI matrix, license/CLA provenance, links, and Pyrefly. Both built artifacts passed. Companion ai-docs and website changes explain internal training, model outputs, and scoped quote requests.

PyPI will receive the new README through a normal subsequent release. Existing published packages are not replaced.

## Summary by Sourcery

Present clear AGPL-3.0-only and commercial licensing options across the project’s public documentation and metadata.

Enhancements:
- Clarify the two available licensing paths, presenting commercial coverage for proprietary teams, products, and deployments alongside the no-cost AGPL-3.0-only option.
- Align the licensing guidance across the README, licensing documentation, package metadata, and commercial-link labeling while preserving existing legal references and license history.

Documentation:
- Update user-facing licensing documentation with clearer commercial terms, AGPL comparison guidance, and quote-request links.