### PR TITLE
docs(contributing): use publishable source links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ For help, ask in the issue, pull request, or Discord discussion.
 ## Contributor License Agreement
 
 Before we can accept your contribution, you must accept our
-[Contributor License Agreement (CLA) Version 2.0](CLA.md). It lets
+[Contributor License Agreement (CLA) Version 2.0](https://github.com/albumentations-team/AlbumentationsX/blob/main/CLA.md).
+It lets
 Albumentations, LLC publish accepted contributions under AGPL-3.0-only and
 offer the same contributions under separately negotiated commercial terms.
 You retain ownership of your work.
@@ -39,7 +40,8 @@ I have read and agree to the AlbumentationsX CLA Version 2.0 (July 14, 2026) as 
 ```
 
 If an employer or another legal entity owns or controls the contribution, use
-the Entity Acceptance process in [CLA.md](CLA.md) instead. A corporate signer
+the Entity Acceptance process in [CLA.md](https://github.com/albumentations-team/AlbumentationsX/blob/main/CLA.md)
+instead. A corporate signer
 must identify the exact legal entity, their authority, and the covered
 contributors. Do not use an individual acceptance to license employer-owned
 work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ For help, ask in the issue, pull request, or Discord discussion.
 ## Contributor License Agreement
 
 Before we can accept your contribution, you must accept our
-[Contributor License Agreement (CLA) Version 2.0](https://github.com/albumentations-team/AlbumentationsX/blob/main/CLA.md).
+[Contributor License Agreement (CLA) Version 2.0](https://github.com/albumentations-team/AlbumentationsX/blob/main/legal/cla/archive/CLA-v2.0-2026-07-14.md).
 It lets
 Albumentations, LLC publish accepted contributions under AGPL-3.0-only and
 offer the same contributions under separately negotiated commercial terms.
@@ -40,7 +40,8 @@ I have read and agree to the AlbumentationsX CLA Version 2.0 (July 14, 2026) as 
 ```
 
 If an employer or another legal entity owns or controls the contribution, use
-the Entity Acceptance process in [CLA.md](https://github.com/albumentations-team/AlbumentationsX/blob/main/CLA.md)
+the Entity Acceptance process in
+[CLA.md](https://github.com/albumentations-team/AlbumentationsX/blob/main/legal/cla/archive/CLA-v2.0-2026-07-14.md)
 instead. A corporate signer
 must identify the exact legal entity, their authority, and the covered
 contributors. Do not use an individual acceptance to license employer-owned

--- a/docs/contributing/coding_guidelines.md
+++ b/docs/contributing/coding_guidelines.md
@@ -500,7 +500,8 @@ read sampled values from `**params` inside the transform method.
 
 Keep batch and channel axes distinct. Reshaping `(N, H, W, 1)` into `(H, W, N)` adds a transpose and may require a
 copy; OpenCV processes those channels sequentially. Use the
-[benchmark skill](../../.codex/skills/benchmark/SKILL.md) for the required direct and Compose measurements.
+[benchmark skill](https://github.com/albumentations-team/AlbumentationsX/blob/main/.codex/skills/benchmark/SKILL.md)
+for the required direct and Compose measurements.
 
 ### Coordinate Systems
 
@@ -557,7 +558,9 @@ interface; do not repeat it on each override.
 - Use `See also` for two to four related transforms, one per bullet with a selection hint. Keep cross-links reciprocal.
 - Use `Note` bullets for factual details. Put recommendations in `See also`.
 
-Use the [docstring review skill](../../.codex/skills/docstring-deep-dive/SKILL.md) to review reader-facing quality.
+Use the
+[docstring review skill](https://github.com/albumentations-team/AlbumentationsX/blob/main/.codex/skills/docstring-deep-dive/SKILL.md)
+to review reader-facing quality.
 
 ### Examples in Docstrings
 
@@ -663,11 +666,15 @@ np.testing.assert_array_equal(transformed_image, image)
 
 ## Performance Optimization
 
-Use [Performance Optimization](../../.codex/skills/performance-optimization/SKILL.md) and its synchronized reference
+Use
+[Performance Optimization](https://github.com/albumentations-team/AlbumentationsX/blob/main/.codex/skills/performance-optimization/SKILL.md)
+and its synchronized reference
 for runtime audits. The workflow covers removable work, memory traffic, vectorization, grouped reductions, LUTs,
 random generation, backend selection, Albucore ownership, and aliasing.
 
-Treat each candidate as a hypothesis. Use the [benchmark skill](../../.codex/skills/benchmark/SKILL.md) to compare
+Treat each candidate as a hypothesis. Use the
+[benchmark skill](https://github.com/albumentations-team/AlbumentationsX/blob/main/.codex/skills/benchmark/SKILL.md)
+to compare
 baseline and candidate on the affected public routes, and record every measured cell and any regressions.
 
 ### Updating Transform Documentation

--- a/docs/contributing/environment_setup.md
+++ b/docs/contributing/environment_setup.md
@@ -97,6 +97,7 @@ uv run python tools/generate_correctness_report.py \
 
 Keep local reports and other temporary artifacts under `_internal/`.
 
-Follow the [Coding Guidelines](coding_guidelines.md) and [Contributing Guide](../../CONTRIBUTING.md) for your change.
+Follow the [Coding Guidelines](coding_guidelines.md) and
+[Contributing Guide](https://github.com/albumentations-team/AlbumentationsX/blob/main/CONTRIBUTING.md) for your change.
 For setup problems, check existing [issues](https://github.com/albumentations-team/AlbumentationsX/issues) or ask in
 [Discord](https://discord.gg/e6zHCXTvaN).


### PR DESCRIPTION
## Summary

- point CLA references at the canonical GitHub file
- point contributor workflow references at their canonical skill files
- keep copied website documentation from generating broken internal routes

## Validation

- `PRE_COMMIT_HOME=/private/tmp/ax-doc-links-precommit pre-commit run --files CONTRIBUTING.md docs/contributing/coding_guidelines.md`

## Summary by Sourcery

Use canonical publishable links throughout contributor documentation to keep references valid across published copies.

Bug Fixes:
- Prevent copied website documentation from producing broken internal links.

Enhancements:
- Use canonical GitHub URLs for the CLA and contributor workflow references.

Documentation:
- Update contributor documentation links to point to publishable source files and canonical skill references.