### PR TITLE
Fix nightly lower-bound dependency drift

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,15 +84,9 @@ jobs:
         python-version: "3.10"
         uv-version: "0.12.0"
     - name: Install declared minimum runtime dependencies
-      run: >
-        uv pip install -e .
-        numpy==2.2.6
-        scipy==1.15.3
-        pydantic==2.12.4
-        albucore==0.2.16
-        opencv-python-headless==5.0.0.93
-        hypothesis
-        pytest
+      run: uv pip install --resolution lowest-direct --strict -e ".[headless]"
+    - name: Install test dependencies
+      run: uv pip install hypothesis pytest
     - name: Install CPU-only Torch runtime
       uses: albumentations-team/ci-foundation/actions/torch-cpu@6b9045dbea58026a1e8f96b0392c411934a27199
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,7 @@ repos:
         language: system
         files: ^(pyproject\.toml|conda\.recipe/meta\.yaml|tools/check_conda_dependencies\.py)$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.5
+    rev: v0.16.6
     hooks:
       - id: ruff
         exclude: '__pycache__/'
@@ -138,7 +138,7 @@ repos:
         args:
           [ --config-file=pyproject.toml ]
   - repo: https://github.com/facebook/pyrefly-pre-commit
-    rev: 1.3.0.dev3
+    rev: 1.3.0.dev4
     hooks:
       - id: pyrefly-check
         name: Pyrefly type check

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python
     - numpy>=2.2.6
     - scipy>=1.15.3
-    - pyyaml
+    - pyyaml>=6.0.3
     - pydantic>=2.12.4
     - typing-extensions>=4.9.0
     - opencv-python-headless>=5.0.0.93

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ dependencies = [
   "numkong>=7.8.0",
   "numpy>=2.2.6",
   "pydantic>=2.12.4",
-  "pyyaml",
+  "pyyaml>=6.0.3",
   "scipy>=1.15.3",
   "typing-extensions>=4.9.0",
 ]

--- a/tests/test_ci_runtime_profiles.py
+++ b/tests/test_ci_runtime_profiles.py
@@ -8,10 +8,17 @@ from typing import Any
 
 import yaml
 
-from tools.ci_matrix import CI_FOUNDATION_SHA, TORCH_RUNTIME_JOBS, _check_ci_dependency_groups
+from tools.ci_matrix import (
+    CI_FOUNDATION_SHA,
+    TORCH_RUNTIME_JOBS,
+    _check_ci_dependency_groups,
+    _check_lower_bound_install_commands,
+    _check_project_runtime_lower_bounds,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SETUP_ACTION = REPO_ROOT / ".github" / "actions" / "setup-ci" / "action.yml"
+NIGHTLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "nightly.yml"
 
 
 def _jobs(path: Path) -> dict[str, dict[str, Any]]:
@@ -68,3 +75,25 @@ def test_dependency_group_check_reports_broken_include_reference() -> None:
     issues = _check_ci_dependency_groups({"ci-release": [{"include-group": "ci-benhcmark"}]})
 
     assert "refers to non-existent group 'ci-benhcmark'" in "\n".join(issues)
+
+
+def test_lower_bound_job_resolves_runtime_versions_from_project_metadata() -> None:
+    job = _jobs(NIGHTLY_WORKFLOW)["lower_bound_dependencies"]
+    runtime_install = next(
+        step for step in job["steps"] if step.get("name") == "Install declared minimum runtime dependencies"
+    )["run"]
+
+    assert _check_lower_bound_install_commands() == []
+    assert re.search(r"\b[a-zA-Z][\w.-]*(?:===|==|~=|!=|>=|<=|>|<)", runtime_install) is None
+
+
+def test_runtime_dependencies_must_declare_lower_bounds() -> None:
+    assert _check_project_runtime_lower_bounds({"dependencies": ["pyyaml; python_version > '3.10'"]}) == [
+        "pyproject.toml runtime dependency \"pyyaml; python_version > '3.10'\" must declare a lower bound",
+    ]
+    assert (
+        _check_project_runtime_lower_bounds(
+            {"dependencies": ["pyyaml>=6.0.3; python_version > '3.10'"]},
+        )
+        == []
+    )

--- a/tools/ci_matrix.py
+++ b/tools/ci_matrix.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from packaging.requirements import InvalidRequirement, Requirement
 
 try:
     import tomllib
@@ -89,13 +90,6 @@ FORBIDDEN_WORKFLOWS = (
 )
 MAX_WORKFLOW_TIMEOUT_MINUTES = 90
 
-LOWER_BOUND_REQUIREMENTS = (
-    "numpy==2.2.6",
-    "scipy==1.15.3",
-    "pydantic==2.12.4",
-    "albucore==0.2.16",
-    "opencv-python-headless==5.0.0.93",
-)
 CI_DEPENDENCY_GROUPS = {
     "ci-benchmark": {"asv", "opencv-python-headless"},
     "ci-package": {"pytest", "twine"},
@@ -373,6 +367,22 @@ def _check_project_torch_metadata(project: dict[str, Any]) -> list[str]:
     return issues
 
 
+def _check_project_runtime_lower_bounds(project: dict[str, Any]) -> list[str]:
+    dependencies = project.get("dependencies")
+    if not isinstance(dependencies, list):
+        return []
+
+    issues: list[str] = []
+    for requirement in dependencies:
+        try:
+            specifiers = Requirement(requirement).specifier if isinstance(requirement, str) else ()
+        except InvalidRequirement:
+            specifiers = ()
+        if not any(specifier.operator in {"===", "==", "~=", ">=", ">"} for specifier in specifiers):
+            issues.append(f"pyproject.toml runtime dependency {requirement!r} must declare a lower bound")
+    return issues
+
+
 def _check_torch_free_install_surfaces() -> list[str]:
     issues: list[str] = []
     development_requirements = _read_text(DEVELOPMENT_REQUIREMENTS)
@@ -430,6 +440,7 @@ def _check_pyproject() -> list[str]:
         )
 
     issues.extend(_check_project_torch_metadata(project))
+    issues.extend(_check_project_runtime_lower_bounds(project))
     issues.extend(_check_torch_free_install_surfaces())
 
     dependency_groups = pyproject.get("dependency-groups", {})
@@ -553,6 +564,30 @@ def _check_lower_bound_torch_runtime() -> list[str]:
     ):
         issues.append(f"{NIGHTLY_WORKFLOW} lower_bound_dependencies must install the shared CPU Torch runtime")
     return issues
+
+
+def _check_lower_bound_install_commands() -> list[str]:
+    job = _workflow_jobs(NIGHTLY_WORKFLOW).get("lower_bound_dependencies")
+    if not isinstance(job, dict):
+        return []
+
+    steps = job.get("steps", [])
+    commands = {
+        step.get("name"): " ".join(str(step.get("run", "")).split())
+        for step in steps
+        if isinstance(step, dict) and isinstance(step.get("name"), str)
+    }
+    expected_commands = {
+        "Install declared minimum runtime dependencies": (
+            'uv pip install --resolution lowest-direct --strict -e ".[headless]"'
+        ),
+        "Install test dependencies": "uv pip install hypothesis pytest",
+    }
+    return [
+        f"{NIGHTLY_WORKFLOW} step {step_name!r} must run {expected_command!r}"
+        for step_name, expected_command in expected_commands.items()
+        if commands.get(step_name) != expected_command
+    ]
 
 
 def _check_workflow_torch_cleanup() -> list[str]:
@@ -786,7 +821,7 @@ def _workflow_job_run_text(job: dict[str, Any]) -> str:
 
 def _check_nightly_workflow() -> list[str]:
     issues = _check_full_matrix_workflow(NIGHTLY_WORKFLOW)
-    issues.extend(_check_text_mentions(NIGHTLY_WORKFLOW, LOWER_BOUND_REQUIREMENTS, "lower-bound dependency"))
+    issues.extend(_check_lower_bound_install_commands())
     issues.extend(
         _check_text_mentions(
             NIGHTLY_WORKFLOW,

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'text'" },
     { name = "pydantic", specifier = ">=2.12.4" },
     { name = "pyvips", extras = ["binary"], marker = "extra == 'pyvips'" },
-    { name = "pyyaml" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "typing-extensions", specifier = ">=4.9.0" },
 ]


### PR DESCRIPTION
## Summary

- resolve nightly runtime floors directly from `pyproject.toml` with uv `lowest-direct`
- require every core runtime dependency to declare a lower bound and set PyYAML 6.0.3 as the supported floor
- replace the stale version-list validator with command-contract checks and regression coverage
- update Ruff pre-commit from 0.16.5 to 0.16.6 and Pyrefly from 1.3.0.dev3 to 1.3.0.dev4

## Why

The nightly workflow and its validator both copied dependency versions. When Albucore moved to 0.2.18, both copies remained at 0.2.16, so the validator passed while the scheduled environment became unsatisfiable. The workflow now consumes package metadata instead of maintaining another version list.

Failed run: https://github.com/albumentations-team/AlbumentationsX/actions/runs/34449276879

## Validation

- isolated Python 3.10 `lowest-direct` runtime install with the workflow commands
- `uv run pytest -q` — 15,975 passed, 32 skipped, 9 xfailed, 3 xpassed
- `pre-commit run --all-files --show-diff-on-failure`
- CI matrix and shard validators
- conda dependency parity check
- zizmor at medium severity and confidence

## Summary by Sourcery

Align nightly minimum-dependency testing with declared project metadata and enforce runtime dependency floors.

Bug Fixes:
- Make nightly lower-bound dependency testing resolve runtime floors from project metadata, preventing duplicated and stale version lists from allowing unsatisfiable environments.

Enhancements:
- Require all core runtime dependencies to declare supported lower bounds, including PyYAML 6.0.3.
- Replace version-list validation with checks for the nightly install command contract and runtime dependency metadata.

CI:
- Update Ruff pre-commit to 0.16.6 and Pyrefly to 1.3.0.dev4.

Tests:
- Add regression coverage for runtime lower-bound declarations and nightly lower-bound installation commands.