### PR TITLE
docs(readme): fix license links on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > 📣 **Stay updated!** [Subscribe to our newsletter](https://albumentations.ai/subscribe?utm_source=github&utm_medium=referral&utm_campaign=readme) for the latest releases, tutorials, and tips.
 
-[![License: AGPL-3.0-only](https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg)](LICENSE)
+[![License: AGPL-3.0-only](https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg)](https://github.com/albumentations-team/AlbumentationsX/blob/main/LICENSE)
 [![Commercial License](https://img.shields.io/badge/Commercial_License-available-brightgreen)](https://albumentations.ai/pricing?utm_source=github&utm_medium=referral&utm_campaign=readme)
 
 [![Docs](https://img.shields.io/badge/docs-albumentations.ai-blue)](https://albumentations.ai/docs/?utm_source=github&utm_medium=referral&utm_campaign=readme) [![Discord](https://img.shields.io/badge/Discord-join-7289da?logo=discord&logoColor=white)](https://discord.gg/AKPrrDYNAt) [![Twitter](https://img.shields.io/badge/Twitter-follow-1da1f2?logo=twitter&logoColor=white)](https://twitter.com/albumentations) [![LinkedIn](https://img.shields.io/badge/LinkedIn-connect-0077b5?logo=linkedin&logoColor=white)](https://www.linkedin.com/company/albumentations/) [![Reddit](https://img.shields.io/badge/Reddit-join-ff4500?logo=reddit&logoColor=white)](https://www.reddit.com/r/Albumentations/)
@@ -42,7 +42,9 @@ AlbumentationsX offers two license options:
   [Read the license guide](https://albumentations.ai/docs/license/).
 
 Commercial, proprietary, internal, or production status alone does not require a commercial license.
-See the [AGPL text](LICENSE) and [licensing details and history](LICENSING.md) for the applicable terms.
+See the [AGPL text](https://github.com/albumentations-team/AlbumentationsX/blob/main/LICENSE)
+and [licensing details and history](https://github.com/albumentations-team/AlbumentationsX/blob/main/LICENSING.md)
+for the applicable terms.
 
 ## Quick Start
 
@@ -495,8 +497,10 @@ We look forward to your contributions to help make the AlbumentationsX ecosystem
 
 ## 📜 License
 
-See [Licensing](#licensing) for the two options. The [AGPL text](LICENSE),
-[licensing history](LICENSING.md), and [third-party notices](THIRD_PARTY_NOTICES.md)
+See [Licensing](#licensing) for the two options.
+The [AGPL text](https://github.com/albumentations-team/AlbumentationsX/blob/main/LICENSE),
+[licensing history](https://github.com/albumentations-team/AlbumentationsX/blob/main/LICENSING.md),
+and [third-party notices](https://github.com/albumentations-team/AlbumentationsX/blob/main/THIRD_PARTY_NOTICES.md)
 record the applicable terms. Earlier releases retain the permissions that accompanied them.
 
 ## 📞 Contact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "albumentationsx"
 
-version = "2.4.7"
+version = "2.4.8"
 
 description = "Fast, flexible, and advanced augmentation library for deep learning, computer vision, and medical imaging. Albumentations offers a wide range of transformations for both 2D (images, masks, bboxes, keypoints) and 3D (volume data, volumetric masks, keypoints) data, with optimized performance and seamless integration into ML workflows. Available under AGPL-3.0-only or a commercial license with agreed coverage for your team, products, and deployments."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "albumentationsx"
-version = "2.4.7"
+version = "2.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "albucore" },


### PR DESCRIPTION
The README published on PyPI resolves relative repository-file links under the PyPI project URL, where those files do not exist. Convert the six links to license and notice files to absolute GitHub URLs.

Bump the package to 2.4.8 so the corrected description is delivered through the normal release process. Previously published artifacts remain unchanged.

Validation: legal-integrity tests, wheel and source-distribution verification, and the complete PR preflight passed on `f414ad540830331ab1c082fb6d357e976c9d8ed2`.
