### PR TITLE
chore(release): prepare 2.4.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.4.6"
+version = "2.4.7"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Available under AGPL-3.0-only or a commercial license with agreed coverage for your team, products, and deployments."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.4.6"
+version = "2.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
Prepare the 2.4.7 patch release so the updated README and package description reach PyPI. Since 2.4.6, main contains the licensing explanations in #501 and contributor documentation link fixes in #502.

This PR increases the version in `pyproject.toml` and refreshes `uv.lock`; dependencies and runtime code are unchanged.

Validation: pre-commit and `uv lock --check` passed. [CI release preflight](https://github.com/albumentations-team/AlbumentationsX/actions/runs/34484624867) passed packaging, legal integrity, clean install, 25 correctness checks, the performance budget, and security checks. The final bundle was downloaded and verified against its GitHub artifact digest, manifest, payload hashes, and tracked source digest; its wheel contains the new README and retains `AGPL-3.0-only`.

Prepared release notes:

> This patch release refreshes the package documentation.
>
> - Present commercial licensing coverage alongside the free AGPL option, with links to the license guide and quote request (#501).
> - Fix contributor documentation links to canonical source files (#502).
>
> Runtime behavior, dependencies, and license terms are unchanged.
